### PR TITLE
frontend: k8s: Add rollback() unit tests for DaemonSet and StatefulSet

### DIFF
--- a/frontend/src/lib/k8s/daemonSet.test.ts
+++ b/frontend/src/lib/k8s/daemonSet.test.ts
@@ -14,9 +14,16 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import App from '../../App';
+import { jsonPatch } from './api/v1/clusterRequests';
 import DaemonSet from './daemonSet';
+
+vi.mock('./api/v1/clusterRequests', () => ({
+  jsonPatch: vi.fn(),
+}));
+
+const mockedJsonPatch = vi.mocked(jsonPatch);
 
 // cyclic imports fix
 // eslint-disable-next-line no-unused-vars
@@ -146,6 +153,344 @@ describe('DaemonSet class', () => {
       data.metadata.generation = undefined;
       const ds = new DaemonSet(data);
       expect(ds.getCurrentRevision()).toBe('');
+    });
+  });
+
+  describe('rollback', () => {
+    const template = {
+      metadata: {
+        labels: {
+          app: 'myapp',
+          'controller-revision-hash': 'test-hash',
+        },
+      },
+      spec: {
+        containers: [{ name: 'app', image: 'myapp:v2' }],
+      },
+    };
+
+    function makeRevision(revision: number, revisionTemplate: any = template) {
+      return {
+        revision,
+        data: revisionTemplate ? { spec: { template: revisionTemplate } } : {},
+      };
+    }
+
+    function makeDaemonSet() {
+      return new DaemonSet(JSON.parse(JSON.stringify(mockDaemonSetData)));
+    }
+
+    beforeEach(() => {
+      mockedJsonPatch.mockReset();
+    });
+
+    it('rolls back to the previous revision', async () => {
+      const ds = makeDaemonSet();
+      vi.spyOn(ds as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2),
+      ]);
+      mockedJsonPatch.mockResolvedValue({} as any);
+
+      const result = await ds.rollback();
+
+      expect(result).toMatchObject({
+        success: true,
+        message: 'Rolled back to revision 2',
+        previousRevision: 2,
+      });
+      expect(mockedJsonPatch).toHaveBeenCalledWith(
+        expect.stringContaining('/apis/apps/v1/namespaces/default/daemonsets/test-daemonset'),
+        [
+          {
+            op: 'replace',
+            path: '/spec/template',
+            value: {
+              metadata: {
+                labels: {
+                  app: 'myapp',
+                },
+              },
+              spec: {
+                containers: [{ name: 'app', image: 'myapp:v2' }],
+              },
+            },
+          },
+        ],
+        true,
+        { cluster: ds.cluster }
+      );
+    });
+
+    it('rolls back to a specific older revision', async () => {
+      const ds = makeDaemonSet();
+      vi.spyOn(ds as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2),
+        makeRevision(1),
+      ]);
+      mockedJsonPatch.mockResolvedValue({} as any);
+
+      const result = await ds.rollback(1);
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('Rolled back to revision 1');
+      expect(result.previousRevision).toBe(1);
+    });
+
+    it('returns failure when no previous revision is available', async () => {
+      const ds = makeDaemonSet();
+      vi.spyOn(ds as any, 'getOwnedControllerRevisions').mockResolvedValue([makeRevision(3)]);
+
+      const result = await ds.rollback();
+
+      expect(result).toEqual({
+        success: false,
+        message: 'No previous revision available to rollback to',
+      });
+      expect(mockedJsonPatch).not.toHaveBeenCalled();
+    });
+
+    it('returns failure when the target revision is not found', async () => {
+      const ds = makeDaemonSet();
+      vi.spyOn(ds as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2),
+      ]);
+
+      const result = await ds.rollback(1);
+
+      expect(result).toEqual({
+        success: false,
+        message: 'Revision 1 not found in history',
+      });
+      expect(mockedJsonPatch).not.toHaveBeenCalled();
+    });
+
+    it('returns failure when rolling back to the current revision', async () => {
+      const ds = makeDaemonSet();
+      vi.spyOn(ds as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2),
+      ]);
+
+      const result = await ds.rollback(3);
+
+      expect(result).toEqual({
+        success: false,
+        message: 'Cannot rollback to current revision',
+      });
+      expect(mockedJsonPatch).not.toHaveBeenCalled();
+    });
+
+    it('returns failure when the target revision has no pod template', async () => {
+      const ds = makeDaemonSet();
+      vi.spyOn(ds as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2, null),
+      ]);
+
+      const result = await ds.rollback();
+
+      expect(result).toEqual({
+        success: false,
+        message: 'Target revision does not contain a valid pod template',
+      });
+      expect(mockedJsonPatch).not.toHaveBeenCalled();
+    });
+
+    it('supports dry run rollback', async () => {
+      const ds = makeDaemonSet();
+      const dryRunResult = { metadata: { name: 'test-daemonset' } };
+      vi.spyOn(ds as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2),
+      ]);
+      mockedJsonPatch.mockResolvedValue(dryRunResult as any);
+
+      const result = await ds.rollback({ dryRun: true });
+
+      expect(result).toEqual({
+        success: true,
+        message: 'Dry-run: would rollback to revision 2',
+        previousRevision: 2,
+        dryRunResult,
+      });
+      expect(mockedJsonPatch).toHaveBeenCalledWith(
+        expect.stringContaining('/daemonsets/test-daemonset?dryRun=All'),
+        expect.any(Array),
+        true,
+        { cluster: ds.cluster }
+      );
+    });
+
+    it('returns failure when the patch request fails', async () => {
+      const ds = makeDaemonSet();
+      vi.spyOn(ds as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2),
+      ]);
+      mockedJsonPatch.mockRejectedValue(new Error('patch failed'));
+
+      const result = await ds.rollback();
+
+      expect(result).toEqual({
+        success: false,
+        message: 'Failed to rollback: patch failed',
+      });
+    });
+
+    it('returns failure when there are no revisions at all', async () => {
+      const ds = makeDaemonSet();
+      vi.spyOn(ds as any, 'getOwnedControllerRevisions').mockResolvedValue([]);
+
+      const result = await ds.rollback();
+
+      expect(result).toEqual({
+        success: false,
+        message: 'No previous revision available to rollback to',
+      });
+      expect(mockedJsonPatch).not.toHaveBeenCalled();
+    });
+
+    it('ignores revisions with revision number <= 0', async () => {
+      const ds = makeDaemonSet();
+      vi.spyOn(ds as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(2),
+        makeRevision(0),
+        makeRevision(-1),
+      ]);
+
+      const result = await ds.rollback();
+
+      expect(result).toEqual({
+        success: false,
+        message: 'No previous revision available to rollback to',
+      });
+      expect(mockedJsonPatch).not.toHaveBeenCalled();
+    });
+
+    it('correctly sorts unsorted revisions and picks the second highest', async () => {
+      const ds = makeDaemonSet();
+      vi.spyOn(ds as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(1),
+        makeRevision(3),
+        makeRevision(2),
+      ]);
+      mockedJsonPatch.mockResolvedValue({} as any);
+
+      const result = await ds.rollback();
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('Rolled back to revision 2');
+      expect(result.previousRevision).toBe(2);
+    });
+
+    it('handles non-Error exceptions gracefully', async () => {
+      const ds = makeDaemonSet();
+      vi.spyOn(ds as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2),
+      ]);
+      mockedJsonPatch.mockRejectedValue('string error');
+
+      const result = await ds.rollback();
+
+      expect(result).toEqual({
+        success: false,
+        message: 'Failed to rollback: string error',
+      });
+    });
+
+    it('strips controller-revision-hash label from the patched template', async () => {
+      const ds = makeDaemonSet();
+      vi.spyOn(ds as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2),
+      ]);
+      mockedJsonPatch.mockResolvedValue({} as any);
+
+      await ds.rollback();
+
+      const patchOps = mockedJsonPatch.mock.calls[0][1];
+      expect(patchOps[0]).toMatchObject({
+        value: {
+          metadata: {
+            labels: {
+              app: 'myapp',
+            },
+          },
+        },
+      });
+      expect(patchOps[0]).not.toMatchObject({
+        value: {
+          metadata: {
+            labels: {
+              'controller-revision-hash': expect.any(String),
+            },
+          },
+        },
+      });
+    });
+
+    it('invalidates the revision history cache after a real rollback', async () => {
+      const ds = makeDaemonSet();
+      (ds as any).revisionHistoryCache = { resourceVersion: '456', history: [] };
+      vi.spyOn(ds as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2),
+      ]);
+      mockedJsonPatch.mockResolvedValue({} as any);
+
+      await ds.rollback();
+
+      expect((ds as any).revisionHistoryCache).toBeUndefined();
+    });
+
+    it('preserves the revision history cache after a dry-run rollback', async () => {
+      const ds = makeDaemonSet();
+      const existingCache = { resourceVersion: '456', history: [] };
+      (ds as any).revisionHistoryCache = existingCache;
+      vi.spyOn(ds as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2),
+      ]);
+      mockedJsonPatch.mockResolvedValue({} as any);
+
+      await ds.rollback({ dryRun: true });
+
+      expect((ds as any).revisionHistoryCache).toBe(existingCache);
+    });
+
+    it('accepts RollbackOptions object with toRevision', async () => {
+      const ds = makeDaemonSet();
+      vi.spyOn(ds as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2),
+        makeRevision(1),
+      ]);
+      mockedJsonPatch.mockResolvedValue({} as any);
+
+      const result = await ds.rollback({ toRevision: 1 });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('Rolled back to revision 1');
+      expect(result.previousRevision).toBe(1);
+    });
+
+    it('returns failure when getOwnedControllerRevisions rejects', async () => {
+      const ds = makeDaemonSet();
+      vi.spyOn(ds as any, 'getOwnedControllerRevisions').mockRejectedValue(
+        new Error('failed to list revisions')
+      );
+
+      const result = await ds.rollback();
+
+      expect(result).toEqual({
+        success: false,
+        message: 'Failed to rollback: failed to list revisions',
+      });
+      expect(mockedJsonPatch).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/lib/k8s/statefulSet.test.ts
+++ b/frontend/src/lib/k8s/statefulSet.test.ts
@@ -14,9 +14,16 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import App from '../../App';
+import { jsonPatch } from './api/v1/clusterRequests';
 import StatefulSet from './statefulSet';
+
+vi.mock('./api/v1/clusterRequests', () => ({
+  jsonPatch: vi.fn(),
+}));
+
+const mockedJsonPatch = vi.mocked(jsonPatch);
 
 // cyclic imports fix
 // eslint-disable-next-line no-unused-vars
@@ -125,6 +132,344 @@ describe('StatefulSet class', () => {
       data.metadata.generation = undefined;
       const sts = new StatefulSet(data);
       expect(sts.getCurrentRevision()).toBe('');
+    });
+  });
+
+  describe('rollback', () => {
+    const template = {
+      metadata: {
+        labels: {
+          app: 'myapp',
+          'controller-revision-hash': 'test-hash',
+        },
+      },
+      spec: {
+        containers: [{ name: 'db', image: 'postgres:16' }],
+      },
+    };
+
+    function makeRevision(revision: number, revisionTemplate: any = template) {
+      return {
+        revision,
+        data: revisionTemplate ? { spec: { template: revisionTemplate } } : {},
+      };
+    }
+
+    function makeStatefulSet() {
+      return new StatefulSet(JSON.parse(JSON.stringify(mockStatefulSetData)));
+    }
+
+    beforeEach(() => {
+      mockedJsonPatch.mockReset();
+    });
+
+    it('rolls back to the previous revision', async () => {
+      const sts = makeStatefulSet();
+      vi.spyOn(sts as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2),
+      ]);
+      mockedJsonPatch.mockResolvedValue({} as any);
+
+      const result = await sts.rollback();
+
+      expect(result).toMatchObject({
+        success: true,
+        message: 'Rolled back to revision 2',
+        previousRevision: 2,
+      });
+      expect(mockedJsonPatch).toHaveBeenCalledWith(
+        expect.stringContaining('/apis/apps/v1/namespaces/default/statefulsets/test-statefulset'),
+        [
+          {
+            op: 'replace',
+            path: '/spec/template',
+            value: {
+              metadata: {
+                labels: {
+                  app: 'myapp',
+                },
+              },
+              spec: {
+                containers: [{ name: 'db', image: 'postgres:16' }],
+              },
+            },
+          },
+        ],
+        true,
+        { cluster: sts.cluster }
+      );
+    });
+
+    it('rolls back to a specific older revision', async () => {
+      const sts = makeStatefulSet();
+      vi.spyOn(sts as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2),
+        makeRevision(1),
+      ]);
+      mockedJsonPatch.mockResolvedValue({} as any);
+
+      const result = await sts.rollback(1);
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('Rolled back to revision 1');
+      expect(result.previousRevision).toBe(1);
+    });
+
+    it('returns failure when no previous revision is available', async () => {
+      const sts = makeStatefulSet();
+      vi.spyOn(sts as any, 'getOwnedControllerRevisions').mockResolvedValue([makeRevision(3)]);
+
+      const result = await sts.rollback();
+
+      expect(result).toEqual({
+        success: false,
+        message: 'No previous revision available to rollback to',
+      });
+      expect(mockedJsonPatch).not.toHaveBeenCalled();
+    });
+
+    it('returns failure when the target revision is not found', async () => {
+      const sts = makeStatefulSet();
+      vi.spyOn(sts as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2),
+      ]);
+
+      const result = await sts.rollback(1);
+
+      expect(result).toEqual({
+        success: false,
+        message: 'Revision 1 not found in history',
+      });
+      expect(mockedJsonPatch).not.toHaveBeenCalled();
+    });
+
+    it('returns failure when rolling back to the current revision', async () => {
+      const sts = makeStatefulSet();
+      vi.spyOn(sts as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2),
+      ]);
+
+      const result = await sts.rollback(3);
+
+      expect(result).toEqual({
+        success: false,
+        message: 'Cannot rollback to current revision',
+      });
+      expect(mockedJsonPatch).not.toHaveBeenCalled();
+    });
+
+    it('returns failure when the target revision has no pod template', async () => {
+      const sts = makeStatefulSet();
+      vi.spyOn(sts as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2, null),
+      ]);
+
+      const result = await sts.rollback();
+
+      expect(result).toEqual({
+        success: false,
+        message: 'Target revision does not contain a valid pod template',
+      });
+      expect(mockedJsonPatch).not.toHaveBeenCalled();
+    });
+
+    it('supports dry run rollback', async () => {
+      const sts = makeStatefulSet();
+      const dryRunResult = { metadata: { name: 'test-statefulset' } };
+      vi.spyOn(sts as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2),
+      ]);
+      mockedJsonPatch.mockResolvedValue(dryRunResult as any);
+
+      const result = await sts.rollback({ dryRun: true });
+
+      expect(result).toEqual({
+        success: true,
+        message: 'Dry-run: would rollback to revision 2',
+        previousRevision: 2,
+        dryRunResult,
+      });
+      expect(mockedJsonPatch).toHaveBeenCalledWith(
+        expect.stringContaining('/statefulsets/test-statefulset?dryRun=All'),
+        expect.any(Array),
+        true,
+        { cluster: sts.cluster }
+      );
+    });
+
+    it('returns failure when the patch request fails', async () => {
+      const sts = makeStatefulSet();
+      vi.spyOn(sts as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2),
+      ]);
+      mockedJsonPatch.mockRejectedValue(new Error('patch failed'));
+
+      const result = await sts.rollback();
+
+      expect(result).toEqual({
+        success: false,
+        message: 'Failed to rollback: patch failed',
+      });
+    });
+
+    it('returns failure when there are no revisions at all', async () => {
+      const sts = makeStatefulSet();
+      vi.spyOn(sts as any, 'getOwnedControllerRevisions').mockResolvedValue([]);
+
+      const result = await sts.rollback();
+
+      expect(result).toEqual({
+        success: false,
+        message: 'No previous revision available to rollback to',
+      });
+      expect(mockedJsonPatch).not.toHaveBeenCalled();
+    });
+
+    it('ignores revisions with revision number <= 0', async () => {
+      const sts = makeStatefulSet();
+      vi.spyOn(sts as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(2),
+        makeRevision(0),
+        makeRevision(-1),
+      ]);
+
+      const result = await sts.rollback();
+
+      expect(result).toEqual({
+        success: false,
+        message: 'No previous revision available to rollback to',
+      });
+      expect(mockedJsonPatch).not.toHaveBeenCalled();
+    });
+
+    it('correctly sorts unsorted revisions and picks the second highest', async () => {
+      const sts = makeStatefulSet();
+      vi.spyOn(sts as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(1),
+        makeRevision(3),
+        makeRevision(2),
+      ]);
+      mockedJsonPatch.mockResolvedValue({} as any);
+
+      const result = await sts.rollback();
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('Rolled back to revision 2');
+      expect(result.previousRevision).toBe(2);
+    });
+
+    it('handles non-Error exceptions gracefully', async () => {
+      const sts = makeStatefulSet();
+      vi.spyOn(sts as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2),
+      ]);
+      mockedJsonPatch.mockRejectedValue('string error');
+
+      const result = await sts.rollback();
+
+      expect(result).toEqual({
+        success: false,
+        message: 'Failed to rollback: string error',
+      });
+    });
+
+    it('strips controller-revision-hash label from the patched template', async () => {
+      const sts = makeStatefulSet();
+      vi.spyOn(sts as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2),
+      ]);
+      mockedJsonPatch.mockResolvedValue({} as any);
+
+      await sts.rollback();
+
+      const patchOps = mockedJsonPatch.mock.calls[0][1];
+      expect(patchOps[0]).toMatchObject({
+        value: {
+          metadata: {
+            labels: {
+              app: 'myapp',
+            },
+          },
+        },
+      });
+      expect(patchOps[0]).not.toMatchObject({
+        value: {
+          metadata: {
+            labels: {
+              'controller-revision-hash': expect.any(String),
+            },
+          },
+        },
+      });
+    });
+
+    it('invalidates the revision history cache after a real rollback', async () => {
+      const sts = makeStatefulSet();
+      (sts as any).revisionHistoryCache = { resourceVersion: '789', history: [] };
+      vi.spyOn(sts as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2),
+      ]);
+      mockedJsonPatch.mockResolvedValue({} as any);
+
+      await sts.rollback();
+
+      expect((sts as any).revisionHistoryCache).toBeUndefined();
+    });
+
+    it('preserves the revision history cache after a dry-run rollback', async () => {
+      const sts = makeStatefulSet();
+      const existingCache = { resourceVersion: '789', history: [] };
+      (sts as any).revisionHistoryCache = existingCache;
+      vi.spyOn(sts as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2),
+      ]);
+      mockedJsonPatch.mockResolvedValue({} as any);
+
+      await sts.rollback({ dryRun: true });
+
+      expect((sts as any).revisionHistoryCache).toBe(existingCache);
+    });
+
+    it('accepts RollbackOptions object with toRevision', async () => {
+      const sts = makeStatefulSet();
+      vi.spyOn(sts as any, 'getOwnedControllerRevisions').mockResolvedValue([
+        makeRevision(3),
+        makeRevision(2),
+        makeRevision(1),
+      ]);
+      mockedJsonPatch.mockResolvedValue({} as any);
+
+      const result = await sts.rollback({ toRevision: 1 });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('Rolled back to revision 1');
+      expect(result.previousRevision).toBe(1);
+    });
+
+    it('returns failure when getOwnedControllerRevisions rejects', async () => {
+      const sts = makeStatefulSet();
+      vi.spyOn(sts as any, 'getOwnedControllerRevisions').mockRejectedValue(
+        new Error('failed to list revisions')
+      );
+
+      const result = await sts.rollback();
+
+      expect(result).toEqual({
+        success: false,
+        message: 'Failed to rollback: failed to list revisions',
+      });
+      expect(mockedJsonPatch).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR adds unit tests for `DaemonSet.rollback()` and `StatefulSet.rollback()` by covering all documented edge cases that were previously untested.

## Related Issue

Fixes #6590

## Changes

- Added rollback() unit tests in `frontend/src/lib/k8s/daemonSet.test.ts`
- Added rollback() unit tests in `frontend/src/lib/k8s/statefulSet.test.ts`
- Covered edge cases: no previous revision, revision not found, rollback to current revision, dry-run mode, missing pod template

## Steps to Test

1. Run `npm run frontend:test` from the project root
2. Verify all tests in `daemonSet.test.ts` and `statefulSet.test.ts` pass
3. Check test coverage for rollback() in both files

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- This only adds tests, no changes to the actual rollback() implementation.