### PR TITLE
Fix missing kubeconfig log 

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -650,7 +650,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 
 	// load kubeConfig clusters
 	err := kubeconfig.LoadAndStoreKubeConfigs(config.KubeConfigStore, kubeConfigPath, kubeconfig.KubeConfig, skipFunc)
-	if err != nil {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		logger.Log(logger.LevelError, nil, err, "loading kubeconfig")
 	}
 


### PR DESCRIPTION
## Summary

This PR suppresses the startup `loading kubeconfig` error when the underlying error is `os.ErrNotExist`.

Users without a kubeconfig file can be in a valid state, so logging this condition at `LevelError` during startup can be misleading. All other kubeconfig-related errors (e.g., malformed files, permission issues) continue to be logged as `LevelError`.

## Related Issue

Fixes #6530

## Changes

- Updated `backend/cmd/headlamp.go` to suppress the startup `loading kubeconfig` error when the underlying error is `os.ErrNotExist`.
- Preserved existing behavior for all other kubeconfig-related errors.
- Kept the change limited to startup logging behavior; no kubeconfig loading logic was modified.

## Steps to Test

1. Ensure no kubeconfig file exists:

   ```sh
   rm ~/.kube/config