### PR TITLE
Add vyncent-t to headlamp-maintainers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,6 +6,7 @@ aliases:
     - yolossn
     - ashu8912
     - skoeva
+    - vyncent-t
   headlamp-reviewers:
     - joaquimrocha
     - illume


### PR DESCRIPTION
## Summary

Been fulltime with the Headlamp team since 2023, no longer limited to just a reviewers capacity through years or contributions and overall project maintenance.

## Changes

- Added  `vyncent-t` to the `maintainers` list in the `OWNERS_ALIASES` file.