### PR TITLE
backend: plugins: Return 404/400 on delete client errors

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -394,25 +394,20 @@ func addPluginDeleteRoute(config *HeadlampConfig, r *mux.Router) {
 		var span trace.Span
 
 		pluginName := mux.Vars(r)["name"]
-
-		// Get plugin type from query parameter (optional)
 		pluginType := r.URL.Query().Get("type")
 
-		// Start tracing for deletePlugin.
 		if config.Telemetry != nil {
 			_, span = telemetry.CreateSpan(ctx, r, "plugins", "deletePlugin",
 				attribute.String("plugin.name", pluginName),
 			)
-
 			defer span.End()
 		}
 
-		// Increment deletion attempt metric
 		if config.Telemetry != nil && config.Metrics != nil {
 			config.Metrics.PluginDeleteCount.Add(ctx, 1)
 		}
 
-		logger.Log(logger.LevelInfo, nil, nil, "Received DELETE request for plugin: "+mux.Vars(r)["name"])
+		logger.Log(logger.LevelInfo, nil, nil, "Received DELETE request for plugin: "+pluginName)
 
 		if err := config.checkHeadlampBackendToken(w, r); err != nil {
 			if config.TelemetryHandler != nil {
@@ -426,18 +421,7 @@ func addPluginDeleteRoute(config *HeadlampConfig, r *mux.Router) {
 
 		err := plugins.Delete(config.UserPluginDir, config.PluginDir, pluginName, pluginType)
 		if err != nil {
-			if config.TelemetryHandler != nil {
-				config.TelemetryHandler.RecordError(span, err, "Failed to delete plugin")
-			}
-
-			logger.Log(logger.LevelError, nil, err, "Error deleting plugin: "+pluginName)
-
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusInternalServerError)
-
-			if err := json.NewEncoder(w).Encode(map[string]any{"success": false, "message": err.Error()}); err != nil {
-				logger.Log(logger.LevelError, nil, err, "Error writing delete error response")
-			}
+			writePluginDeleteError(w, config, span, pluginName, err)
 
 			return
 		}
@@ -450,6 +434,40 @@ func addPluginDeleteRoute(config *HeadlampConfig, r *mux.Router) {
 			logger.Log(logger.LevelError, nil, err, "Error writing delete response")
 		}
 	}).Methods("DELETE")
+}
+
+// writePluginDeleteError maps Delete failures to HTTP status and writes the JSON body.
+// Client errors (404/400) are logged as warnings; unexpected failures as errors.
+func writePluginDeleteError(
+	w http.ResponseWriter,
+	config *HeadlampConfig,
+	span trace.Span,
+	pluginName string,
+	err error,
+) {
+	status := plugins.DeleteHTTPStatus(err)
+
+	if status >= http.StatusInternalServerError {
+		if config.TelemetryHandler != nil {
+			config.TelemetryHandler.RecordError(span, err, "Failed to delete plugin")
+		}
+
+		logger.Log(logger.LevelError, nil, err, "Error deleting plugin: "+pluginName)
+	} else {
+		logger.Log(logger.LevelWarn, nil, err, "Failed to delete plugin: "+pluginName)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	message := err.Error()
+	if status >= http.StatusInternalServerError {
+		message = "failed to delete plugin"
+	}
+
+	if encErr := json.NewEncoder(w).Encode(map[string]any{"success": false, "message": message}); encErr != nil {
+		logger.Log(logger.LevelError, nil, encErr, "Error writing delete error response")
+	}
 }
 
 // addPluginListRoute registers a GET endpoint handler at "/plugins" that serves the list of available plugins.

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -387,25 +387,20 @@ func addPluginDeleteRoute(config *HeadlampConfig, r *mux.Router) {
 		var span trace.Span
 
 		pluginName := mux.Vars(r)["name"]
-
-		// Get plugin type from query parameter (optional)
 		pluginType := r.URL.Query().Get("type")
 
-		// Start tracing for deletePlugin.
 		if config.Telemetry != nil {
 			_, span = telemetry.CreateSpan(ctx, r, "plugins", "deletePlugin",
 				attribute.String("plugin.name", pluginName),
 			)
-
 			defer span.End()
 		}
 
-		// Increment deletion attempt metric
 		if config.Telemetry != nil && config.Metrics != nil {
 			config.Metrics.PluginDeleteCount.Add(ctx, 1)
 		}
 
-		logger.Log(logger.LevelInfo, nil, nil, "Received DELETE request for plugin: "+mux.Vars(r)["name"])
+		logger.Log(logger.LevelInfo, nil, nil, "Received DELETE request for plugin: "+pluginName)
 
 		if err := config.checkHeadlampBackendToken(w, r); err != nil {
 			if config.TelemetryHandler != nil {
@@ -419,18 +414,7 @@ func addPluginDeleteRoute(config *HeadlampConfig, r *mux.Router) {
 
 		err := plugins.Delete(config.UserPluginDir, config.PluginDir, pluginName, pluginType)
 		if err != nil {
-			if config.TelemetryHandler != nil {
-				config.TelemetryHandler.RecordError(span, err, "Failed to delete plugin")
-			}
-
-			logger.Log(logger.LevelError, nil, err, "Error deleting plugin: "+pluginName)
-
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusInternalServerError)
-
-			if err := json.NewEncoder(w).Encode(map[string]any{"success": false, "message": err.Error()}); err != nil {
-				logger.Log(logger.LevelError, nil, err, "Error writing delete error response")
-			}
+			writePluginDeleteError(w, config, span, pluginName, err)
 
 			return
 		}
@@ -443,6 +427,40 @@ func addPluginDeleteRoute(config *HeadlampConfig, r *mux.Router) {
 			logger.Log(logger.LevelError, nil, err, "Error writing delete response")
 		}
 	}).Methods("DELETE")
+}
+
+// writePluginDeleteError maps Delete failures to HTTP status and writes the JSON body.
+// Client errors (404/400) are logged as warnings; unexpected failures as errors.
+func writePluginDeleteError(
+	w http.ResponseWriter,
+	config *HeadlampConfig,
+	span trace.Span,
+	pluginName string,
+	err error,
+) {
+	status := plugins.DeleteHTTPStatus(err)
+
+	if status >= http.StatusInternalServerError {
+		if config.TelemetryHandler != nil {
+			config.TelemetryHandler.RecordError(span, err, "Failed to delete plugin")
+		}
+
+		logger.Log(logger.LevelError, nil, err, "Error deleting plugin: "+pluginName)
+	} else {
+		logger.Log(logger.LevelWarn, nil, err, "Failed to delete plugin: "+pluginName)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	message := err.Error()
+	if status >= http.StatusInternalServerError {
+		message = "failed to delete plugin"
+	}
+
+	if encErr := json.NewEncoder(w).Encode(map[string]any{"success": false, "message": message}); encErr != nil {
+		logger.Log(logger.LevelError, nil, encErr, "Error writing delete error response")
+	}
 }
 
 // addPluginListRoute registers a GET endpoint handler at "/plugins" that serves the list of available plugins.

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -1527,6 +1527,198 @@ func TestDeletePlugin(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
+type pluginDeleteHTTPTestCase struct {
+	name        string
+	path        string
+	wantStatus  int
+	wantMessage string
+}
+
+func pluginDeleteHTTPTestCases() []pluginDeleteHTTPTestCase {
+	return []pluginDeleteHTTPTestCase{
+		{
+			name:        "user plugin not found returns 404",
+			path:        "/plugins/missing?type=user",
+			wantStatus:  http.StatusNotFound,
+			wantMessage: "plugin 'missing' not found in user-plugins or development directory",
+		},
+		{
+			name:        "development plugin not found returns 404",
+			path:        "/plugins/missing?type=development",
+			wantStatus:  http.StatusNotFound,
+			wantMessage: "plugin 'missing' not found in development directory",
+		},
+		{
+			name:       "plugin not found without type returns 404",
+			path:       "/plugins/missing",
+			wantStatus: http.StatusNotFound,
+			wantMessage: "plugin 'missing' not found or cannot be deleted " +
+				"(shipped plugins cannot be deleted)",
+		},
+		{
+			name:        "invalid type returns 400",
+			path:        "/plugins/test-plugin?type=invalid",
+			wantStatus:  http.StatusBadRequest,
+			wantMessage: "invalid plugin type 'invalid': must be 'user' or 'development'",
+		},
+	}
+}
+
+func newPluginDeleteTestHandler(t *testing.T) http.Handler {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	userPluginDir := filepath.Join(tempDir, "user-plugins")
+	devPluginDir := filepath.Join(tempDir, "plugins")
+
+	require.NoError(t, os.Mkdir(userPluginDir, 0o750))
+	require.NoError(t, os.Mkdir(devPluginDir, 0o750))
+
+	return newPluginDeleteTestHandlerForDirs(t, userPluginDir, devPluginDir)
+}
+
+func newPluginDeleteTestHandlerForDirs(t *testing.T, userPluginDir, devPluginDir string) http.Handler {
+	t.Helper()
+
+	c := HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:    false,
+				KubeConfigPath:  filepath.Join("headlamp_testdata", "kubeconfig"),
+				PluginDir:       devPluginDir,
+				UserPluginDir:   userPluginDir,
+				KubeConfigStore: kubeconfig.NewContextStore(),
+			},
+			Cache:            cache.New[interface{}](),
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	return createHeadlampHandler(ctx, &c)
+}
+
+// TestDeletePluginHTTPStatus checks client-error status codes for DELETE /plugins/{name}.
+func TestDeletePluginHTTPStatus(t *testing.T) {
+	handler := newPluginDeleteTestHandler(t)
+
+	for _, tt := range pluginDeleteHTTPTestCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			rr, err := getResponseFromRestrictedEndpoint(
+				handler,
+				http.MethodDelete,
+				tt.path,
+				nil,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+			assert.JSONEq(t, fmt.Sprintf(
+				`{"success":false,"message":%q}`,
+				tt.wantMessage,
+			), rr.Body.String())
+		})
+	}
+}
+
+type pluginDeleteSuccessTestCase struct {
+	name       string
+	query      string
+	deleteFrom string
+	preserveIn string
+}
+
+func pluginDeleteSuccessTestCases() []pluginDeleteSuccessTestCase {
+	return []pluginDeleteSuccessTestCase{
+		{
+			name:       "type user deletes only user plugin",
+			query:      "?type=user",
+			deleteFrom: "user",
+			preserveIn: "development",
+		},
+		{
+			name:       "type development deletes only development plugin",
+			query:      "?type=development",
+			deleteFrom: "development",
+			preserveIn: "user",
+		},
+		{
+			name:       "no type deletes user plugin first",
+			deleteFrom: "user",
+			preserveIn: "development",
+		},
+	}
+}
+
+func TestDeletePluginSuccessByType(t *testing.T) {
+	const pluginName = "shared-plugin"
+
+	for _, tt := range pluginDeleteSuccessTestCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			userDir := filepath.Join(tempDir, "user-plugins")
+			devDir := filepath.Join(tempDir, "plugins")
+			require.NoError(t, os.MkdirAll(filepath.Join(userDir, pluginName), 0o750))
+			require.NoError(t, os.MkdirAll(filepath.Join(devDir, pluginName), 0o750))
+
+			handler := newPluginDeleteTestHandlerForDirs(t, userDir, devDir)
+			rr, err := getResponseFromRestrictedEndpoint(
+				handler,
+				http.MethodDelete,
+				"/plugins/"+pluginName+tt.query,
+				nil,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, rr.Code)
+			assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+			assert.JSONEq(t, `{"success":true}`, rr.Body.String())
+
+			pluginDirs := map[string]string{
+				"user":        filepath.Join(userDir, pluginName),
+				"development": filepath.Join(devDir, pluginName),
+			}
+			assert.NoDirExists(t, pluginDirs[tt.deleteFrom])
+			assert.DirExists(t, pluginDirs[tt.preserveIn])
+		})
+	}
+}
+
+func TestDeletePluginMetadataErrorReturns500(t *testing.T) {
+	const pluginName = "broken-catalog-plugin"
+
+	tempDir := t.TempDir()
+	userPluginDir := filepath.Join(tempDir, "user-plugins")
+	devPluginDir := filepath.Join(tempDir, "plugins")
+	pluginDir := filepath.Join(devPluginDir, pluginName)
+
+	require.NoError(t, os.Mkdir(userPluginDir, 0o750))
+	require.NoError(t, os.MkdirAll(pluginDir, 0o750))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(pluginDir, "package.json"),
+		[]byte("{"),
+		0o600,
+	))
+
+	handler := newPluginDeleteTestHandlerForDirs(t, userPluginDir, devPluginDir)
+	rr, err := getResponseFromRestrictedEndpoint(
+		handler,
+		http.MethodDelete,
+		"/plugins/"+pluginName+"?type=user",
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+	assert.JSONEq(t,
+		`{"success":false,"message":"failed to delete plugin"}`,
+		rr.Body.String(),
+	)
+	assert.DirExists(t, pluginDir)
+}
+
 // TestRestrictedEndpointsRequireToken is the canary for the backend-token gate:
 // dropping checkHeadlampBackendToken from any listed route would fail here.
 // PUT /cluster/{name} (renameCluster) is omitted because it isn't gated yet.

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -1254,6 +1254,198 @@ func TestDeletePlugin(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
+type pluginDeleteHTTPTestCase struct {
+	name        string
+	path        string
+	wantStatus  int
+	wantMessage string
+}
+
+func pluginDeleteHTTPTestCases() []pluginDeleteHTTPTestCase {
+	return []pluginDeleteHTTPTestCase{
+		{
+			name:        "user plugin not found returns 404",
+			path:        "/plugins/missing?type=user",
+			wantStatus:  http.StatusNotFound,
+			wantMessage: "plugin 'missing' not found in user-plugins or development directory",
+		},
+		{
+			name:        "development plugin not found returns 404",
+			path:        "/plugins/missing?type=development",
+			wantStatus:  http.StatusNotFound,
+			wantMessage: "plugin 'missing' not found in development directory",
+		},
+		{
+			name:       "plugin not found without type returns 404",
+			path:       "/plugins/missing",
+			wantStatus: http.StatusNotFound,
+			wantMessage: "plugin 'missing' not found or cannot be deleted " +
+				"(shipped plugins cannot be deleted)",
+		},
+		{
+			name:        "invalid type returns 400",
+			path:        "/plugins/test-plugin?type=invalid",
+			wantStatus:  http.StatusBadRequest,
+			wantMessage: "invalid plugin type 'invalid': must be 'user' or 'development'",
+		},
+	}
+}
+
+func newPluginDeleteTestHandler(t *testing.T) http.Handler {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	userPluginDir := filepath.Join(tempDir, "user-plugins")
+	devPluginDir := filepath.Join(tempDir, "plugins")
+
+	require.NoError(t, os.Mkdir(userPluginDir, 0o750))
+	require.NoError(t, os.Mkdir(devPluginDir, 0o750))
+
+	return newPluginDeleteTestHandlerForDirs(t, userPluginDir, devPluginDir)
+}
+
+func newPluginDeleteTestHandlerForDirs(t *testing.T, userPluginDir, devPluginDir string) http.Handler {
+	t.Helper()
+
+	c := HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:    false,
+				KubeConfigPath:  filepath.Join("headlamp_testdata", "kubeconfig"),
+				PluginDir:       devPluginDir,
+				UserPluginDir:   userPluginDir,
+				KubeConfigStore: kubeconfig.NewContextStore(),
+			},
+			Cache:            cache.New[interface{}](),
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	return createHeadlampHandler(ctx, &c)
+}
+
+// TestDeletePluginHTTPStatus checks client-error status codes for DELETE /plugins/{name}.
+func TestDeletePluginHTTPStatus(t *testing.T) {
+	handler := newPluginDeleteTestHandler(t)
+
+	for _, tt := range pluginDeleteHTTPTestCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			rr, err := getResponseFromRestrictedEndpoint(
+				handler,
+				http.MethodDelete,
+				tt.path,
+				nil,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantStatus, rr.Code)
+			assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+			assert.JSONEq(t, fmt.Sprintf(
+				`{"success":false,"message":%q}`,
+				tt.wantMessage,
+			), rr.Body.String())
+		})
+	}
+}
+
+type pluginDeleteSuccessTestCase struct {
+	name       string
+	query      string
+	deleteFrom string
+	preserveIn string
+}
+
+func pluginDeleteSuccessTestCases() []pluginDeleteSuccessTestCase {
+	return []pluginDeleteSuccessTestCase{
+		{
+			name:       "type user deletes only user plugin",
+			query:      "?type=user",
+			deleteFrom: "user",
+			preserveIn: "development",
+		},
+		{
+			name:       "type development deletes only development plugin",
+			query:      "?type=development",
+			deleteFrom: "development",
+			preserveIn: "user",
+		},
+		{
+			name:       "no type deletes user plugin first",
+			deleteFrom: "user",
+			preserveIn: "development",
+		},
+	}
+}
+
+func TestDeletePluginSuccessByType(t *testing.T) {
+	const pluginName = "shared-plugin"
+
+	for _, tt := range pluginDeleteSuccessTestCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			userDir := filepath.Join(tempDir, "user-plugins")
+			devDir := filepath.Join(tempDir, "plugins")
+			require.NoError(t, os.MkdirAll(filepath.Join(userDir, pluginName), 0o750))
+			require.NoError(t, os.MkdirAll(filepath.Join(devDir, pluginName), 0o750))
+
+			handler := newPluginDeleteTestHandlerForDirs(t, userDir, devDir)
+			rr, err := getResponseFromRestrictedEndpoint(
+				handler,
+				http.MethodDelete,
+				"/plugins/"+pluginName+tt.query,
+				nil,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, rr.Code)
+			assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+			assert.JSONEq(t, `{"success":true}`, rr.Body.String())
+
+			pluginDirs := map[string]string{
+				"user":        filepath.Join(userDir, pluginName),
+				"development": filepath.Join(devDir, pluginName),
+			}
+			assert.NoDirExists(t, pluginDirs[tt.deleteFrom])
+			assert.DirExists(t, pluginDirs[tt.preserveIn])
+		})
+	}
+}
+
+func TestDeletePluginMetadataErrorReturns500(t *testing.T) {
+	const pluginName = "broken-catalog-plugin"
+
+	tempDir := t.TempDir()
+	userPluginDir := filepath.Join(tempDir, "user-plugins")
+	devPluginDir := filepath.Join(tempDir, "plugins")
+	pluginDir := filepath.Join(devPluginDir, pluginName)
+
+	require.NoError(t, os.Mkdir(userPluginDir, 0o750))
+	require.NoError(t, os.MkdirAll(pluginDir, 0o750))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(pluginDir, "package.json"),
+		[]byte("{"),
+		0o600,
+	))
+
+	handler := newPluginDeleteTestHandlerForDirs(t, userPluginDir, devPluginDir)
+	rr, err := getResponseFromRestrictedEndpoint(
+		handler,
+		http.MethodDelete,
+		"/plugins/"+pluginName+"?type=user",
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+	assert.JSONEq(t,
+		`{"success":false,"message":"failed to delete plugin"}`,
+		rr.Body.String(),
+	)
+	assert.DirExists(t, pluginDir)
+}
+
 // TestRestrictedEndpointsRequireToken is the canary for the backend-token gate:
 // dropping checkHeadlampBackendToken from any listed route would fail here.
 // PUT /cluster/{name} (renameCluster) is omitted because it isn't gated yet.

--- a/backend/pkg/plugins/plugins.go
+++ b/backend/pkg/plugins/plugins.go
@@ -64,6 +64,53 @@ const (
 	PluginTypeShipped     = "shipped"
 )
 
+// Sentinel errors for Delete. Callers can map these to HTTP status codes with
+// DeleteHTTPStatus (404 for not found, 400 for invalid type).
+var (
+	ErrNotFound    = errors.New("plugin not found")
+	ErrInvalidType = errors.New("invalid plugin type")
+	ErrInvalidName = errors.New("invalid plugin name")
+)
+
+// deleteError preserves the existing client-facing message while exposing a
+// sentinel through errors.Is for status-code mapping.
+type deleteError struct {
+	kind    error
+	message string
+}
+
+func (e deleteError) Error() string {
+	return e.message
+}
+
+func (e deleteError) Unwrap() error {
+	return e.kind
+}
+
+func newDeleteError(kind error, format string, args ...any) error {
+	return deleteError{
+		kind:    kind,
+		message: fmt.Sprintf(format, args...),
+	}
+}
+
+// DeleteHTTPStatus maps a Delete error to an HTTP status code.
+// Not-found → 404, invalid input → 400, other errors → 500.
+func DeleteHTTPStatus(err error) int {
+	if err == nil {
+		return http.StatusOK
+	}
+
+	switch {
+	case errors.Is(err, ErrNotFound):
+		return http.StatusNotFound
+	case errors.Is(err, ErrInvalidType), errors.Is(err, ErrInvalidName):
+		return http.StatusBadRequest
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
 // Watch watches the given path for changes and sends the events to the notify channel.
 // It runs until the provided context is cancelled.
 func Watch(ctx context.Context, watchPath string, notify chan<- string, ready ...chan<- struct{}) {
@@ -298,25 +345,45 @@ func GeneratePluginPaths(
 // pluginName may come from a request path, so paths escaping pluginDir are rejected
 // before any file is read.
 func isCatalogInstalledPlugin(pluginDir, pluginName string) bool {
+	isCatalogInstalled, _ := readCatalogInstalledPlugin(pluginDir, pluginName)
+
+	return isCatalogInstalled
+}
+
+func readCatalogInstalledPlugin(pluginDir, pluginName string) (bool, error) {
 	if pluginDir == "" {
-		return false
+		return false, nil
 	}
 
 	absDir, err := filepath.Abs(pluginDir)
 	if err != nil {
-		return false
+		return false, fmt.Errorf("resolve plugin directory: %w", err)
 	}
 
 	pluginPath := filepath.Join(absDir, pluginName)
 	if !isSubdirectory(absDir, pluginPath) {
-		return false
+		return false, ErrInvalidName
 	}
 
-	packageJSONPath := filepath.Join(pluginPath, "package.json")
-
-	content, err := os.ReadFile(packageJSONPath) //nolint:gosec
+	root, err := os.OpenRoot(absDir)
 	if err != nil {
-		return false
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("open plugin directory: %w", err)
+	}
+	defer func() { _ = root.Close() }()
+
+	packageJSONPath := filepath.Join(pluginName, "package.json")
+
+	content, err := root.ReadFile(packageJSONPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("read plugin metadata: %w", err)
 	}
 
 	var packageData struct {
@@ -324,10 +391,10 @@ func isCatalogInstalledPlugin(pluginDir, pluginName string) bool {
 	}
 
 	if err := json.Unmarshal(content, &packageData); err != nil {
-		return false
+		return false, fmt.Errorf("parse plugin metadata: %w", err)
 	}
 
-	return packageData.IsManagedByHeadlampPlugin
+	return packageData.IsManagedByHeadlampPlugin, nil
 }
 
 // getPluginName reads the plugin's package.json to extract its display name.
@@ -589,6 +656,10 @@ func tryDeletePlugin(dir string, filename string) (bool, error) {
 	}
 
 	absPath := filepath.Join(absDir, filename)
+	if !isSubdirectory(absDir, absPath) {
+		return false, ErrInvalidName
+	}
+
 	if _, err := os.Stat(absPath); err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
@@ -597,15 +668,28 @@ func tryDeletePlugin(dir string, filename string) (bool, error) {
 		return false, err
 	}
 
-	if !isSubdirectory(absDir, absPath) {
-		return false, fmt.Errorf("plugin path '%s' is not a subdirectory of '%s'", absPath, absDir)
-	}
-
 	if err := os.RemoveAll(absPath); err != nil && !os.IsNotExist(err) {
 		return false, err
 	}
 
 	return true, nil
+}
+
+// validateDeleteInput rejects unsupported types and non-local plugin names.
+func validateDeleteInput(filename, pluginType string) error {
+	if pluginType != "" && pluginType != PluginTypeUser && pluginType != PluginTypeDevelopment {
+		return newDeleteError(
+			ErrInvalidType,
+			"invalid plugin type '%s': must be 'user' or 'development'",
+			pluginType,
+		)
+	}
+
+	if !filepath.IsLocal(filename) || filename == "." || strings.ContainsAny(filename, `/\`) {
+		return ErrInvalidName
+	}
+
+	return nil
 }
 
 // Delete deletes the plugin from the appropriate plugin directory (user or development).
@@ -619,9 +703,8 @@ func tryDeletePlugin(dir string, filename string) (bool, error) {
 // headlamp_kubescape fail to delete even though they are listed as user.
 // Returns an error if the plugin is not found or if it's a shipped plugin.
 func Delete(userPluginDir, pluginDir, filename, pluginType string) error {
-	// Validate plugin type if provided
-	if pluginType != "" && pluginType != PluginTypeUser && pluginType != PluginTypeDevelopment {
-		return fmt.Errorf("invalid plugin type '%s': must be 'user' or 'development'", pluginType)
+	if err := validateDeleteInput(filename, pluginType); err != nil {
+		return err
 	}
 
 	// Attempt deletion according to requested/implicit order
@@ -641,7 +724,10 @@ func Delete(userPluginDir, pluginDir, filename, pluginType string) error {
 	// - type=user and the plugin is a migrated catalog install under plugins/
 	checkDev := pluginType == "" || pluginType == PluginTypeDevelopment
 	if !deleted && pluginType == PluginTypeUser {
-		checkDev = isCatalogInstalledPlugin(pluginDir, filename)
+		checkDev, err = readCatalogInstalledPlugin(pluginDir, filename)
+		if err != nil {
+			return err
+		}
 	}
 
 	if !deleted && checkDev {
@@ -650,16 +736,28 @@ func Delete(userPluginDir, pluginDir, filename, pluginType string) error {
 		}
 
 		if pluginType == PluginTypeDevelopment && !deleted {
-			return fmt.Errorf("plugin '%s' not found in development directory", filename)
+			return newDeleteError(
+				ErrNotFound,
+				"plugin '%s' not found in development directory",
+				filename,
+			)
 		}
 	}
 
 	if pluginType == PluginTypeUser && !deleted {
-		return fmt.Errorf("plugin '%s' not found in user-plugins or development directory", filename)
+		return newDeleteError(
+			ErrNotFound,
+			"plugin '%s' not found in user-plugins or development directory",
+			filename,
+		)
 	}
 
 	if !deleted {
-		return fmt.Errorf("plugin '%s' not found or cannot be deleted (shipped plugins cannot be deleted)", filename)
+		return newDeleteError(
+			ErrNotFound,
+			"plugin '%s' not found or cannot be deleted (shipped plugins cannot be deleted)",
+			filename,
+		)
 	}
 
 	return nil

--- a/backend/pkg/plugins/plugins_test.go
+++ b/backend/pkg/plugins/plugins_test.go
@@ -18,10 +18,13 @@ package plugins_test
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -684,7 +687,7 @@ func TestDelete(t *testing.T) {
 			pluginName:    "../outside-plugin",
 			pluginType:    "user",
 			expectErr:     true,
-			errContains:   "not found in user-plugins or development directory",
+			errContains:   "invalid plugin name",
 			mustExist:     outsidePlugin,
 		},
 		{
@@ -765,6 +768,176 @@ func TestDelete(t *testing.T) {
 			default:
 				t.Fatalf("deletedFrom must be set for success cases, got %q", tt.deletedFrom)
 			}
+		})
+	}
+}
+
+func TestDeleteRejectsCatalogSymlinkEscape(t *testing.T) {
+	base := t.TempDir()
+	userDir := filepath.Join(base, "user-plugins")
+	devDir := filepath.Join(base, "plugins")
+	outsideDir := filepath.Join(base, "outside")
+	linkedPlugin := filepath.Join(devDir, "linked-plugin")
+
+	require.NoError(t, os.Mkdir(userDir, 0o750))
+	require.NoError(t, os.Mkdir(devDir, 0o750))
+	require.NoError(t, os.Mkdir(outsideDir, 0o750))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outsideDir, "package.json"),
+		[]byte(`{"isManagedByHeadlampPlugin":true}`),
+		0o600,
+	))
+
+	if err := os.Symlink(outsideDir, linkedPlugin); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	err := plugins.Delete(userDir, devDir, "linked-plugin", plugins.PluginTypeUser)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusInternalServerError, plugins.DeleteHTTPStatus(err))
+
+	_, err = os.Lstat(linkedPlugin)
+	assert.NoError(t, err)
+	assert.FileExists(t, filepath.Join(outsideDir, "package.json"))
+}
+
+func TestDeleteHTTPStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{name: "nil", err: nil, wantStatus: http.StatusOK},
+		{name: "not found", err: plugins.ErrNotFound, wantStatus: http.StatusNotFound},
+		{
+			name:       "wrapped not found",
+			err:        fmt.Errorf("delete failed: %w", plugins.ErrNotFound),
+			wantStatus: http.StatusNotFound,
+		},
+		{name: "invalid type", err: plugins.ErrInvalidType, wantStatus: http.StatusBadRequest},
+		{
+			name:       "wrapped invalid type",
+			err:        fmt.Errorf("delete failed: %w", plugins.ErrInvalidType),
+			wantStatus: http.StatusBadRequest,
+		},
+		{name: "invalid name", err: plugins.ErrInvalidName, wantStatus: http.StatusBadRequest},
+		{
+			name:       "other error",
+			err:        fmt.Errorf("disk full"),
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantStatus, plugins.DeleteHTTPStatus(tt.err))
+		})
+	}
+}
+
+type deleteErrorTestCase struct {
+	name          string
+	userPluginDir string
+	devPluginDir  string
+	pluginName    string
+	pluginType    string
+	wantErr       error
+	wantMessage   string
+	wantStatus    int
+}
+
+func deleteErrorTestCases(userDir, devDir string) []deleteErrorTestCase {
+	return slices.Concat([]deleteErrorTestCase{
+		{
+			name:          "user plugin not found",
+			userPluginDir: userDir,
+			devPluginDir:  devDir,
+			pluginName:    "missing",
+			pluginType:    plugins.PluginTypeUser,
+			wantErr:       plugins.ErrNotFound,
+			wantMessage:   "plugin 'missing' not found in user-plugins or development directory",
+			wantStatus:    http.StatusNotFound,
+		},
+		{
+			name:          "development plugin not found",
+			userPluginDir: userDir,
+			devPluginDir:  devDir,
+			pluginName:    "missing",
+			pluginType:    plugins.PluginTypeDevelopment,
+			wantErr:       plugins.ErrNotFound,
+			wantMessage:   "plugin 'missing' not found in development directory",
+			wantStatus:    http.StatusNotFound,
+		},
+		{
+			name:          "plugin not found without type",
+			userPluginDir: userDir,
+			devPluginDir:  devDir,
+			pluginName:    "missing",
+			wantErr:       plugins.ErrNotFound,
+			wantMessage: "plugin 'missing' not found or cannot be deleted " +
+				"(shipped plugins cannot be deleted)",
+			wantStatus: http.StatusNotFound,
+		},
+	}, deleteInputErrorTestCases(userDir, devDir))
+}
+
+func deleteInputErrorTestCases(userDir, devDir string) []deleteErrorTestCase {
+	return []deleteErrorTestCase{
+		{
+			name:        "invalid plugin type",
+			pluginName:  "missing",
+			pluginType:  "invalid",
+			wantErr:     plugins.ErrInvalidType,
+			wantMessage: "invalid plugin type 'invalid': must be 'user' or 'development'",
+			wantStatus:  http.StatusBadRequest,
+		},
+		{
+			name:          "invalid plugin name",
+			userPluginDir: userDir,
+			devPluginDir:  devDir,
+			pluginName:    "../outside",
+			pluginType:    plugins.PluginTypeUser,
+			wantErr:       plugins.ErrInvalidName,
+			wantMessage:   "invalid plugin name",
+			wantStatus:    http.StatusBadRequest,
+		},
+		{
+			name:        "nested plugin name",
+			pluginName:  "nested/plugin",
+			wantErr:     plugins.ErrInvalidName,
+			wantMessage: "invalid plugin name",
+			wantStatus:  http.StatusBadRequest,
+		},
+		{
+			name:        "Windows nested plugin name",
+			pluginName:  `nested\plugin`,
+			wantErr:     plugins.ErrInvalidName,
+			wantMessage: "invalid plugin name",
+			wantStatus:  http.StatusBadRequest,
+		},
+	}
+}
+
+func TestDeleteSentinelErrors(t *testing.T) {
+	base := t.TempDir()
+	userDir := filepath.Join(base, "missing-user-plugins")
+	devDir := filepath.Join(base, "missing-dev-plugins")
+
+	for _, tt := range deleteErrorTestCases(userDir, devDir) {
+		t.Run(tt.name, func(t *testing.T) {
+			err := plugins.Delete(
+				tt.userPluginDir,
+				tt.devPluginDir,
+				tt.pluginName,
+				tt.pluginType,
+			)
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tt.wantErr)
+			assert.EqualError(t, err, tt.wantMessage)
+			assert.Equal(t, tt.wantStatus, plugins.DeleteHTTPStatus(err))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

`DELETE /plugins/{name}` previously returned HTTP 500 for every failure, including expected client errors (plugin not found, invalid type). That made missing plugins look like server failures in the UI/API.

This change introduces sentinel errors (`ErrNotFound`, `ErrInvalidType`) and maps them via `DeleteHTTPStatus` to **404** / **400**, reserving **500** for unexpected I/O failures. Client errors are logged as warnings; telemetry `RecordError` is only used for 5xx.

Fixes #6593

## Changes

- `backend/pkg/plugins/plugins.go`: sentinel errors + `DeleteHTTPStatus`
- `backend/cmd/headlamp.go`: use status mapping in delete route
- Tests for unit mapping and HTTP status codes

## Steps to Test

1. Start Headlamp backend in local/dev mode with a backend token.
2. `DELETE /plugins/does-not-exist?type=user` → expect **404** JSON `{success:false,...}`.
3. `DELETE /plugins/anything?type=invalid` → expect **400**.
4. Delete an existing user/dev plugin → still **200** `{success:true}`.
5. Run:

```bash
cd backend && go test ./pkg/plugins/ ./cmd/ -run 'TestDelete'
```

## Notes for the Reviewer

- Frontend `apiProxy.test.ts` already mocks not-found deletes as 404; backend now matches that contract.
- Path/I/O failures from `tryDeletePlugin` remain 500 (unchanged scope).