### PR TITLE
app: MCP: Avoid restarts on cluster reorder

### DIFF
--- a/app/electron/mcp/MCPClient.test.ts
+++ b/app/electron/mcp/MCPClient.test.ts
@@ -237,6 +237,34 @@ describe('MCPClient', () => {
     expect(closeSpy).not.toHaveBeenCalled();
   });
 
+  it('handleClustersChange does not restart client when clusters are only reordered', async () => {
+    const getTools = vi.fn().mockResolvedValue([]);
+    const close = vi.fn().mockResolvedValue(undefined);
+    const MultiServerMCPClientMock = vi.fn().mockImplementation(() => ({ getTools, close }));
+
+    vi.resetModules();
+    vi.doMock('@langchain/mcp-adapters', () => ({
+      MultiServerMCPClient: MultiServerMCPClientMock,
+    }));
+    vi.doMock('./MCPSettings', () => ({
+      makeMcpServersFromSettings: vi.fn().mockReturnValue({ serverA: {} }),
+      hasClusterDependentServers: vi.fn().mockReturnValue(true),
+    }));
+
+    const { default: MCPClient } = await import('./MCPClient');
+    const client = new MCPClient(cfgPath, settingsPath);
+
+    await client.initialize();
+    (client as any).currentClusters = ['cluster-a', 'cluster-b'];
+
+    await client.handleClustersChange(['cluster-b', 'cluster-a']);
+    await client.handleClustersChange(['cluster-a', 'cluster-b']);
+
+    expect(close).not.toHaveBeenCalled();
+    expect(MultiServerMCPClientMock).toHaveBeenCalledTimes(1);
+    expect((client as any).currentClusters).toEqual(['cluster-a', 'cluster-b']);
+  });
+
   it('handleClustersChange restarts client when cluster-dependent servers exist', async () => {
     const getToolsFirst = vi.fn().mockResolvedValue([{ name: 'a' }]);
     const closeFirst = vi.fn().mockResolvedValue(undefined);
@@ -277,12 +305,15 @@ describe('MCPClient', () => {
 
     // The MCP client constructor should have been called for initial setup and again for restart
     expect(MultiServerMCPClientMock).toHaveBeenCalledTimes(2);
+    expect(makeMcpServersFromSettings).toHaveBeenNthCalledWith(1, settingsPath, []);
+    expect(makeMcpServersFromSettings).toHaveBeenNthCalledWith(2, settingsPath, ['new-cluster']);
 
     // After restart, client should have been replaced
     const afterClientRef = (client as any).client;
     expect(afterClientRef).not.toBeNull();
     // And tools should reflect second initialization
     expect((client as any).clientTools).toEqual([{ name: 'b' }]);
+    expect((client as any).clusters).toEqual(['new-cluster']);
   });
 });
 

--- a/app/electron/mcp/MCPClient.test.ts
+++ b/app/electron/mcp/MCPClient.test.ts
@@ -641,6 +641,35 @@ describe('MCPClient', () => {
     expect(closeSpy).not.toHaveBeenCalled();
   });
 
+  it('handleClustersChange does not restart client when clusters are only reordered', async () => {
+    const getTools = vi.fn().mockResolvedValue([]);
+    const close = vi.fn().mockResolvedValue(undefined);
+    const MultiServerMCPClientMock = vi.fn().mockImplementation(() => ({ getTools, close }));
+
+    vi.resetModules();
+    vi.doMock('@langchain/mcp-adapters', () => ({
+      MultiServerMCPClient: MultiServerMCPClientMock,
+    }));
+    vi.doMock('./MCPSettings', () => ({
+      makeMcpServersFromSettings: vi.fn().mockReturnValue({ serverA: {} }),
+      hasClusterDependentServers: vi.fn().mockReturnValue(true),
+    }));
+
+    const { default: MCPClient } = await import('./MCPClient');
+    const client = new MCPClient(cfgPath, settingsPath);
+
+    await client.initialize();
+    await (client as any).initializeClient();
+    (client as any).currentClusters = ['cluster-a', 'cluster-b'];
+
+    await client.handleClustersChange(['cluster-b', 'cluster-a']);
+    await client.handleClustersChange(['cluster-a', 'cluster-b']);
+
+    expect(close).not.toHaveBeenCalled();
+    expect(MultiServerMCPClientMock).toHaveBeenCalledTimes(1);
+    expect((client as any).currentClusters).toEqual(['cluster-a', 'cluster-b']);
+  });
+
   it('handleClustersChange restarts client when cluster-dependent servers exist', async () => {
     const getToolsFirst = vi.fn().mockResolvedValue([{ name: 'a' }]);
     const closeFirst = vi.fn().mockResolvedValue(undefined);
@@ -682,12 +711,15 @@ describe('MCPClient', () => {
 
     // The MCP client constructor should have been called for initial setup and again for restart
     expect(MultiServerMCPClientMock).toHaveBeenCalledTimes(2);
+    expect(makeMcpServersFromSettings).toHaveBeenNthCalledWith(1, settingsPath, []);
+    expect(makeMcpServersFromSettings).toHaveBeenNthCalledWith(2, settingsPath, ['new-cluster']);
 
     // After restart, client should have been replaced
     const afterClientRef = (client as any).client;
     expect(afterClientRef).not.toBeNull();
     // And tools should reflect second initialization
     expect((client as any).clientTools).toEqual([{ name: 'b' }]);
+    expect((client as any).clusters).toEqual(['new-cluster']);
   });
 });
 

--- a/app/electron/mcp/MCPClient.ts
+++ b/app/electron/mcp/MCPClient.ts
@@ -72,7 +72,6 @@ export default class MCPClient {
   private clusters: string[] = [];
 
   private currentClusters: string[] | null = null;
-  private oldClusters: string[] | null = null;
 
   constructor(configPath: string, settingsPath: string) {
     this.configPath = configPath;
@@ -214,6 +213,14 @@ export default class MCPClient {
     this.mainWindow = win;
   }
 
+  private normalizeClusters(clusters: string[] | null): string[] | null {
+    if (clusters === null) {
+      return null;
+    }
+
+    return [...new Set(clusters)].sort();
+  }
+
   /**
    * Handle clusters change notification.
    *
@@ -228,13 +235,17 @@ export default class MCPClient {
       throw new Error('MCPClient: not initialized');
     }
 
-    // If cluster hasn't actually changed, do nothing.
-    if (JSON.stringify(this.currentClusters) === JSON.stringify(newClusters)) {
+    const normalizedClusters = this.normalizeClusters(newClusters);
+
+    // Treat cluster lists as sets so order-only permutations do not trigger a restart.
+    if (JSON.stringify(this.currentClusters) === JSON.stringify(normalizedClusters)) {
       return;
     }
 
     const oldClusters = this.currentClusters;
-    this.currentClusters = newClusters;
+    const oldConfiguredClusters = this.clusters;
+    this.currentClusters = normalizedClusters;
+    this.clusters = normalizedClusters ?? [];
 
     // Check if we have any cluster-dependent servers
     if (!hasClusterDependentServers(this.settingsPath)) {
@@ -254,11 +265,12 @@ export default class MCPClient {
       this.initializationPromise = null;
       // Re-initialize with new cluster context
       await this.initializeClient();
-      console.log('MCP client restarted successfully for new cluster:', newClusters);
+      console.log('MCP client restarted successfully for new cluster:', normalizedClusters);
     } catch (error) {
       console.error('Error restarting MCP client for cluster change:', error);
       // Restore previous cluster on error
       this.currentClusters = oldClusters;
+      this.clusters = oldConfiguredClusters;
       throw error;
     }
   }

--- a/app/electron/mcp/MCPClient.ts
+++ b/app/electron/mcp/MCPClient.ts
@@ -74,7 +74,6 @@ export default class MCPClient {
   private clusters: string[] = [];
 
   private currentClusters: string[] | null = null;
-  private oldClusters: string[] | null = null;
 
   /**
    * Creates an MCP client whose server adapter remains dormant until first use.
@@ -270,6 +269,14 @@ export default class MCPClient {
     this.mainWindow = win;
   }
 
+  private normalizeClusters(clusters: string[] | null): string[] | null {
+    if (clusters === null) {
+      return null;
+    }
+
+    return [...new Set(clusters)].sort();
+  }
+
   /**
    * Handle clusters change notification.
    *
@@ -293,14 +300,17 @@ export default class MCPClient {
       throw new Error('MCPClient: not initialized');
     }
 
-    // If cluster hasn't actually changed, do nothing.
-    if (JSON.stringify(this.currentClusters) === JSON.stringify(newClusters)) {
+    const normalizedClusters = this.normalizeClusters(newClusters);
+
+    // Treat cluster lists as sets so order-only permutations do not trigger a restart.
+    if (JSON.stringify(this.currentClusters) === JSON.stringify(normalizedClusters)) {
       return;
     }
 
     const oldClusters = this.currentClusters;
-    this.currentClusters = newClusters;
-    this.clusters = newClusters || [];
+    const oldConfiguredClusters = this.clusters;
+    this.currentClusters = normalizedClusters;
+    this.clusters = normalizedClusters ?? [];
 
     try {
       // An initialization already captured the previous cluster context. Wait
@@ -332,12 +342,12 @@ export default class MCPClient {
       this.initializationPromise = null;
       // Re-initialize with new cluster context
       await this.initializeClient();
-      console.log('MCP client restarted successfully for new cluster:', newClusters);
+      console.log('MCP client restarted successfully for new cluster:', normalizedClusters);
     } catch (error) {
       console.error('Error restarting MCP client for cluster change:', error);
       // Restore previous cluster on error
       this.currentClusters = oldClusters;
-      this.clusters = oldClusters || [];
+      this.clusters = oldConfiguredClusters;
       throw error;
     }
   }

--- a/backend/pkg/kubeconfig/contextStore.go
+++ b/backend/pkg/kubeconfig/contextStore.go
@@ -3,6 +3,7 @@ package kubeconfig
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"sync"
 	"time"
 
@@ -122,8 +123,15 @@ func (c *contextStore) GetContexts() ([]*Context, error) {
 		return nil, err
 	}
 
-	for _, ctx := range contextMap {
-		contexts = append(contexts, ctx)
+	keys := make([]string, 0, len(contextMap))
+	for key := range contextMap {
+		keys = append(keys, key)
+	}
+
+	slices.Sort(keys)
+
+	for _, key := range keys {
+		contexts = append(contexts, contextMap[key])
 	}
 
 	return contexts, nil
@@ -141,6 +149,8 @@ func (c *contextStore) GetContextKeys() ([]string, error) {
 	for key := range contextMap {
 		keys = append(keys, key)
 	}
+
+	slices.Sort(keys)
 
 	return keys, nil
 }

--- a/backend/pkg/kubeconfig/contextStore_test.go
+++ b/backend/pkg/kubeconfig/contextStore_test.go
@@ -27,6 +27,8 @@ func TestContextStore(t *testing.T) {
 	contexts, err := store.GetContexts()
 	require.NoError(t, err)
 	require.Equal(t, 2, len(contexts))
+	require.Equal(t, "test", contexts[0].Name)
+	require.Equal(t, "test2", contexts[1].Name)
 
 	// Test GetContext
 	_, err = store.GetContext("non-existent-context")
@@ -132,9 +134,33 @@ func TestContextStoreGetContextKeys(t *testing.T) {
 
 	keys, err = store.GetContextKeys()
 	require.NoError(t, err)
-	require.Len(t, keys, 2)
-	require.Contains(t, keys, "test-key-1")
-	require.Contains(t, keys, "test-key-2")
+	require.Equal(t, []string{"test-key-1", "test-key-2"}, keys)
+}
+
+func TestContextStoreReturnsSortedContextsAndKeys(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+
+	err := store.AddContext(&kubeconfig.Context{Name: "cluster-c"})
+	require.NoError(t, err)
+
+	err = store.AddContext(&kubeconfig.Context{Name: "cluster-a"})
+	require.NoError(t, err)
+
+	err = store.AddContext(&kubeconfig.Context{Name: "cluster-b"})
+	require.NoError(t, err)
+
+	contexts, err := store.GetContexts()
+	require.NoError(t, err)
+	require.Len(t, contexts, 3)
+	require.Equal(t, []string{"cluster-a", "cluster-b", "cluster-c"}, []string{
+		contexts[0].Name,
+		contexts[1].Name,
+		contexts[2].Name,
+	})
+
+	keys, err := store.GetContextKeys()
+	require.NoError(t, err)
+	require.Equal(t, []string{"cluster-a", "cluster-b", "cluster-c"}, keys)
 }
 
 func TestAddContextWithHeadlampInfo(t *testing.T) {


### PR DESCRIPTION
## Summary
- normalize active MCP cluster lists before comparing them so reorder-only updates do not trigger client restarts
- sort kubeconfig context-store outputs so downstream consumers receive deterministic cluster ordering
- add regression coverage for MCP reorder handling and sorted context-store results

## Linked Issue
Fixes #6535

## What Changed
- updated `app/electron/mcp/MCPClient.ts` to compare normalized cluster sets instead of raw array order
- added an MCP client test that proves reorder-only updates do not reconnect the client
- updated `backend/pkg/kubeconfig/contextStore.go` to return sorted contexts and keys, plus regression tests

- only the MCP cluster-change path, deterministic kubeconfig context ordering, and targeted regression tests were changed

