### PR TITLE
frontend: Guard against missing Deployment status conditions

### DIFF
--- a/frontend/src/components/resourceMap/KubeObjectGlance/DeploymentGlance.tsx
+++ b/frontend/src/components/resourceMap/KubeObjectGlance/DeploymentGlance.tsx
@@ -30,7 +30,7 @@ export function DeploymentGlance({ deployment }: { deployment: Deployment }) {
       <StatusLabel status="">
         {t('glossary|Pods')}: {pods}
       </StatusLabel>
-      {deployment.status.conditions.map((it: KubeCondition) => (
+      {deployment.status?.conditions?.map((it: KubeCondition) => (
         <StatusLabel status="" key={it.type}>
           {it.type}
         </StatusLabel>


### PR DESCRIPTION
## Summary

Guard access to `deployment.status.conditions` in the Deployment glance view to prevent crashes when the `conditions` field is missing.

## Why

Some Deployment objects may not include `status.conditions`. The previous implementation accessed `deployment.status.conditions` unconditionally, which could cause the UI to crash when rendering the resource map.

This change uses optional chaining so the condition labels are rendered only when `conditions` is present, while preserving the existing behavior for Deployments that provide status conditions.

## Testing

- Verified that the Deployment glance view renders correctly when `status.conditions` is present.
- Verified that the view no longer crashes when `status.conditions` is missing.
- All existing tests pass.