### PR TITLE
app: runCmd: block command on first consent denial

### DIFF
--- a/app/electron/runCmd.test.ts
+++ b/app/electron/runCmd.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { dialog } from 'electron';
 import { EventEmitter } from 'events';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
@@ -26,6 +27,7 @@ const { getShellEnvironmentMock, spawnMock } = vi.hoisted(() => ({
 vi.mock('child_process', () => ({
   spawn: spawnMock,
 }));
+import { loadSettings, saveSettings } from './settings';
 
 vi.mock('./plugin-management', () => ({
   defaultPluginsDir: vi.fn(() => '/plugins/default'),
@@ -50,8 +52,14 @@ vi.mock('./main', () => ({
   getShellEnvironment: getShellEnvironmentMock,
 }));
 
+vi.mock('electron', () => ({
+  BrowserWindow: vi.fn(),
+  dialog: { showMessageBoxSync: vi.fn() },
+}));
+
 import {
   addRunCmdConsent,
+  checkCommandConsent,
   checkPermissionSecret,
   environmentOverrides,
   handleRunCommand,
@@ -146,6 +154,44 @@ describe('checkPermissionSecret', () => {
       permissionSecrets: { 'runCmd-scriptjs-plugins/minikube/myscript.js': 42 },
     };
     expect(checkPermissionSecret(commandData, permissionSecrets)[0]).toBe(true);
+  });
+});
+
+describe('checkCommandConsent', () => {
+  const fakeMainWindow = { id: 1 } as any;
+
+  afterEach(() => {
+    vi.mocked(loadSettings).mockReturnValue({
+      confirmedCommands: { 'minikube start': true, 'gh auth': true, 'az account': true },
+    } as any);
+    vi.mocked(dialog.showMessageBoxSync).mockClear();
+    vi.mocked(saveSettings).mockClear();
+  });
+
+  it('blocks the command on the first run when the user denies it', () => {
+    vi.mocked(loadSettings).mockReturnValue({ confirmedCommands: {} } as any);
+    vi.mocked(dialog.showMessageBoxSync).mockReturnValue(1); // Deny
+
+    expect(checkCommandConsent('minikube', ['delete'], fakeMainWindow)).toBe(false);
+    expect(saveSettings).toHaveBeenCalledWith('/fake/settings.json', {
+      confirmedCommands: { 'minikube delete': false },
+    });
+  });
+
+  it('allows the command on the first run when the user allows it', () => {
+    vi.mocked(loadSettings).mockReturnValue({ confirmedCommands: {} } as any);
+    vi.mocked(dialog.showMessageBoxSync).mockReturnValue(0); // Allow
+
+    expect(checkCommandConsent('minikube', ['delete'], fakeMainWindow)).toBe(true);
+  });
+
+  it('blocks the command without prompting once denial is saved', () => {
+    vi.mocked(loadSettings).mockReturnValue({
+      confirmedCommands: { 'minikube delete': false },
+    } as any);
+
+    expect(checkCommandConsent('minikube', ['delete'], fakeMainWindow)).toBe(false);
+    expect(dialog.showMessageBoxSync).not.toHaveBeenCalled();
   });
 });
 

--- a/app/electron/runCmd.ts
+++ b/app/electron/runCmd.ts
@@ -85,7 +85,11 @@ function confirmCommandDialog(command: string, mainWindow: BrowserWindow): boole
  * @param args - The arguments to the command.
  * @returns true if the user has consented to running the command, false otherwise.
  */
-function checkCommandConsent(command: string, args: string[], mainWindow: BrowserWindow): boolean {
+export function checkCommandConsent(
+  command: string,
+  args: string[],
+  mainWindow: BrowserWindow
+): boolean {
   const settings = loadSettings(SETTINGS_PATH);
   const confirmedCommands = settings?.confirmedCommands;
 
@@ -109,6 +113,7 @@ function checkCommandConsent(command: string, args: string[], mainWindow: Browse
     }
     settings.confirmedCommands[consentKey] = commandChoice;
     saveSettings(SETTINGS_PATH, settings);
+    return commandChoice;
   }
   return true;
 }


### PR DESCRIPTION
Fixes #6558

When a plugin runs a command that hasn't been consented to yet, checkCommandConsent shows the Allow/Deny dialog and saves whatever the user picks. The problem was that after saving the choice, the function fell through to an unconditional return true, so even a Deny let that first invocation through. The command only got blocked starting from the second call, once the saved false was read back.

Fixed it by returning the actual choice the user made right after saving it, instead of falling through. This affects every consent gated command in app mode: minikube, az, and gh.

Added tests for checkCommandConsent covering the three paths: denies and blocks on the first prompt, allows on the first prompt, and skips the dialog entirely once a denial is already saved.

Ran the full app test suite and tsc, everything passes.