### PR TITLE
backend: drainNode: Skip DaemonSet pods via ownerReferences

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -64,6 +64,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -2918,6 +2919,32 @@ func (c *HeadlampConfig) drainNode(
 	}()
 }
 
+// isDaemonSetPod reports whether pod is managed by a DaemonSet. It replaces the
+// kubernetes.io/created-by label, which was removed in Kubernetes 1.16.
+//
+// A DaemonSet controller reference is the normal case. A pod owned by some other
+// controller is not a DaemonSet pod even if it also lists a DaemonSet owner. When
+// no controller reference is set at all, a plain DaemonSet owner still counts,
+// because drain must not delete a pod nothing will recreate.
+func isDaemonSetPod(pod corev1.Pod) bool {
+	if controller := v1.GetControllerOf(&pod); controller != nil {
+		return isDaemonSetOwner(*controller)
+	}
+
+	for _, ref := range pod.OwnerReferences {
+		if isDaemonSetOwner(ref) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isDaemonSetOwner(ref v1.OwnerReference) bool {
+	return ref.APIVersion == appsv1.SchemeGroupVersion.String() &&
+		ref.Kind == "DaemonSet"
+}
+
 func (c *HeadlampConfig) drainNodePods(
 	ctx context.Context,
 	clientset kubernetes.Interface,
@@ -2935,7 +2962,7 @@ func (c *HeadlampConfig) drainNodePods(
 		}
 
 		// ignore daemonsets
-		if pod.Labels["kubernetes.io/created-by"] == "daemonset-controller" {
+		if isDaemonSetPod(pod) {
 			continue
 		}
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -912,6 +913,120 @@ func TestDrainAndCordonNode(t *testing.T) { //nolint:funlen
 	}
 }
 
+func daemonSetPod(name, namespace, nodeName string) *corev1.Pod {
+	controller := true
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "DaemonSet",
+					Name:       "kube-proxy",
+					Controller: &controller,
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+		},
+	}
+}
+
+func ownerRef(kind string, controller bool) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: "apps/v1",
+		Kind:       kind,
+		Name:       "owner",
+		Controller: &controller,
+	}
+}
+
+func podWithOwners(refs ...metav1.OwnerReference) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{OwnerReferences: refs},
+	}
+}
+
+type daemonSetPodTestCase struct {
+	name string
+	pod  corev1.Pod
+	want bool
+}
+
+func daemonSetPodTestCases() []daemonSetPodTestCase {
+	wrongAPIVersion := ownerRef("DaemonSet", true)
+	wrongAPIVersion.APIVersion = "example.io/v1"
+
+	return []daemonSetPodTestCase{
+		{
+			name: "DaemonSet controller owner reference",
+			pod:  *daemonSetPod("kube-proxy-abc", "kube-system", "node-1"),
+			want: true,
+		},
+		{
+			// Nothing else controls the pod, so drain must still skip it.
+			name: "DaemonSet owner reference without controller",
+			pod:  podWithOwners(ownerRef("DaemonSet", false)),
+			want: true,
+		},
+		{
+			name: "DaemonSet owner reference with nil controller",
+			pod: podWithOwners(metav1.OwnerReference{
+				APIVersion: "apps/v1",
+				Kind:       "DaemonSet",
+				Name:       "kube-proxy",
+			}),
+			want: true,
+		},
+		{
+			// The ReplicaSet recreates the pod, so it is drainable.
+			name: "controlled by another controller with DaemonSet owner",
+			pod:  podWithOwners(ownerRef("DaemonSet", false), ownerRef("ReplicaSet", true)),
+			want: false,
+		},
+		{
+			name: "DaemonSet controller with another non-controller owner",
+			pod:  podWithOwners(ownerRef("ReplicaSet", false), ownerRef("DaemonSet", true)),
+			want: true,
+		},
+		{
+			name: "DaemonSet kind from another API",
+			pod:  podWithOwners(wrongAPIVersion),
+			want: false,
+		},
+		{
+			name: "deprecated label only",
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"kubernetes.io/created-by": "daemonset-controller"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "regular pod",
+			pod:  podWithOwners(ownerRef("ReplicaSet", true)),
+			want: false,
+		},
+	}
+}
+
+func TestIsDaemonSetPod(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range daemonSetPodTestCases() {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isDaemonSetPod(tt.pod))
+		})
+	}
+}
+
 func TestDrainNodePodDeletionFailure(t *testing.T) { //nolint:funlen
 	podOk := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -922,16 +1037,7 @@ func TestDrainNodePodDeletionFailure(t *testing.T) { //nolint:funlen
 			NodeName: "test-node",
 		},
 	}
-	podDaemonset := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pod-daemonset",
-			Namespace: "default",
-			Labels:    map[string]string{"kubernetes.io/created-by": "daemonset-controller"},
-		},
-		Spec: corev1.PodSpec{
-			NodeName: "test-node",
-		},
-	}
+	podDaemonset := daemonSetPod("pod-daemonset", "default", "test-node")
 	podFail := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pod-fail",
@@ -992,6 +1098,15 @@ func TestDrainNodePodDeletionFailure(t *testing.T) { //nolint:funlen
 	assert.True(t, strings.HasPrefix(status, "error:"),
 		"expected error status, got: %s", status)
 	assert.Contains(t, status, "failed to delete")
+
+	_, err = fakeClient.CoreV1().Pods("default").Get(ctx, "pod-ok", metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(err))
+
+	_, err = fakeClient.CoreV1().Pods("default").Get(ctx, "pod-daemonset", metav1.GetOptions{})
+	assert.NoError(t, err)
+
+	_, err = fakeClient.CoreV1().Pods("kube-system").Get(ctx, "pod-fail", metav1.GetOptions{})
+	assert.NoError(t, err)
 }
 
 func TestDrainNodeAllPodsDeletedSuccessfully(t *testing.T) {
@@ -1004,16 +1119,7 @@ func TestDrainNodeAllPodsDeletedSuccessfully(t *testing.T) {
 			NodeName: "test-node",
 		},
 	}
-	podDaemonset := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pod-daemonset",
-			Namespace: "default",
-			Labels:    map[string]string{"kubernetes.io/created-by": "daemonset-controller"},
-		},
-		Spec: corev1.PodSpec{
-			NodeName: "test-node",
-		},
-	}
+	podDaemonset := daemonSetPod("pod-daemonset", "default", "test-node")
 
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1053,6 +1159,12 @@ func TestDrainNodeAllPodsDeletedSuccessfully(t *testing.T) {
 	require.True(t, ok)
 
 	assert.Equal(t, "success", status)
+
+	_, err = fakeClient.CoreV1().Pods("default").Get(ctx, "pod-1", metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(err))
+
+	_, err = fakeClient.CoreV1().Pods("default").Get(ctx, "pod-daemonset", metav1.GetOptions{})
+	assert.NoError(t, err)
 }
 
 func TestHandleNodeDrainUsesRequestedClusterCookieForCustomNamedContext(t *testing.T) { //nolint:funlen


### PR DESCRIPTION
## Summary

Node drain used the deprecated `kubernetes.io/created-by: daemonset-controller` label to skip DaemonSet pods. That label was removed in Kubernetes 1.16, so on modern clusters the filter silently did nothing and drain deleted kube-proxy, CNI agents, and other DaemonSet pods that should be skipped.

This change detects `apps/v1` DaemonSet owner references instead. It prefers the controlling owner and safely falls back to a DaemonSet owner only when no controller reference exists.

Fixes #5736

## Changes

- Replace the removed label check with `apps/v1` owner-reference detection
- Preserve pods controlled by DaemonSets during drain
- Cover controller, fallback, multiple-owner, and invalid API cases
- Verify drain deletes regular pods while retaining DaemonSet pods

## Steps to Test

1. Connect Headlamp to a cluster with DaemonSet pods such as kube-proxy.
2. Drain a node that runs those pods.
3. Confirm DaemonSet pods remain and regular pods are deleted.
4. Run:

```bash
cd backend && go test ./cmd/ -run 'TestIsDaemonSetPod|TestDrainNode'
```

## Notes for the Reviewer

- The deprecated label alone no longer classifies a pod as DaemonSet-owned.
- Owner references from APIs other than `apps/v1` are rejected.
- Drain tests use realistic owner references and assert pod retention/deletion.