### PR TITLE
backend: plugins: Fix delete for migrated catalog plugins

### DIFF
--- a/backend/pkg/plugins/plugins.go
+++ b/backend/pkg/plugins/plugins.go
@@ -295,8 +295,24 @@ func GeneratePluginPaths(
 
 // isCatalogInstalledPlugin checks if a plugin was installed via the catalog.
 // Catalog-installed plugins have isManagedByHeadlampPlugin: true in their package.json.
+// pluginName may come from a request path, so paths escaping pluginDir are rejected
+// before any file is read.
 func isCatalogInstalledPlugin(pluginDir, pluginName string) bool {
-	packageJSONPath := filepath.Join(pluginDir, pluginName, "package.json")
+	if pluginDir == "" {
+		return false
+	}
+
+	absDir, err := filepath.Abs(pluginDir)
+	if err != nil {
+		return false
+	}
+
+	pluginPath := filepath.Join(absDir, pluginName)
+	if !isSubdirectory(absDir, pluginPath) {
+		return false
+	}
+
+	packageJSONPath := filepath.Join(pluginPath, "package.json")
 
 	content, err := os.ReadFile(packageJSONPath) //nolint:gosec
 	if err != nil {
@@ -594,8 +610,13 @@ func tryDeletePlugin(dir string, filename string) (bool, error) {
 
 // Delete deletes the plugin from the appropriate plugin directory (user or development).
 // Shipped plugins cannot be deleted.
-// If pluginType is specified ("user" or "development"), only that directory is checked.
-// If pluginType is empty, it checks user-plugins first, then development (for backward compatibility).
+// If pluginType is "development", only the development directory is checked.
+// If pluginType is "user", user-plugins is checked first, then development only
+// for catalog-installed plugins still under plugins/ (isManagedByHeadlampPlugin).
+// If pluginType is empty, it checks user-plugins first, then development.
+//
+// Without the type=user catalog fallback, migrated plugins such as
+// headlamp_kubescape fail to delete even though they are listed as user.
 // Returns an error if the plugin is not found or if it's a shipped plugin.
 func Delete(userPluginDir, pluginDir, filename, pluginType string) error {
 	// Validate plugin type if provided
@@ -612,13 +633,18 @@ func Delete(userPluginDir, pluginDir, filename, pluginType string) error {
 		if deleted, err = tryDeletePlugin(userPluginDir, filename); err != nil {
 			return err
 		}
-
-		if pluginType == PluginTypeUser && !deleted {
-			return fmt.Errorf("plugin '%s' not found in user-plugins directory", filename)
-		}
 	}
 
-	if !deleted && (pluginType == "" || pluginType == PluginTypeDevelopment) {
+	// Check development when:
+	// - no type was specified (legacy behavior), or
+	// - type=development, or
+	// - type=user and the plugin is a migrated catalog install under plugins/
+	checkDev := pluginType == "" || pluginType == PluginTypeDevelopment
+	if !deleted && pluginType == PluginTypeUser {
+		checkDev = isCatalogInstalledPlugin(pluginDir, filename)
+	}
+
+	if !deleted && checkDev {
 		if deleted, err = tryDeletePlugin(pluginDir, filename); err != nil {
 			return err
 		}
@@ -626,6 +652,10 @@ func Delete(userPluginDir, pluginDir, filename, pluginType string) error {
 		if pluginType == PluginTypeDevelopment && !deleted {
 			return fmt.Errorf("plugin '%s' not found in development directory", filename)
 		}
+	}
+
+	if pluginType == PluginTypeUser && !deleted {
+		return fmt.Errorf("plugin '%s' not found in user-plugins or development directory", filename)
 	}
 
 	if !deleted {

--- a/backend/pkg/plugins/plugins_test.go
+++ b/backend/pkg/plugins/plugins_test.go
@@ -580,6 +580,30 @@ func TestDelete(t *testing.T) {
 	err = os.Mkdir(sharedPluginDev, 0o750)
 	require.NoError(t, err)
 
+	// Catalog-installed plugin that still lives only under development
+	// plugins/ (GeneratePluginPaths reports these as type=user).
+	migratedCatalogPlugin := filepath.Join(devPluginDir, "headlamp_kubescape")
+	err = os.Mkdir(migratedCatalogPlugin, 0o750)
+	require.NoError(t, err)
+
+	packageJSON := []byte(`{"name":"kubescape","isManagedByHeadlampPlugin":true}`)
+	err = os.WriteFile(filepath.Join(migratedCatalogPlugin, "package.json"), packageJSON, 0o600)
+	require.NoError(t, err)
+
+	// Non-catalog development plugin: type=user must not delete this.
+	plainDevPlugin := filepath.Join(devPluginDir, "plain-dev-plugin")
+	err = os.Mkdir(plainDevPlugin, 0o750)
+	require.NoError(t, err)
+
+	// Catalog plugin sitting outside the development directory: the type=user
+	// fallback must not follow a traversal path to it.
+	outsidePlugin := filepath.Join(tempDir, "outside-plugin")
+	err = os.Mkdir(outsidePlugin, 0o750)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(outsidePlugin, "package.json"), packageJSON, 0o600)
+	require.NoError(t, err)
+
 	// Test cases
 	tests := []struct {
 		name          string
@@ -589,6 +613,10 @@ func TestDelete(t *testing.T) {
 		pluginType    string
 		expectErr     bool
 		errContains   string
+		// deletedFrom is "user" or "development" when expectErr is false.
+		deletedFrom string
+		// mustExist is a path that has to survive a failed delete.
+		mustExist string
 	}{
 		{
 			name:          "Delete user plugin (no type specified)",
@@ -597,6 +625,7 @@ func TestDelete(t *testing.T) {
 			pluginName:    "user-plugin-1",
 			pluginType:    "",
 			expectErr:     false,
+			deletedFrom:   "user",
 		},
 		{
 			name:          "Delete dev plugin (no type specified)",
@@ -605,6 +634,7 @@ func TestDelete(t *testing.T) {
 			pluginName:    "dev-plugin-1",
 			pluginType:    "",
 			expectErr:     false,
+			deletedFrom:   "development",
 		},
 		{
 			name:          "Delete user plugin with type=user",
@@ -613,6 +643,7 @@ func TestDelete(t *testing.T) {
 			pluginName:    "shared-plugin",
 			pluginType:    "user",
 			expectErr:     false,
+			deletedFrom:   "user",
 		},
 		{
 			name:          "Delete dev plugin with type=development",
@@ -621,6 +652,40 @@ func TestDelete(t *testing.T) {
 			pluginName:    "shared-plugin",
 			pluginType:    "development",
 			expectErr:     false,
+			deletedFrom:   "development",
+		},
+		{
+			// Catalog plugins may still live under plugins/ while listed as
+			// type=user (pre-user-plugins migration). Delete must find them.
+			name:          "Delete migrated catalog plugin with type=user",
+			userPluginDir: userPluginDir,
+			devPluginDir:  devPluginDir,
+			pluginName:    "headlamp_kubescape",
+			pluginType:    "user",
+			expectErr:     false,
+			deletedFrom:   "development",
+		},
+		{
+			name:          "Do not delete plain development plugin with type=user",
+			userPluginDir: userPluginDir,
+			devPluginDir:  devPluginDir,
+			pluginName:    "plain-dev-plugin",
+			pluginType:    "user",
+			expectErr:     true,
+			errContains:   "not found in user-plugins or development directory",
+			mustExist:     plainDevPlugin,
+		},
+		{
+			// The catalog check must reject names escaping plugins/ instead of
+			// reading a package.json outside it.
+			name:          "Do not follow traversal path in catalog check",
+			userPluginDir: "",
+			devPluginDir:  devPluginDir,
+			pluginName:    "../outside-plugin",
+			pluginType:    "user",
+			expectErr:     true,
+			errContains:   "not found in user-plugins or development directory",
+			mustExist:     outsidePlugin,
 		},
 		{
 			name:          "Invalid plugin type",
@@ -638,7 +703,7 @@ func TestDelete(t *testing.T) {
 			pluginName:    "non-existent",
 			pluginType:    "user",
 			expectErr:     true,
-			errContains:   "not found in user-plugins directory",
+			errContains:   "not found in user-plugins or development directory",
 		},
 		{
 			name:          "Non-existent plugin with type=development",
@@ -677,18 +742,28 @@ func TestDelete(t *testing.T) {
 				if tt.errContains != "" {
 					assert.Contains(t, err.Error(), tt.errContains)
 				}
-			} else {
-				assert.NoError(t, err, "Delete should not return an error")
-				// check if the plugin was deleted from the correct directory
-				if tt.pluginType == "user" || (tt.pluginType == "" && tt.pluginName == "user-plugin-1") {
-					userPath := filepath.Join(tt.userPluginDir, tt.pluginName)
-					_, userErr := os.Stat(userPath)
-					assert.True(t, os.IsNotExist(userErr), "User plugin should be deleted")
-				} else if tt.pluginType == "development" || (tt.pluginType == "" && tt.pluginName == "dev-plugin-1") {
-					devPath := filepath.Join(tt.devPluginDir, tt.pluginName)
-					_, devErr := os.Stat(devPath)
-					assert.True(t, os.IsNotExist(devErr), "Dev plugin should be deleted")
+
+				if tt.mustExist != "" {
+					_, statErr := os.Stat(tt.mustExist)
+					assert.NoError(t, statErr, "%s should not be deleted", tt.mustExist)
 				}
+
+				return
+			}
+
+			assert.NoError(t, err, "Delete should not return an error")
+
+			switch tt.deletedFrom {
+			case "user":
+				userPath := filepath.Join(tt.userPluginDir, tt.pluginName)
+				_, userErr := os.Stat(userPath)
+				assert.True(t, os.IsNotExist(userErr), "User plugin should be deleted")
+			case "development":
+				devPath := filepath.Join(tt.devPluginDir, tt.pluginName)
+				_, devErr := os.Stat(devPath)
+				assert.True(t, os.IsNotExist(devErr), "Plugin should be deleted from development dir")
+			default:
+				t.Fatalf("deletedFrom must be set for success cases, got %q", tt.deletedFrom)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Fixes plugin deletion for catalog-installed plugins that still live under
the development `plugins/` directory but are listed as `type=user`
(migration from before `user-plugins/` existed).

- Previously, `DELETE /plugins/{name}?type=user` only looked in
`user-plugins/`, so deletes failed with:

`plugin 'headlamp_kubescape' not found in user-plugins directory`

`Delete()` now falls back to the development `plugins/` directory when a
`type=user` delete misses `user-plugins/`. Shipped plugins remain
undeletable.

Fixes #4489

## Changes

- `backend/pkg/plugins/plugins.go`: fall back to development dir for `type=user`
- `backend/pkg/plugins/plugins_test.go`: cover the migrated catalog plugin case
