### PR TITLE
backend: telemetry: Add cache hit/miss and SSAR duration metrics

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -53,6 +53,7 @@ import (
 	cfg "github.com/kubernetes-sigs/headlamp/backend/pkg/config"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/helm"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/plugins"
@@ -1398,6 +1399,7 @@ func StartHeadlampServer(config *HeadlampConfig) {
 	router := mux.NewRouter()
 
 	if config.Telemetry != nil && config.Metrics != nil {
+		k8cache.SetMetrics(config.Metrics)
 		router.Use(telemetry.TracingMiddleware("headlamp-server"))
 		router.Use(config.Metrics.RequestCounterMiddleware)
 	}

--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -548,11 +548,16 @@ func IsAllowed(
 		},
 	}
 
+	ssarStart := time.Now()
+
 	result, err := clientset.AuthorizationV1().SelfSubjectAccessReviews().Create(
 		r.Context(),
 		review,
 		metav1.CreateOptions{},
 	)
+
+	recordSSARDuration(r.Context(), time.Since(ssarStart))
+
 	if err != nil {
 		return false, err
 	}

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -270,9 +270,15 @@ func LoadFromCache(k8scache cache.Cache[string], isAllowed bool,
 			return false, writeErr
 		}
 
+		recordCacheHit(r.Context())
+
 		logger.Log(logger.LevelInfo, nil, nil, "serving from the cache with key "+redactCacheKey(key))
 
 		return true, nil
+	}
+
+	if isAllowed && (err == cache.ErrNotFound || (err == nil && strings.TrimSpace(k8Resource) == "")) {
+		recordCacheMiss(r.Context())
 	}
 
 	return false, nil

--- a/backend/pkg/k8cache/metrics.go
+++ b/backend/pkg/k8cache/metrics.go
@@ -1,0 +1,65 @@
+// Copyright 2025 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8cache
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/telemetry"
+)
+
+// metricsRef holds an optional reference to the telemetry Metrics instance.
+// It is set once at startup via SetMetrics and read concurrently from request
+// handlers, so access is guarded by metricsOnce / sync.Once semantics.
+//
+//nolint:gochecknoglobals // injected once at startup; read-only after init
+var (
+	metricsRef  *telemetry.Metrics
+	metricsOnce sync.Once
+)
+
+// SetMetrics injects the telemetry Metrics instance into the k8cache package.
+// It must be called once during server startup, before any requests are served.
+// Subsequent calls are silently ignored.
+func SetMetrics(m *telemetry.Metrics) {
+	metricsOnce.Do(func() {
+		metricsRef = m
+	})
+}
+
+// recordCacheHit increments the cache hit counter. It is a no-op when
+// telemetry is disabled (metricsRef is nil).
+func recordCacheHit(ctx context.Context) {
+	if metricsRef != nil && metricsRef.CacheHitCount != nil {
+		metricsRef.CacheHitCount.Add(ctx, 1)
+	}
+}
+
+// recordCacheMiss increments the cache miss counter. It is a no-op when
+// telemetry is disabled (metricsRef is nil).
+func recordCacheMiss(ctx context.Context) {
+	if metricsRef != nil && metricsRef.CacheMissCount != nil {
+		metricsRef.CacheMissCount.Add(ctx, 1)
+	}
+}
+
+// recordSSARDuration records the duration of a SelfSubjectAccessReview API
+// call. It is a no-op when telemetry is disabled (metricsRef is nil).
+func recordSSARDuration(ctx context.Context, d time.Duration) {
+	if metricsRef != nil && metricsRef.SSARDuration != nil {
+		metricsRef.SSARDuration.Record(ctx, d.Seconds())
+	}
+}

--- a/backend/pkg/telemetry/metrics.go
+++ b/backend/pkg/telemetry/metrics.go
@@ -31,6 +31,12 @@ type Metrics struct {
 	ErrorCounter metric.Int64Counter
 	// KubeconfigRefreshCounter tracks the number of kubeconfig refresh operations
 	KubeconfigRefreshCounter metric.Int64Counter
+	// CacheHitCount tracks the number of K8s API response cache hits
+	CacheHitCount metric.Int64Counter
+	// CacheMissCount tracks the number of K8s API response cache misses
+	CacheMissCount metric.Int64Counter
+	// SSARDuration measures the duration of SelfSubjectAccessReview API calls
+	SSARDuration metric.Float64Histogram
 }
 
 // NewMetrics creates and registers a set of common application metrics.
@@ -116,6 +122,43 @@ func initApplicationMetrics(meter metric.Meter, metrics *Metrics) error {
 	metrics.ErrorCounter, err = meter.Int64Counter(
 		"headlamp.errors",
 		metric.WithDescription("Count of errors"),
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := initCacheMetrics(meter, metrics); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// initCacheMetrics initializes metrics for the K8s API response cache and
+// SelfSubjectAccessReview authorization calls.
+func initCacheMetrics(meter metric.Meter, metrics *Metrics) error {
+	var err error
+
+	metrics.CacheHitCount, err = meter.Int64Counter(
+		"headlamp.k8scache.hits",
+		metric.WithDescription("Total number of K8s API response cache hits"),
+	)
+	if err != nil {
+		return err
+	}
+
+	metrics.CacheMissCount, err = meter.Int64Counter(
+		"headlamp.k8scache.misses",
+		metric.WithDescription("Total number of K8s API response cache misses"),
+	)
+	if err != nil {
+		return err
+	}
+
+	metrics.SSARDuration, err = meter.Float64Histogram(
+		"headlamp.ssar.duration",
+		metric.WithDescription("Duration of SelfSubjectAccessReview API calls"),
+		metric.WithUnit("s"),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

This PR adds operational visibility into the Kubernetes cache layer and authorization hot-paths by introducing three new Prometheus metrics: cache hits, cache misses, and SelfSubjectAccessReview (SSAR) call durations.

## Related Issue

Fixes #6566 

## Changes

- Added `CacheHitCount`, `CacheMissCount`, and `SSARDuration` to the central telemetry metrics schema in `backend/pkg/telemetry/metrics.go`
- Added a package-level injected metrics bridge (`SetMetrics`) in `backend/pkg/k8cache/metrics.go` to safely decouple the cache layer from telemetry and avoid circular imports
- Updated `LoadFromCache` in `backend/pkg/k8cache/cacheStore.go` to accurately increment cache hit/miss counters
- Updated `IsAllowed` in `backend/pkg/k8cache/authorization.go` to measure and record the wall-clock duration of SSAR API calls to the Kubernetes control plane
- Wired the telemetry metrics into the `k8cache` layer during initialization in `backend/cmd/headlamp.go`

## Steps to Test

1. Start the Headlamp backend locally with dynamic clusters or a kubeconfig context enabled:
   `$env:HEADLAMP_BACKEND_TOKEN="headlamp"; $env:HEADLAMP_CONFIG_ENABLE_HELM="true"; .\backend\headlamp-server.exe -dev`
2. Open your browser and navigate around the Headlamp UI to trigger API requests that utilize the cache (e.g., viewing Pods, Namespaces).
3. Query the exposed Prometheus metrics endpoint (usually `http://localhost:4466/metrics`).
4. Search the output for the new metrics and observe their values increasing based on your UI interactions:
   - `headlamp_k8scache_hits_total`
   - `headlamp_k8scache_misses_total`
   - `headlamp_ssar_duration_seconds`

## Screenshots 
<img width="1289" height="583" alt="image" src="https://github.com/user-attachments/assets/1001e349-698f-4e06-8e3c-82e2c4b312cb" />
 

## Notes for the Reviewer

- To avoid a circular import between `k8cache` and `telemetry`, the `Metrics` reference is injected into `k8cache` via `k8cache.SetMetrics()` during server startup in `cmd/headlamp.go`. This safely handles the `nil` case if telemetry is disabled.
- The `go test` and `npm run backend:test` suites were run locally and all tests in `telemetry`, `k8cache`, and `cmd` pass successfully.
