### PR TITLE
frontend: tests: share canvas mock setup

### DIFF
--- a/frontend/src/components/common/Resource/LogsButton.test.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.test.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import 'vitest-canvas-mock';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { labelSelectorToQuery } from '../../../lib/k8s';

--- a/frontend/src/components/common/Terminal.test.tsx
+++ b/frontend/src/components/common/Terminal.test.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import 'vitest-canvas-mock';
 import { act, render } from '@testing-library/react';
 import React from 'react';
 import { TestContext } from '../../test';

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -16,7 +16,11 @@
 
 /// <reference types="@testing-library/jest-dom" />
 import '@testing-library/jest-dom/vitest';
+import 'vitest-canvas-mock';
 import indexeddb from 'fake-indexeddb';
+
+// xterm initializes canvas APIs during module setup, so install the canvas mock
+// here once for the entire Vitest environment instead of per test file.
 
 // nock v14 uses @mswjs/interceptors, which calls `new Request(url, init)` internally when
 // intercepting a fetch. In jsdom v24+, globalThis.Request wraps undici's native Request,

--- a/frontend/src/storybook.test.tsx
+++ b/frontend/src/storybook.test.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import 'vitest-canvas-mock';
 import { composeStories, type Meta, setProjectAnnotations, type StoryFn } from '@storybook/react';
 import { act, render as testingLibraryRender, waitFor } from '@testing-library/react';
 import { getWorker } from 'msw-storybook-addon';


### PR DESCRIPTION
## Summary

This PR fixes frontend test harness noise by moving the canvas mock into the shared Vitest setup used by the whole frontend suite.

## Related Issue

Fixes #6568

## Changes

- Added `vitest-canvas-mock` to `frontend/src/setupTests.ts`
- Removed redundant per-test canvas mock imports from the affected frontend tests
- Documented why the shared setup owns the xterm canvas mock

## Steps to Test

1. Run `npm run frontend:tsc`.
2. Run `npm run frontend:lint`.
3. Run `npm test`.
4. Confirm the frontend test run no longer emits repeated `HTMLCanvasElement.prototype.getContext` errors from xterm-backed tests.

## Screenshots (if applicable)

Not applicable.

## Notes for the Reviewer

- Scope is limited to the frontend test harness and duplicate imports.
- `TOP_10_ISSUES.md` and `FEATURE_SUGGESTIONS.md` remain untracked and were not modified.
