### PR TITLE
app: redact MCP debug logging

### DIFF
--- a/app/electron/mcp/MCPClient.test.ts
+++ b/app/electron/mcp/MCPClient.test.ts
@@ -20,6 +20,18 @@ import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import MCPClient from './MCPClient';
 
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn().mockReturnValue('/tmp'),
+  },
+  dialog: {
+    showMessageBox: vi.fn(),
+  },
+  ipcMain: {
+    handle: vi.fn(),
+  },
+}));
+
 function tmpPath(): string {
   return path.join(os.tmpdir(), `mcp-test-${Date.now()}-${Math.random()}.json`);
 }
@@ -27,11 +39,15 @@ function tmpPath(): string {
 describe('MCPClient', () => {
   let client: MCPClient;
   let infoSpy: Mock;
+  let logSpy: Mock;
+  let originalMCPDebug: string | undefined;
 
   let cfgPath: string;
   let settingsPath: string;
 
   beforeEach(() => {
+    originalMCPDebug = process.env.HEADLAMP_MCP_DEBUG;
+    delete process.env.HEADLAMP_MCP_DEBUG;
     cfgPath = tmpPath();
     settingsPath = tmpPath();
     try {
@@ -47,6 +63,11 @@ describe('MCPClient', () => {
   });
 
   afterEach(() => {
+    if (originalMCPDebug === undefined) {
+      delete process.env.HEADLAMP_MCP_DEBUG;
+    } else {
+      process.env.HEADLAMP_MCP_DEBUG = originalMCPDebug;
+    }
     try {
       if (fs.existsSync(cfgPath)) fs.unlinkSync(cfgPath);
     } catch {
@@ -63,6 +84,7 @@ describe('MCPClient', () => {
     client = new MCPClient(cfgPath, settingsPath);
     // spy on console.info to avoid noisy output and to assert calls
     infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {}) as unknown as Mock;
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {}) as unknown as Mock;
   });
 
   afterEach(() => {
@@ -75,12 +97,12 @@ describe('MCPClient', () => {
     );
   });
 
-  it('initialize is idempotent and logs exactly once', async () => {
+  it('initialize is idempotent and does not emit debug logs by default', async () => {
     await client.initialize();
     await client.initialize(); // second call should be a no-op
 
-    expect(infoSpy).toHaveBeenCalledTimes(1);
-    expect(infoSpy).toHaveBeenCalledWith('MCPClient: initialized');
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
   });
 
   it('config is set after initialize', async () => {
@@ -89,12 +111,25 @@ describe('MCPClient', () => {
     expect((client as any).mcpToolState).not.toBeNull();
   });
 
-  it('handleClustersChange resolves when initialized and logs clusters', async () => {
+  it('handles malformed tool config update payloads through IPC error handling', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const result = await (client as any).mcpUpdateToolsConfig(null);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Cannot convert undefined or null to object/);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('handleClustersChange resolves when initialized without default debug logs', async () => {
     await client.initialize();
     await expect(client.handleClustersChange(['cluster-1'])).resolves.toBeUndefined();
 
-    // initialize + clusters change => at least two calls
-    expect(infoSpy).toHaveBeenCalledWith('MCPClient: clusters changed ->', ['cluster-1']);
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
   });
 
   it('setMainWindow accepts a BrowserWindow-like object and cleanup resets state', async () => {
@@ -107,9 +142,10 @@ describe('MCPClient', () => {
     // handleClustersChange should work when initialized
     await expect(client.handleClustersChange(['c-x'])).resolves.toBeUndefined();
 
-    // cleanup should reset initialized and log cleanup
+    // cleanup should reset initialized without debug logging by default
     await client.cleanup();
-    expect(infoSpy).toHaveBeenCalledWith('MCPClient: cleaned up');
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
 
     // after cleanup, handleClustersChange should again reject as not initialized
     await expect(client.handleClustersChange(['after-cleanup'])).rejects.toThrow(
@@ -144,8 +180,7 @@ describe('MCPClient', () => {
 
     expect((client as any).isInitialized).toBe(true);
     expect((client as any).client).toBeNull();
-    // ensure the public log happened
-    expect(infoSpy).toHaveBeenCalledWith('MCPClient: initialized');
+    expect(infoSpy).not.toHaveBeenCalled();
   });
 
   it('initialize constructs MCP client and caches tools when servers exist', async () => {
@@ -287,7 +322,22 @@ describe('MCPClient', () => {
 });
 
 describe('MCPClient logging behavior', () => {
-  it('logs clusters change even when not initialized', async () => {
+  let originalMCPDebug: string | undefined;
+
+  beforeEach(() => {
+    originalMCPDebug = process.env.HEADLAMP_MCP_DEBUG;
+    delete process.env.HEADLAMP_MCP_DEBUG;
+  });
+
+  afterEach(() => {
+    if (originalMCPDebug === undefined) {
+      delete process.env.HEADLAMP_MCP_DEBUG;
+    } else {
+      process.env.HEADLAMP_MCP_DEBUG = originalMCPDebug;
+    }
+  });
+
+  it('does not log clusters change when debug logging is disabled', async () => {
     const cfgPath = path.join(os.tmpdir(), `mcp-test-${Date.now()}-${Math.random()}.json`);
     const { default: MCPClientLocal } = await import('./MCPClient');
     const client = new MCPClientLocal(cfgPath, cfgPath) as InstanceType<
@@ -300,7 +350,26 @@ describe('MCPClient logging behavior', () => {
       'MCPClient: not initialized'
     );
 
-    expect(infoSpy).toHaveBeenCalledWith('MCPClient: clusters changed ->', ['cluster-log']);
+    expect(infoSpy).not.toHaveBeenCalled();
+
+    infoSpy.mockRestore();
+  });
+
+  it('redacts clusters when debug logging is enabled', async () => {
+    process.env.HEADLAMP_MCP_DEBUG = 'true';
+    const cfgPath = path.join(os.tmpdir(), `mcp-test-${Date.now()}-${Math.random()}.json`);
+    const { default: MCPClientLocal } = await import('./MCPClient');
+    const client = new MCPClientLocal(cfgPath, cfgPath) as InstanceType<
+      typeof import('./MCPClient').default
+    >;
+
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {}) as unknown as Mock;
+
+    await expect(client.handleClustersChange(['cluster-log'])).rejects.toThrow(
+      'MCPClient: not initialized'
+    );
+
+    expect(infoSpy).toHaveBeenCalledWith('MCPClient: clusters changed ->', ['[REDACTED]']);
 
     infoSpy.mockRestore();
   });
@@ -309,14 +378,25 @@ describe('MCPClient logging behavior', () => {
 describe('MCPClient#mcpExecuteTool', () => {
   const cfgPath = tmpPath();
   const settingsPath = tmpPath();
+  let originalMCPDebug: string | undefined;
 
   beforeEach(() => {
+    originalMCPDebug = process.env.HEADLAMP_MCP_DEBUG;
+    delete process.env.HEADLAMP_MCP_DEBUG;
     try {
       if (fs.existsSync(cfgPath)) fs.unlinkSync(cfgPath);
     } catch {}
     try {
       if (fs.existsSync(settingsPath)) fs.unlinkSync(settingsPath);
     } catch {}
+  });
+
+  afterEach(() => {
+    if (originalMCPDebug === undefined) {
+      delete process.env.HEADLAMP_MCP_DEBUG;
+    } else {
+      process.env.HEADLAMP_MCP_DEBUG = originalMCPDebug;
+    }
   });
 
   it('executes a tool successfully and records usage', async () => {

--- a/app/electron/mcp/MCPClient.test.ts
+++ b/app/electron/mcp/MCPClient.test.ts
@@ -20,6 +20,18 @@ import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import MCPClient from './MCPClient';
 
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn().mockReturnValue('/tmp'),
+  },
+  dialog: {
+    showMessageBox: vi.fn(),
+  },
+  ipcMain: {
+    handle: vi.fn(),
+  },
+}));
+
 function tmpPath(): string {
   return path.join(os.tmpdir(), `mcp-test-${Date.now()}-${Math.random()}.json`);
 }
@@ -27,11 +39,15 @@ function tmpPath(): string {
 describe('MCPClient', () => {
   let client: MCPClient;
   let infoSpy: Mock;
+  let logSpy: Mock;
+  let originalMCPDebug: string | undefined;
 
   let cfgPath: string;
   let settingsPath: string;
 
   beforeEach(() => {
+    originalMCPDebug = process.env.HEADLAMP_MCP_DEBUG;
+    delete process.env.HEADLAMP_MCP_DEBUG;
     cfgPath = tmpPath();
     settingsPath = tmpPath();
     try {
@@ -47,6 +63,11 @@ describe('MCPClient', () => {
   });
 
   afterEach(() => {
+    if (originalMCPDebug === undefined) {
+      delete process.env.HEADLAMP_MCP_DEBUG;
+    } else {
+      process.env.HEADLAMP_MCP_DEBUG = originalMCPDebug;
+    }
     try {
       if (fs.existsSync(cfgPath)) fs.unlinkSync(cfgPath);
     } catch {
@@ -63,6 +84,7 @@ describe('MCPClient', () => {
     client = new MCPClient(cfgPath, settingsPath);
     // spy on console.info to avoid noisy output and to assert calls
     infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {}) as unknown as Mock;
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {}) as unknown as Mock;
   });
 
   afterEach(() => {
@@ -75,12 +97,12 @@ describe('MCPClient', () => {
     );
   });
 
-  it('initialize is idempotent and logs exactly once', async () => {
+  it('initialize is idempotent and does not emit debug logs by default', async () => {
     await client.initialize();
     await client.initialize(); // second call should be a no-op
 
-    expect(infoSpy).toHaveBeenCalledTimes(1);
-    expect(infoSpy).toHaveBeenCalledWith('MCPClient: initialized');
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
   });
 
   it('config is set after initialize', async () => {
@@ -89,12 +111,25 @@ describe('MCPClient', () => {
     expect((client as any).mcpToolState).not.toBeNull();
   });
 
-  it('handleClustersChange resolves when initialized and logs clusters', async () => {
+  it('handles malformed tool config update payloads through IPC error handling', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const result = await (client as any).mcpUpdateToolsConfig(null);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Cannot convert undefined or null to object/);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('handleClustersChange resolves when initialized without default debug logs', async () => {
     await client.initialize();
     await expect(client.handleClustersChange(['cluster-1'])).resolves.toBeUndefined();
 
-    // initialize + clusters change => at least two calls
-    expect(infoSpy).toHaveBeenCalledWith('MCPClient: clusters changed ->', ['cluster-1']);
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
   });
 
   it('setMainWindow accepts a BrowserWindow-like object and cleanup resets state', async () => {
@@ -107,9 +142,10 @@ describe('MCPClient', () => {
     // handleClustersChange should work when initialized
     await expect(client.handleClustersChange(['c-x'])).resolves.toBeUndefined();
 
-    // cleanup should reset initialized and log cleanup
+    // cleanup should reset initialized without debug logging by default
     await client.cleanup();
-    expect(infoSpy).toHaveBeenCalledWith('MCPClient: cleaned up');
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
 
     // after cleanup, handleClustersChange should again reject as not initialized
     await expect(client.handleClustersChange(['after-cleanup'])).rejects.toThrow(
@@ -186,8 +222,7 @@ describe('MCPClient', () => {
 
     expect((client as any).isInitialized).toBe(false);
     expect((client as any).client).toBeNull();
-    // ensure the public log happened
-    expect(infoSpy).toHaveBeenCalledWith('MCPClient: initialized');
+    expect(infoSpy).not.toHaveBeenCalled();
   });
 
   it('does not load the MCP adapter when configured servers are unused', async () => {
@@ -692,7 +727,23 @@ describe('MCPClient', () => {
 });
 
 describe('MCPClient logging behavior', () => {
-  it('logs clusters change even when not initialized', async () => {
+  let originalMCPDebug: string | undefined;
+
+  beforeEach(() => {
+    originalMCPDebug = process.env.HEADLAMP_MCP_DEBUG;
+    delete process.env.HEADLAMP_MCP_DEBUG;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalMCPDebug === undefined) {
+      delete process.env.HEADLAMP_MCP_DEBUG;
+    } else {
+      process.env.HEADLAMP_MCP_DEBUG = originalMCPDebug;
+    }
+  });
+
+  it('does not log clusters change when debug logging is disabled', async () => {
     const cfgPath = path.join(os.tmpdir(), `mcp-test-${Date.now()}-${Math.random()}.json`);
     const { default: MCPClientLocal } = await import('./MCPClient');
     const client = new MCPClientLocal(cfgPath, cfgPath) as InstanceType<
@@ -705,23 +756,49 @@ describe('MCPClient logging behavior', () => {
       'MCPClient: not initialized'
     );
 
-    expect(infoSpy).toHaveBeenCalledWith('MCPClient: clusters changed ->', ['cluster-log']);
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
 
-    infoSpy.mockRestore();
+  it('redacts clusters when debug logging is enabled', async () => {
+    process.env.HEADLAMP_MCP_DEBUG = 'true';
+    const cfgPath = path.join(os.tmpdir(), `mcp-test-${Date.now()}-${Math.random()}.json`);
+    const { default: MCPClientLocal } = await import('./MCPClient');
+    const client = new MCPClientLocal(cfgPath, cfgPath) as InstanceType<
+      typeof import('./MCPClient').default
+    >;
+
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {}) as unknown as Mock;
+
+    await expect(client.handleClustersChange(['cluster-log'])).rejects.toThrow(
+      'MCPClient: not initialized'
+    );
+
+    expect(infoSpy).toHaveBeenCalledWith('MCPClient: clusters changed ->', ['[REDACTED]']);
   });
 });
 
 describe('MCPClient#mcpExecuteTool', () => {
   const cfgPath = tmpPath();
   const settingsPath = tmpPath();
+  let originalMCPDebug: string | undefined;
 
   beforeEach(() => {
+    originalMCPDebug = process.env.HEADLAMP_MCP_DEBUG;
+    delete process.env.HEADLAMP_MCP_DEBUG;
     try {
       if (fs.existsSync(cfgPath)) fs.unlinkSync(cfgPath);
     } catch {}
     try {
       if (fs.existsSync(settingsPath)) fs.unlinkSync(settingsPath);
     } catch {}
+  });
+
+  afterEach(() => {
+    if (originalMCPDebug === undefined) {
+      delete process.env.HEADLAMP_MCP_DEBUG;
+    } else {
+      process.env.HEADLAMP_MCP_DEBUG = originalMCPDebug;
+    }
   });
 
   it('executes a tool successfully and records usage', async () => {
@@ -772,6 +849,53 @@ describe('MCPClient#mcpExecuteTool', () => {
     expect(res.result).toEqual({ ok: true });
     expect(res.toolCallId).toBe('call-1');
     expect(client.mcpToolState.recordToolUsage).toHaveBeenCalledWith('serverA', 'tool1');
+  });
+
+  it('does not log tool arguments when MCP debug logging is enabled', async () => {
+    process.env.HEADLAMP_MCP_DEBUG = 'true';
+
+    vi.resetModules();
+    vi.doMock('./MCPSettings', () => ({
+      makeMcpServersFromSettings: vi.fn().mockReturnValue({}),
+      hasClusterDependentServers: vi.fn().mockReturnValue(false),
+    }));
+    vi.doMock('./MCPToolStateStore', () => ({
+      parseServerNameToolName: vi
+        .fn()
+        .mockReturnValue({ serverName: 'serverA', toolName: 'tool1' }),
+      validateToolArgs: vi.fn().mockReturnValue({ valid: true }),
+      MCPToolStateStore: vi.fn().mockImplementation(() => ({
+        initialize: vi.fn().mockResolvedValue(undefined),
+        initConfigFromClientTools: vi.fn(),
+      })),
+    }));
+    vi.doMock('@langchain/mcp-adapters', () => ({
+      MultiServerMCPClient: vi.fn().mockImplementation(() => ({
+        getTools: vi.fn().mockResolvedValue([]),
+        close: vi.fn().mockResolvedValue(undefined),
+      })),
+    }));
+
+    const { default: MCPClient } = await import('./MCPClient');
+    const client = new MCPClient(cfgPath, settingsPath) as any;
+    const debugLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const invoke = vi.fn().mockResolvedValue({ ok: true });
+
+    await client.initialize();
+
+    client.clientTools = [{ name: 'serverA.tool1', schema: {}, invoke }];
+    client.mcpToolState = {
+      isToolEnabled: vi.fn().mockReturnValue(true),
+      recordToolUsage: vi.fn(),
+    };
+    client.isInitialized = true;
+    client.client = {};
+
+    await client.mcpExecuteTool('serverA.tool1', [{ pin: 1234 }], 'call-args');
+
+    expect(debugLogSpy).toHaveBeenCalledWith('Executing MCP tool:', { toolName: '[REDACTED]' });
+    expect(debugLogSpy.mock.calls.some(call => JSON.stringify(call).includes('1234'))).toBe(false);
+    expect(debugLogSpy.mock.calls.some(call => JSON.stringify(call).includes('pin'))).toBe(false);
   });
 
   it('returns error when parameter validation fails', async () => {

--- a/app/electron/mcp/MCPClient.ts
+++ b/app/electron/mcp/MCPClient.ts
@@ -16,6 +16,7 @@
 
 import type { DynamicStructuredTool } from '@langchain/core/dist/tools/index';
 import { type BrowserWindow, dialog, ipcMain } from 'electron';
+import { mcpDebugInfo, mcpDebugLog } from './debug';
 import type { MultiServerMCPClient } from './MCPAdapter';
 import {
   hasClusterDependentServers,
@@ -32,8 +33,6 @@ import {
   showToolsConfigConfirmationDialog,
   validateToolArgs,
 } from './MCPToolStateStore';
-
-const DEBUG = true;
 
 /**
  * MCPClient
@@ -93,6 +92,33 @@ export default class MCPClient {
     this.setupIpcHandlers();
   }
 
+  private summarizeMCPSettings(mcpSettings: MCPSettings) {
+    return {
+      enabled: mcpSettings.enabled,
+      serverCount: mcpSettings.servers.length,
+      enabledServerCount: mcpSettings.servers.filter(server => server.enabled).length,
+    };
+  }
+
+  private summarizeMCPToolsConfig(toolsConfig: MCPToolsConfig) {
+    const serverNames = Object.keys(toolsConfig);
+    let toolCount = 0;
+    let enabledToolCount = 0;
+
+    for (const serverName of serverNames) {
+      const tools = Object.values(toolsConfig[serverName] ?? {});
+
+      toolCount += tools.length;
+      enabledToolCount += tools.filter(tool => tool.enabled).length;
+    }
+
+    return {
+      serverCount: serverNames.length,
+      toolCount,
+      enabledToolCount,
+    };
+  }
+
   /**
    * Runs a client lifecycle mutation after all earlier mutations complete.
    *
@@ -121,9 +147,7 @@ export default class MCPClient {
 
     this.initialized = true;
 
-    if (DEBUG) {
-      console.info('MCPClient: initialized');
-    }
+    mcpDebugInfo('MCPClient: initialized');
   }
 
   /**
@@ -132,12 +156,10 @@ export default class MCPClient {
    * @return Promise that resolves when initialization is complete.
    */
   private async initializeClient(): Promise<void> {
-    if (DEBUG) {
-      console.log('MCPClient: initializeClient: ', {
-        isInitialized: this.isInitialized,
-        initializationPromise: this.initializationPromise,
-      });
-    }
+    mcpDebugLog('MCPClient: initializeClient: ', {
+      isInitialized: this.isInitialized,
+      initializationPromise: this.initializationPromise,
+    });
 
     if (this.isInitialized) {
       return;
@@ -146,9 +168,7 @@ export default class MCPClient {
       return this.initializationPromise;
     }
 
-    if (DEBUG) {
-      console.log('MCPClient: initializeClient: Starting doInitialize()...');
-    }
+    mcpDebugLog('MCPClient: initializeClient: Starting doInitialize()...');
 
     const initializationPromise = this.doInitializeClient();
     this.initializationPromise = initializationPromise;
@@ -173,18 +193,14 @@ export default class MCPClient {
 
       // If no enabled servers, skip initialization
       if (Object.keys(mcpServers).length === 0) {
-        if (DEBUG) {
-          console.log('MCPClient: doInitialize: No enabled MCP servers found');
-        }
+        mcpDebugLog('MCPClient: doInitialize: No enabled MCP servers found');
         this.isInitialized = true;
         return;
       }
-      if (DEBUG) {
-        console.log(
-          'MCPClient: doInitialize: Initializing MCP client with servers:',
-          Object.keys(mcpServers)
-        );
-      }
+      mcpDebugLog(
+        'MCPClient: doInitialize: Initializing MCP client with servers:',
+        Object.keys(mcpServers)
+      );
       this.ensureCertificates();
       // Importing here keeps the large adapter graph out of startup memory.
       const { MultiServerMCPClient } = await import('./MCPAdapter');
@@ -203,13 +219,11 @@ export default class MCPClient {
       this.mcpToolState?.initConfigFromClientTools(this.clientTools);
 
       this.isInitialized = true;
-      if (DEBUG) {
-        console.log(
-          'MCPClient: doInitialize: MCP client initialized successfully with',
-          this.clientTools.length,
-          'tools'
-        );
-      }
+      mcpDebugLog(
+        'MCPClient: doInitialize: MCP client initialized successfully with tools:',
+        this.clientTools.length,
+        { count: this.clientTools.length }
+      );
     } catch (error) {
       console.error('Failed to initialize MCP client:', error);
       this.client = null;
@@ -256,9 +270,7 @@ export default class MCPClient {
     this.isInitialized = false;
     this.initializationPromise = null;
 
-    if (DEBUG) {
-      console.info('MCPClient: cleaned up');
-    }
+    mcpDebugInfo('MCPClient: cleaned up');
   }
 
   /**
@@ -285,9 +297,7 @@ export default class MCPClient {
    * @param newClusters - The new active clusters array, or null if none.
    */
   private async applyClustersChange(newClusters: string[] | null): Promise<void> {
-    if (DEBUG) {
-      console.info('MCPClient: clusters changed ->', newClusters);
-    }
+    mcpDebugInfo('MCPClient: clusters changed ->', newClusters);
 
     if (!this.initialized) {
       throw new Error('MCPClient: not initialized');
@@ -311,13 +321,13 @@ export default class MCPClient {
 
       // Recording context must not start configured servers or load the adapter.
       if (!this.client) {
-        console.log('MCP client not yet started, skipping cluster-change restart');
+        mcpDebugLog('MCP client not yet started, skipping cluster-change restart');
         return;
       }
 
       // Check if we have any cluster-dependent servers
       if (!hasClusterDependentServers(this.settingsPath)) {
-        console.log('No cluster-dependent MCP servers found, skipping restart');
+        mcpDebugLog('No cluster-dependent MCP servers found, skipping restart');
         return;
       }
 
@@ -332,7 +342,7 @@ export default class MCPClient {
       this.initializationPromise = null;
       // Re-initialize with new cluster context
       await this.initializeClient();
-      console.log('MCP client restarted successfully for new cluster:', newClusters);
+      mcpDebugLog('MCP client restarted successfully for new cluster:', newClusters);
     } catch (error) {
       console.error('Error restarting MCP client for cluster change:', error);
       // Restore previous cluster on error
@@ -352,7 +362,6 @@ export default class MCPClient {
    * @returns Result object containing success status and output or error message
    */
   private async mcpExecuteTool(toolName: string, args: any[], toolCallId: string) {
-    console.log('args in mcp-execute-tool:', args);
     if (!this.mcpToolState) {
       return;
     }
@@ -380,10 +389,14 @@ export default class MCPClient {
       if (!validation.valid) {
         throw new Error(`Parameter validation failed: ${validation.error}`);
       }
-      console.log(`Executing MCP tool: ${toolName} with args:`, args);
+      mcpDebugLog('Executing MCP tool:', {
+        toolName,
+      });
       // Execute the tool directly using LangChain's invoke method
       const result = await tool.invoke(args);
-      console.log(`MCP tool ${toolName} executed successfully`);
+      mcpDebugLog('MCP tool executed successfully:', {
+        toolName,
+      });
       // Record tool usage
       this.mcpToolState.recordToolUsage(serverName, actualToolName);
       return {
@@ -427,7 +440,7 @@ export default class MCPClient {
         };
       }
 
-      console.log('Resetting MCP client...');
+      mcpDebugLog('Resetting MCP client...');
       return await this.enqueueLifecycleMutation(async () => {
         if (this.client) {
           // If the client has a close/dispose method, call it
@@ -461,7 +474,7 @@ export default class MCPClient {
       }
       // Get current configuration for comparison
       const currentSettings = loadMCPSettings(this.settingsPath);
-      console.log('Requested MCP configuration update:', mcpSettings);
+      mcpDebugLog('Requested MCP configuration update:', this.summarizeMCPSettings(mcpSettings));
       // Show detailed confirmation dialog with changes
       const userConfirmed = await showSettingsChangeDialog(
         this.mainWindow,
@@ -476,7 +489,7 @@ export default class MCPClient {
         };
       }
 
-      console.log('Updating MCP configuration with user confirmation...');
+      mcpDebugLog('Updating MCP configuration with user confirmation...');
       return await this.enqueueLifecycleMutation(async () => {
         if (this.initializationPromise) {
           await this.initializationPromise;
@@ -497,7 +510,7 @@ export default class MCPClient {
           await this.initializeClient();
         }
 
-        console.log('MCP configuration updated successfully');
+        mcpDebugLog('MCP configuration updated successfully');
         return { success: true };
       });
     } catch (error) {
@@ -548,8 +561,11 @@ export default class MCPClient {
   }
 
   private async mcpUpdateToolsConfig(toolsConfig: MCPToolsConfig) {
-    console.log('Requested MCP tools configuration update:', toolsConfig);
     try {
+      mcpDebugLog(
+        'Requested MCP tools configuration update:',
+        this.summarizeMCPToolsConfig(toolsConfig)
+      );
       if (!this.mainWindow) {
         throw new Error('Main window not set for MCP client');
       }
@@ -611,7 +627,7 @@ export default class MCPClient {
 
   private async mcpClusterChange(cluster: string | null) {
     try {
-      console.log('Received cluster change event:', cluster);
+      mcpDebugLog('Received cluster change event:', cluster);
       // @todo: support multiple clusters
       await this.handleClustersChange(cluster === null ? null : [cluster]);
       return {

--- a/app/electron/mcp/MCPClient.ts
+++ b/app/electron/mcp/MCPClient.ts
@@ -17,6 +17,7 @@
 import type { DynamicStructuredTool } from '@langchain/core/dist/tools/index';
 import { MultiServerMCPClient } from '@langchain/mcp-adapters';
 import { type BrowserWindow, dialog, ipcMain } from 'electron';
+import { mcpDebugInfo, mcpDebugLog } from './debug';
 import {
   hasClusterDependentServers,
   loadMCPSettings,
@@ -32,8 +33,6 @@ import {
   showToolsConfigConfirmationDialog,
   validateToolArgs,
 } from './MCPToolStateStore';
-
-const DEBUG = true;
 
 /**
  * MCPClient
@@ -80,6 +79,33 @@ export default class MCPClient {
     this.setupIpcHandlers();
   }
 
+  private summarizeMCPSettings(mcpSettings: MCPSettings) {
+    return {
+      enabled: mcpSettings.enabled,
+      serverCount: mcpSettings.servers.length,
+      enabledServerCount: mcpSettings.servers.filter(server => server.enabled).length,
+    };
+  }
+
+  private summarizeMCPToolsConfig(toolsConfig: MCPToolsConfig) {
+    const serverNames = Object.keys(toolsConfig);
+    let toolCount = 0;
+    let enabledToolCount = 0;
+
+    for (const serverName of serverNames) {
+      const tools = Object.values(toolsConfig[serverName] ?? {});
+
+      toolCount += tools.length;
+      enabledToolCount += tools.filter(tool => tool.enabled).length;
+    }
+
+    return {
+      serverCount: serverNames.length,
+      toolCount,
+      enabledToolCount,
+    };
+  }
+
   /**
    * Initialize the MCP client.
    */
@@ -93,9 +119,7 @@ export default class MCPClient {
 
     this.initialized = true;
 
-    if (DEBUG) {
-      console.info('MCPClient: initialized');
-    }
+    mcpDebugInfo('MCPClient: initialized');
   }
 
   /**
@@ -104,12 +128,10 @@ export default class MCPClient {
    * @return Promise that resolves when initialization is complete.
    */
   private async initializeClient(): Promise<void> {
-    if (DEBUG) {
-      console.log('MCPClient: initializeClient: ', {
-        isInitialized: this.isInitialized,
-        initializationPromise: this.initializationPromise,
-      });
-    }
+    mcpDebugLog('MCPClient: initializeClient: ', {
+      isInitialized: this.isInitialized,
+      initializationPromise: this.initializationPromise,
+    });
 
     if (this.isInitialized) {
       return;
@@ -118,9 +140,7 @@ export default class MCPClient {
       return this.initializationPromise;
     }
 
-    if (DEBUG) {
-      console.log('MCPClient: initializeClient: Starting doInitialize()...');
-    }
+    mcpDebugLog('MCPClient: initializeClient: Starting doInitialize()...');
 
     this.initializationPromise = this.doInitializeClient();
     return this.initializationPromise;
@@ -137,18 +157,14 @@ export default class MCPClient {
 
       // If no enabled servers, skip initialization
       if (Object.keys(mcpServers).length === 0) {
-        if (DEBUG) {
-          console.log('MCPClient: doInitialize: No enabled MCP servers found');
-        }
+        mcpDebugLog('MCPClient: doInitialize: No enabled MCP servers found');
         this.isInitialized = true;
         return;
       }
-      if (DEBUG) {
-        console.log(
-          'MCPClient: doInitialize: Initializing MCP client with servers:',
-          Object.keys(mcpServers)
-        );
-      }
+      mcpDebugLog(
+        'MCPClient: doInitialize: Initializing MCP client with servers:',
+        Object.keys(mcpServers)
+      );
       this.client = new MultiServerMCPClient({
         throwOnLoadError: false, // Don't throw on load error to allow partial initialization
         prefixToolNameWithServerName: true, // Prefix to avoid name conflicts
@@ -162,13 +178,11 @@ export default class MCPClient {
       this.mcpToolState?.initConfigFromClientTools(this.clientTools);
 
       this.isInitialized = true;
-      if (DEBUG) {
-        console.log(
-          'MCPClient: doInitialize: MCP client initialized successfully with',
-          this.clientTools.length,
-          'tools'
-        );
-      }
+      mcpDebugLog(
+        'MCPClient: doInitialize: MCP client initialized successfully with tools:',
+        this.clientTools.length,
+        { count: this.clientTools.length }
+      );
     } catch (error) {
       console.error('Failed to initialize MCP client:', error);
       this.client = null;
@@ -200,9 +214,7 @@ export default class MCPClient {
     this.isInitialized = false;
     this.initializationPromise = null;
 
-    if (DEBUG) {
-      console.info('MCPClient: cleaned up');
-    }
+    mcpDebugInfo('MCPClient: cleaned up');
   }
 
   /**
@@ -220,9 +232,7 @@ export default class MCPClient {
    * @param clusters - The new active clusters array, or null if none.
    */
   async handleClustersChange(newClusters: string[] | null): Promise<void> {
-    if (DEBUG) {
-      console.info('MCPClient: clusters changed ->', newClusters);
-    }
+    mcpDebugInfo('MCPClient: clusters changed ->', newClusters);
 
     if (!this.initialized) {
       throw new Error('MCPClient: not initialized');
@@ -238,7 +248,7 @@ export default class MCPClient {
 
     // Check if we have any cluster-dependent servers
     if (!hasClusterDependentServers(this.settingsPath)) {
-      console.log('No cluster-dependent MCP servers found, skipping restart');
+      mcpDebugLog('No cluster-dependent MCP servers found, skipping restart');
       return;
     }
 
@@ -254,7 +264,7 @@ export default class MCPClient {
       this.initializationPromise = null;
       // Re-initialize with new cluster context
       await this.initializeClient();
-      console.log('MCP client restarted successfully for new cluster:', newClusters);
+      mcpDebugLog('MCP client restarted successfully for new cluster:', newClusters);
     } catch (error) {
       console.error('Error restarting MCP client for cluster change:', error);
       // Restore previous cluster on error
@@ -273,7 +283,7 @@ export default class MCPClient {
    * @returns Result object containing success status and output or error message
    */
   private async mcpExecuteTool(toolName: string, args: any[], toolCallId: string) {
-    console.log('args in mcp-execute-tool:', args);
+    mcpDebugLog('args in mcp-execute-tool:', args);
     if (!this.mcpToolState) {
       return;
     }
@@ -301,10 +311,15 @@ export default class MCPClient {
       if (!validation.valid) {
         throw new Error(`Parameter validation failed: ${validation.error}`);
       }
-      console.log(`Executing MCP tool: ${toolName} with args:`, args);
+      mcpDebugLog('Executing MCP tool with args:', {
+        toolName,
+        args,
+      });
       // Execute the tool directly using LangChain's invoke method
       const result = await tool.invoke(args);
-      console.log(`MCP tool ${toolName} executed successfully`);
+      mcpDebugLog('MCP tool executed successfully:', {
+        toolName,
+      });
       // Record tool usage
       this.mcpToolState.recordToolUsage(serverName, actualToolName);
       return {
@@ -348,7 +363,7 @@ export default class MCPClient {
         };
       }
 
-      console.log('Resetting MCP client...');
+      mcpDebugLog('Resetting MCP client...');
 
       if (this.client) {
         // If the client has a close/dispose method, call it
@@ -381,7 +396,7 @@ export default class MCPClient {
       }
       // Get current configuration for comparison
       const currentSettings = loadMCPSettings(this.settingsPath);
-      console.log('Requested MCP configuration update:', mcpSettings);
+      mcpDebugLog('Requested MCP configuration update:', this.summarizeMCPSettings(mcpSettings));
       // Show detailed confirmation dialog with changes
       const userConfirmed = await showSettingsChangeDialog(
         this.mainWindow,
@@ -396,7 +411,7 @@ export default class MCPClient {
         };
       }
 
-      console.log('Updating MCP configuration with user confirmation...');
+      mcpDebugLog('Updating MCP configuration with user confirmation...');
       saveMCPSettings(this.settingsPath, mcpSettings);
 
       // Reset and reinitialize client with new config
@@ -410,7 +425,7 @@ export default class MCPClient {
       // Re-initialize with new config
       await this.initializeClient();
 
-      console.log('MCP configuration updated successfully');
+      mcpDebugLog('MCP configuration updated successfully');
       return { success: true };
     } catch (error) {
       console.error('Error updating MCP configuration:', error);
@@ -457,8 +472,11 @@ export default class MCPClient {
   }
 
   private async mcpUpdateToolsConfig(toolsConfig: MCPToolsConfig) {
-    console.log('Requested MCP tools configuration update:', toolsConfig);
     try {
+      mcpDebugLog(
+        'Requested MCP tools configuration update:',
+        this.summarizeMCPToolsConfig(toolsConfig)
+      );
       if (!this.mainWindow) {
         throw new Error('Main window not set for MCP client');
       }
@@ -520,7 +538,7 @@ export default class MCPClient {
 
   private async mcpClusterChange(cluster: string | null) {
     try {
-      console.log('Received cluster change event:', cluster);
+      mcpDebugLog('Received cluster change event:', cluster);
       if (cluster !== null) {
         // @todo: support multiple clusters
         await this.handleClustersChange([cluster]);

--- a/app/electron/mcp/MCPSettings.test.ts
+++ b/app/electron/mcp/MCPSettings.test.ts
@@ -19,6 +19,15 @@ import { loadSettings, saveSettings } from '../settings';
 import { expandEnvAndResolvePaths, loadMCPSettings, saveMCPSettings } from './MCPSettings';
 import * as MCP from './MCPSettings';
 
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn().mockReturnValue('/tmp'),
+  },
+  dialog: {
+    showMessageBox: vi.fn(),
+  },
+}));
+
 vi.mock('../settings', () => ({
   loadSettings: vi.fn(),
   saveSettings: vi.fn(),
@@ -135,13 +144,22 @@ describe('expandEnvAndResolvePaths', () => {
 });
 
 describe('MultiServerMCPClient', () => {
+  let originalMCPDebug: string | undefined;
+
   beforeEach(() => {
+    originalMCPDebug = process.env.HEADLAMP_MCP_DEBUG;
+    delete process.env.HEADLAMP_MCP_DEBUG;
     // ensure predictable env for merging tests
     process.env.TEST_ORIG_ENV = 'orig';
     vi.resetAllMocks();
   });
 
   afterEach(() => {
+    if (originalMCPDebug === undefined) {
+      delete process.env.HEADLAMP_MCP_DEBUG;
+    } else {
+      process.env.HEADLAMP_MCP_DEBUG = originalMCPDebug;
+    }
     delete process.env.TEST_ORIG_ENV;
   });
 
@@ -240,6 +258,35 @@ describe('MultiServerMCPClient', () => {
     const entry = result['withCluster'] as any;
     // the expand function should have replaced the placeholder
     expect(entry.args).toEqual(['connect', 'my-current-cluster']);
+  });
+
+  it('redacts expanded args when MCP debug logging is enabled', () => {
+    process.env.HEADLAMP_MCP_DEBUG = 'true';
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const mcpSettings = {
+        enabled: true,
+        servers: [
+          {
+            name: 'withSecret',
+            command: 'cmd',
+            args: ['--token=secret-value', 'HEADLAMP_CURRENT_CLUSTER'],
+            enabled: true,
+          },
+        ],
+      };
+
+      (loadSettings as Mock).mockReturnValue({ mcp: mcpSettings });
+
+      MCP.makeMcpServersFromSettings('/cfg', ['prod-cluster']);
+
+      expect(logSpy).toHaveBeenCalledWith('Expanded args for MCP server:', {
+        serverName: '[REDACTED]',
+        expandedArgs: ['[REDACTED]', '[REDACTED]'],
+      });
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 });
 

--- a/app/electron/mcp/MCPSettings.ts
+++ b/app/electron/mcp/MCPSettings.ts
@@ -19,8 +19,7 @@ import { type BrowserWindow, dialog } from 'electron';
 import os from 'os';
 import path from 'path';
 import { loadSettings, saveSettings } from '../settings';
-
-const DEBUG = true;
+import { mcpDebugLog } from './debug';
 
 export interface MCPSettings {
   /**
@@ -177,9 +176,10 @@ export function makeMcpServersFromSettings(
 
     const expandedArgs = expandEnvAndResolvePaths(server.args || [], clusters[0] || null);
 
-    if (DEBUG) {
-      console.log(`Expanded args for ${server.name}:`, expandedArgs);
-    }
+    mcpDebugLog('Expanded args for MCP server:', {
+      serverName: server.name,
+      expandedArgs,
+    });
 
     const serverEnv = server.env ? { ...process.env, ...server.env } : process.env;
 

--- a/app/electron/mcp/MCPToolStateStore.ts
+++ b/app/electron/mcp/MCPToolStateStore.ts
@@ -17,6 +17,7 @@
 import type { DynamicStructuredTool } from '@langchain/core/dist/tools/index';
 import { type BrowserWindow, dialog } from 'electron';
 import * as fs from 'fs';
+import { mcpDebugLog } from './debug';
 
 /**
  * State of a single MCP tool.
@@ -484,7 +485,7 @@ export class MCPToolStateStore {
    */
   initConfigFromClientTools(clientTools: DynamicStructuredTool[]): void {
     if (!clientTools || clientTools.length === 0) {
-      console.log('No tools available for configuration initialization');
+      mcpDebugLog('No tools available for configuration initialization');
       // Clear the config if no tools are available
       this.replaceConfig({});
       return;
@@ -506,11 +507,11 @@ export class MCPToolStateStore {
 
       // Extract schema from the tool (LangChain tools use .schema property)
       const toolSchema = tool.schema || (tool as any).inputSchema || null;
-      console.log(
-        `Processing tool: ${toolName}, has inputSchema: ${!!toolSchema}, description: "${
-          tool.description
-        }"`
-      );
+      mcpDebugLog('Processing MCP tool for configuration initialization:', {
+        toolName,
+        hasInputSchema: !!toolSchema,
+        description: tool.description,
+      });
 
       if (!toolsByServer[serverName]) {
         toolsByServer[serverName] = [];
@@ -523,7 +524,9 @@ export class MCPToolStateStore {
       });
     }
 
-    console.log('Tools grouped by server:', Object.keys(toolsByServer));
+    mcpDebugLog('MCP tools grouped by server for configuration initialization:', {
+      serverNames: Object.keys(toolsByServer),
+    });
 
     // Replace the entire configuration with current tools
     this.replaceToolsConfig(toolsByServer);

--- a/app/electron/mcp/debug.test.ts
+++ b/app/electron/mcp/debug.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mcpDebugLog, redactMCPLogValue } from './debug';
+
+let originalMcpDebugEnv: string | undefined;
+let hadMcpDebugEnv = false;
+
+beforeEach(() => {
+  hadMcpDebugEnv = Object.prototype.hasOwnProperty.call(process.env, 'HEADLAMP_MCP_DEBUG');
+  originalMcpDebugEnv = process.env.HEADLAMP_MCP_DEBUG;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (!hadMcpDebugEnv || originalMcpDebugEnv === undefined) {
+    delete process.env.HEADLAMP_MCP_DEBUG;
+  } else {
+    process.env.HEADLAMP_MCP_DEBUG = originalMcpDebugEnv;
+  }
+});
+
+describe('redactMCPLogValue', () => {
+  it('redacts both name and message for Error values', () => {
+    const err = new Error('secret message');
+    err.name = 'SecretError';
+
+    expect(redactMCPLogValue(err)).toEqual({
+      name: '[REDACTED]',
+      message: '[REDACTED]',
+    });
+  });
+
+  it('does not throw when debug redaction fails', () => {
+    process.env.HEADLAMP_MCP_DEBUG = 'true';
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+
+    expect(() => mcpDebugLog('debug message', cyclic)).not.toThrow();
+    expect(consoleLogSpy).toHaveBeenCalledWith('debug message', '[REDACTED]');
+  });
+});

--- a/app/electron/mcp/debug.test.ts
+++ b/app/electron/mcp/debug.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mcpDebugLog, redactMCPLogValue } from './debug';
+
+let originalMcpDebugEnv: string | undefined;
+let hadMcpDebugEnv = false;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (!hadMcpDebugEnv || originalMcpDebugEnv === undefined) {
+    delete process.env.HEADLAMP_MCP_DEBUG;
+  } else {
+    process.env.HEADLAMP_MCP_DEBUG = originalMcpDebugEnv;
+  }
+});
+
+describe('redactMCPLogValue', () => {
+  it('redacts both name and message for Error values', () => {
+    const err = new Error('secret message');
+    err.name = 'SecretError';
+
+    expect(redactMCPLogValue(err)).toEqual({
+      name: '[REDACTED]',
+      message: '[REDACTED]',
+    });
+  });
+
+  it('does not throw when debug redaction fails', () => {
+    hadMcpDebugEnv = Object.prototype.hasOwnProperty.call(process.env, 'HEADLAMP_MCP_DEBUG');
+    originalMcpDebugEnv = process.env.HEADLAMP_MCP_DEBUG;
+    process.env.HEADLAMP_MCP_DEBUG = 'true';
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+
+    expect(() => mcpDebugLog('debug message', cyclic)).not.toThrow();
+    expect(consoleLogSpy).toHaveBeenCalledWith('debug message', '[REDACTED]');
+  });
+});

--- a/app/electron/mcp/debug.ts
+++ b/app/electron/mcp/debug.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const REDACTED = '[REDACTED]';
+
+export function isMCPDebugLoggingEnabled(): boolean {
+  return process.env.HEADLAMP_MCP_DEBUG === 'true';
+}
+
+export function redactMCPLogValue(value: unknown): unknown {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    return REDACTED;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(entry => redactMCPLogValue(entry));
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: REDACTED,
+      message: REDACTED,
+    };
+  }
+
+  if (typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, redactMCPLogValue(entry)])
+    );
+  }
+
+  return REDACTED;
+}
+
+function writeMCPDebugLog(method: 'info' | 'log', message: string, ...details: unknown[]): void {
+  if (!isMCPDebugLoggingEnabled()) {
+    return;
+  }
+
+  try {
+    console[method](message, ...details.map(detail => redactMCPLogValue(detail)));
+  } catch {
+    console[method](message, REDACTED);
+  }
+}
+
+export function mcpDebugInfo(message: string, ...details: unknown[]): void {
+  writeMCPDebugLog('info', message, ...details);
+}
+
+export function mcpDebugLog(message: string, ...details: unknown[]): void {
+  writeMCPDebugLog('log', message, ...details);
+}


### PR DESCRIPTION
## Summary

This PR fixes always-on MCP desktop debug logging by disabling it by default and redacting any values that are still emitted when `HEADLAMP_MCP_DEBUG=true` is explicitly enabled.

## Related Issue

Fixes #6528

## Changes

- Added an MCP-specific debug logging helper that only logs when `HEADLAMP_MCP_DEBUG=true`
- Replaced always-on MCP debug logs in `MCPClient.ts` and `MCPSettings.ts` with redacted helper calls
- Updated MCP unit tests to verify default silence and redacted debug output

## Steps to Test

1. Run `npm run app:test:unit`, `npm run app:tsc`, and `npm run app:lint`.
2. Run `npm test` and `npm run lint` from the repository root.
3. Optionally start the desktop app with and without `HEADLAMP_MCP_DEBUG=true` and confirm MCP logs are absent by default and redacted when enabled.

## Screenshots (if applicable)

Not applicable.

## Notes for the Reviewer

- This change is intentionally limited to the desktop MCP logging paths and associated tests.
- The MCP debug flag is explicit (`HEADLAMP_MCP_DEBUG=true`) so production/default runs stay silent.

