### PR TITLE
frontend: ActionButton: Wrap disabled tooltip target

### DIFF
--- a/frontend/src/components/common/ActionButton/ActionButton.stories.tsx
+++ b/frontend/src/components/common/ActionButton/ActionButton.stories.tsx
@@ -45,3 +45,10 @@ LongDescription.args = {
   longDescription: 'Although this is Some label, there is more to it than meets the eye.',
   icon: 'mdi:pencil',
 };
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  description: 'Cannot edit this resource',
+  icon: 'mdi:pencil',
+  iconButtonProps: { disabled: true },
+};

--- a/frontend/src/components/common/ActionButton/ActionButton.test.tsx
+++ b/frontend/src/components/common/ActionButton/ActionButton.test.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ComponentProps } from 'react';
+import { theme } from '../../TestHelpers/theme';
+import ActionButton from './ActionButton';
+
+function renderActionButton(props: Partial<ComponentProps<typeof ActionButton>> = {}) {
+  return render(
+    <ThemeProvider theme={theme}>
+      <ActionButton description="Delete" icon="mdi:delete" onClick={() => {}} {...props} />
+    </ThemeProvider>
+  );
+}
+
+describe('ActionButton', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('keeps enabled icon buttons directly interactive', () => {
+    renderActionButton();
+
+    expect(screen.getByRole('button', { name: 'Delete' }).tagName).toBe('BUTTON');
+  });
+
+  it('wraps disabled icon buttons so the tooltip can still open', async () => {
+    const user = userEvent.setup();
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const onClick = vi.fn();
+    const parentClick = vi.fn();
+    const parentKeyDown = vi.fn();
+
+    render(
+      <ThemeProvider theme={theme}>
+        {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+        <div onClick={parentClick} onKeyDown={parentKeyDown}>
+          <ActionButton
+            description="Delete"
+            icon="mdi:delete"
+            onClick={onClick}
+            iconButtonProps={{ disabled: true, 'aria-label': 'Delete action' }}
+          />
+        </div>
+      </ThemeProvider>
+    );
+
+    const wrapper = screen.getByRole('button', { name: 'Delete action' });
+
+    expect(wrapper?.tagName).toBe('SPAN');
+    expect(wrapper).toHaveAttribute('aria-disabled', 'true');
+
+    await user.hover(wrapper);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Delete');
+
+    await user.unhover(wrapper);
+    await waitFor(() => expect(screen.queryByRole('tooltip')).not.toBeInTheDocument());
+
+    await user.tab();
+
+    expect(wrapper).toHaveFocus();
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Delete');
+
+    await user.click(wrapper);
+    await user.keyboard('{Enter}');
+    await user.keyboard(' ');
+
+    expect(onClick).not.toHaveBeenCalled();
+    expect(parentClick).not.toHaveBeenCalled();
+    expect(parentKeyDown).not.toHaveBeenCalled();
+
+    const tooltipWarnings = consoleErrorSpy.mock.calls.filter(call =>
+      call.some(arg => /disabled/i.test(String(arg)) && /tooltip/i.test(String(arg)))
+    );
+
+    expect(tooltipWarnings).toHaveLength(0);
+  });
+});

--- a/frontend/src/components/common/ActionButton/ActionButton.test.tsx
+++ b/frontend/src/components/common/ActionButton/ActionButton.test.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ComponentProps } from 'react';
+import { theme } from '../../TestHelpers/theme';
+import ActionButton from './ActionButton';
+
+function renderActionButton(props: Partial<ComponentProps<typeof ActionButton>> = {}) {
+  return render(
+    <ThemeProvider theme={theme}>
+      <ActionButton description="Delete" icon="mdi:delete" onClick={() => {}} {...props} />
+    </ThemeProvider>
+  );
+}
+
+describe('ActionButton', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('wraps disabled icon buttons so the tooltip can still open', async () => {
+    const user = userEvent.setup();
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    renderActionButton({
+      iconButtonProps: { disabled: true },
+    });
+
+    const wrapper = screen.getByRole('button', { name: 'Delete' });
+
+    expect(wrapper?.tagName).toBe('SPAN');
+    expect(wrapper).toHaveAttribute('aria-disabled', 'true');
+
+    await user.hover(wrapper);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Delete');
+
+    await user.unhover(wrapper);
+    await waitFor(() => expect(screen.queryByRole('tooltip')).not.toBeInTheDocument());
+
+    await user.tab();
+
+    expect(wrapper).toHaveFocus();
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Delete');
+
+    const tooltipWarnings = consoleErrorSpy.mock.calls.filter(call =>
+      call.some(arg => /disabled/i.test(String(arg)) && /tooltip/i.test(String(arg)))
+    );
+
+    expect(tooltipWarnings).toHaveLength(0);
+  });
+});

--- a/frontend/src/components/common/ActionButton/ActionButton.tsx
+++ b/frontend/src/components/common/ActionButton/ActionButton.tsx
@@ -65,6 +65,11 @@ export default function ActionButton({
   iconProps,
   buttonStyle = 'action',
 }: ActionButtonProps) {
+  const preventDisabledActivation = (event: React.SyntheticEvent<HTMLElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
   if (buttonStyle === 'menu') {
     return (
       <MenuItem onClick={onClick}>
@@ -75,17 +80,42 @@ export default function ActionButton({
       </MenuItem>
     );
   }
+
+  const isDisabled = !!iconButtonProps?.disabled;
+  const buttonLabel = iconButtonProps?.['aria-label'] ?? description;
+  const button = (
+    <IconButton
+      aria-label={buttonLabel}
+      onClick={onClick}
+      edge={edge}
+      size="medium"
+      {...iconButtonProps}
+    >
+      <Icon icon={icon} color={color} width={width} {...iconProps} />
+    </IconButton>
+  );
+
   return (
     <Tooltip title={longDescription || description}>
-      <IconButton
-        aria-label={description}
-        onClick={onClick}
-        edge={edge}
-        size="medium"
-        {...iconButtonProps}
-      >
-        <Icon icon={icon} color={color} width={width} {...iconProps} />
-      </IconButton>
+      {isDisabled ? (
+        <span
+          role="button"
+          aria-label={buttonLabel}
+          aria-disabled="true"
+          tabIndex={0}
+          onClick={preventDisabledActivation}
+          onKeyDown={event => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              preventDisabledActivation(event);
+            }
+          }}
+          style={{ display: 'inline-flex' }}
+        >
+          {React.cloneElement(button, { 'aria-hidden': true, tabIndex: -1 })}
+        </span>
+      ) : (
+        button
+      )}
     </Tooltip>
   );
 }

--- a/frontend/src/components/common/ActionButton/ActionButton.tsx
+++ b/frontend/src/components/common/ActionButton/ActionButton.tsx
@@ -65,6 +65,11 @@ export default function ActionButton({
   iconProps,
   buttonStyle = 'action',
 }: ActionButtonProps) {
+  const preventDisabledActivation = (event: React.SyntheticEvent<HTMLElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
   if (buttonStyle === 'menu') {
     return (
       <MenuItem onClick={onClick}>
@@ -75,17 +80,41 @@ export default function ActionButton({
       </MenuItem>
     );
   }
+
+  const isDisabled = !!iconButtonProps?.disabled;
+  const button = (
+    <IconButton
+      aria-label={description}
+      onClick={onClick}
+      edge={edge}
+      size="medium"
+      {...iconButtonProps}
+    >
+      <Icon icon={icon} color={color} width={width} {...iconProps} />
+    </IconButton>
+  );
+
   return (
     <Tooltip title={longDescription || description}>
-      <IconButton
-        aria-label={description}
-        onClick={onClick}
-        edge={edge}
-        size="medium"
-        {...iconButtonProps}
-      >
-        <Icon icon={icon} color={color} width={width} {...iconProps} />
-      </IconButton>
+      {isDisabled ? (
+        <span
+          role="button"
+          aria-label={description}
+          aria-disabled="true"
+          tabIndex={0}
+          onClick={preventDisabledActivation}
+          onKeyDown={event => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              preventDisabledActivation(event);
+            }
+          }}
+          style={{ display: 'inline-flex' }}
+        >
+          {React.cloneElement(button, { 'aria-hidden': true, tabIndex: -1 })}
+        </span>
+      ) : (
+        button
+      )}
     </Tooltip>
   );
 }

--- a/frontend/src/components/common/ActionButton/__snapshots__/ActionButton.Disabled.stories.storyshot
+++ b/frontend/src/components/common/ActionButton/__snapshots__/ActionButton.Disabled.stories.storyshot
@@ -1,0 +1,22 @@
+<body>
+  <div>
+    <span
+      aria-disabled="true"
+      aria-label="Cannot edit this resource"
+      class=""
+      data-mui-internal-clone-element="true"
+      role="button"
+      style="display: inline-flex;"
+      tabindex="0"
+    >
+      <button
+        aria-hidden="true"
+        aria-label="Cannot edit this resource"
+        class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+        disabled=""
+        tabindex="-1"
+        type="button"
+      />
+    </span>
+  </div>
+</body>


### PR DESCRIPTION
## Summary
This PR wraps disabled ActionButton icon buttons in a neutral span so the tooltip still opens on hover and keyboard focus.

## Related Issue
Fixes #6583

## Changes
- Updated ActionButton to reuse the existing IconButton element and wrap it only when iconButtonProps.disabled is true.
- Added a regression test that covers the disabled tooltip path, keyboard focus, activation guards, and the enabled path.
- Added a Disabled Storybook story so the behavior has a focused visual demo.
- Kept the disabled wrapper in the tab order as an explicit accessibility tradeoff so keyboard users can still discover the tooltip, while activation stays blocked.

## Steps to Test
1. Run `cd frontend && npm test -- src/components/common/ActionButton/ActionButton.test.tsx`.
2. Run `npm run frontend:lint`.
3. Run `npm run frontend:tsc`.
4. Run `npm run frontend:test`.
5. In Storybook, open `common/ActionButton` and confirm the Disabled story still shows the tooltip on hover and focus.

## Screenshots (if applicable)
Screen recording of the disabled tooltip opening on hover:
https://github.com/user-attachments/assets/2eaf483e-cee6-447a-b18b-88eb1039ef33

## Notes for the Reviewer
I removed the unrelated CronJobDetails story changes from this PR to keep the scope on ActionButton.
