### PR TITLE
backend: helm: Propagate discovery client creation errors

### DIFF
--- a/backend/pkg/helm/handler.go
+++ b/backend/pkg/helm/handler.go
@@ -103,8 +103,10 @@ func (r *restConfigGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterfa
 	// double it just so we don't end up here again for a while.  This config is only used for discovery.
 	config.Burst = 100
 
-	discoveryClient, _ := discovery.NewDiscoveryClientForConfig(config)
-
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return nil, err
+	}
 	return memory.NewMemCacheClient(discoveryClient), nil
 }
 


### PR DESCRIPTION
## Summary

This PR fixes Helm REST config discovery by returning errors from
`NewDiscoveryClientForConfig` instead of ignoring them and returning a
broken client with a nil error.

## Changes

- Updated `ToDiscoveryClient` in `backend/pkg/helm/handler.go` to check and
  return the error from `discovery.NewDiscoveryClientForConfig`
- Aligned error handling with the existing pattern in `ToRESTMapper`

## Steps to Test

1. From `backend/`, run:
   `go test ./pkg/helm/ -run 'TestRestConfigGetterToDiscovery|TestRestConfigGetterToRESTMapper' -count=1`
2. Confirm the tests pass
3. Optionally run `go test ./pkg/helm/ -count=1` for the full package

## Screenshots 

<img width="1269" height="65" alt="image" src="https://github.com/user-attachments/assets/0c00d7fe-1831-4b89-b42d-27ca85a23b5d" />


## Notes for the Reviewer

- Backward compatible: success path is unchanged; only failure handling
  improves (silent success → proper error)
- Diff is ~3 lines in one file
- Existing bad-config tests already cover this path