### PR TITLE
backend: k8cache: Use SplitN when parsing ClusterID to avoid incorrect context name parsing

### DIFF
--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -346,7 +346,7 @@ func GetClientSet(headlampContextKey string, k *kubeconfig.Context, token string
 		return nil, fmt.Errorf("empty headlamp context key in GetClientSet")
 	}
 
-	contextKey := strings.Split(k.ClusterID, "+")
+	contextKey := strings.SplitN(k.ClusterID, "+", 2)
 	if len(contextKey) < 2 {
 		return nil, fmt.Errorf("unexpected ClusterID format in GetClientSet: %q", k.ClusterID)
 	}

--- a/backend/pkg/k8cache/authorization_test.go
+++ b/backend/pkg/k8cache/authorization_test.go
@@ -350,3 +350,25 @@ func TestServeFromCacheOrForwardToK8s(t *testing.T) {
 		assert.Contains(t, w2.Body.String(), "next handler called")
 	})
 }
+
+func TestGetClientSet_ClusterIDWithPlusErrorFormatting(t *testing.T) {
+	// Set a custom clientset creator that always returns an error
+	restore := k8cache.SetClientsetCreator(func(k *kubeconfig.Context, token string) (*kubernetes.Clientset, error) {
+		return nil, fmt.Errorf("simulated connection failure")
+	})
+	defer restore()
+
+	ctx := &kubeconfig.Context{
+		ClusterID:   "/home/user/.kubeconfig+prod+cluster+name",
+		Cluster:     &api.Cluster{Server: "https://example.com"},
+		AuthInfo:    &api.AuthInfo{Token: "abcdef"},
+		KubeContext: &api.Context{Cluster: "kind-headlamp-admin"},
+	}
+
+	_, err := k8cache.GetClientSet("prod+cluster+name", ctx, "some-token")
+	assert.Error(t, err)
+
+	if err != nil {
+		assert.Contains(t, err.Error(), "error while creating clientset for cluster prod+cluster+name")
+	}
+}

--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -46,7 +46,7 @@ import (
 func DeleteKeys(key string, k8scache cache.Cache[string]) {
 	_ = k8scache.Delete(context.Background(), key)
 
-	keyPart := strings.Split(key, "+")
+	keyPart := strings.SplitN(key, "+", 4)
 	if len(keyPart) < 4 {
 		return // malformed key; nothing to namespace-strip
 	}


### PR DESCRIPTION
## Description

This PR improves `ClusterID` parsing in the `k8cache` package by replacing `strings.Split` with `strings.SplitN` where appropriate. The current implementation can incorrectly parse `ClusterID` values when the Kubernetes context name contains one or more `+` characters, resulting in truncated context names in error messages.

This change also updates cache key parsing in `cacheInvalidation.go` to use bounded splitting, making it consistent with the parsing logic already used in other parts of the `k8cache` package.

## Related Issue

Fixes #6571

## Changes

- Updated `backend/pkg/k8cache/authorization.go` to parse `ClusterID` using `strings.SplitN(k.ClusterID, "+", 2)`.
- Updated `backend/pkg/k8cache/cacheInvalidation.go` to parse cache keys using `strings.SplitN(key, "+", 4)` for consistency with other cache parsing logic.
- Added `TestGetClientSet_ClusterIDWithPlusErrorFormatting` to verify that context names containing `+` characters are preserved correctly in error messages.
- Added regression test coverage to prevent future parsing regressions.

## Steps to Test

1. Run the k8cache unit tests:

   ```bash
   go test -v ./pkg/k8cache/...
   ```

2. Verify that `TestGetClientSet_ClusterIDWithPlusErrorFormatting` passes.
3. Confirm that all existing tests in the `k8cache` package continue to pass.
4. (Optional) Use a kubeconfig with a context name containing `+` characters and verify that any clientset creation errors include the full context name.

## Screenshots (if applicable)

N/A (Backend logic change)

## Notes for the Reviewer

- This change is limited to parsing logic and does not modify the `ClusterID` format or any public APIs.
- `strings.SplitN` preserves the complete context name while maintaining backward compatibility.
- Cache key parsing now follows the same bounded-splitting approach already used elsewhere in the `k8cache` package.
- Verified by running:

  ```bash
  go test -v ./pkg/k8cache/...
  ```