### PR TITLE
frontend: KubeList: compare resourceVersion as an opaque string

### DIFF
--- a/frontend/src/lib/k8s/api/v2/KubeList.test.ts
+++ b/frontend/src/lib/k8s/api/v2/KubeList.test.ts
@@ -112,6 +112,53 @@ describe('KubeList.applyUpdate', () => {
     expect(updatedList.items).toHaveLength(0);
   });
 
+  it('should skip an update carrying the same resourceVersion as the list', () => {
+    const updateEvent: KubeListUpdateEvent<MockKubeObject> = {
+      type: 'MODIFIED',
+      object: {
+        apiVersion: 'v1',
+        kind: 'MockKubeObject',
+        metadata: { uid: '1', resourceVersion: '1' },
+      },
+    };
+
+    const updatedList = KubeList.applyUpdate(initialList, updateEvent, itemClass, cluster);
+
+    // Same resourceVersion means a duplicate event, so the list is returned as is.
+    expect(updatedList).toBe(initialList);
+  });
+
+  it('should apply a newer update whose resourceVersion exceeds MAX_SAFE_INTEGER', () => {
+    // Both strings parse to the same float via parseInt (2^53), so a numeric
+    // comparison would wrongly drop this genuinely newer update.
+    const list: KubeList<any> = {
+      kind: 'MockKubeList',
+      apiVersion: 'v1',
+      items: [
+        {
+          apiVersion: 'v1',
+          kind: 'MockKubeObject',
+          metadata: { uid: '1', resourceVersion: '9007199254740992' },
+        },
+      ],
+      metadata: { resourceVersion: '9007199254740992' },
+    };
+    const updateEvent: KubeListUpdateEvent<MockKubeObject> = {
+      type: 'MODIFIED',
+      object: {
+        apiVersion: 'v1',
+        kind: 'MockKubeObject',
+        metadata: { uid: '1', resourceVersion: '9007199254740993' },
+      },
+    };
+
+    const updatedList = KubeList.applyUpdate(list, updateEvent, itemClass, cluster);
+
+    expect(updatedList).not.toBe(list);
+    expect(updatedList.metadata.resourceVersion).toBe('9007199254740993');
+    expect(updatedList.items[0].metadata.resourceVersion).toBe('9007199254740993');
+  });
+
   it('should log an error on ERROR event', () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const updateEvent: KubeListUpdateEvent<MockKubeObject> = {

--- a/frontend/src/lib/k8s/api/v2/KubeList.ts
+++ b/frontend/src/lib/k8s/api/v2/KubeList.ts
@@ -49,11 +49,15 @@ export const KubeList = {
     itemClass: ObjectClass,
     cluster: string
   ): KubeList<KubeObject<ObjectInterface>> {
-    // Skip if the update's resource version is older than or equal to what we have
+    // Skip a duplicate event that carries the same resourceVersion we already
+    // have. resourceVersion is an opaque string in the Kubernetes API and must
+    // not be compared numerically: large values lose precision past
+    // Number.MAX_SAFE_INTEGER, and non-numeric versions parse to NaN. Watch
+    // events arrive in order, so an equality check is enough here.
     if (
       list.metadata.resourceVersion &&
       update.object.metadata.resourceVersion &&
-      parseInt(update.object.metadata.resourceVersion) <= parseInt(list.metadata.resourceVersion)
+      update.object.metadata.resourceVersion === list.metadata.resourceVersion
     ) {
       return list;
     }


### PR DESCRIPTION
## Summary

applyUpdate figures out whether to skip a watch update by comparing the resourceVersions as numbers with parseInt. Problem is, Kubernetes treats resourceVersion as an opaque string, clients aren't meant to assume it's numeric or comparable. The parseInt compare breaks two ways: big values past Number.MAX_SAFE_INTEGER (2^53) lose precision, so a newer update can come out as older-or-equal and just get dropped, and non-numeric versions turn into NaN, and NaN <= NaN is false so the skip never happens.

Watch events come in order anyway, so the guard only really needs to catch a duplicate event with the same version. So I just compare the version strings for equality now instead of parsing them.

To be honest about severity: on a normal etcd3 cluster the resourceVersion is a counter that won't realistically hit 2^53 in the cluster's lifetime, so the dropped-update case is more of a correctness/contract thing than something people are actually running into. The non-numeric case (some aggregated API servers) just means the dedup doesn't fire and an event gets re-applied, which is harmless. mostly this is just about not relying on parseInt for something the API says is opaque.

## Related Issue

Fixes #6548

## Changes

- frontend/src/lib/k8s/api/v2/KubeList.ts: compare the resourceVersion strings for equality instead of parseInt <=, added a comment on why the numeric compare is wrong
- frontend/src/lib/k8s/api/v2/KubeList.test.ts: tests for skipping a same-version event and for applying a newer update whose resourceVersion is past MAX_SAFE_INTEGER

## Steps to Test

1. npm run frontend:test and look at the KubeList.applyUpdate suite
2. the new "exceeds MAX_SAFE_INTEGER" test fails on the old parseInt code and passes with the string compare

I also poked at it locally by calling applyUpdate directly. with the list at 9007199254740992 and a newer update at 9007199254740993, parseInt turns both into 9007199254740992, so the old code dropped the update and gave back the list unchanged. the string compare applies it fine.

## Screenshots (if applicable)

N/A, it's watch merge logic, nothing visual.

## Notes for the Reviewer

Went with equality instead of trying to keep a "newer than" ordering since you can't really order opaque strings and the watch stream is ordered already. if you'd rather keep an actual magnitude compare it'd need BigInt with an integer-string check, can switch to that if you prefer.
