### PR TITLE
frontend: Pod: Show the network policies that apply to a pod (#4039)

### DIFF
--- a/frontend/src/components/networkpolicy/Details.tsx
+++ b/frontend/src/components/networkpolicy/Details.tsx
@@ -16,19 +16,25 @@
 
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 import { matchExpressionSimplifier, matchLabelsSimplifier } from '../../lib/k8s';
 import { LabelSelector } from '../../lib/k8s/cluster';
+import { matchesLabelSelector } from '../../lib/k8s/labelSelector';
 import NetworkPolicy, {
   NetworkPolicyEgressRule,
   NetworkPolicyIngressRule,
   NetworkPolicyPort,
 } from '../../lib/k8s/networkpolicy';
+import Pod from '../../lib/k8s/pod';
+import Link from '../common/Link';
+import Loader from '../common/Loader';
 import NameValueTable from '../common/NameValueTable';
 import { DetailsGrid } from '../common/Resource';
 import { metadataStyles } from '../common/Resource';
 import SectionBox from '../common/SectionBox';
+import SimpleTable from '../common/SimpleTable';
 
 export function NetworkPolicyDetails(props: {
   name?: string;
@@ -67,6 +73,49 @@ export function NetworkPolicyDetails(props: {
     return prepareMatchLabelsAndExpressions(
       networkPolicy.spec?.podSelector?.matchLabels,
       networkPolicy.spec?.podSelector?.matchExpressions
+    );
+  }
+
+  function SelectedPods(props: { networkPolicy: NetworkPolicy }) {
+    const { networkPolicy } = props;
+    const policyNamespace = networkPolicy.metadata.namespace;
+    const { items: pods } = Pod.useList({
+      namespace: policyNamespace,
+      cluster: networkPolicy.cluster,
+    });
+
+    const podSelector = networkPolicy.spec?.podSelector;
+    const selectedPods = useMemo(
+      () => (pods ?? []).filter(pod => matchesLabelSelector(pod.metadata.labels, podSelector)),
+      [pods, podSelector]
+    );
+
+    return (
+      <SectionBox title={t('Selected Pods')}>
+        {pods === null ? (
+          <Loader title={t('translation|Loading pods')} />
+        ) : selectedPods.length === 0 ? (
+          <Typography color="textSecondary">
+            {t('No pods in the {{ namespace }} namespace are selected by this policy.', {
+              namespace: policyNamespace,
+            })}
+          </Typography>
+        ) : (
+          <SimpleTable
+            columns={[
+              {
+                label: t('translation|Name'),
+                getter: (pod: Pod) => <Link kubeObject={pod}>{pod.getName()}</Link>,
+              },
+              {
+                label: t('translation|Status'),
+                getter: (pod: Pod) => pod.status?.phase ?? '-',
+              },
+            ]}
+            data={selectedPods}
+          />
+        )}
+      </SectionBox>
     );
   }
 
@@ -252,6 +301,10 @@ export function NetworkPolicyDetails(props: {
       }
       extraSections={item =>
         item && [
+          {
+            id: 'networkpolicy-selected-pods',
+            section: <SelectedPods networkPolicy={item} />,
+          },
           {
             id: 'networkpolicy-ingress',
             section: <Ingress ingress={item.spec?.ingress ?? []} />,

--- a/frontend/src/components/networkpolicy/__snapshots__/Details.Default.stories.storyshot
+++ b/frontend/src/components/networkpolicy/__snapshots__/Details.Default.stories.storyshot
@@ -232,6 +232,47 @@
                   <h2
                     class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
                   >
+                    Selected Pods
+                  </h2>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-3mzles-MuiTypography-root"
+              >
+                No pods in the default namespace are selected by this policy.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+                  >
                     Ingress
                   </h2>
                   <div

--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -31,6 +31,8 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, useParams } from 'react-router-dom';
 import { getDefaultContainer, resolveContainerName } from '../../helpers/podContainer';
 import { KubeContainerStatus } from '../../lib/k8s/cluster';
+import { matchesLabelSelector } from '../../lib/k8s/labelSelector';
+import NetworkPolicy from '../../lib/k8s/networkpolicy';
 import Pod from '../../lib/k8s/pod';
 import { localeDate } from '../../lib/util';
 import { DefaultHeaderAction } from '../../redux/actionButtonsSlice';
@@ -528,6 +530,29 @@ export function VolumeDetails(props: VolumeDetailsProps) {
   );
 }
 
+function PodNetworkPolicies(props: { policies: NetworkPolicy[] }) {
+  const { policies } = props;
+  const { t } = useTranslation(['glossary', 'translation']);
+
+  return (
+    <SectionBox title={t('glossary|Network Policies')}>
+      <SimpleTable
+        columns={[
+          {
+            label: t('translation|Name'),
+            getter: (policy: NetworkPolicy) => <Link kubeObject={policy}>{policy.getName()}</Link>,
+          },
+          {
+            label: t('glossary|Policy Types'),
+            getter: (policy: NetworkPolicy) => policy.policyTypes.join(', ') || '-',
+          },
+        ]}
+        data={policies}
+      />
+    </SectionBox>
+  );
+}
+
 function TolerationsSection(props: { tolerations: any[] }) {
   const { tolerations } = props;
   const { t } = useTranslation(['glossary', 'translation']);
@@ -585,6 +610,16 @@ export default function PodDetails(props: PodDetailsProps) {
   const autoLaunchView = queryParams.get('view');
   const autoLaunchContainer = queryParams.get('container') ?? undefined;
   const [podItem, setPodItem] = React.useState<Pod | null>(null);
+
+  const { items: networkPolicies } = NetworkPolicy.useList({ namespace, cluster });
+  const applicableNetworkPolicies = React.useMemo(
+    () =>
+      (networkPolicies ?? []).filter(
+        policy =>
+          !!podItem && matchesLabelSelector(podItem.metadata.labels, policy.spec?.podSelector)
+      ),
+    [networkPolicies, podItem]
+  );
 
   const launchLogs = React.useCallback(
     (item: Pod) => {
@@ -892,6 +927,13 @@ export default function PodDetails(props: PodDetailsProps) {
       extraInfo={item => prepareExtraInfo(item)}
       extraSections={item =>
         item && [
+          {
+            id: 'headlamp.pod-network-policies',
+            section:
+              applicableNetworkPolicies.length > 0 ? (
+                <PodNetworkPolicies policies={applicableNetworkPolicies} />
+              ) : null,
+          },
           {
             id: 'headlamp.pod-tolerations',
             section: <TolerationsSection tolerations={item?.spec?.tolerations || []} />,

--- a/frontend/src/i18n/locales/ar/glossary.json
+++ b/frontend/src/i18n/locales/ar/glossary.json
@@ -117,6 +117,8 @@
   "Job Sets": "مجموعات المهام",
   "Lease": "الإيجار",
   "LimitRange": "نطاق الحدود",
+  "Selected Pods": "",
+  "No pods in the {{ namespace }} namespace are selected by this policy.": "",
   "Ingress": "Ingress",
   "ipBlock": "حظر IP",
   "namespaceSelector": "محدد مساحة الأسماء",

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -707,6 +707,7 @@
   "Namespaces must be under 64 characters.": "يجب أن يكون اسم النطاق أقل من 64 حرفًا",
   "A namespace with this name already exists.": "يوجد نطاق بهذا الاسم بالفعل",
   "Create Namespace": "إنشاء نطاق",
+  "Loading pods": "",
   "To": "إلى",
   "used": "مستخدم",
   "Scheduling Disabled": "تم تعطيل الجدولة",

--- a/frontend/src/i18n/locales/bn/glossary.json
+++ b/frontend/src/i18n/locales/bn/glossary.json
@@ -117,6 +117,8 @@
   "Job Sets": "জব সেট",
   "Lease": "লিজ",
   "LimitRange": "সীমার পরিসর",
+  "Selected Pods": "",
+  "No pods in the {{ namespace }} namespace are selected by this policy.": "",
   "Ingress": "Ingress",
   "ipBlock": "IP ব্লক",
   "namespaceSelector": "নেমস্পেস সিলেক্টর",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -687,6 +687,7 @@
   "Namespaces must be under 64 characters.": "namespace গুলি অবশ্যই 64 টি অক্ষরের অধীনে থাকতে হবে।",
   "A namespace with this name already exists.": "এই নাম সহ একটি namespace ইতিমধ্যে বিদ্যমান।",
   "Create Namespace": "namespace Create করুন",
+  "Loading pods": "",
   "To": "থেকে",
   "used": "ব্যবহৃত",
   "Scheduling Disabled": "Scheduling Disable করা হয়েছে",

--- a/frontend/src/i18n/locales/de/glossary.json
+++ b/frontend/src/i18n/locales/de/glossary.json
@@ -117,6 +117,8 @@
   "Job Sets": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
+  "Selected Pods": "",
+  "No pods in the {{ namespace }} namespace are selected by this policy.": "",
   "Ingress": "Ingress",
   "ipBlock": "ipBlock",
   "namespaceSelector": "Namespace-Auswahl",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -687,6 +687,7 @@
   "Namespaces must be under 64 characters.": "",
   "A namespace with this name already exists.": "",
   "Create Namespace": "",
+  "Loading pods": "",
   "To": "",
   "used": "",
   "Scheduling Disabled": "",

--- a/frontend/src/i18n/locales/en/glossary.json
+++ b/frontend/src/i18n/locales/en/glossary.json
@@ -117,6 +117,8 @@
   "Job Sets": "Job Sets",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
+  "Selected Pods": "Selected Pods",
+  "No pods in the {{ namespace }} namespace are selected by this policy.": "No pods in the {{ namespace }} namespace are selected by this policy.",
   "Ingress": "Ingress",
   "ipBlock": "ipBlock",
   "namespaceSelector": "namespaceSelector",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -687,6 +687,7 @@
   "Namespaces must be under 64 characters.": "Namespaces must be under 64 characters.",
   "A namespace with this name already exists.": "A namespace with this name already exists.",
   "Create Namespace": "Create Namespace",
+  "Loading pods": "Loading pods",
   "To": "To",
   "used": "used",
   "Scheduling Disabled": "Scheduling Disabled",

--- a/frontend/src/i18n/locales/es/glossary.json
+++ b/frontend/src/i18n/locales/es/glossary.json
@@ -117,6 +117,8 @@
   "Job Sets": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
+  "Selected Pods": "",
+  "No pods in the {{ namespace }} namespace are selected by this policy.": "",
   "Ingress": "Ingress",
   "ipBlock": "ipBlock",
   "namespaceSelector": "namespaceSelector",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -692,6 +692,7 @@
   "Namespaces must be under 64 characters.": "",
   "A namespace with this name already exists.": "",
   "Create Namespace": "",
+  "Loading pods": "",
   "To": "",
   "used": "",
   "Scheduling Disabled": "",

--- a/frontend/src/i18n/locales/fr/glossary.json
+++ b/frontend/src/i18n/locales/fr/glossary.json
@@ -117,6 +117,8 @@
   "Job Sets": "Ensembles de jobs",
   "Lease": "Bail",
   "LimitRange": "LimitRange",
+  "Selected Pods": "",
+  "No pods in the {{ namespace }} namespace are selected by this policy.": "",
   "Ingress": "Ingress",
   "ipBlock": "ipBlock",
   "namespaceSelector": "sélecteur d'espace de noms",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -692,6 +692,7 @@
   "Namespaces must be under 64 characters.": "",
   "A namespace with this name already exists.": "",
   "Create Namespace": "",
+  "Loading pods": "",
   "To": "",
   "used": "",
   "Scheduling Disabled": "",

--- a/frontend/src/i18n/locales/he/glossary.json
+++ b/frontend/src/i18n/locales/he/glossary.json
@@ -117,6 +117,8 @@
   "Job Sets": "Job Sets",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
+  "Selected Pods": "",
+  "No pods in the {{ namespace }} namespace are selected by this policy.": "",
   "Ingress": "Ingress",
   "ipBlock": "ipBlock",
   "namespaceSelector": "namespaceSelector",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -692,6 +692,7 @@
   "Namespaces must be under 64 characters.": "Namespaces must be under 64 characters.",
   "A namespace with this name already exists.": "A namespace with this name already exists.",
   "Create Namespace": "Create Namespace",
+  "Loading pods": "",
   "To": "To",
   "used": "used",
   "Scheduling Disabled": "Scheduling Disabled",

--- a/frontend/src/i18n/locales/hi/glossary.json
+++ b/frontend/src/i18n/locales/hi/glossary.json
@@ -117,6 +117,8 @@
   "Job Sets": "",
   "Lease": "लीज़",
   "LimitRange": "लिमिट रेंज",
+  "Selected Pods": "",
+  "No pods in the {{ namespace }} namespace are selected by this policy.": "",
   "Ingress": "इंग्रेस",
   "ipBlock": "ipBlock",
   "namespaceSelector": "namespaceSelector",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -687,6 +687,7 @@
   "Namespaces must be under 64 characters.": "",
   "A namespace with this name already exists.": "",
   "Create Namespace": "",
+  "Loading pods": "",
   "To": "",
   "used": "",
   "Scheduling Disabled": "",

--- a/frontend/src/i18n/locales/it/glossary.json
+++ b/frontend/src/i18n/locales/it/glossary.json
@@ -117,6 +117,8 @@
   "Job Sets": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
+  "Selected Pods": "",
+  "No pods in the {{ namespace }} namespace are selected by this policy.": "",
   "Ingress": "Ingress",
   "ipBlock": "ipBlock",
   "namespaceSelector": "namespaceSelector",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -692,6 +692,7 @@
   "Namespaces must be under 64 characters.": "",
   "A namespace with this name already exists.": "",
   "Create Namespace": "",
+  "Loading pods": "",
   "To": "",
   "used": "",
   "Scheduling Disabled": "",

--- a/frontend/src/i18n/locales/ja/glossary.json
+++ b/frontend/src/i18n/locales/ja/glossary.json
@@ -117,6 +117,8 @@
   "Job Sets": "",
   "Lease": "リース",
   "LimitRange": "制限範囲",
+  "Selected Pods": "",
+  "No pods in the {{ namespace }} namespace are selected by this policy.": "",
   "Ingress": "イングレス",
   "ipBlock": "IP ブロック",
   "namespaceSelector": "ネームスペースセレクター",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -682,6 +682,7 @@
   "Namespaces must be under 64 characters.": "",
   "A namespace with this name already exists.": "",
   "Create Namespace": "",
+  "Loading pods": "",
   "To": "",
   "used": "",
   "Scheduling Disabled": "",

--- a/frontend/src/i18n/locales/ko/glossary.json
+++ b/frontend/src/i18n/locales/ko/glossary.json
@@ -117,6 +117,8 @@
   "Job Sets": "",
   "Lease": "리스",
   "LimitRange": "리미트 레인지",
+  "Selected Pods": "",
+  "No pods in the {{ namespace }} namespace are selected by this policy.": "",
   "Ingress": "인그레스",
   "ipBlock": "IP 블록",
   "namespaceSelector": "네임스페이스 셀렉터",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -682,6 +682,7 @@
   "Namespaces must be under 64 characters.": "",
   "A namespace with this name already exists.": "",
   "Create Namespace": "",
+  "Loading pods": "",
   "To": "",
   "used": "",
   "Scheduling Disabled": "",

--- a/frontend/src/i18n/locales/pt/glossary.json
+++ b/frontend/src/i18n/locales/pt/glossary.json
@@ -117,6 +117,8 @@
   "Job Sets": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
+  "Selected Pods": "",
+  "No pods in the {{ namespace }} namespace are selected by this policy.": "",
   "Ingress": "Ingress",
   "ipBlock": "blocoIP",
   "namespaceSelector": "seletor de Namespace",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -692,6 +692,7 @@
   "Namespaces must be under 64 characters.": "",
   "A namespace with this name already exists.": "",
   "Create Namespace": "",
+  "Loading pods": "",
   "To": "",
   "used": "",
   "Scheduling Disabled": "",

--- a/frontend/src/i18n/locales/ru/glossary.json
+++ b/frontend/src/i18n/locales/ru/glossary.json
@@ -117,6 +117,8 @@
   "Job Sets": "Job Sets",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
+  "Selected Pods": "",
+  "No pods in the {{ namespace }} namespace are selected by this policy.": "",
   "Ingress": "Ingress",
   "ipBlock": "ipBlock",
   "namespaceSelector": "namespaceSelector",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -697,6 +697,7 @@
   "Namespaces must be under 64 characters.": "Пространства имён должны содержать менее 64 символов.",
   "A namespace with this name already exists.": "Пространство имён с таким именем уже существует.",
   "Create Namespace": "Создать пространство имён",
+  "Loading pods": "",
   "To": "К",
   "used": "использовано",
   "Scheduling Disabled": "Планирование отключено",

--- a/frontend/src/i18n/locales/ta/glossary.json
+++ b/frontend/src/i18n/locales/ta/glossary.json
@@ -117,6 +117,8 @@
   "Job Sets": "",
   "Lease": "லீஸ்",
   "LimitRange": "லிமிட்ரேஞ்ச்",
+  "Selected Pods": "",
+  "No pods in the {{ namespace }} namespace are selected by this policy.": "",
   "Ingress": "இன்க்ரெஸ்",
   "ipBlock": "ஐபி பிளாக்",
   "namespaceSelector": "நேம்ஸ்பேஸ் செலக்டர்",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -687,6 +687,7 @@
   "Namespaces must be under 64 characters.": "",
   "A namespace with this name already exists.": "",
   "Create Namespace": "",
+  "Loading pods": "",
   "To": "",
   "used": "",
   "Scheduling Disabled": "",

--- a/frontend/src/i18n/locales/ur/glossary.json
+++ b/frontend/src/i18n/locales/ur/glossary.json
@@ -117,6 +117,8 @@
   "Job Sets": "جاب سیٹس",
   "Lease": "لیز",
   "LimitRange": "لمٹ رینج",
+  "Selected Pods": "",
+  "No pods in the {{ namespace }} namespace are selected by this policy.": "",
   "Ingress": "انگریس",
   "ipBlock": "ipBlock",
   "namespaceSelector": "نییم اسپیس سلیکٹر",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -687,6 +687,7 @@
   "Namespaces must be under 64 characters.": "نیم اسپیس 64 حروف سے کم ہونا چاہیے",
   "A namespace with this name already exists.": "اس نام کا نیم اسپیس پہلے سے موجود ہے",
   "Create Namespace": "نیم اسپیس بنائیں",
+  "Loading pods": "",
   "To": "تک",
   "used": "استعمال شدہ",
   "Scheduling Disabled": "شیڈولنگ غیر فعال",

--- a/frontend/src/i18n/locales/zh-tw/glossary.json
+++ b/frontend/src/i18n/locales/zh-tw/glossary.json
@@ -117,6 +117,8 @@
   "Job Sets": "",
   "Lease": "租約",
   "LimitRange": "限制範圍",
+  "Selected Pods": "",
+  "No pods in the {{ namespace }} namespace are selected by this policy.": "",
   "Ingress": "Ingress",
   "ipBlock": "ipBlock",
   "namespaceSelector": "命名空間選擇器",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -682,6 +682,7 @@
   "Namespaces must be under 64 characters.": "",
   "A namespace with this name already exists.": "",
   "Create Namespace": "",
+  "Loading pods": "",
   "To": "",
   "used": "",
   "Scheduling Disabled": "",

--- a/frontend/src/i18n/locales/zh/glossary.json
+++ b/frontend/src/i18n/locales/zh/glossary.json
@@ -117,6 +117,8 @@
   "Job Sets": "",
   "Lease": "租约",
   "LimitRange": "限制范围",
+  "Selected Pods": "",
+  "No pods in the {{ namespace }} namespace are selected by this policy.": "",
   "Ingress": "Ingress",
   "ipBlock": "ipBlock",
   "namespaceSelector": "命名空间选择器",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -682,6 +682,7 @@
   "Namespaces must be under 64 characters.": "",
   "A namespace with this name already exists.": "",
   "Create Namespace": "",
+  "Loading pods": "",
   "To": "",
   "used": "",
   "Scheduling Disabled": "",

--- a/frontend/src/lib/k8s/labelSelector.test.ts
+++ b/frontend/src/lib/k8s/labelSelector.test.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { matchesLabelSelector } from './labelSelector';
+
+const podLabels = { app: 'web', tier: 'frontend', env: 'prod' };
+
+describe('matchesLabelSelector', () => {
+  describe('empty and absent selectors match everything', () => {
+    it.each([undefined, {}, { matchLabels: {} }, { matchExpressions: [] }])(
+      'matches for selector %j',
+      selector => {
+        expect(matchesLabelSelector(podLabels, selector)).toBe(true);
+        expect(matchesLabelSelector({}, selector)).toBe(true);
+        expect(matchesLabelSelector(undefined, selector)).toBe(true);
+      }
+    );
+  });
+
+  describe('matchLabels (AND of equalities)', () => {
+    it('matches when every key/value is present', () => {
+      expect(
+        matchesLabelSelector(podLabels, { matchLabels: { app: 'web', tier: 'frontend' } })
+      ).toBe(true);
+    });
+
+    it('does not match when a value differs', () => {
+      expect(matchesLabelSelector(podLabels, { matchLabels: { app: 'api' } })).toBe(false);
+    });
+
+    it('does not match when a key is missing', () => {
+      expect(matchesLabelSelector(podLabels, { matchLabels: { team: 'payments' } })).toBe(false);
+    });
+
+    it('does not match labels that are undefined', () => {
+      expect(matchesLabelSelector(undefined, { matchLabels: { app: 'web' } })).toBe(false);
+    });
+  });
+
+  describe('matchExpressions operators', () => {
+    it('In matches when the value is in the set', () => {
+      expect(
+        matchesLabelSelector(podLabels, {
+          matchExpressions: [{ key: 'tier', operator: 'In', values: ['frontend', 'backend'] }],
+        })
+      ).toBe(true);
+    });
+
+    it('In does not match when the value is absent or not in the set', () => {
+      expect(
+        matchesLabelSelector(podLabels, {
+          matchExpressions: [{ key: 'tier', operator: 'In', values: ['backend'] }],
+        })
+      ).toBe(false);
+      expect(
+        matchesLabelSelector(podLabels, {
+          matchExpressions: [{ key: 'missing', operator: 'In', values: ['x'] }],
+        })
+      ).toBe(false);
+    });
+
+    it('NotIn matches when the value is not in the set, including a missing key', () => {
+      expect(
+        matchesLabelSelector(podLabels, {
+          matchExpressions: [{ key: 'tier', operator: 'NotIn', values: ['backend'] }],
+        })
+      ).toBe(true);
+      expect(
+        matchesLabelSelector(podLabels, {
+          matchExpressions: [{ key: 'missing', operator: 'NotIn', values: ['x'] }],
+        })
+      ).toBe(true);
+    });
+
+    it('NotIn does not match when the value is in the set', () => {
+      expect(
+        matchesLabelSelector(podLabels, {
+          matchExpressions: [{ key: 'tier', operator: 'NotIn', values: ['frontend'] }],
+        })
+      ).toBe(false);
+    });
+
+    it('Exists and DoesNotExist check key presence', () => {
+      expect(
+        matchesLabelSelector(podLabels, {
+          matchExpressions: [{ key: 'app', operator: 'Exists', values: [] }],
+        })
+      ).toBe(true);
+      expect(
+        matchesLabelSelector(podLabels, {
+          matchExpressions: [{ key: 'canary', operator: 'Exists', values: [] }],
+        })
+      ).toBe(false);
+      expect(
+        matchesLabelSelector(podLabels, {
+          matchExpressions: [{ key: 'canary', operator: 'DoesNotExist', values: [] }],
+        })
+      ).toBe(true);
+      expect(
+        matchesLabelSelector(podLabels, {
+          matchExpressions: [{ key: 'app', operator: 'DoesNotExist', values: [] }],
+        })
+      ).toBe(false);
+    });
+
+    it('fails closed on an unknown operator', () => {
+      expect(
+        matchesLabelSelector(podLabels, {
+          matchExpressions: [{ key: 'app', operator: 'Contains', values: ['web'] }],
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe('combined criteria are ANDed', () => {
+    it('matches only when matchLabels and every expression hold', () => {
+      const selector = {
+        matchLabels: { env: 'prod' },
+        matchExpressions: [
+          { key: 'tier', operator: 'In', values: ['frontend'] },
+          { key: 'canary', operator: 'DoesNotExist', values: [] },
+        ],
+      };
+      expect(matchesLabelSelector(podLabels, selector)).toBe(true);
+      expect(matchesLabelSelector({ ...podLabels, canary: 'true' }, selector)).toBe(false);
+      expect(matchesLabelSelector({ ...podLabels, env: 'dev' }, selector)).toBe(false);
+    });
+  });
+});

--- a/frontend/src/lib/k8s/labelSelector.ts
+++ b/frontend/src/lib/k8s/labelSelector.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { LabelSelector } from './cluster';
+
+type MatchExpression = NonNullable<LabelSelector['matchExpressions']>[number];
+
+function matchesExpression(labels: Record<string, string>, req: MatchExpression): boolean {
+  const present = Object.prototype.hasOwnProperty.call(labels, req.key);
+  const values = req.values ?? [];
+
+  switch (req.operator) {
+    case 'In':
+      return present && values.includes(labels[req.key]);
+    case 'NotIn':
+      // A missing key satisfies NotIn, matching the API server's set-based semantics.
+      return !present || !values.includes(labels[req.key]);
+    case 'Exists':
+      return present;
+    case 'DoesNotExist':
+      return !present;
+    default:
+      // Unknown operator: fail closed rather than silently matching.
+      return false;
+  }
+}
+
+/**
+ * Evaluates a Kubernetes label selector against a set of labels on the client,
+ * with the same semantics the API server uses for `matchLabels` and
+ * `matchExpressions`.
+ *
+ * An empty or absent selector (no `matchLabels` and no `matchExpressions`)
+ * matches everything, as Kubernetes does. Callers that need the
+ * context-specific meaning of an absent selector (for example a NetworkPolicy
+ * peer where `null` and `{}` differ) should handle that before calling.
+ *
+ * @param labels - the labels to test, for example a Pod's `metadata.labels`.
+ * @param selector - the selector to evaluate.
+ * @returns whether the labels satisfy the selector.
+ */
+export function matchesLabelSelector(
+  labels: Record<string, string> | undefined,
+  selector: LabelSelector | undefined
+): boolean {
+  const { matchLabels, matchExpressions } = selector ?? {};
+
+  const hasCriteria =
+    (matchLabels && Object.keys(matchLabels).length > 0) ||
+    (matchExpressions && matchExpressions.length > 0);
+  if (!hasCriteria) {
+    return true;
+  }
+
+  const target = labels ?? {};
+
+  if (matchLabels) {
+    for (const [key, value] of Object.entries(matchLabels)) {
+      if (target[key] !== value) {
+        return false;
+      }
+    }
+  }
+
+  if (matchExpressions) {
+    for (const req of matchExpressions) {
+      if (!matchesExpression(target, req)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
## What

Completes the pod side of #4039, building on #6574. Adds a **Network Policies** section to the Pod details page that lists the NetworkPolicies whose `podSelector` selects this pod, each linked to its details page, so you can answer "which policies apply to this pod" directly from the pod view.

The section only appears when at least one policy actually governs the pod, so pods with no policies get no extra clutter. Resolution is lifted to the details component so the section entry is omitted entirely (rather than rendering an empty box) when nothing applies.

Together with #6574 (the inverse: which pods a policy selects), this closes both directions the issue asks for:

> finding which pods a given policy actually applies to, as well as finding which policies apply to a given pod

## Note on stacking

This is **stacked on #6574** — it reuses the shared `matchesLabelSelector` helper added there, so the diff currently also shows those commits. Marked as a **draft** until #6574 merges, after which I will rebase so this reduces to just the pod-page commit (`7bfd44280`). Please review #6574 first.

## Testing

- The resolution logic (`matchesLabelSelector`) is exhaustively unit tested in #6574.
- `tsc`, `eslint`, `prettier` clean; the Pod story snapshots are unchanged (the section is conditional and the stories carry no network policies); i18n strings extracted.

cc @illume

Part of #4039
