### PR TITLE
refactor(helm): deduplicate JSON response encoding in repository and charts handlers

### DIFF
--- a/backend/pkg/helm/charts.go
+++ b/backend/pkg/helm/charts.go
@@ -17,8 +17,6 @@ limitations under the License.
 package helm
 
 import (
-	"bytes"
-	"encoding/json"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -107,20 +105,5 @@ func (h *Handler) ListCharts(w http.ResponseWriter, r *http.Request) {
 		Charts: chartInfos,
 	}
 
-	var buf bytes.Buffer
-
-	err = json.NewEncoder(&buf).Encode(response)
-	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "encoding charts response")
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-
-	if _, err := w.Write(buf.Bytes()); err != nil {
-		logger.Log(logger.LevelError, nil, err, "writing charts response")
-	}
+	writeJSONResponse(w, http.StatusOK, response)
 }

--- a/backend/pkg/helm/repository.go
+++ b/backend/pkg/helm/repository.go
@@ -196,6 +196,27 @@ func addRepository(request AddUpdateRepoRequest, settings *cli.EnvSettings) erro
 	return nil
 }
 
+// writeJSONResponse encodes data as JSON and writes it to w with the given
+// HTTP status. Encoding is buffered so errors are caught before headers are
+// sent.
+func writeJSONResponse(w http.ResponseWriter, status int, data interface{}) {
+	var buf bytes.Buffer
+
+	if err := json.NewEncoder(&buf).Encode(data); err != nil {
+		logger.Log(logger.LevelError, nil, err, "encoding response")
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		logger.Log(logger.LevelError, nil, err, "writing response")
+	}
+}
+
 func (h *Handler) AddRepo(w http.ResponseWriter, r *http.Request) {
 	var request AddUpdateRepoRequest
 
@@ -224,21 +245,7 @@ func (h *Handler) AddRepo(w http.ResponseWriter, r *http.Request) {
 		"message": "success",
 	}
 
-	var buf bytes.Buffer
-
-	if err = json.NewEncoder(&buf).Encode(response); err != nil {
-		logger.Log(logger.LevelError, nil, err, "encoding response")
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-
-	if _, err = w.Write(buf.Bytes()); err != nil {
-		logger.Log(logger.LevelError, nil, err, "writing response")
-	}
+	writeJSONResponse(w, http.StatusOK, response)
 }
 
 type repositoryInfo struct {
@@ -294,21 +301,7 @@ func (h *Handler) ListRepo(w http.ResponseWriter, r *http.Request) {
 		Repositories: repositories,
 	}
 
-	var buf bytes.Buffer
-
-	if err = json.NewEncoder(&buf).Encode(response); err != nil {
-		logger.Log(logger.LevelError, nil, err, "encoding response")
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-
-	if _, err = w.Write(buf.Bytes()); err != nil {
-		logger.Log(logger.LevelError, nil, err, "writing response")
-	}
+	writeJSONResponse(w, http.StatusOK, response)
 }
 
 func RemoveRepository(name string, settings *cli.EnvSettings) error {


### PR DESCRIPTION
## Summary

This PR removes duplicated JSON response encoding logic from the Helm HTTP handlers by introducing a shared `writeJSONResponse` helper.

The helper preserves the existing behavior by encoding the response into a buffer before writing headers, ensuring encoding errors are handled before any response is sent.

## Changes

* Replace duplicated response-writing code in:

  * `AddRepo`
  * `ListRepo`
  * `ListCharts`
* Reuse the shared `writeJSONResponse` helper.
* Remove now-unused imports from `charts.go`.

## Behavior

This is a **refactoring only**. There are **no functional or API behavior changes**.

* Response status codes are unchanged.
* Response bodies are unchanged.
* `Content-Type` headers are unchanged.
* Encoding continues to occur before headers are written, matching the previous implementation.
