### PR TITLE
Watcher Goroutine Churn & Failure Cooldown

### DIFF
--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -22,11 +22,13 @@ package k8cache
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
@@ -179,29 +181,80 @@ func filterImportantResources(gvrList []schema.GroupVersionResource) []schema.Gr
 	return filtered
 }
 
-// Corrected CheckForChanges.
-var (
-	watcherRegistry sync.Map
-	contextCancel   sync.Map
-)
+type watcherState struct {
+	mu           sync.Mutex
+	running      bool
+	retryAfter   time.Time
+	failureCount int
+	lastError    error
+	cancel       context.CancelFunc
+}
+
+func (s *watcherState) recordSuccess() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.running = false
+	s.failureCount = 0
+	s.lastError = nil
+	s.retryAfter = time.Time{}
+}
+
+func (s *watcherState) recordFailure(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.running = false
+	s.failureCount++
+	s.lastError = err
+
+	backoffShift := min(s.failureCount-1, 4)
+	backoff := time.Duration(1<<uint(backoffShift)) * 30 * time.Second
+
+	if backoff > 60*time.Second {
+		backoff = 60 * time.Second
+	}
+
+	s.retryAfter = time.Now().Add(backoff)
+}
+
+func (s *watcherState) resetFailureCount() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.failureCount = 0
+	s.lastError = nil
+	s.retryAfter = time.Time{}
+}
+
+var watcherRegistry sync.Map
 
 // CheckForChanges lets 1 go routine to run for a contextKey which prevents
-// running go routines for every requests which can become performance issue if
+// running go routines for every request which can become performance issue if
 // there are many resource and events are going on.
 func CheckForChanges(
 	k8scache cache.Cache[string],
 	contextKey string,
 	kContext kubeconfig.Context,
 ) {
-	if _, loaded := watcherRegistry.LoadOrStore(contextKey, struct{}{}); loaded {
+	val, _ := watcherRegistry.LoadOrStore(contextKey, &watcherState{})
+	state := val.(*watcherState)
+
+	state.mu.Lock()
+	now := time.Now()
+
+	if state.running || now.Before(state.retryAfter) {
+		state.mu.Unlock()
+
 		return
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	state.running = true
+	state.cancel = cancel
+	state.mu.Unlock()
 
-	contextCancel.Store(contextKey, cancel)
-
-	go runWatcher(ctx, k8scache, contextKey, kContext)
+	go runWatcher(ctx, k8scache, contextKey, kContext, state)
 }
 
 // SyncWatchers stops watchers for contexts that are no longer active and purges
@@ -217,18 +270,22 @@ func SyncWatchers(k8scache cache.Cache[string], activeContexts []string) {
 
 	cleaned := make(map[string]struct{})
 
-	contextCancel.Range(func(key, value interface{}) bool {
+	watcherRegistry.Range(func(key, value interface{}) bool {
 		contextKey, ok := key.(string)
 		if !ok {
 			return true
 		}
 
 		if !activeMap[contextKey] {
-			if cancel, ok := value.(context.CancelFunc); ok {
-				logger.Log(logger.LevelInfo, nil, nil, "canceling watcher for removed context: "+redactContextKey(contextKey))
-				cancel()
+			if state, ok := value.(*watcherState); ok {
+				state.mu.Lock()
+				if state.cancel != nil {
+					logger.Log(logger.LevelInfo, nil, nil, "canceling watcher for removed context: "+redactContextKey(contextKey))
+					state.cancel()
+				}
+				state.mu.Unlock()
+
 				watcherRegistry.Delete(contextKey)
-				contextCancel.Delete(contextKey)
 				cleanupRemovedContext(k8scache, contextKey)
 				cleaned[contextKey] = struct{}{}
 			}
@@ -250,6 +307,25 @@ func SyncWatchers(k8scache cache.Cache[string], activeContexts []string) {
 	}
 }
 
+func createKubeClients(kContext kubeconfig.Context) (dynamic.Interface, discovery.DiscoveryInterface, error) {
+	config, err := kContext.RESTConfig()
+	if err != nil {
+		return nil, nil, fmt.Errorf("error getting REST config: %w", err)
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating dynamic client: %w", err)
+	}
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating discovery client: %w", err)
+	}
+
+	return dynamicClient, discoveryClient, nil
+}
+
 // runWatcher is a long-lived goroutine that sets up and runs Kubernetes informers.
 // It watches for resource changes and invalidates corresponding cache entries.
 // This function will only exit when its context is cancelled.
@@ -258,33 +334,37 @@ func runWatcher(
 	k8scache cache.Cache[string],
 	contextKey string,
 	kContext kubeconfig.Context,
+	state *watcherState,
 ) {
+	var runErr error
+
 	defer func() {
-		watcherRegistry.Delete(contextKey)
-		contextCancel.Delete(contextKey)
+		if ctx.Err() != nil || runErr == nil {
+			state.recordSuccess()
+		} else {
+			state.recordFailure(runErr)
+		}
 	}()
 
 	logger.Log(logger.LevelInfo, nil, nil, "running runWatcher for watching k8s resource: "+redactContextKey(contextKey))
 
-	config, err := kContext.RESTConfig()
+	dynamicClient, discoveryClient, err := createKubeClients(kContext)
 	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "error getting REST config for context:")
+		logger.Log(logger.LevelError, nil, err, "error creating clients for context: "+redactContextKey(contextKey))
+		runErr = err
+
 		return
 	}
-
-	dynamicClient, err := dynamic.NewForConfig(config)
-	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "error creating dynamic client for context: "+redactContextKey(contextKey))
-		return
-	}
-
-	discoveryClient := discovery.NewDiscoveryClientForConfigOrDie(config)
 
 	apiResourceLists, err := discoveryClient.ServerPreferredResources()
 	if apiResourceLists == nil && err != nil {
 		logger.Log(logger.LevelError, nil, err, "error fetching resource list for context: "+redactContextKey(contextKey))
+		runErr = err
+
 		return
 	}
+
+	state.resetFailureCount()
 
 	gvrList := returnGVRList(apiResourceLists)
 	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, 0, "", nil)

--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -22,11 +22,13 @@ package k8cache
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
@@ -179,29 +181,82 @@ func filterImportantResources(gvrList []schema.GroupVersionResource) []schema.Gr
 	return filtered
 }
 
-// Corrected CheckForChanges.
-var (
-	watcherRegistry sync.Map
-	contextCancel   sync.Map
-)
+type watcherState struct {
+	mu           sync.Mutex
+	running      bool
+	retryAfter   time.Time
+	failureCount int
+	lastError    error
+	cancel       context.CancelFunc
+}
+
+func (s *watcherState) recordSuccess() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.running = false
+	s.failureCount = 0
+	s.lastError = nil
+	s.retryAfter = time.Time{}
+	s.cancel = nil
+}
+
+func (s *watcherState) recordFailure(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.running = false
+	s.failureCount++
+	s.lastError = err
+	s.cancel = nil
+
+	backoffShift := min(s.failureCount-1, 4)
+	backoff := time.Duration(1<<uint(backoffShift)) * 30 * time.Second
+
+	if backoff > 60*time.Second {
+		backoff = 60 * time.Second
+	}
+
+	s.retryAfter = time.Now().Add(backoff)
+}
+
+func (s *watcherState) resetFailureCount() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.failureCount = 0
+	s.lastError = nil
+	s.retryAfter = time.Time{}
+}
+
+var watcherRegistry sync.Map
 
 // CheckForChanges lets 1 go routine to run for a contextKey which prevents
-// running go routines for every requests which can become performance issue if
+// running go routines for every request which can become performance issue if
 // there are many resource and events are going on.
 func CheckForChanges(
 	k8scache cache.Cache[string],
 	contextKey string,
 	kContext kubeconfig.Context,
 ) {
-	if _, loaded := watcherRegistry.LoadOrStore(contextKey, struct{}{}); loaded {
+	val, _ := watcherRegistry.LoadOrStore(contextKey, &watcherState{})
+	state := val.(*watcherState)
+
+	state.mu.Lock()
+	now := time.Now()
+
+	if state.running || now.Before(state.retryAfter) {
+		state.mu.Unlock()
+
 		return
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	state.running = true
+	state.cancel = cancel
+	state.mu.Unlock()
 
-	contextCancel.Store(contextKey, cancel)
-
-	go runWatcher(ctx, k8scache, contextKey, kContext)
+	go runWatcher(ctx, k8scache, contextKey, kContext, state)
 }
 
 // SyncWatchers stops watchers for contexts that are no longer active and purges
@@ -217,18 +272,22 @@ func SyncWatchers(k8scache cache.Cache[string], activeContexts []string) {
 
 	cleaned := make(map[string]struct{})
 
-	contextCancel.Range(func(key, value interface{}) bool {
+	watcherRegistry.Range(func(key, value interface{}) bool {
 		contextKey, ok := key.(string)
 		if !ok {
 			return true
 		}
 
 		if !activeMap[contextKey] {
-			if cancel, ok := value.(context.CancelFunc); ok {
-				logger.Log(logger.LevelInfo, nil, nil, "canceling watcher for removed context: "+redactContextKey(contextKey))
-				cancel()
+			if state, ok := value.(*watcherState); ok {
+				state.mu.Lock()
+				if state.cancel != nil {
+					logger.Log(logger.LevelInfo, nil, nil, "canceling watcher for removed context: "+redactContextKey(contextKey))
+					state.cancel()
+				}
+				state.mu.Unlock()
+
 				watcherRegistry.Delete(contextKey)
-				contextCancel.Delete(contextKey)
 				cleanupRemovedContext(k8scache, contextKey)
 				cleaned[contextKey] = struct{}{}
 			}
@@ -250,6 +309,25 @@ func SyncWatchers(k8scache cache.Cache[string], activeContexts []string) {
 	}
 }
 
+func createKubeClients(kContext kubeconfig.Context) (dynamic.Interface, discovery.DiscoveryInterface, error) {
+	config, err := kContext.RESTConfig()
+	if err != nil {
+		return nil, nil, fmt.Errorf("error getting REST config: %w", err)
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating dynamic client: %w", err)
+	}
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating discovery client: %w", err)
+	}
+
+	return dynamicClient, discoveryClient, nil
+}
+
 // runWatcher is a long-lived goroutine that sets up and runs Kubernetes informers.
 // It watches for resource changes and invalidates corresponding cache entries.
 // This function will only exit when its context is cancelled.
@@ -258,33 +336,37 @@ func runWatcher(
 	k8scache cache.Cache[string],
 	contextKey string,
 	kContext kubeconfig.Context,
+	state *watcherState,
 ) {
+	var runErr error
+
 	defer func() {
-		watcherRegistry.Delete(contextKey)
-		contextCancel.Delete(contextKey)
+		if ctx.Err() != nil || runErr == nil {
+			state.recordSuccess()
+		} else {
+			state.recordFailure(runErr)
+		}
 	}()
 
 	logger.Log(logger.LevelInfo, nil, nil, "running runWatcher for watching k8s resource: "+redactContextKey(contextKey))
 
-	config, err := kContext.RESTConfig()
+	dynamicClient, discoveryClient, err := createKubeClients(kContext)
 	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "error getting REST config for context:")
+		logger.Log(logger.LevelError, nil, err, "error creating clients for context: "+redactContextKey(contextKey))
+		runErr = err
+
 		return
 	}
-
-	dynamicClient, err := dynamic.NewForConfig(config)
-	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "error creating dynamic client for context: "+redactContextKey(contextKey))
-		return
-	}
-
-	discoveryClient := discovery.NewDiscoveryClientForConfigOrDie(config)
 
 	apiResourceLists, err := discoveryClient.ServerPreferredResources()
 	if apiResourceLists == nil && err != nil {
 		logger.Log(logger.LevelError, nil, err, "error fetching resource list for context: "+redactContextKey(contextKey))
+		runErr = err
+
 		return
 	}
+
+	state.resetFailureCount()
 
 	gvrList := returnGVRList(apiResourceLists)
 	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, 0, "", nil)

--- a/backend/pkg/k8cache/cacheInvalidation_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_test.go
@@ -882,3 +882,119 @@ func TestSyncWatchers(t *testing.T) {
 	assert.True(t, canceled["ctx2"], "ctx2 should be canceled")
 	assert.False(t, canceled["ctx3"], "ctx3 should not be canceled")
 }
+
+func TestCheckForChangesGoroutineRateLimiting(t *testing.T) {
+	key := t.Name()
+	k8cache.ResetRegistries(key)
+
+	defer k8cache.ResetRegistries(key)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	defer cancel()
+
+	// Trigger runWatcher with an empty Context (which fails RESTConfig immediately)
+	k8cache.ExportedRunWatcher(ctx, nil, key, kubeconfig.Context{})
+
+	// Simulate 100 concurrent incoming HTTP requests during failure cooldown
+	var wg sync.WaitGroup
+
+	for range 100 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			k8cache.CheckForChanges(nil, key, kubeconfig.Context{})
+		}()
+	}
+
+	wg.Wait()
+
+	running, loaded := k8cache.RegistryLoaded(key)
+	assert.True(t, loaded)
+	assert.False(t, running, "Watcher should remain in cooldown without spawning redundant goroutines")
+	assert.True(t, k8cache.ExportedWatcherInCooldown(key), "Watcher must remain in cooldown state")
+}
+
+func TestCheckForChanges_NoGoroutineSpamDuringCooldown(t *testing.T) {
+	key := t.Name()
+	k8cache.ResetRegistries(key)
+
+	defer k8cache.ResetRegistries(key)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	defer cancel()
+
+	// Initial failing execution sets failureCount to 1 and places watcher in cooldown
+	k8cache.ExportedRunWatcher(ctx, nil, key, kubeconfig.Context{})
+
+	assert.Equal(t, 1, k8cache.ExportedWatcherFailureCount(key))
+	assert.True(t, k8cache.ExportedWatcherInCooldown(key))
+
+	// Perform 100 repeated CheckForChanges calls
+	for range 100 {
+		k8cache.CheckForChanges(nil, key, kubeconfig.Context{})
+	}
+
+	// failureCount must remain 1 because no new watchers were spawned during cooldown
+	assert.Equal(t, 1, k8cache.ExportedWatcherFailureCount(key), "failureCount should not increase during cooldown")
+	running, loaded := k8cache.RegistryLoaded(key)
+	assert.True(t, loaded)
+	assert.False(t, running, "watcher should not be running during cooldown")
+}
+
+func TestCheckForChanges_RestartsWatcherAfterCooldownExpiry(t *testing.T) {
+	key := t.Name()
+	k8cache.ResetRegistries(key)
+
+	defer k8cache.ResetRegistries(key)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	defer cancel()
+
+	// First attempt fails and starts cooldown (failureCount = 1)
+	k8cache.ExportedRunWatcher(ctx, nil, key, kubeconfig.Context{})
+	assert.True(t, k8cache.ExportedWatcherInCooldown(key))
+	assert.Equal(t, 1, k8cache.ExportedWatcherFailureCount(key))
+
+	// Expire the cooldown period
+	k8cache.ExportedExpireWatcherCooldown(key)
+	assert.False(t, k8cache.ExportedWatcherInCooldown(key))
+
+	// Calling CheckForChanges now must allow a new watcher attempt to run
+	k8cache.CheckForChanges(nil, key, kubeconfig.Context{})
+
+	// Wait briefly for the goroutine to execute
+	assert.Eventually(t, func() bool {
+		return k8cache.ExportedWatcherFailureCount(key) == 2
+	}, 1*time.Second, 10*time.Millisecond, "failureCount should increment to 2 after second failed attempt post-cooldown")
+}
+
+func TestSyncWatchers_CleansUpWatcherStateOnContextRemoval(t *testing.T) {
+	activeKey := "ctx-active"
+	removedKey := "ctx-removed"
+
+	k8cache.ResetRegistries(activeKey, removedKey)
+
+	defer k8cache.ResetRegistries(activeKey, removedKey)
+
+	activeCanceled := false
+	removedCanceled := false
+
+	k8cache.StoreTestContextCancel(activeKey, func() { activeCanceled = true })
+	k8cache.StoreTestContextCancel(removedKey, func() { removedCanceled = true })
+
+	// SyncWatchers with only activeKey present
+	k8cache.SyncWatchers(nil, []string{activeKey})
+
+	// Active context state must be preserved; removed context state must be deleted
+	_, activeLoaded := k8cache.RegistryLoaded(activeKey)
+	_, removedLoaded := k8cache.RegistryLoaded(removedKey)
+
+	assert.True(t, activeLoaded, "active context state should remain in watcherRegistry")
+	assert.False(t, removedLoaded, "removed context state should be cleaned up from watcherRegistry")
+	assert.False(t, activeCanceled, "active context cancel should not be invoked")
+	assert.True(t, removedCanceled, "removed context cancel should be invoked")
+}

--- a/backend/pkg/k8cache/export_test.go
+++ b/backend/pkg/k8cache/export_test.go
@@ -18,19 +18,26 @@ func ExportedRunWatcher(
 	contextKey string,
 	kContext kubeconfig.Context,
 ) {
-	runWatcher(ctx, k8scache, contextKey, kContext)
+	val, _ := watcherRegistry.LoadOrStore(contextKey, &watcherState{})
+	state := val.(*watcherState)
+	runWatcher(ctx, k8scache, contextKey, kContext, state)
 }
 
 // ResetRegistries clears both registries for test isolation.
 // If no keys are provided, it clears all entries.
 func ResetRegistries(keys ...string) {
 	if len(keys) == 0 {
-		watcherRegistry.Range(func(key, _ interface{}) bool {
+		watcherRegistry.Range(func(key, val interface{}) bool {
+			if state, ok := val.(*watcherState); ok {
+				state.mu.Lock()
+				if state.cancel != nil {
+					state.cancel()
+				}
+				state.mu.Unlock()
+			}
+
 			watcherRegistry.Delete(key)
-			return true
-		})
-		contextCancel.Range(func(key, _ interface{}) bool {
-			contextCancel.Delete(key)
+
 			return true
 		})
 
@@ -38,28 +45,105 @@ func ResetRegistries(keys ...string) {
 	}
 
 	for _, k := range keys {
-		watcherRegistry.Delete(k)
-		contextCancel.Delete(k)
+		if val, loaded := watcherRegistry.LoadAndDelete(k); loaded {
+			if state, ok := val.(*watcherState); ok {
+				state.mu.Lock()
+				if state.cancel != nil {
+					state.cancel()
+				}
+				state.mu.Unlock()
+			}
+		}
 	}
 }
 
-// StoreTestRegistry populates both registries for test setup.
+// StoreTestRegistry populates registries for test setup.
 func StoreTestRegistry(key string, cancel context.CancelFunc) {
-	watcherRegistry.Store(key, struct{}{})
-	contextCancel.Store(key, cancel)
+	watcherRegistry.Store(key, &watcherState{
+		running: true,
+		cancel:  cancel,
+	})
 }
 
 // StoreTestContextCancel stores a cancel function in the registry for tests.
 func StoreTestContextCancel(contextKey string, cancel context.CancelFunc) {
-	contextCancel.Store(contextKey, cancel)
+	val, _ := watcherRegistry.LoadOrStore(contextKey, &watcherState{})
+	state := val.(*watcherState)
+	state.mu.Lock()
+	state.cancel = cancel
+	state.mu.Unlock()
 }
 
-// RegistryLoaded checks if a key exists in both registries.
-func RegistryLoaded(key string) (watcher, cancel bool) {
-	_, watcher = watcherRegistry.Load(key)
-	_, cancel = contextCancel.Load(key)
+// RegistryLoaded checks if a key exists in registries and its running state.
+func RegistryLoaded(key string) (running, loaded bool) {
+	val, ok := watcherRegistry.Load(key)
+	if !ok {
+		return false, false
+	}
 
-	return
+	state, ok := val.(*watcherState)
+	if !ok {
+		return false, false
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	return state.running, true
+}
+
+// ExportedWatcherInCooldown reports whether the context key is currently in cooldown.
+func ExportedWatcherInCooldown(contextKey string) bool {
+	val, ok := watcherRegistry.Load(contextKey)
+	if !ok {
+		return false
+	}
+
+	state, ok := val.(*watcherState)
+	if !ok {
+		return false
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	return time.Now().Before(state.retryAfter)
+}
+
+// ExportedExpireWatcherCooldown manually sets the retryAfter timestamp in the past for testing.
+func ExportedExpireWatcherCooldown(contextKey string) {
+	val, ok := watcherRegistry.Load(contextKey)
+	if !ok {
+		return
+	}
+
+	state, ok := val.(*watcherState)
+	if !ok {
+		return
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	state.retryAfter = time.Now().Add(-1 * time.Second)
+}
+
+// ExportedWatcherFailureCount returns failureCount for testing.
+func ExportedWatcherFailureCount(contextKey string) int {
+	val, ok := watcherRegistry.Load(contextKey)
+	if !ok {
+		return 0
+	}
+
+	state, ok := val.(*watcherState)
+	if !ok {
+		return 0
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	return state.failureCount
 }
 
 // ResetClientsetCache clears the clientset cache for test isolation.

--- a/backend/pkg/k8cache/registry_cleanup_test.go
+++ b/backend/pkg/k8cache/registry_cleanup_test.go
@@ -2,32 +2,102 @@ package k8cache_test
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/stretchr/testify/assert"
+	api "k8s.io/client-go/tools/clientcmd/api"
 )
 
-func TestRunWatcherCleansUpRegistryOnFailure(t *testing.T) {
+func TestRunWatcherEnforcesCooldownOnFailure(t *testing.T) {
 	key := t.Name()
 	// Ensure clean state before and after the test.
 	k8cache.ResetRegistries(key)
 	defer k8cache.ResetRegistries(key)
 
-	// Simulate what CheckForChanges does before launching the goroutine.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
-	k8cache.StoreTestRegistry(key, cancel)
 
 	// An empty Context causes RESTConfig() to return an error,
 	// which makes runWatcher exit on its first error path.
 	k8cache.ExportedRunWatcher(ctx, nil, key, kubeconfig.Context{})
 
-	// After the early return, both registry entries must be cleaned up
-	// so that a subsequent CheckForChanges call can start a new watcher.
-	watcherLoaded, cancelLoaded := k8cache.RegistryLoaded(key)
-	assert.False(t, watcherLoaded, "watcherRegistry entry should be removed after early exit")
-	assert.False(t, cancelLoaded, "contextCancel entry should be removed after early exit")
+	// After early return on failure, watcher should no longer be running,
+	// but must be in cooldown state to prevent per-HTTP-request goroutine churn.
+	running, loaded := k8cache.RegistryLoaded(key)
+	assert.True(t, loaded, "watcher state should remain registered during cooldown")
+	assert.False(t, running, "watcher should not be running after error exit")
+	assert.True(t, k8cache.ExportedWatcherInCooldown(key), "watcher should be in cooldown after failure")
+
+	// Verify CheckForChanges does not spawn a new watcher while in cooldown
+	k8cache.CheckForChanges(nil, key, kubeconfig.Context{})
+	runningAfterCheck, loadedAfterCheck := k8cache.RegistryLoaded(key)
+	assert.True(t, loadedAfterCheck)
+	assert.False(t, runningAfterCheck, "CheckForChanges must not start watcher during cooldown")
+}
+
+func TestRunWatcherResetsFailureCountOnSuccess(t *testing.T) {
+	key := t.Name()
+	k8cache.ResetRegistries(key)
+
+	defer k8cache.ResetRegistries(key)
+
+	// 1. Simulate a prior failure to set failureCount > 0 and put watcher in cooldown
+	ctxFail, cancelFail := context.WithCancel(context.Background())
+	k8cache.ExportedRunWatcher(ctxFail, nil, key, kubeconfig.Context{})
+	cancelFail()
+
+	assert.Equal(t, 1, k8cache.ExportedWatcherFailureCount(key))
+	assert.True(t, k8cache.ExportedWatcherInCooldown(key))
+
+	// 2. Set up mock API server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/api":
+			_, _ = w.Write([]byte(`{"kind":"APIVersions","versions":["v1"]}`))
+		case "/apis":
+			_, _ = w.Write([]byte(`{"kind":"APIGroupList","groups":[]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	// 3. Build a valid Context pointing to the mock server
+	kContext := kubeconfig.Context{
+		Name: "test-context",
+		KubeContext: &api.Context{
+			Cluster:  "test-cluster",
+			AuthInfo: "test-auth",
+		},
+		Cluster: &api.Cluster{
+			Server: server.URL,
+		},
+		AuthInfo: &api.AuthInfo{},
+	}
+
+	// 4. Expire the cooldown and call CheckForChanges with the valid context
+	k8cache.ExportedExpireWatcherCooldown(key)
+
+	// Direct call to CheckForChanges spawns the runWatcher goroutine.
+	k8cache.CheckForChanges(nil, key, kContext)
+
+	// 5. Verify that failureCount is reset to 0 once runWatcher successfully initializes.
+	assert.Eventually(t, func() bool {
+		return k8cache.ExportedWatcherFailureCount(key) == 0
+	}, 3*time.Second, 50*time.Millisecond, "failure count should be reset to 0 after successful watcher initialization")
+
+	// Ensure it is running
+	running, loaded := k8cache.RegistryLoaded(key)
+	assert.True(t, loaded)
+	assert.True(t, running, "watcher should be running")
+
+	// Clean up by syncing (cancels the active watcher)
+	k8cache.SyncWatchers(nil, []string{})
 }

--- a/backend/pkg/k8cache/registry_cleanup_test.go
+++ b/backend/pkg/k8cache/registry_cleanup_test.go
@@ -2,32 +2,104 @@ package k8cache_test
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/stretchr/testify/assert"
+	api "k8s.io/client-go/tools/clientcmd/api"
 )
 
-func TestRunWatcherCleansUpRegistryOnFailure(t *testing.T) {
+func TestRunWatcherEnforcesCooldownOnFailure(t *testing.T) {
 	key := t.Name()
 	// Ensure clean state before and after the test.
 	k8cache.ResetRegistries(key)
 	defer k8cache.ResetRegistries(key)
 
-	// Simulate what CheckForChanges does before launching the goroutine.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
-	k8cache.StoreTestRegistry(key, cancel)
 
 	// An empty Context causes RESTConfig() to return an error,
 	// which makes runWatcher exit on its first error path.
 	k8cache.ExportedRunWatcher(ctx, nil, key, kubeconfig.Context{})
 
-	// After the early return, both registry entries must be cleaned up
-	// so that a subsequent CheckForChanges call can start a new watcher.
-	watcherLoaded, cancelLoaded := k8cache.RegistryLoaded(key)
-	assert.False(t, watcherLoaded, "watcherRegistry entry should be removed after early exit")
-	assert.False(t, cancelLoaded, "contextCancel entry should be removed after early exit")
+	// After early return on failure, watcher should no longer be running,
+	// but must be in cooldown state to prevent per-HTTP-request goroutine churn.
+	running, loaded := k8cache.RegistryLoaded(key)
+	assert.True(t, loaded, "watcher state should remain registered during cooldown")
+	assert.False(t, running, "watcher should not be running after error exit")
+	assert.True(t, k8cache.ExportedWatcherInCooldown(key), "watcher should be in cooldown after failure")
+
+	// Verify CheckForChanges does not spawn a new watcher while in cooldown
+	k8cache.CheckForChanges(nil, key, kubeconfig.Context{})
+	runningAfterCheck, loadedAfterCheck := k8cache.RegistryLoaded(key)
+	assert.True(t, loadedAfterCheck)
+	assert.False(t, runningAfterCheck, "CheckForChanges must not start watcher during cooldown")
+}
+
+func TestRunWatcherResetsFailureCountOnSuccess(t *testing.T) {
+	key := t.Name()
+	k8cache.ResetRegistries(key)
+
+	defer k8cache.ResetRegistries(key)
+
+	// 1. Simulate a prior failure to set failureCount > 0 and put watcher in cooldown
+	ctxFail, cancelFail := context.WithCancel(context.Background())
+	k8cache.ExportedRunWatcher(ctxFail, nil, key, kubeconfig.Context{})
+	cancelFail()
+
+	assert.Equal(t, 1, k8cache.ExportedWatcherFailureCount(key))
+	assert.True(t, k8cache.ExportedWatcherInCooldown(key))
+
+	// 2. Set up mock API server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/api":
+			_, _ = w.Write([]byte(`{"kind":"APIVersions","versions":["v1"]}`))
+		case "/api/v1":
+			_, _ = w.Write([]byte(`{"kind":"APIResourceList","groupVersion":"v1","resources":[]}`))
+		case "/apis":
+			_, _ = w.Write([]byte(`{"kind":"APIGroupList","groups":[]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	// 3. Build a valid Context pointing to the mock server
+	kContext := kubeconfig.Context{
+		Name: "test-context",
+		KubeContext: &api.Context{
+			Cluster:  "test-cluster",
+			AuthInfo: "test-auth",
+		},
+		Cluster: &api.Cluster{
+			Server: server.URL,
+		},
+		AuthInfo: &api.AuthInfo{},
+	}
+
+	// 4. Expire the cooldown and call CheckForChanges with the valid context
+	k8cache.ExportedExpireWatcherCooldown(key)
+
+	// Direct call to CheckForChanges spawns the runWatcher goroutine.
+	k8cache.CheckForChanges(nil, key, kContext)
+
+	// 5. Verify that failureCount is reset to 0 once runWatcher successfully initializes.
+	assert.Eventually(t, func() bool {
+		return k8cache.ExportedWatcherFailureCount(key) == 0
+	}, 3*time.Second, 50*time.Millisecond, "failure count should be reset to 0 after successful watcher initialization")
+
+	// Ensure it is running
+	running, loaded := k8cache.RegistryLoaded(key)
+	assert.True(t, loaded)
+	assert.True(t, running, "watcher should be running")
+
+	// Clean up by syncing (cancels the active watcher)
+	k8cache.SyncWatchers(nil, []string{})
 }

--- a/backend/pkg/k8cache/testing_reset.go
+++ b/backend/pkg/k8cache/testing_reset.go
@@ -13,8 +13,6 @@
 
 package k8cache
 
-import "context"
-
 // ResetForTesting clears package-global k8cache state between integration tests.
 func ResetForTesting() {
 	mu.Lock()
@@ -29,16 +27,15 @@ func ResetForTesting() {
 }
 
 func clearWatcherRegistriesForTesting() {
-	contextCancel.Range(func(key, value interface{}) bool {
-		if cancel, ok := value.(context.CancelFunc); ok {
-			cancel()
+	watcherRegistry.Range(func(key, value interface{}) bool {
+		if state, ok := value.(*watcherState); ok {
+			state.mu.Lock()
+			if state.cancel != nil {
+				state.cancel()
+			}
+			state.mu.Unlock()
 		}
 
-		contextCancel.Delete(key)
-
-		return true
-	})
-	watcherRegistry.Range(func(key, _ interface{}) bool {
 		watcherRegistry.Delete(key)
 
 		return true


### PR DESCRIPTION
## Summary

This PR fixes a bug in `backend/pkg/k8cache/cacheInvalidation.go` where an unreachable or degraded Kubernetes cluster could cause uncontrolled watcher goroutine creation.

Previously, if `runWatcher()` failed during REST client creation or API discovery, it immediately removed the context from `watcherRegistry` before exiting. As a result, every subsequent HTTP request triggered a new watcher, causing repeated discovery attempts, excessive goroutine creation, and unnecessary load on both the backend and the Kubernetes API server.

This change introduces a per-context `watcherState` that tracks watcher lifecycle and applies an exponential backoff cooldown (30s–60s) after initialization failures. During the cooldown period, additional HTTP requests do not spawn duplicate watcher goroutines.

## Related Issue

Fixes #6585

## Changes

### `backend/pkg/k8cache/cacheInvalidation.go`

- Introduced a `watcherState` struct to track watcher lifecycle (`running`, `retryAfter`, `failureCount`, `lastError`, and `cancel`).
- Updated `CheckForChanges()` to prevent duplicate watcher creation while a watcher is already running or within a retry cooldown.
- Updated `runWatcher()` to retain watcher state after transient initialization failures and apply exponential backoff before retrying.
- Updated `SyncWatchers()` to cleanly cancel and remove watcher state only when a Kubernetes context is removed.

### Tests

Added unit tests covering:

- Preventing duplicate watcher creation during failure cooldown.
- Restarting a watcher after the cooldown expires.
- Cleaning up watcher state when a Kubernetes context is removed.

## Steps to Test

1. Run the backend test suite:

   ```bash
   cd backend
   go test -v -vet=off ./pkg/k8cache/...
   ```

2. Verify all existing and newly added tests pass.

3. Configure a Kubernetes context that is unreachable or has invalid credentials.

4. Start the Headlamp backend.

5. Open the cluster in the Headlamp UI and repeatedly refresh the page (or allow normal frontend polling).

6. Verify that discovery attempts occur at the configured retry interval instead of creating a new watcher for every request.

## Screenshots (if applicable)

N/A (backend-only change)

## Notes for the Reviewer

- This change only affects watcher initialization when connection or discovery fails. Behavior for healthy clusters remains unchanged.
- Watcher cleanup is now centralized in `SyncWatchers()` when contexts are removed.
- Retry behavior is implemented using a per-context watcher state with exponential backoff to avoid repeated watcher creation during cluster outages.