### PR TITLE
ci: app: Retry npm install on the Windows runners

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -73,6 +73,28 @@ jobs:
       uses: crazy-max/ghaction-chocolatey@e80bd39bb49cae70b67ea53d52d00833a7255c21 # v1.7.0
       with:
         args: install make
+    - name: Install app dependencies
+      shell: pwsh
+      # Electron's postinstall downloads its binary from github.com, which
+      # intermittently fails DNS resolution on the Windows runners and takes the
+      # whole job down before a single test runs. Retry the install here so the
+      # later targets find node_modules already in place. Only the install is
+      # retried: a failing test still fails the job on the first attempt.
+      run: |
+        $attempts = 3
+        for ($i = 1; $i -le $attempts; $i++) {
+          Push-Location app
+          npm install
+          $code = $LASTEXITCODE
+          Pop-Location
+          if ($code -eq 0) { exit 0 }
+          if ($i -lt $attempts) {
+            Write-Host "::warning::npm install failed (attempt $i/$attempts), retrying in 15s"
+            Start-Sleep -Seconds 15
+          }
+        }
+        Write-Host "::error::npm install failed after $attempts attempts"
+        exit 1
     - name: Run tests
       run: make app-test
     - name: Run tsc type checker


### PR DESCRIPTION
## Summary

The `build-windows` jobs intermittently fail before running any tests, because Electron's postinstall cannot resolve `github.com` from the Windows runners:

```
npm error command C:\Windows\system32\cmd.exe /d /s /c node install.js
npm error RequestError: getaddrinfo ENOTFOUND github.com
npm error path D:\a\headlamp\headlamp\app\node_modules\electron
make: *** [Makefile:104: app-test] Error 1
```

`make app-test` runs `cd app && npm install` before `npm run test`, so when the download fails the job dies during install — no test is ever executed. npm then can't remove the partial tree either (`EPERM: operation not permitted, rmdir ...`), which is the noise that follows in the log.

Re-running the job passes with no code change, so this currently shows up as a red check on unrelated PRs and costs a maintainer a manual re-run each time. A recent example: [job 87676315926](https://github.com/kubernetes-sigs/headlamp/actions/runs/29514595035/job/87676315926) on #6282, a frontend-only PR that touches nothing under `app/`.

## Changes

- `.github/workflows/app.yml`: Install the app dependencies for `build-windows` in a dedicated step that retries up to three times (15s apart) before giving up. The subsequent `make app-test` / `make app-tsc` / `make app-build` targets then find `node_modules` already populated.

## Notes for the Reviewer

- **Only the install is retried.** A failing test still fails the job on the first attempt — this doesn't weaken the signal the job gives you.
- **No `continue-on-error`.** If all three install attempts fail, the step exits 1 and the job goes red, so a genuine dependency problem is still surfaced rather than masked.
- Scoped to the Windows jobs, where this failure occurs. Linux/mac are left alone.
- The retry is plain `pwsh` rather than a third-party action, to avoid adding a dependency for something this small (`shell: pwsh` is already used by the "Verify Windows build" step in the same job).

## Steps to Test

CI on this PR exercises the changed step on both `windows-2022` (x64) and `windows-11-arm` (arm64) — a green `build-windows` here means the install step works in the normal, non-flaky case.
