### PR TITLE
app: runCmd: Use Login Shell Environment

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -721,18 +721,22 @@ async function getShellEnv(): Promise<NodeJS.ProcessEnv> {
 
 let shellEnvironmentPromise: Promise<NodeJS.ProcessEnv> | null = null;
 
-/**
- * Returns the user's login-shell environment, cached after the first request.
- * Falls back to Electron's process environment when shell discovery fails.
- */
+/** Returns the cached login-shell changes merged with the current process environment. */
 export async function getShellEnvironment(): Promise<NodeJS.ProcessEnv> {
   if (!shellEnvironmentPromise) {
-    shellEnvironmentPromise = getShellEnv().catch(error => {
-      console.warn('Failed to get shell environment, using process.env:', error);
-      return process.env;
-    });
+    const initialEnvironment = { ...process.env };
+    shellEnvironmentPromise = getShellEnv()
+      .then(environment =>
+        Object.fromEntries(
+          Object.entries(environment).filter(([key, value]) => initialEnvironment[key] !== value)
+        )
+      )
+      .catch(error => {
+        console.warn('Failed to get shell environment, using process.env:', error);
+        return {};
+      });
   }
-  return shellEnvironmentPromise;
+  return { ...process.env, ...(await shellEnvironmentPromise) };
 }
 
 /**

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -52,7 +52,13 @@ import {
   getPluginBinDirectories,
   PluginManager,
 } from './plugin-management';
-import { addRunCmdConsent, removeRunCmdConsent, runScript, setupRunCmdHandlers } from './runCmd';
+import {
+  addRunCmdConsent,
+  environmentOverrides,
+  removeRunCmdConsent,
+  runScript,
+  setupRunCmdHandlers,
+} from './runCmd';
 import { loadSettings, SETTINGS_PATH } from './settings';
 import {
   cleanupHeadlampTray,
@@ -724,13 +730,8 @@ let shellEnvironmentPromise: Promise<NodeJS.ProcessEnv> | null = null;
 /** Returns the cached login-shell changes merged with the current process environment. */
 export async function getShellEnvironment(): Promise<NodeJS.ProcessEnv> {
   if (!shellEnvironmentPromise) {
-    const initialEnvironment = { ...process.env };
     shellEnvironmentPromise = getShellEnv()
-      .then(environment =>
-        Object.fromEntries(
-          Object.entries(environment).filter(([key, value]) => initialEnvironment[key] !== value)
-        )
-      )
+      .then(environment => environmentOverrides(environment))
       .catch(error => {
         console.warn('Failed to get shell environment, using process.env:', error);
         return {};

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -719,6 +719,22 @@ async function getShellEnv(): Promise<NodeJS.ProcessEnv> {
   }
 }
 
+let shellEnvironmentPromise: Promise<NodeJS.ProcessEnv> | null = null;
+
+/**
+ * Returns the user's login-shell environment, cached after the first request.
+ * Falls back to Electron's process environment when shell discovery fails.
+ */
+export async function getShellEnvironment(): Promise<NodeJS.ProcessEnv> {
+  if (!shellEnvironmentPromise) {
+    shellEnvironmentPromise = getShellEnv().catch(error => {
+      console.warn('Failed to get shell environment, using process.env:', error);
+      return process.env;
+    });
+  }
+  return shellEnvironmentPromise;
+}
+
 /**
  * Check if a port is available by attempting to create a server on it
  */

--- a/app/electron/runCmd.test.ts
+++ b/app/electron/runCmd.test.ts
@@ -17,7 +17,15 @@
 import { EventEmitter } from 'events';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
-import { checkPermissionSecret, handleRunCommand, validateCommandData } from './runCmd';
+
+const { getShellEnvironmentMock, spawnMock } = vi.hoisted(() => ({
+  getShellEnvironmentMock: vi.fn(),
+  spawnMock: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  spawn: spawnMock,
+}));
 
 vi.mock('./plugin-management', () => ({
   defaultPluginsDir: vi.fn(() => '/plugins/default'),
@@ -26,7 +34,7 @@ vi.mock('./plugin-management', () => ({
 
 vi.mock('./settings', () => ({
   loadSettings: vi.fn(() => ({
-    confirmedCommands: { 'minikube start': true, 'gh auth': true, az: true },
+    confirmedCommands: { 'minikube start': true, 'gh auth': true, 'az account': true },
   })),
   saveSettings: vi.fn(),
   SETTINGS_PATH: '/fake/settings.json',
@@ -39,8 +47,10 @@ vi.mock('./i18next.config', () => ({
 const shellEnvironment = { PATH: '/opt/homebrew/bin:/usr/bin', SHELL: '/bin/zsh' };
 
 vi.mock('./main', () => ({
-  getShellEnvironment: vi.fn(async () => shellEnvironment),
+  getShellEnvironment: getShellEnvironmentMock,
 }));
+
+import { checkPermissionSecret, handleRunCommand, validateCommandData } from './runCmd';
 
 describe('checkPermissionSecret', () => {
   const baseCommandData = {
@@ -247,25 +257,31 @@ describe('validateCommandData', () => {
 });
 
 describe('handleRunCommand', () => {
-  it('runs gh with the login-shell environment and reports child errors', async () => {
-    const childEmitter = new EventEmitter() as any;
+  let childEmitter: any;
+  let fakeEvent: any;
+  let sentMessages: Array<[string, ...unknown[]]>;
+
+  beforeEach(() => {
+    getShellEnvironmentMock.mockReset();
+    getShellEnvironmentMock.mockResolvedValue(shellEnvironment);
+    spawnMock.mockReset();
+    childEmitter = new EventEmitter();
     childEmitter.stdout = new EventEmitter();
     childEmitter.stderr = new EventEmitter();
-
-    vi.mock('child_process', () => ({
-      spawn: vi.fn(() => childEmitter),
-    }));
-
-    const { spawn } = await import('child_process');
-    (spawn as Mock).mockReturnValue(childEmitter);
-
-    const sentMessages: Array<[string, ...unknown[]]> = [];
-    const fakeEvent = {
+    spawnMock.mockReturnValue(childEmitter);
+    sentMessages = [];
+    fakeEvent = {
       sender: {
         send: vi.fn((...args: [string, ...unknown[]]) => sentMessages.push(args)),
       },
     } as any;
+  });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('runs gh with the login-shell environment and reports child errors', async () => {
     const fakeMainWindow = { id: 1 } as any;
     const permissionSecrets = { 'runCmd-gh': 99 };
 
@@ -279,7 +295,7 @@ describe('handleRunCommand', () => {
 
     await handleRunCommand(fakeEvent, eventData, fakeMainWindow, permissionSecrets);
 
-    expect(spawn).toHaveBeenCalledWith(
+    expect(spawnMock).toHaveBeenCalledWith(
       'gh',
       ['auth', 'token'],
       expect.objectContaining({ env: shellEnvironment })
@@ -290,6 +306,29 @@ describe('handleRunCommand', () => {
 
     expect(sentMessages).toContainEqual(['command-stderr', 'test-id', 'spawn error']);
     expect(sentMessages).toContainEqual(['command-exit', 'test-id', -1]);
+  });
+
+  it('falls back to process.env when shell environment resolution fails', async () => {
+    getShellEnvironmentMock.mockRejectedValue(new Error('shell unavailable'));
+    vi.stubEnv('HEADLAMP_TEST_ENV', 'current');
+    const eventData = {
+      id: 'test-id',
+      command: 'gh',
+      args: ['auth', 'token'],
+      options: {},
+      permissionSecrets: { 'runCmd-gh': 99 },
+    };
+
+    await expect(
+      handleRunCommand(fakeEvent, eventData, { id: 1 } as any, { 'runCmd-gh': 99 })
+    ).resolves.toBeUndefined();
+    expect(spawnMock).toHaveBeenCalledWith(
+      'gh',
+      ['auth', 'token'],
+      expect.objectContaining({
+        env: expect.objectContaining({ HEADLAMP_TEST_ENV: 'current' }),
+      })
+    );
   });
 });
 

--- a/app/electron/runCmd.test.ts
+++ b/app/electron/runCmd.test.ts
@@ -26,7 +26,7 @@ vi.mock('./plugin-management', () => ({
 
 vi.mock('./settings', () => ({
   loadSettings: vi.fn(() => ({
-    confirmedCommands: { 'minikube start': true, gh: true, az: true },
+    confirmedCommands: { 'minikube start': true, 'gh auth': true, az: true },
   })),
   saveSettings: vi.fn(),
   SETTINGS_PATH: '/fake/settings.json',
@@ -34,6 +34,12 @@ vi.mock('./settings', () => ({
 
 vi.mock('./i18next.config', () => ({
   default: { t: (s: string) => s },
+}));
+
+const shellEnvironment = { PATH: '/opt/homebrew/bin:/usr/bin', SHELL: '/bin/zsh' };
+
+vi.mock('./main', () => ({
+  getShellEnvironment: vi.fn(async () => shellEnvironment),
 }));
 
 describe('checkPermissionSecret', () => {
@@ -240,8 +246,8 @@ describe('validateCommandData', () => {
   });
 });
 
-describe('handleRunCommand - child process error event', () => {
-  it('sends command-stderr and command-exit with -1 when child emits error', async () => {
+describe('handleRunCommand', () => {
+  it('runs gh with the login-shell environment and reports child errors', async () => {
     const childEmitter = new EventEmitter() as any;
     childEmitter.stdout = new EventEmitter();
     childEmitter.stderr = new EventEmitter();
@@ -261,17 +267,23 @@ describe('handleRunCommand - child process error event', () => {
     } as any;
 
     const fakeMainWindow = { id: 1 } as any;
-    const permissionSecrets = { 'runCmd-minikube': 99 };
+    const permissionSecrets = { 'runCmd-gh': 99 };
 
     const eventData = {
       id: 'test-id',
-      command: 'minikube',
-      args: ['start'],
+      command: 'gh',
+      args: ['auth', 'token'],
       options: {},
-      permissionSecrets: { 'runCmd-minikube': 99 },
+      permissionSecrets: { 'runCmd-gh': 99 },
     };
 
-    handleRunCommand(fakeEvent, eventData, fakeMainWindow, permissionSecrets);
+    await handleRunCommand(fakeEvent, eventData, fakeMainWindow, permissionSecrets);
+
+    expect(spawn).toHaveBeenCalledWith(
+      'gh',
+      ['auth', 'token'],
+      expect.objectContaining({ env: shellEnvironment })
+    );
 
     const err = new Error('spawn error');
     childEmitter.emit('error', err);

--- a/app/electron/runCmd.test.ts
+++ b/app/electron/runCmd.test.ts
@@ -50,7 +50,21 @@ vi.mock('./main', () => ({
   getShellEnvironment: getShellEnvironmentMock,
 }));
 
-import { checkPermissionSecret, handleRunCommand, validateCommandData } from './runCmd';
+import {
+  checkPermissionSecret,
+  environmentOverrides,
+  handleRunCommand,
+  validateCommandData,
+} from './runCmd';
+
+it('does not cache process environment changes as shell overrides', () => {
+  expect(
+    environmentOverrides(
+      { PATH: '/opt/homebrew/bin:/usr/bin', HEADLAMP_CONFIG_ENABLE_HELM: 'true' },
+      { PATH: '/usr/bin', HEADLAMP_CONFIG_ENABLE_HELM: 'true' }
+    )
+  ).toEqual({ PATH: '/opt/homebrew/bin:/usr/bin' });
+});
 
 describe('checkPermissionSecret', () => {
   const baseCommandData = {

--- a/app/electron/runCmd.test.ts
+++ b/app/electron/runCmd.test.ts
@@ -322,6 +322,26 @@ describe('handleRunCommand', () => {
     expect(sentMessages).toContainEqual(['command-exit', 'test-id', -1]);
   });
 
+  it('reports synchronous spawn errors without rejecting', async () => {
+    spawnMock.mockImplementation(() => {
+      throw new Error('spawn failed');
+    });
+    const eventData = {
+      id: 'test-id',
+      command: 'gh',
+      args: ['auth', 'token'],
+      options: {},
+      permissionSecrets: { 'runCmd-gh': 99 },
+    };
+
+    await expect(
+      handleRunCommand(fakeEvent, eventData, { id: 1 } as any, { 'runCmd-gh': 99 })
+    ).resolves.toBeUndefined();
+
+    expect(sentMessages).toContainEqual(['command-stderr', 'test-id', 'spawn failed']);
+    expect(sentMessages).toContainEqual(['command-exit', 'test-id', -1]);
+  });
+
   it('falls back to process.env when shell environment resolution fails', async () => {
     getShellEnvironmentMock.mockRejectedValue(new Error('shell unavailable'));
     vi.stubEnv('HEADLAMP_TEST_ENV', 'current');

--- a/app/electron/runCmd.ts
+++ b/app/electron/runCmd.ts
@@ -285,8 +285,13 @@ export async function handleRunCommand(
       ? [getPluginsScriptPath(commandData.args[0]), ...commandData.args.slice(1)]
       : commandData.args;
 
-  const { getShellEnvironment } = await import('./main');
-  const shellEnvironment = await getShellEnvironment();
+  let shellEnvironment = process.env;
+  try {
+    const { getShellEnvironment } = await import('./main');
+    shellEnvironment = await getShellEnvironment();
+  } catch (error) {
+    console.warn('Failed to get shell environment, using process.env:', error);
+  }
 
   // If the command is 'scriptjs', we pass the HEADLAMP_RUN_SCRIPT=true
   // env var so that the Headlamp or Electron process runs the script.

--- a/app/electron/runCmd.ts
+++ b/app/electron/runCmd.ts
@@ -250,12 +250,12 @@ function getPluginsScriptPath(scriptName: string) {
  * @param permissionSecrets - The permission secrets required for the command to run.
  *                            Checks against eventData.permissionSecrets.
  */
-export function handleRunCommand(
+export async function handleRunCommand(
   event: IpcMainEvent,
   eventData: CommandDataPartial,
   mainWindow: BrowserWindow | null,
   permissionSecrets: Record<string, number>
-): void {
+): Promise<void> {
   if (mainWindow === null) {
     console.error('Main window is null, cannot run command');
     return;
@@ -285,13 +285,16 @@ export function handleRunCommand(
       ? [getPluginsScriptPath(commandData.args[0]), ...commandData.args.slice(1)]
       : commandData.args;
 
+  const { getShellEnvironment } = await import('./main');
+  const shellEnvironment = await getShellEnvironment();
+
   // If the command is 'scriptjs', we pass the HEADLAMP_RUN_SCRIPT=true
   // env var so that the Headlamp or Electron process runs the script.
   const child: ChildProcessWithoutNullStreams = spawn(command, args, {
     ...commandData.options,
     shell: false,
     env: {
-      ...process.env,
+      ...shellEnvironment,
       ...(commandData.command === 'scriptjs' ? { HEADLAMP_RUN_SCRIPT: 'true' } : {}),
     },
   });

--- a/app/electron/runCmd.ts
+++ b/app/electron/runCmd.ts
@@ -43,6 +43,16 @@ interface CommandData {
   permissionSecrets: Record<string, number>;
 }
 
+/** Returns only values changed by shell initialization. */
+export function environmentOverrides(
+  environment: NodeJS.ProcessEnv,
+  currentEnvironment: NodeJS.ProcessEnv = process.env
+): NodeJS.ProcessEnv {
+  return Object.fromEntries(
+    Object.entries(environment).filter(([key, value]) => currentEnvironment[key] !== value)
+  );
+}
+
 /**
  * Ask the user with an electron dialog if they want to allow the command
  * to be executed.

--- a/app/electron/runCmd.ts
+++ b/app/electron/runCmd.ts
@@ -305,14 +305,22 @@ export async function handleRunCommand(
 
   // If the command is 'scriptjs', we pass the HEADLAMP_RUN_SCRIPT=true
   // env var so that the Headlamp or Electron process runs the script.
-  const child: ChildProcessWithoutNullStreams = spawn(command, args, {
-    ...commandData.options,
-    shell: false,
-    env: {
-      ...shellEnvironment,
-      ...(commandData.command === 'scriptjs' ? { HEADLAMP_RUN_SCRIPT: 'true' } : {}),
-    },
-  });
+  let child: ChildProcessWithoutNullStreams;
+  try {
+    child = spawn(command, args, {
+      ...commandData.options,
+      shell: false,
+      env: {
+        ...shellEnvironment,
+        ...(commandData.command === 'scriptjs' ? { HEADLAMP_RUN_SCRIPT: 'true' } : {}),
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    event.sender.send('command-stderr', commandData.id, message);
+    event.sender.send('command-exit', commandData.id, -1);
+    return;
+  }
 
   child.stdout.on('data', (data: string | Buffer) => {
     event.sender.send('command-stdout', commandData.id, data.toString());


### PR DESCRIPTION
Run plugin commands with the user's login-shell environment so desktop
launches can resolve executables installed outside the GUI process PATH.

Cache shell discovery and fall back to process.env on failure. Cover the
GitHub Copilot gh auth token command with a Homebrew-style PATH.


## Testing

On MacOS with the built app, run the ai-assistant plugin, and use the GitHub autodetect feature. It should auto detect.