### PR TITLE
fix(k8cache): Set informer resyncPeriod to 30m for self-healing cache

### DIFF
--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -87,6 +87,7 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 		SkippedKubeContexts:    conf.SkippedKubeContexts,
 		ListenAddr:             conf.ListenAddr,
 		CacheEnabled:           conf.CacheEnabled,
+		CacheResyncPeriod:      conf.CacheResyncPeriod,
 		Port:                   conf.Port,
 		DevMode:                conf.DevMode,
 		StaticDir:              conf.StaticDir,
@@ -321,7 +322,7 @@ func cacheMiddlewareHandler(c *HeadlampConfig, next http.Handler, w http.Respons
 		return
 	}
 
-	k8cache.CheckForChanges(k8sResponseCache, contextKey, *kContext)
+	k8cache.CheckForChanges(k8sResponseCache, contextKey, *kContext, c.CacheResyncPeriod)
 
 	next.ServeHTTP(rcw, r)
 

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -90,6 +90,7 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 		SkippedKubeContexts:    conf.SkippedKubeContexts,
 		ListenAddr:             conf.ListenAddr,
 		CacheEnabled:           conf.CacheEnabled,
+		CacheResyncPeriod:      conf.CacheResyncPeriod,
 		Port:                   conf.Port,
 		DevMode:                conf.DevMode,
 		StaticDir:              conf.StaticDir,
@@ -325,7 +326,7 @@ func cacheMiddlewareHandler(c *HeadlampConfig, next http.Handler, w http.Respons
 		return
 	}
 
-	k8cache.CheckForChanges(k8sResponseCache, contextKey, *kContext)
+	k8cache.CheckForChanges(k8sResponseCache, contextKey, *kContext, c.CacheResyncPeriod)
 
 	next.ServeHTTP(rcw, r)
 

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -45,26 +45,27 @@ type Config struct {
 	// NoBrowser disables automatically opening the default browser when running
 	// a locally embedded Headlamp binary (non in-cluster with spa.UseEmbeddedFiles == true).
 	// It has no effect in in-cluster mode or when running without embedded frontend.
-	NoBrowser              bool   `koanf:"no-browser"`
-	CacheEnabled           bool   `koanf:"cache-enabled"`
-	EnableHelm             bool   `koanf:"enable-helm"`
-	EnableDynamicClusters  bool   `koanf:"enable-dynamic-clusters"`
-	EnableClusterInventory bool   `koanf:"enable-cluster-inventory"`
-	AllowKubeconfigChanges bool   `koanf:"allow-kubeconfig-changes"`
-	ListenAddr             string `koanf:"listen-addr"`
-	WatchPluginsChanges    bool   `koanf:"watch-plugins-changes"`
-	Port                   uint   `koanf:"port"`
-	KubeConfigPath         string `koanf:"kubeconfig"`
-	SkippedKubeContexts    string `koanf:"skipped-kube-contexts"`
-	StaticDir              string `koanf:"html-static-dir"`
-	PluginsDir             string `koanf:"plugins-dir"`
-	UserPluginsDir         string `koanf:"user-plugins-dir"`
-	BaseURL                string `koanf:"base-url"`
-	SessionTTL             int    `koanf:"session-ttl"`
-	PodDebugImage          string `koanf:"pod-debug-image"`
-	NodeShellImage         string `koanf:"node-shell-image"`
-	NodeShellNamespace     string `koanf:"node-shell-namespace"`
-	ProxyURLs              string `koanf:"proxy-urls"`
+	NoBrowser              bool          `koanf:"no-browser"`
+	CacheEnabled           bool          `koanf:"cache-enabled"`
+	CacheResyncPeriod      time.Duration `koanf:"cache-resync-period"`
+	EnableHelm             bool          `koanf:"enable-helm"`
+	EnableDynamicClusters  bool          `koanf:"enable-dynamic-clusters"`
+	EnableClusterInventory bool          `koanf:"enable-cluster-inventory"`
+	AllowKubeconfigChanges bool          `koanf:"allow-kubeconfig-changes"`
+	ListenAddr             string        `koanf:"listen-addr"`
+	WatchPluginsChanges    bool          `koanf:"watch-plugins-changes"`
+	Port                   uint          `koanf:"port"`
+	KubeConfigPath         string        `koanf:"kubeconfig"`
+	SkippedKubeContexts    string        `koanf:"skipped-kube-contexts"`
+	StaticDir              string        `koanf:"html-static-dir"`
+	PluginsDir             string        `koanf:"plugins-dir"`
+	UserPluginsDir         string        `koanf:"user-plugins-dir"`
+	BaseURL                string        `koanf:"base-url"`
+	SessionTTL             int           `koanf:"session-ttl"`
+	PodDebugImage          string        `koanf:"pod-debug-image"`
+	NodeShellImage         string        `koanf:"node-shell-image"`
+	NodeShellNamespace     string        `koanf:"node-shell-namespace"`
+	ProxyURLs              string        `koanf:"proxy-urls"`
 
 	ClusterInventoryProviderFile          string        `koanf:"cluster-inventory-provider-file"`
 	ClusterInventoryLabelSelector         string        `koanf:"cluster-inventory-label-selector"`
@@ -544,6 +545,8 @@ func addGeneralFlags(f *flag.FlagSet) {
 	f.String("in-cluster-context-name", "main", "Name to use for the in-cluster Kubernetes context")
 	f.Bool("dev", false, "Allow connections from other origins")
 	f.Bool("cache-enabled", false, "K8s cache in backend")
+	f.Duration("cache-resync-period", 30*time.Minute,
+		"How often informers re-list resources to recover from missed watch events (0 disables resync)")
 	f.Bool("no-browser", false, "Disable automatically opening the browser when using embedded frontend")
 	f.Bool("insecure-ssl", false, "Accept/Ignore all server SSL certificates")
 	f.String("log-level", "info", "Set backend log verbosity. Options: debug, info (default), warn, error")

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -46,27 +46,28 @@ type Config struct {
 	// NoBrowser disables automatically opening the default browser when running
 	// a locally embedded Headlamp binary (non in-cluster with spa.UseEmbeddedFiles == true).
 	// It has no effect in in-cluster mode or when running without embedded frontend.
-	NoBrowser              bool   `koanf:"no-browser"`
-	CacheEnabled           bool   `koanf:"cache-enabled"`
-	EnableHelm             bool   `koanf:"enable-helm"`
-	EnableDynamicClusters  bool   `koanf:"enable-dynamic-clusters"`
-	EnableClusterInventory bool   `koanf:"enable-cluster-inventory"`
-	AllowKubeconfigChanges bool   `koanf:"allow-kubeconfig-changes"`
-	ListenAddr             string `koanf:"listen-addr"`
-	WatchPluginsChanges    bool   `koanf:"watch-plugins-changes"`
-	Port                   uint   `koanf:"port"`
-	KubeConfigPath         string `koanf:"kubeconfig"`
-	KubeConfigDir          string `koanf:"kubeconfig-dir"`
-	SkippedKubeContexts    string `koanf:"skipped-kube-contexts"`
-	StaticDir              string `koanf:"html-static-dir"`
-	PluginsDir             string `koanf:"plugins-dir"`
-	UserPluginsDir         string `koanf:"user-plugins-dir"`
-	BaseURL                string `koanf:"base-url"`
-	SessionTTL             int    `koanf:"session-ttl"`
-	PodDebugImage          string `koanf:"pod-debug-image"`
-	NodeShellImage         string `koanf:"node-shell-image"`
-	NodeShellNamespace     string `koanf:"node-shell-namespace"`
-	ProxyURLs              string `koanf:"proxy-urls"`
+	NoBrowser              bool          `koanf:"no-browser"`
+	CacheEnabled           bool          `koanf:"cache-enabled"`
+	CacheResyncPeriod      time.Duration `koanf:"cache-resync-period"`
+	EnableHelm             bool          `koanf:"enable-helm"`
+	EnableDynamicClusters  bool          `koanf:"enable-dynamic-clusters"`
+	EnableClusterInventory bool          `koanf:"enable-cluster-inventory"`
+	AllowKubeconfigChanges bool          `koanf:"allow-kubeconfig-changes"`
+	ListenAddr             string        `koanf:"listen-addr"`
+	WatchPluginsChanges    bool          `koanf:"watch-plugins-changes"`
+	Port                   uint          `koanf:"port"`
+	KubeConfigPath         string        `koanf:"kubeconfig"`
+	KubeConfigDir          string        `koanf:"kubeconfig-dir"`
+	SkippedKubeContexts    string        `koanf:"skipped-kube-contexts"`
+	StaticDir              string        `koanf:"html-static-dir"`
+	PluginsDir             string        `koanf:"plugins-dir"`
+	UserPluginsDir         string        `koanf:"user-plugins-dir"`
+	BaseURL                string        `koanf:"base-url"`
+	SessionTTL             int           `koanf:"session-ttl"`
+	PodDebugImage          string        `koanf:"pod-debug-image"`
+	NodeShellImage         string        `koanf:"node-shell-image"`
+	NodeShellNamespace     string        `koanf:"node-shell-namespace"`
+	ProxyURLs              string        `koanf:"proxy-urls"`
 
 	ClusterInventoryProviderFile          string        `koanf:"cluster-inventory-provider-file"`
 	ClusterInventoryLabelSelector         string        `koanf:"cluster-inventory-label-selector"`
@@ -582,6 +583,7 @@ func flagset(appName string) *flag.FlagSet {
 	f := flag.NewFlagSet("config", flag.ContinueOnError)
 
 	addGeneralFlags(f, appName)
+	addCacheFlags(f)
 	addOIDCFlags(f)
 	addProxyAuthFlags(f)
 	addTelemetryFlags(f)
@@ -603,7 +605,6 @@ func addGeneralFlags(f *flag.FlagSet, appName string) {
 			"If unset, it is derived from the kube-system/kubeadm-config ConfigMap (treating \"kubernetes\" as unset), "+
 			"falling back to \"main\"")
 	f.Bool("dev", false, "Allow connections from other origins")
-	f.Bool("cache-enabled", false, "K8s cache in backend")
 	f.Bool("no-browser", false, "Disable automatically opening the browser when using embedded frontend")
 	f.Bool("insecure-ssl", false, "Accept/Ignore all server SSL certificates")
 	f.String("log-level", "info", "Set backend log verbosity. Options: debug, info (default), warn, error")
@@ -651,6 +652,12 @@ func addGeneralFlags(f *flag.FlagSet, appName string) {
 	f.String("service-account-token-path", "",
 		"Path to the service account token. "+
 			"Only used when --unsafe-use-service-account-token is set and in-cluster")
+}
+
+func addCacheFlags(f *flag.FlagSet) {
+	f.Bool("cache-enabled", false, "K8s cache in backend")
+	f.Duration("cache-resync-period", 30*time.Minute,
+		"How often informers re-list resources to recover from missed watch events (0 disables resync)")
 }
 
 func addOIDCFlags(f *flag.FlagSet) {

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -132,6 +132,26 @@ func TestParseBasic(t *testing.T) {
 	}
 }
 
+func TestParseCacheResyncPeriod(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		expect time.Duration
+	}{
+		{"default", nil, 30 * time.Minute},
+		{"custom", []string{"go run ./cmd", "--cache-resync-period=15m"}, 15 * time.Minute},
+		{"disabled", []string{"go run ./cmd", "--cache-resync-period=0s"}, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf, err := config.Parse(tt.args)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expect, conf.CacheResyncPeriod)
+		})
+	}
+}
+
 var ParseWithEnvTests = []struct {
 	name   string
 	args   []string

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -231,6 +231,26 @@ func TestParseInvalidAppName(t *testing.T) {
 	}
 }
 
+func TestParseCacheResyncPeriod(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		expect time.Duration
+	}{
+		{"default", nil, 30 * time.Minute},
+		{"custom", []string{"go run ./cmd", "--cache-resync-period=15m"}, 15 * time.Minute},
+		{"disabled", []string{"go run ./cmd", "--cache-resync-period=0s"}, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf, err := config.Parse(tt.args)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expect, conf.CacheResyncPeriod)
+		})
+	}
+}
+
 var ParseWithEnvTests = []struct {
 	name   string
 	args   []string

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -51,6 +51,7 @@ type HeadlampCFG struct {
 	InClusterContextName   string
 	ListenAddr             string
 	CacheEnabled           bool
+	CacheResyncPeriod      time.Duration
 	DevMode                bool
 	Insecure               bool
 	EnableHelm             bool

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -52,6 +52,7 @@ type HeadlampCFG struct {
 	InClusterContextName   string
 	ListenAddr             string
 	CacheEnabled           bool
+	CacheResyncPeriod      time.Duration
 	DevMode                bool
 	Insecure               bool
 	EnableHelm             bool

--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -27,6 +27,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
@@ -192,6 +193,7 @@ func CheckForChanges(
 	k8scache cache.Cache[string],
 	contextKey string,
 	kContext kubeconfig.Context,
+	resyncPeriod time.Duration,
 ) {
 	if _, loaded := watcherRegistry.LoadOrStore(contextKey, struct{}{}); loaded {
 		return
@@ -201,7 +203,7 @@ func CheckForChanges(
 
 	contextCancel.Store(contextKey, cancel)
 
-	go runWatcher(ctx, k8scache, contextKey, kContext)
+	go runWatcher(ctx, k8scache, contextKey, kContext, resyncPeriod)
 }
 
 // SyncWatchers stops watchers for contexts that are no longer active and purges
@@ -258,6 +260,7 @@ func runWatcher(
 	k8scache cache.Cache[string],
 	contextKey string,
 	kContext kubeconfig.Context,
+	resyncPeriod time.Duration,
 ) {
 	defer func() {
 		watcherRegistry.Delete(contextKey)
@@ -287,7 +290,7 @@ func runWatcher(
 	}
 
 	gvrList := returnGVRList(apiResourceLists)
-	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, 0, "", nil)
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, resyncPeriod, "", nil)
 
 	RunInformerToWatch(gvrList, factory, contextKey, k8scache)
 

--- a/backend/pkg/k8cache/export_test.go
+++ b/backend/pkg/k8cache/export_test.go
@@ -17,8 +17,9 @@ func ExportedRunWatcher(
 	k8scache cache.Cache[string],
 	contextKey string,
 	kContext kubeconfig.Context,
+	resyncPeriod time.Duration,
 ) {
-	runWatcher(ctx, k8scache, contextKey, kContext)
+	runWatcher(ctx, k8scache, contextKey, kContext, resyncPeriod)
 }
 
 // ResetRegistries clears both registries for test isolation.

--- a/backend/pkg/k8cache/registry_cleanup_test.go
+++ b/backend/pkg/k8cache/registry_cleanup_test.go
@@ -23,7 +23,7 @@ func TestRunWatcherCleansUpRegistryOnFailure(t *testing.T) {
 
 	// An empty Context causes RESTConfig() to return an error,
 	// which makes runWatcher exit on its first error path.
-	k8cache.ExportedRunWatcher(ctx, nil, key, kubeconfig.Context{})
+	k8cache.ExportedRunWatcher(ctx, nil, key, kubeconfig.Context{}, 0)
 
 	// After the early return, both registry entries must be cleaned up
 	// so that a subsequent CheckForChanges call can start a new watcher.


### PR DESCRIPTION
## Summary
This PR fixes a cache reliability issue where the informer never self-healsafter a dropped watch event. It changes the default resyncPeriod from 0(never resync) to 30 minutes and adds a configurable `--cache-resync-period` CLI flag so operators can tune it for their environment.

## Related Issue
Fixes #6595 

## Changes
- Updated `backend/pkg/k8cache/cacheInvalidation.go` to accept a configurable `resyncPeriod` parameter instead of hardcoding `0`
- Added `--cache-resync-period` CLI flag to `backend/pkg/config/config.go` with a default value of 30 minutes
- Added `CacheResyncPeriod` field to `HeadlampCFG` in `backend/pkg/headlampconfig/headlampConfig.go`
- Wired the config value through `backend/cmd/server.go` to the `CheckForChanges` and `runWatcher` functions
- Updated `export_test.go` and `registry_cleanup_test.go` to pass the new parameter
- Added 3 new test cases in `backend/pkg/config/config_test.go` covering the default (30m), custom (15m), and disabled (0s) resync period values

## Steps to Test
1. Build the backend: `cd backend && go build ./...`
2. Run the backend tests: `cd backend && go test ./...`
3. Verify the default: run with `--cache-enabled` and confirm informers start with a 30-minute resync period (check logs)
4. Verify custom value: run with `--cache-enabled --cache-resync-period=15m` and confirm the custom value is used
5. Verify disable: run with `--cache-enabled --cache-resync-period=0s` to confirm the old behavior (no resync) can still be selected

## Notes for the Reviewer
- The `DynamicSharedInformerFactory` was previously initialized with `resyncPeriod=0`, meaning the cache never reconciled with the API server after the initial list-watch. If a watch event was dropped (due to network partition, API server restart, or etcd compaction), cached data would remain stale until the 10-minute cache TTL expired.
- The default of 30 minutes follows the standard Kubernetes recommendation used by kube-controller-manager and most production informer setups.
- The existing event handlers are fully idempotent (they only delete cache keys via `DeleteKeys`), so periodic resync `UpdateFunc` calls are harmless no-ops that add no meaningful API server load.
- The flag accepts any Go `time.Duration` string (e.g. `15m`, `1h`, `0s`). Setting `0s` restores the old behavior for operators who prefer it.
 