### PR TITLE
backend: externalproxy: strip auth headers before forwarding

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -763,11 +763,18 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			return
 		}
 
-		// We may want to filter some headers, otherwise we could just use a shallow copy
 		proxyReq.Header = make(http.Header)
 		for h, val := range r.Header {
 			proxyReq.Header[h] = val
 		}
+
+		// Don't leak the caller's credentials or Headlamp's own auth/routing
+		// headers to the (external) proxy target. The target only needs the
+		// proxied request, not the user's Kubernetes token or Headlamp's secrets.
+		clearRequestAuthorization(proxyReq)
+		proxyReq.Header.Del("X-HEADLAMP_BACKEND-TOKEN")
+		proxyReq.Header.Del("proxy-to")
+		proxyReq.Header.Del("Forward-to")
 
 		// Disable caching
 		w.Header().Set("Cache-Control", "no-cache, private, max-age=0")
@@ -1163,6 +1170,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 
 func clearRequestAuthorization(r *http.Request) {
 	r.Header.Del("Authorization")
+	r.Header.Del("Proxy-Authorization")
 	r.Header.Del("Cookie")
 }
 

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -883,11 +883,19 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			return
 		}
 
-		// We may want to filter some headers, otherwise we could just use a shallow copy
 		proxyReq.Header = make(http.Header)
 		for h, val := range r.Header {
 			proxyReq.Header[h] = val
 		}
+
+		// Don't leak the caller's credentials or Headlamp's own auth/routing
+		// headers to the (external) proxy target. The target only needs the
+		// proxied request, not the user's Kubernetes token or Headlamp's secrets.
+		clearRequestAuthorization(proxyReq)
+		clearConfiguredProxyTokenHeader(proxyReq, config.ProxyAuthTokenHeader)
+		proxyReq.Header.Del("X-HEADLAMP_BACKEND-TOKEN")
+		proxyReq.Header.Del("proxy-to")
+		proxyReq.Header.Del("Forward-to")
 
 		// Disable caching
 		w.Header().Set("Cache-Control", "no-cache, private, max-age=0")
@@ -1295,6 +1303,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 
 func clearRequestAuthorization(r *http.Request) {
 	r.Header.Del("Authorization")
+	r.Header.Del("Proxy-Authorization")
 	r.Header.Del("Cookie")
 }
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -662,6 +662,59 @@ func TestExternalProxy(t *testing.T) {
 	}
 }
 
+func TestExternalProxyStripsAuthHeaders(t *testing.T) {
+	// The proxy target sends back the headers it received over a channel, so the
+	// test goroutine reads them without racing the server goroutine.
+	receivedCh := make(chan http.Header, 1)
+
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedCh <- r.Header.Clone()
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	}))
+	defer target.Close()
+
+	handler := createHeadlampHandler(context.Background(), &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:    false,
+				ProxyURLs:       []string{target.URL},
+				KubeConfigStore: kubeconfig.NewContextStore(),
+			},
+			Cache: cache.New[interface{}](),
+		},
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/externalproxy", nil)
+	req.Header.Set("proxy-to", target.URL)
+	req.Header.Set("Authorization", "Bearer user-kubernetes-token")
+	req.Header.Set("X-HEADLAMP_BACKEND-TOKEN", "headlamp-backend-secret")
+	req.Header.Set("Cookie", "headlamp-auth=secret-cookie")
+	req.Header.Set("X-Custom-Header", "keep-me")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var received http.Header
+	select {
+	case received = <-receivedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the proxy target to receive the request")
+	}
+
+	// Sensitive/internal headers must not reach the external target.
+	assert.Empty(t, received.Get("Authorization"), "Authorization should be stripped")
+	assert.Empty(t, received.Get("X-HEADLAMP_BACKEND-TOKEN"), "backend token should be stripped")
+	assert.Empty(t, received.Get("Cookie"), "Cookie should be stripped")
+	assert.Empty(t, received.Get("proxy-to"), "proxy-to should be stripped")
+
+	// Ordinary headers are still forwarded.
+	assert.Equal(t, "keep-me", received.Get("X-Custom-Header"))
+}
+
 func TestCompileProxyURLPatternsInvalidPattern(t *testing.T) {
 	_, err := compileProxyURLPatterns([]string{"["})
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -880,6 +880,70 @@ func TestExternalProxy(t *testing.T) {
 	}
 }
 
+func TestExternalProxyStripsAuthHeaders(t *testing.T) {
+	const proxyAuthTokenHeader = "X-Forwarded-Id-Token" // #nosec G101 -- header name, not a credential
+
+	// The proxy target sends back the headers it received over a channel, so the
+	// test goroutine reads them without racing the server goroutine.
+	receivedCh := make(chan http.Header, 1)
+
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedCh <- r.Header.Clone()
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	}))
+	defer target.Close()
+
+	handler := createHeadlampHandler(context.Background(), &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:    false,
+				ProxyURLs:       []string{target.URL},
+				KubeConfigStore: kubeconfig.NewContextStore(),
+			},
+			ProxyAuthEnabled:     true,
+			ProxyAuthTokenHeader: proxyAuthTokenHeader,
+			Cache:                cache.New[interface{}](),
+		},
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/externalproxy", nil)
+	// Both routing headers name the target; proxy-to is the one the handler picks.
+	req.Header.Set("proxy-to", target.URL)
+	req.Header.Set("Forward-to", target.URL)
+	req.Header.Set("Authorization", "Bearer user-kubernetes-token")
+	req.Header.Set("Proxy-Authorization", "Basic proxy-credentials")
+	req.Header.Set(proxyAuthTokenHeader, "proxy-auth-id-token")
+	req.Header.Set("X-HEADLAMP_BACKEND-TOKEN", "headlamp-backend-secret")
+	req.Header.Set("Cookie", "headlamp-auth=secret-cookie")
+	req.Header.Set("X-Custom-Header", "keep-me")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var received http.Header
+	select {
+	case received = <-receivedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the proxy target to receive the request")
+	}
+
+	// Sensitive/internal headers must not reach the external target.
+	assert.Empty(t, received.Get("Authorization"), "Authorization should be stripped")
+	assert.Empty(t, received.Get("Proxy-Authorization"), "Proxy-Authorization should be stripped")
+	assert.Empty(t, received.Get(proxyAuthTokenHeader), "proxy auth token header should be stripped")
+	assert.Empty(t, received.Get("X-HEADLAMP_BACKEND-TOKEN"), "backend token should be stripped")
+	assert.Empty(t, received.Get("Cookie"), "Cookie should be stripped")
+	assert.Empty(t, received.Get("proxy-to"), "proxy-to should be stripped")
+	assert.Empty(t, received.Get("Forward-to"), "Forward-to should be stripped")
+
+	// Ordinary headers are still forwarded.
+	assert.Equal(t, "keep-me", received.Get("X-Custom-Header"))
+}
+
 func TestCompileProxyURLPatternsInvalidPattern(t *testing.T) {
 	_, err := compileProxyURLPatterns([]string{"["})
 


### PR DESCRIPTION
## Summary

The /externalproxy handler was copying every incoming request header onto the outbound request it makes to the proxy target, no filtering at all. Since that target is an allowlisted external service (reaching non-cluster URLs is the whole point of externalproxy), the caller's credentials got forwarded straight to it: the Authorization bearer token, which is often a live Kubernetes/OIDC credential, Headlamp's own X-HEADLAMP_BACKEND-TOKEN secret, and auth cookies. A target that logs its request headers (pretty common) or gets compromised would then have working creds it was never meant to see.

This deletes the Headlamp-internal auth and routing headers from the outbound request after the copy, so only the headers the target actually needs get through. The old code even had a comment right there saying "We may want to filter some headers", so it looks like a known gap that just never got done.

Being upfront about severity: it's a credential leak across a trust boundary, not an anonymous remote exploit. It needs the external-proxy feature configured with an allowlisted third-party target. But it's still handing cluster tokens and the backend secret out to external services, which shouldn't happen.

## Related Issue

Fixes #6587

## Changes

- backend/cmd/headlamp.go: after copying headers onto the outbound /externalproxy request, delete Authorization, X-HEADLAMP_BACKEND-TOKEN, Cookie, proxy-to and Forward-to so they don't reach the target
- backend/cmd/headlamp_test.go: added a test that points /externalproxy at a recording server and checks those headers are stripped while an ordinary header still gets forwarded

## Steps to Test

1. npm run backend:test (the TestExternalProxy* suite)
2. the new TestExternalProxyStripsAuthHeaders fails on the old code and passes with the fix

I also checked it locally before the fix by pointing /externalproxy at a small server that just records what it receives. the target got:

    Authorization:           "Bearer USER-KUBERNETES-TOKEN"
    X-HEADLAMP_BACKEND-TOKEN: "HEADLAMP-BACKEND-SECRET"
    Cookie:                   "headlamp-auth=SECRET-COOKIE"

after the fix those come through empty and the plain custom header still gets forwarded.

## Screenshots (if applicable)

N/A, backend header handling, nothing visual.

## Notes for the Reviewer

I stripped Cookie and the proxy-to/Forward-to control headers too, not just the tokens, since none of those really belong on the outbound request to an external target. if there's a case where a forwarded cookie is actually wanted i can narrow it down, but i don't think there is.
