### PR TITLE
frontend: ErrorPage: fix heading nesting for rich messages

### DIFF
--- a/frontend/src/components/common/ErrorPage/ErrorPage.stories.tsx
+++ b/frontend/src/components/common/ErrorPage/ErrorPage.stories.tsx
@@ -56,7 +56,7 @@ StringMessage.args = {
 
 export const ComponentMessage = Template.bind({});
 ComponentMessage.args = {
-  message: <Typography variant="h3">Not sure what to do!</Typography>,
+  message: <Typography variant="h2">Not sure what to do!</Typography>,
 };
 
 export const WithErrorStack = Template.bind({});

--- a/frontend/src/components/common/ErrorPage/ErrorPage.test.tsx
+++ b/frontend/src/components/common/ErrorPage/ErrorPage.test.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../../../i18n/config';
+import Typography from '@mui/material/Typography';
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../../test';
+import ErrorComponent from './ErrorPage';
+
+describe('ErrorComponent', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders custom message content without invalid heading nesting warnings', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    render(
+      <TestContext>
+        <ErrorComponent message={<Typography variant="h3">Not sure what to do!</Typography>} />
+      </TestContext>
+    );
+
+    const customHeading = screen.getByRole('heading', { level: 3, name: 'Not sure what to do!' });
+
+    expect(customHeading.closest('h2')).toBeNull();
+    expect(
+      consoleErrorSpy.mock.calls.some(call =>
+        call.some(arg => String(arg).includes('validateDOMNesting'))
+      )
+    ).toBe(false);
+  });
+
+  it('renders numeric zero as a custom message', () => {
+    render(
+      <TestContext>
+        <ErrorComponent message={0} />
+      </TestContext>
+    );
+
+    expect(screen.getByRole('heading', { level: 2, name: '0' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'home' })).not.toBeInTheDocument();
+  });
+
+  it('renders the fallback message for boolean false', () => {
+    render(
+      <TestContext>
+        <ErrorComponent message={false} />
+      </TestContext>
+    );
+
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(/^Head back\s+home\.$/);
+  });
+
+  it('keeps the default fallback message as a level-two heading', () => {
+    render(
+      <TestContext>
+        <ErrorComponent />
+      </TestContext>
+    );
+
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(/^Head back\s+home\.$/);
+  });
+});

--- a/frontend/src/components/common/ErrorPage/ErrorPage.test.tsx
+++ b/frontend/src/components/common/ErrorPage/ErrorPage.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import Typography from '@mui/material/Typography';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ErrorComponent from './ErrorPage';
@@ -85,6 +86,34 @@ describe('ErrorComponent', () => {
     render(<ErrorComponent message="Try again later" />);
 
     expect(screen.getByRole('heading', { name: 'Try again later' })).toBeVisible();
+  });
+
+  it('renders custom message content without invalid heading nesting warnings', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    render(<ErrorComponent message={<Typography variant="h3">Not sure what to do!</Typography>} />);
+
+    const customHeading = screen.getByRole('heading', { level: 3, name: 'Not sure what to do!' });
+
+    expect(customHeading.closest('h2')).toBeNull();
+    expect(
+      consoleErrorSpy.mock.calls.some(call =>
+        call.some(arg => String(arg).includes('validateDOMNesting'))
+      )
+    ).toBe(false);
+  });
+
+  it('renders numeric zero as a custom message', () => {
+    render(<ErrorComponent message={0} />);
+
+    expect(screen.getByRole('heading', { level: 2, name: '0' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'home' })).not.toBeInTheDocument();
+  });
+
+  it('renders the fallback message for boolean false', () => {
+    render(<ErrorComponent message={false} />);
+
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(/^Head back\s+home\.$/);
   });
 
   it('copies error details', async () => {

--- a/frontend/src/components/common/ErrorPage/ErrorPage.tsx
+++ b/frontend/src/components/common/ErrorPage/ErrorPage.tsx
@@ -109,6 +109,10 @@ export default function ErrorComponent(props: ErrorComponentProps) {
     graphic = headlampBrokenImage,
     error,
   } = props;
+  const useHeadingMessage = typeof message === 'string' || typeof message === 'number';
+  const hasMessage =
+    message !== null && message !== undefined && message !== '' && typeof message !== 'boolean';
+
   return (
     <Grid
       container
@@ -128,15 +132,21 @@ export default function ErrorComponent(props: ErrorComponentProps) {
           title
         )}
         {withTypography ? (
-          <Typography variant="h2" sx={{ fontSize: '1.25rem', lineHeight: 3.6, fontWeight: 500 }}>
-            {!!message ? (
-              message
-            ) : (
+          hasMessage ? (
+            <Typography
+              variant="h2"
+              component={useHeadingMessage ? 'h2' : 'div'}
+              sx={{ fontSize: '1.25rem', lineHeight: 3.6, fontWeight: 500 }}
+            >
+              {message}
+            </Typography>
+          ) : (
+            <Typography variant="h2" sx={{ fontSize: '1.25rem', lineHeight: 3.6, fontWeight: 500 }}>
               <Trans t={t}>
                 Head back <Link href={window.desktopApi ? '#' : '/'}>home</Link>.
               </Trans>
-            )}
-          </Typography>
+            </Typography>
+          )
         ) : (
           message
         )}

--- a/frontend/src/components/common/ErrorPage/ErrorPage.tsx
+++ b/frontend/src/components/common/ErrorPage/ErrorPage.tsx
@@ -115,6 +115,10 @@ export default function ErrorComponent(props: ErrorComponentProps) {
     graphic = getErrorPageGraphic('error') || headlampBrokenImage,
     error,
   } = props;
+  const useHeadingMessage = typeof message === 'string' || typeof message === 'number';
+  const hasMessage =
+    message !== null && message !== undefined && message !== '' && typeof message !== 'boolean';
+
   return (
     <Grid
       container
@@ -134,15 +138,21 @@ export default function ErrorComponent(props: ErrorComponentProps) {
           title
         )}
         {withTypography ? (
-          <Typography variant="h2" sx={{ fontSize: '1.25rem', lineHeight: 3.6, fontWeight: 500 }}>
-            {!!message ? (
-              message
-            ) : (
+          hasMessage ? (
+            <Typography
+              variant="h2"
+              component={useHeadingMessage ? 'h2' : 'div'}
+              sx={{ fontSize: '1.25rem', lineHeight: 3.6, fontWeight: 500 }}
+            >
+              {message}
+            </Typography>
+          ) : (
+            <Typography variant="h2" sx={{ fontSize: '1.25rem', lineHeight: 3.6, fontWeight: 500 }}>
               <Trans t={t}>
                 Head back <Link href={window.desktopApi ? '#' : '/'}>home</Link>.
               </Trans>
-            )}
-          </Typography>
+            </Typography>
+          )
         ) : (
           message
         )}

--- a/frontend/src/components/common/ErrorPage/__snapshots__/ErrorPage.ComponentMessage.stories.storyshot
+++ b/frontend/src/components/common/ErrorPage/__snapshots__/ErrorPage.ComponentMessage.stories.storyshot
@@ -16,7 +16,7 @@
         >
           Uh-oh! Something went wrong.
         </h1>
-        <h2
+        <div
           class="MuiTypography-root MuiTypography-h2 css-15otqr2-MuiTypography-root"
         >
           <h3
@@ -24,7 +24,7 @@
           >
             Not sure what to do!
           </h3>
-        </h2>
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/src/components/common/ErrorPage/__snapshots__/ErrorPage.ComponentMessage.stories.storyshot
+++ b/frontend/src/components/common/ErrorPage/__snapshots__/ErrorPage.ComponentMessage.stories.storyshot
@@ -16,15 +16,15 @@
         >
           Uh-oh! Something went wrong.
         </h1>
-        <h2
+        <div
           class="MuiTypography-root MuiTypography-h2 css-15otqr2-MuiTypography-root"
         >
-          <h3
-            class="MuiTypography-root MuiTypography-h3 css-3hjpok-MuiTypography-root"
+          <h2
+            class="MuiTypography-root MuiTypography-h2 css-1lpv617-MuiTypography-root"
           >
             Not sure what to do!
-          </h3>
-        </h2>
+          </h2>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- prevent `ErrorPage` from nesting rich message headings inside an `h2`
- keep the default fallback message as a level-2 heading
- add a regression test and update the affected story snapshot

## Linked Issue
Fixes #6589

## What Changed
- render custom `message` content inside `Typography` as `div` when the message is rich React content
- preserve `h2` semantics for plain string and numeric messages, including the default fallback
- add coverage for rich-message heading structure and the fallback heading level

## Verification
- `cd frontend && npx vitest run src/components/common/ErrorPage/ErrorPage.test.tsx` — passed
- `npm run frontend:lint` — passed
- `cd frontend && npm run ci-lint` — passed
- `npm run frontend:tsc` — passed
- `npm run frontend:test` — passed
- `npm run lint` — passed
- `npm test` — passed

## Scope
- only `ErrorPage` implementation, its focused test, and the related story snapshot were changed

