### PR TITLE
frontend: EditorDialog: fix tab navigation for create resource page

### DIFF
--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.ClusterParentSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.ClusterParentSelected.stories.storyshot
@@ -43,7 +43,7 @@
                 class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                 id="full-width-tab-1-NavigationTabs-tabs-id"
                 role="tab"
-                tabindex="-1"
+                tabindex="0"
                 type="button"
               >
                 Namespaces
@@ -57,7 +57,7 @@
                 class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                 id="full-width-tab-2-NavigationTabs-tabs-id"
                 role="tab"
-                tabindex="-1"
+                tabindex="0"
                 type="button"
               >
                 Nodes
@@ -77,6 +77,7 @@
           class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
           id="full-width-tabpanel-0-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="0"
         />
         <div
           aria-labelledby="full-width-tab-1-NavigationTabs-tabs-id"
@@ -84,6 +85,7 @@
           hidden=""
           id="full-width-tabpanel-1-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="-1"
         />
         <div
           aria-labelledby="full-width-tab-2-NavigationTabs-tabs-id"
@@ -91,6 +93,7 @@
           hidden=""
           id="full-width-tabpanel-2-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="-1"
         />
         <hr
           class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.ItemWithoutOwnURLSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.ItemWithoutOwnURLSelected.stories.storyshot
@@ -29,7 +29,7 @@
                 class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                 id="full-width-tab-0-NavigationTabs-tabs-id"
                 role="tab"
-                tabindex="-1"
+                tabindex="0"
                 type="button"
               >
                 Workloads
@@ -43,7 +43,7 @@
                 class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                 id="full-width-tab-1-NavigationTabs-tabs-id"
                 role="tab"
-                tabindex="-1"
+                tabindex="0"
                 type="button"
               >
                 Pods
@@ -57,7 +57,7 @@
                 class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                 id="full-width-tab-2-NavigationTabs-tabs-id"
                 role="tab"
-                tabindex="-1"
+                tabindex="0"
                 type="button"
               >
                 Deployments
@@ -92,6 +92,7 @@
           hidden=""
           id="full-width-tabpanel-0-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="-1"
         />
         <div
           aria-labelledby="full-width-tab-1-NavigationTabs-tabs-id"
@@ -99,6 +100,7 @@
           hidden=""
           id="full-width-tabpanel-1-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="-1"
         />
         <div
           aria-labelledby="full-width-tab-2-NavigationTabs-tabs-id"
@@ -106,12 +108,14 @@
           hidden=""
           id="full-width-tabpanel-2-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="-1"
         />
         <div
           aria-labelledby="full-width-tab-3-NavigationTabs-tabs-id"
           class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
           id="full-width-tabpanel-3-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="0"
         />
         <hr
           class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.NetworkPoliciesSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.NetworkPoliciesSelected.stories.storyshot
@@ -29,7 +29,7 @@
                 class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                 id="full-width-tab-0-NavigationTabs-tabs-id"
                 role="tab"
-                tabindex="-1"
+                tabindex="0"
                 type="button"
               >
                 Services
@@ -43,7 +43,7 @@
                 class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                 id="full-width-tab-1-NavigationTabs-tabs-id"
                 role="tab"
-                tabindex="-1"
+                tabindex="0"
                 type="button"
               >
                 Endpoints
@@ -57,7 +57,7 @@
                 class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                 id="full-width-tab-2-NavigationTabs-tabs-id"
                 role="tab"
-                tabindex="-1"
+                tabindex="0"
                 type="button"
               >
                 Endpoint Slices
@@ -71,7 +71,7 @@
                 class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                 id="full-width-tab-3-NavigationTabs-tabs-id"
                 role="tab"
-                tabindex="-1"
+                tabindex="0"
                 type="button"
               >
                 Ingresses
@@ -85,7 +85,7 @@
                 class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                 id="full-width-tab-4-NavigationTabs-tabs-id"
                 role="tab"
-                tabindex="-1"
+                tabindex="0"
                 type="button"
               >
                 Ingress Classes
@@ -120,6 +120,7 @@
           hidden=""
           id="full-width-tabpanel-0-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="-1"
         />
         <div
           aria-labelledby="full-width-tab-1-NavigationTabs-tabs-id"
@@ -127,6 +128,7 @@
           hidden=""
           id="full-width-tabpanel-1-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="-1"
         />
         <div
           aria-labelledby="full-width-tab-2-NavigationTabs-tabs-id"
@@ -134,6 +136,7 @@
           hidden=""
           id="full-width-tabpanel-2-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="-1"
         />
         <div
           aria-labelledby="full-width-tab-3-NavigationTabs-tabs-id"
@@ -141,6 +144,7 @@
           hidden=""
           id="full-width-tabpanel-3-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="-1"
         />
         <div
           aria-labelledby="full-width-tab-4-NavigationTabs-tabs-id"
@@ -148,12 +152,14 @@
           hidden=""
           id="full-width-tabpanel-4-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="-1"
         />
         <div
           aria-labelledby="full-width-tab-5-NavigationTabs-tabs-id"
           class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
           id="full-width-tabpanel-5-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="0"
         />
         <hr
           class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.SettingsParentSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.SettingsParentSelected.stories.storyshot
@@ -43,7 +43,7 @@
                 class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                 id="full-width-tab-1-NavigationTabs-tabs-id"
                 role="tab"
-                tabindex="-1"
+                tabindex="0"
                 type="button"
               >
                 General
@@ -57,7 +57,7 @@
                 class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                 id="full-width-tab-2-NavigationTabs-tabs-id"
                 role="tab"
-                tabindex="-1"
+                tabindex="0"
                 type="button"
               >
                 Plugins
@@ -77,6 +77,7 @@
           class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
           id="full-width-tabpanel-0-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="0"
         />
         <div
           aria-labelledby="full-width-tab-1-NavigationTabs-tabs-id"
@@ -84,6 +85,7 @@
           hidden=""
           id="full-width-tabpanel-1-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="-1"
         />
         <div
           aria-labelledby="full-width-tab-2-NavigationTabs-tabs-id"
@@ -91,6 +93,7 @@
           hidden=""
           id="full-width-tabpanel-2-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="-1"
         />
         <hr
           class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.WorkloadsChildSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.WorkloadsChildSelected.stories.storyshot
@@ -29,7 +29,7 @@
                 class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                 id="full-width-tab-0-NavigationTabs-tabs-id"
                 role="tab"
-                tabindex="-1"
+                tabindex="0"
                 type="button"
               >
                 Workloads
@@ -57,7 +57,7 @@
                 class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                 id="full-width-tab-2-NavigationTabs-tabs-id"
                 role="tab"
-                tabindex="-1"
+                tabindex="0"
                 type="button"
               >
                 Deployments
@@ -71,7 +71,7 @@
                 class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                 id="full-width-tab-3-NavigationTabs-tabs-id"
                 role="tab"
-                tabindex="-1"
+                tabindex="0"
                 type="button"
               >
                 Item Without URL
@@ -92,12 +92,14 @@
           hidden=""
           id="full-width-tabpanel-0-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="-1"
         />
         <div
           aria-labelledby="full-width-tab-1-NavigationTabs-tabs-id"
           class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
           id="full-width-tabpanel-1-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="0"
         />
         <div
           aria-labelledby="full-width-tab-2-NavigationTabs-tabs-id"
@@ -105,6 +107,7 @@
           hidden=""
           id="full-width-tabpanel-2-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="-1"
         />
         <div
           aria-labelledby="full-width-tab-3-NavigationTabs-tabs-id"
@@ -112,6 +115,7 @@
           hidden=""
           id="full-width-tabpanel-3-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="-1"
         />
         <hr
           class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.WorkloadsParentSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.WorkloadsParentSelected.stories.storyshot
@@ -43,7 +43,7 @@
                 class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                 id="full-width-tab-1-NavigationTabs-tabs-id"
                 role="tab"
-                tabindex="-1"
+                tabindex="0"
                 type="button"
               >
                 Pods
@@ -57,7 +57,7 @@
                 class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                 id="full-width-tab-2-NavigationTabs-tabs-id"
                 role="tab"
-                tabindex="-1"
+                tabindex="0"
                 type="button"
               >
                 Deployments
@@ -71,7 +71,7 @@
                 class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                 id="full-width-tab-3-NavigationTabs-tabs-id"
                 role="tab"
-                tabindex="-1"
+                tabindex="0"
                 type="button"
               >
                 Item Without URL
@@ -91,6 +91,7 @@
           class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
           id="full-width-tabpanel-0-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="0"
         />
         <div
           aria-labelledby="full-width-tab-1-NavigationTabs-tabs-id"
@@ -98,6 +99,7 @@
           hidden=""
           id="full-width-tabpanel-1-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="-1"
         />
         <div
           aria-labelledby="full-width-tab-2-NavigationTabs-tabs-id"
@@ -105,6 +107,7 @@
           hidden=""
           id="full-width-tabpanel-2-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="-1"
         />
         <div
           aria-labelledby="full-width-tab-3-NavigationTabs-tabs-id"
@@ -112,6 +115,7 @@
           hidden=""
           id="full-width-tabpanel-3-NavigationTabs-tabs-id"
           role="tabpanel"
+          tabindex="-1"
         />
         <hr
           class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"

--- a/frontend/src/components/common/Resource/EditorDialog.test.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.test.tsx
@@ -35,11 +35,13 @@ const { mockSetModelMarkers, mockGetModel, mockTextarea, mockEditorInstance, moc
             }
             return null;
           },
+          closest: () => null,
         }),
         getScrollTop: vi.fn(() => 123),
         getPosition: vi.fn(() => ({ lineNumber: 5, column: 10 })),
         setScrollTop: vi.fn(),
         setPosition: vi.fn(),
+        addCommand: vi.fn(),
       },
       mockOnChangeRef: { current: undefined as ((value: string | undefined) => void) | undefined },
     };
@@ -78,7 +80,11 @@ vi.mock('@monaco-editor/react', () => {
       React.useEffect(() => {
         onMount?.(
           { ...mockEditorInstance, getModel: mockGetModel },
-          { editor: { setModelMarkers: mockSetModelMarkers }, MarkerSeverity: { Error: 8 } }
+          {
+            editor: { setModelMarkers: mockSetModelMarkers },
+            MarkerSeverity: { Error: 8 },
+            KeyCode: { Escape: 9 },
+          }
         );
       }, [onMount]);
 
@@ -315,5 +321,17 @@ describe('EditorDialog', () => {
 
     expect(mockEditorInstance.setScrollTop).not.toHaveBeenCalled();
     expect(mockEditorInstance.setPosition).not.toHaveBeenCalled();
+  });
+
+  it('registers an Escape command with the correct precondition to exit the Monaco editor', () => {
+    localStorage.setItem('useSimpleEditor', 'false');
+
+    renderEditorDialog();
+
+    expect(mockEditorInstance.addCommand).toHaveBeenCalledWith(
+      9, // KeyCode.Escape from the mock
+      expect.any(Function),
+      '!suggestWidgetVisible && !findWidgetVisible && !renameInputVisible && !parameterHintsVisible && !inSnippetMode && !editorHasMultipleSelections'
+    );
   });
 });

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -570,6 +570,25 @@ export default function EditorDialog(props: EditorDialogProps) {
               if (textarea && editorId) {
                 textarea.id = editorId;
               }
+              // Escape exits the editor so Tab can reach the action buttons.
+              // The precondition prevents stealing Escape from autocomplete, find, etc.
+              editor.addCommand(
+                monaco.KeyCode.Escape,
+                () => {
+                  // Find the first focusable button in DialogActions (the sibling
+                  // of DialogContent) so Tab doesn't loop back into the editor.
+                  const dialogContent = editor.getDomNode()?.closest('.MuiDialogContent-root');
+                  const actions =
+                    dialogContent?.parentElement?.querySelector('.MuiDialogActions-root');
+                  const firstBtn = actions?.querySelector(
+                    'button:not([disabled])'
+                  ) as HTMLElement | null;
+                  if (firstBtn) {
+                    firstBtn.focus();
+                  }
+                },
+                '!suggestWidgetVisible && !findWidgetVisible && !renameInputVisible && !parameterHintsVisible && !inSnippetMode && !editorHasMultipleSelections'
+              );
             }}
             height="100%"
           />

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
@@ -177,7 +177,7 @@
                   class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                   id="full-width-tab-1-Editor-tabs-id"
                   role="tab"
-                  tabindex="-1"
+                  tabindex="0"
                   type="button"
                 >
                   Documentation
@@ -191,7 +191,7 @@
                   class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                   id="full-width-tab-2-Editor-tabs-id"
                   role="tab"
-                  tabindex="-1"
+                  tabindex="0"
                   type="button"
                 >
                   Review Changes
@@ -211,6 +211,7 @@
             class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
             id="full-width-tabpanel-0-Editor-tabs-id"
             role="tabpanel"
+            tabindex="0"
           >
             <div
               class="MuiBox-root css-10klw3m"
@@ -226,6 +227,7 @@
             hidden=""
             id="full-width-tabpanel-1-Editor-tabs-id"
             role="tabpanel"
+            tabindex="-1"
           >
             <div
               class="MuiBox-root css-u718rw"
@@ -247,6 +249,7 @@
             hidden=""
             id="full-width-tabpanel-2-Editor-tabs-id"
             role="tabpanel"
+            tabindex="-1"
           />
         </div>
         <div

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
@@ -213,7 +213,7 @@
                   class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                   id="full-width-tab-1-Editor-tabs-id"
                   role="tab"
-                  tabindex="-1"
+                  tabindex="0"
                   type="button"
                 >
                   Documentation
@@ -227,7 +227,7 @@
                   class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                   id="full-width-tab-2-Editor-tabs-id"
                   role="tab"
-                  tabindex="-1"
+                  tabindex="0"
                   type="button"
                 >
                   Review Changes
@@ -247,6 +247,7 @@
             class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
             id="full-width-tabpanel-0-Editor-tabs-id"
             role="tabpanel"
+            tabindex="0"
           >
             <div
               class="MuiBox-root css-10klw3m"
@@ -262,6 +263,7 @@
             hidden=""
             id="full-width-tabpanel-1-Editor-tabs-id"
             role="tabpanel"
+            tabindex="-1"
           >
             <div
               class="MuiBox-root css-u718rw"
@@ -283,6 +285,7 @@
             hidden=""
             id="full-width-tabpanel-2-Editor-tabs-id"
             role="tabpanel"
+            tabindex="-1"
           />
         </div>
         <div

--- a/frontend/src/components/common/Resource/__snapshots__/UploadDialog.Default.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/UploadDialog.Default.stories.storyshot
@@ -65,7 +65,7 @@
                   class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                   id="full-width-tab-1-UploadFile/URL-tabs-id"
                   role="tab"
-                  tabindex="-1"
+                  tabindex="0"
                   type="button"
                 >
                   Load from URL
@@ -85,6 +85,7 @@
             class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
             id="full-width-tabpanel-0-UploadFile/URL-tabs-id"
             role="tabpanel"
+            tabindex="0"
           >
             <div
               class="MuiBox-root css-1v3caum"
@@ -147,6 +148,7 @@
             hidden=""
             id="full-width-tabpanel-1-UploadFile/URL-tabs-id"
             role="tabpanel"
+            tabindex="-1"
           >
             <div
               class="MuiBox-root css-1v3caum"

--- a/frontend/src/components/common/Tabs.tsx
+++ b/frontend/src/components/common/Tabs.tsx
@@ -110,6 +110,7 @@ export default function Tabs(props: TabsProps) {
           <MuiTab
             key={i}
             label={label}
+            tabIndex={0}
             sx={
               tabs?.length > 7
                 ? {
@@ -170,6 +171,7 @@ export function TabPanel(props: TabPanelProps) {
       hidden={tabIndex !== index}
       id={id}
       aria-labelledby={labeledBy}
+      tabIndex={tabIndex === index ? 0 : -1}
       sx={{ flexGrow: 1, overflow: 'hidden' }}
     >
       {children}

--- a/frontend/src/components/common/__snapshots__/Tabs.BasicTabs.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Tabs.BasicTabs.stories.storyshot
@@ -36,7 +36,7 @@
             class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
             id="full-width-tab-1-BasicTabs-tabs-id"
             role="tab"
-            tabindex="-1"
+            tabindex="0"
             type="button"
           >
             tab 2 label
@@ -56,6 +56,7 @@
       class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
       id="full-width-tabpanel-0-BasicTabs-tabs-id"
       role="tabpanel"
+      tabindex="0"
     >
       <p>
         tab body 1
@@ -67,6 +68,7 @@
       hidden=""
       id="full-width-tabpanel-1-BasicTabs-tabs-id"
       role="tabpanel"
+      tabindex="-1"
     >
       <p>
         tab body 2

--- a/frontend/src/components/common/__snapshots__/Tabs.StartingTab.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Tabs.StartingTab.stories.storyshot
@@ -22,7 +22,7 @@
             class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
             id="full-width-tab-0-StartingTabs-tabs-id"
             role="tab"
-            tabindex="-1"
+            tabindex="0"
             type="button"
           >
             tab 1 label
@@ -57,6 +57,7 @@
       hidden=""
       id="full-width-tabpanel-0-StartingTabs-tabs-id"
       role="tabpanel"
+      tabindex="-1"
     >
       <p>
         tab body 1
@@ -67,6 +68,7 @@
       class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
       id="full-width-tabpanel-1-StartingTabs-tabs-id"
       role="tabpanel"
+      tabindex="0"
     >
       <p>
         We start on the second tab using defaultIndex=1


### PR DESCRIPTION
## Summary

Fixes keyboard (Tab key) navigation on the Create Resource page so users can move through the full UI without a mouse.

## Changes

- **Tabs component:** Added `tabIndex={0}` to all `MuiTab` buttons so each tab is individually reachable via the Tab key (previously only the selected tab was focusable). Added `tabIndex={0}` to the active `TabPanel` so the panel content is reachable from the tab bar.
- **EditorDialog (Monaco):** Added an Escape key handler that moves focus from the Monaco editor to the first enabled action button (Undo / Close / Dry Run / Apply). The handler only fires when no Monaco popups are open (autocomplete, find, rename, parameter hints, snippets, multi-cursor).

## Steps to Test

1. Navigate to any resource list (e.g. Pods, Deployments).
2. Click the **Create** action button.
3. Press Tab repeatedly — focus should move through:
   - Toolbar controls (editor toggles, Upload button)
   - Tab buttons (Editor, Form, Documentation, Review Changes)
   - Into the editor content
4. Type in the Monaco editor, then press **Escape**.
5. Confirm focus lands on the first action button (Undo Changes or Close).
6. Continue pressing Tab to cycle through the remaining buttons (Dry Run, Apply).
7. Verify Escape does **not** exit the editor when autocomplete or the find widget is open.

## Notes for the Reviewer

- The `tabIndex={0}` change on `MuiTab` applies globally to the shared `Tabs` component. Updated storyshots reflect the new attribute.
- Monaco's built-in Escape handlers (close autocomplete, close find, collapse multi-cursor) take priority via the `precondition` string passed to `editor.addCommand`.
