### PR TITLE
frontend: scope redux serializable check exceptions

### DIFF
--- a/frontend/src/components/App/Settings/SettingsCluster.stories.tsx
+++ b/frontend/src/components/App/Settings/SettingsCluster.stories.tsx
@@ -54,7 +54,7 @@ function getMockStore(clusters: Record<string, any> = {}) {
       ui: (state = {}) => state,
       filter: (
         state = {
-          namespaces: new Set(),
+          namespaces: [],
           search: '',
         }
       ) => state,

--- a/frontend/src/components/Sidebar/NavigationTabs.stories.tsx
+++ b/frontend/src/components/Sidebar/NavigationTabs.stories.tsx
@@ -122,7 +122,7 @@ const createMockStoryStore = (sidebarConfig: Partial<SidebarState>) => {
       sidebar: createSlice({ name: 'sidebar', initialState: fullSidebarState, reducers: {} })
         .reducer,
       config: (state = configInitialState) => state,
-      filter: (state = { namespaces: new Set() }) => state,
+      filter: (state = { namespaces: [] }) => state,
       routes: (state = { routes: {}, routeFilters: [] }) => state,
       ui: (state = { functionsToOverride: {} }) => state,
       projects: (state = { projects: {} }) => state,

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -217,7 +217,7 @@ export default function Sidebar() {
 
   const items = useSidebarItems(sidebar?.selected?.sidebar ?? undefined);
 
-  const search = namespaces.size !== 0 ? `?namespace=${[...namespaces].join('+')}` : '';
+  const search = namespaces.length !== 0 ? `?namespace=${namespaces.join('+')}` : '';
 
   const handleToggleOpen = useCallback(() => {
     dispatch(setWhetherSidebarOpen(!sidebar.isSidebarOpen));

--- a/frontend/src/components/common/NamespacesAutocomplete.stories.tsx
+++ b/frontend/src/components/common/NamespacesAutocomplete.stories.tsx
@@ -28,15 +28,15 @@ export default {
 } as Meta;
 
 const Template: StoryFn<PureNamespacesAutocompleteProps> = args => {
-  const [filter, setFilter] = React.useState<{ namespaces: Set<string>; search: string }>({
-    namespaces: new Set([]),
+  const [filter, setFilter] = React.useState<{ namespaces: string[]; search: string }>({
+    namespaces: [],
     search: '',
   });
   const namespaceNames = React.useState<string[]>(['default', 'kube-system', 'kube-public'])[0];
 
   const onChange = (event: React.ChangeEvent<{}>, newValue: string[]) => {
     setFilter({
-      namespaces: new Set(newValue),
+      namespaces: newValue,
       search: '',
     });
   };

--- a/frontend/src/components/common/NamespacesAutocomplete.tsx
+++ b/frontend/src/components/common/NamespacesAutocomplete.tsx
@@ -77,7 +77,7 @@ function addQuery(
 export interface PureNamespacesAutocompleteProps {
   namespaceNames: string[];
   onChange: (event: React.ChangeEvent<{}>, newValue: string[]) => void;
-  filter: { namespaces: Set<string> };
+  filter: { namespaces: string[] };
 }
 
 export function PureNamespacesAutocomplete({
@@ -117,7 +117,7 @@ export function PureNamespacesAutocomplete({
       inputValue={namespaceInput}
       // We reverse the namespaces so the last chosen appear as the first in the label. This
       // is useful since the label is ellipsized and this we get to see it change.
-      value={[...filter.namespaces.values()].reverse()}
+      value={[...filter.namespaces].reverse()}
       renderOption={(props, option, { selected }) => (
         <li {...props} key={props.key}>
           <Checkbox
@@ -185,7 +185,7 @@ export function PureNamespacesAutocomplete({
             fullWidth
             InputLabelProps={{ shrink: true }}
             style={{ marginTop: 0 }}
-            placeholder={[...filter.namespaces.values()].length > 0 ? '' : t('Filter')}
+            placeholder={filter.namespaces.length > 0 ? '' : t('Filter')}
           />
         </Box>
       )}
@@ -250,7 +250,7 @@ const useDefaultNamespaceFallback = (
       allClustersConfigs &&
       isNamespaceError &&
       (!namespacesList || namespacesList?.length === 0) &&
-      selectedNamespaces.size === 0
+      selectedNamespaces.length === 0
     ) {
       const defaultNamespaceFromKubeconfig =
         allClustersConfigs[currentCluster]?.meta_data.namespace;

--- a/frontend/src/components/common/Resource/ResourceTable.stories.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.stories.tsx
@@ -53,7 +53,7 @@ const TemplateWithFilter: StoryFn<{
   const storeWithFilterAndSettings = configureStore({
     reducer: (
       state = {
-        filter: { namespaces: new Set<string>() },
+        filter: { namespaces: [] },
         config: { settings: { tableRowsPerPageOptions: [10, 20, 50, 100] } },
         ui: { ...uiSlice.getInitialState() },
         drawerMode: { isDetailDrawerEnabled: false },
@@ -63,7 +63,7 @@ const TemplateWithFilter: StoryFn<{
     preloadedState: {
       ui: { ...uiSlice.getInitialState() },
       filter: {
-        namespaces: new Set(namespaces),
+        namespaces,
       },
       config: {
         settings: {

--- a/frontend/src/components/common/SectionFilterHeader.stories.tsx
+++ b/frontend/src/components/common/SectionFilterHeader.stories.tsx
@@ -26,7 +26,7 @@ import SectionFilterHeader, { SectionFilterHeaderProps } from './SectionFilterHe
 function makeStore(namespaces: string[] = []) {
   return configureStore({
     reducer: reducers,
-    preloadedState: { filter: { namespaces: new Set(namespaces), search: '' } } as any,
+    preloadedState: { filter: { namespaces, search: '' } } as any,
     middleware: getDefaultMiddleware => getDefaultMiddleware({ serializableCheck: false }),
   });
 }

--- a/frontend/src/components/common/SimpleTable.stories.tsx
+++ b/frontend/src/components/common/SimpleTable.stories.tsx
@@ -258,13 +258,13 @@ const TemplateWithFilter: StoryFn<{
   const storeWithFilterAndSettings = configureStore({
     reducer: (
       state = {
-        filter: { namespaces: new Set<string>() },
+        filter: { namespaces: [] },
         config: { settings: { tableRowsPerPageOptions: [10, 20, 50, 100] } },
       }
     ) => state,
     preloadedState: {
       filter: {
-        namespaces: new Set(namespaces),
+        namespaces,
       },
       config: {
         settings: {

--- a/frontend/src/components/common/Table/Table.stories.tsx
+++ b/frontend/src/components/common/Table/Table.stories.tsx
@@ -263,14 +263,14 @@ const TemplateWithFilter: StoryFn<{
   const storeWithFilterAndSettings = configureStore({
     reducer: (
       state = {
-        filter: { namespaces: new Set<string>(), search: '' },
+        filter: { namespaces: [], search: '' },
         config: { settings: { tableRowsPerPageOptions: [10, 20, 50, 100] } },
         shortcuts: { ...shortcutsReducer(undefined, { type: '' }) },
       }
     ) => state,
     preloadedState: {
       filter: {
-        namespaces: new Set(namespaces),
+        namespaces,
         search,
       },
       config: {

--- a/frontend/src/components/project/ProjectDetails.tsx
+++ b/frontend/src/components/project/ProjectDetails.tsx
@@ -634,7 +634,7 @@ function ProjectGraph({ project: { namespaces, clusters } }: { project: ProjectD
         namespaces.length > 0
           ? {
               type: 'namespace',
-              namespaces: new Set(namespaces),
+              namespaces,
             }
           : undefined,
       ].filter(Boolean) as GraphFilter[],

--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -213,7 +213,7 @@ function GraphViewContent({
     if (hasErrorsFilter) {
       filters.push({ type: 'hasErrors' });
     }
-    if (namespaces?.size > 0) {
+    if (namespaces.length > 0) {
       filters.push({ type: 'namespace', namespaces });
     }
     return filters;
@@ -507,7 +507,7 @@ function GraphViewContent({
                 />
                 <Box sx={{ fontSize: '14px', marginLeft: 1 }}>{t('Group By')}</Box>
                 <ChipGroup>
-                  {namespaces.size !== 1 && (
+                  {namespaces.length !== 1 && (
                     <ChipToggleButton
                       label={t('Namespace')}
                       isActive={groupBy === 'namespace'}

--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -223,7 +223,7 @@ function GraphViewContent({
     if (hasErrorsFilter) {
       filters.push({ type: 'hasErrors' });
     }
-    if (namespaces?.size > 0) {
+    if (namespaces.length > 0) {
       filters.push({ type: 'namespace', namespaces });
     }
     return filters;
@@ -508,7 +508,7 @@ function GraphViewContent({
                 />
                 <Box sx={{ fontSize: '14px', marginLeft: 1 }}>{t('Group By')}</Box>
                 <ChipGroup>
-                  {namespaces.size !== 1 && (
+                  {namespaces.length !== 1 && (
                     <ChipToggleButton
                       label={t('Namespace')}
                       isActive={groupBy === 'namespace'}

--- a/frontend/src/components/resourceMap/graph/graphFiltering.test.ts
+++ b/frontend/src/components/resourceMap/graph/graphFiltering.test.ts
@@ -70,7 +70,7 @@ describe('filterGraph', () => {
   ];
 
   it('filters nodes by namespace', () => {
-    const filters: GraphFilter[] = [{ type: 'namespace', namespaces: new Set(['ns3']) }];
+    const filters: GraphFilter[] = [{ type: 'namespace', namespaces: ['ns3'] }];
     const { nodes: filteredNodes } = filterGraph(nodes, edges, filters);
 
     // Output contains two nodes that both have same namespace ns3
@@ -216,7 +216,7 @@ describe('filterGraph', () => {
     const testNodes = [nsNode, errNode, otherNode];
     const testEdges: GraphEdge[] = [];
     const filters: GraphFilter[] = [
-      { type: 'namespace', namespaces: new Set(['kube-system']) },
+      { type: 'namespace', namespaces: ['kube-system'] },
       { type: 'hasErrors' },
     ];
 
@@ -255,7 +255,7 @@ describe('filterGraph', () => {
     ];
     const testEdges: GraphEdge[] = [];
     const filters: GraphFilter[] = [
-      { type: 'namespace', namespaces: new Set(['kube-system']) },
+      { type: 'namespace', namespaces: ['kube-system'] },
       { type: 'hasErrors' },
     ];
 
@@ -694,7 +694,7 @@ describe('filterGraphIncremental', () => {
     const addedNodeIds = new Set(['pod-3']);
 
     // Filter by 'default' namespace (same filter as before)
-    const filters: GraphFilter[] = [{ type: 'namespace', namespaces: new Set(['default']) }];
+    const filters: GraphFilter[] = [{ type: 'namespace', namespaces: ['default'] }];
 
     const result = filterGraphIncremental(
       prevFilteredNodes,
@@ -1050,7 +1050,7 @@ describe('filterGraphIncremental', () => {
     const addedNodeIds = new Set(['pod-1', 'pod-2', 'pod-3']);
 
     const filters: GraphFilter[] = [
-      { type: 'namespace', namespaces: new Set(['kube-system']) },
+      { type: 'namespace', namespaces: ['kube-system'] },
       { type: 'hasErrors' },
     ];
 
@@ -1221,7 +1221,7 @@ describe('filterGraphIncremental', () => {
       { id: 'e2', source: 'healthy-pod', target: 'isolated-pod' },
     ];
     const filters: GraphFilter[] = [
-      { type: 'namespace', namespaces: new Set(['kube-system']) },
+      { type: 'namespace', namespaces: ['kube-system'] },
       { type: 'hasErrors' },
     ];
 
@@ -1282,7 +1282,7 @@ describe('filterGraphIncremental', () => {
     ];
     const prevEdges: GraphEdge[] = [{ id: 'e1', source: 'pod-0', target: 'pod-1' }];
     const filters: GraphFilter[] = [
-      { type: 'namespace', namespaces: new Set(['kube-system']) },
+      { type: 'namespace', namespaces: ['kube-system'] },
       { type: 'hasErrors' },
     ];
 
@@ -1350,7 +1350,7 @@ describe('filterGraphIncremental', () => {
     };
 
     const filters: GraphFilter[] = [
-      { type: 'namespace', namespaces: new Set(['kube-system']) },
+      { type: 'namespace', namespaces: ['kube-system'] },
       { type: 'hasErrors' },
     ];
 

--- a/frontend/src/components/resourceMap/graph/graphFiltering.ts
+++ b/frontend/src/components/resourceMap/graph/graphFiltering.ts
@@ -25,7 +25,7 @@ export type GraphFilter =
     }
   | {
       type: 'namespace';
-      namespaces: Set<string>;
+      namespaces: string[];
     };
 
 /**
@@ -39,9 +39,9 @@ export function matchesAllFilters(node: GraphNode, filters: GraphFilter[]): bool
     if (filter.type === 'hasErrors') {
       return getGraphNodeStatus(node) !== 'success';
     }
-    if (filter.type === 'namespace' && filter.namespaces.size > 0) {
+    if (filter.type === 'namespace' && filter.namespaces.length > 0) {
       const namespace = node.kubeObject?.metadata?.namespace;
-      return !!namespace && filter.namespaces.has(namespace);
+      return !!namespace && filter.namespaces.includes(namespace);
     }
     return true;
   });

--- a/frontend/src/redux/filterSlice.test.ts
+++ b/frontend/src/redux/filterSlice.test.ts
@@ -33,7 +33,7 @@ describe('filterSlice', () => {
   const STORAGE_KEY = 'headlamp-selected-namespace_test-cluster';
 
   beforeEach(() => {
-    state = { ...initialState, namespaces: new Set() };
+    state = { ...initialState, namespaces: [] };
     localStorage.clear();
     vi.clearAllMocks();
   });
@@ -43,7 +43,7 @@ describe('filterSlice', () => {
     state = filterReducer(state, setNamespaceFilter(namespaces));
 
     // Verify state update
-    expect(state.namespaces).toEqual(new Set(namespaces));
+    expect(state.namespaces).toEqual(namespaces);
 
     // Verify localStorage write
     const stored = localStorage.getItem(STORAGE_KEY);
@@ -54,11 +54,11 @@ describe('filterSlice', () => {
   it('should handle resetFilter and clear namespaces', () => {
     state = {
       ...state,
-      namespaces: new Set(['default']),
+      namespaces: ['default'],
     };
 
     state = filterReducer(state, resetFilter());
-    expect(state.namespaces).toEqual(new Set());
+    expect(state.namespaces).toEqual([]);
   });
 
   describe('getSavedNamespaces (Persistence Logic)', () => {
@@ -91,7 +91,7 @@ describe('filterSlice', () => {
   });
 
   describe('filterResource search', () => {
-    const filter: FilterState = { ...initialState, namespaces: new Set() };
+    const filter: FilterState = { ...initialState, namespaces: [] };
 
     const makeItem = (metadata: object) => ({ kind: 'Pod', apiVersion: 'v1', metadata } as any);
 

--- a/frontend/src/redux/filterSlice.ts
+++ b/frontend/src/redux/filterSlice.ts
@@ -25,11 +25,11 @@ import { getSavedNamespaces, saveNamespaces } from '../lib/storage';
 
 export interface FilterState {
   /** The namespaces to filter on. */
-  namespaces: Set<string>;
+  namespaces: string[];
 }
 
 export const initialState: FilterState = {
-  namespaces: new Set(getSavedNamespaces()),
+  namespaces: getSavedNamespaces(),
 };
 
 /**
@@ -49,8 +49,8 @@ export function filterResource(
 ) {
   let matches: boolean = true;
 
-  if (item.metadata.namespace && filter.namespaces.size > 0) {
-    matches = filter.namespaces.has(item.metadata.namespace);
+  if (item.metadata.namespace && filter.namespaces.length > 0) {
+    matches = filter.namespaces.includes(item.metadata.namespace);
   }
 
   if (!matches) {
@@ -144,16 +144,16 @@ const filterSlice = createSlice({
         .map(ns => (typeof ns === 'string' ? ns.trim() : ''))
         .filter(Boolean);
 
-      const namespacesSet = new Set(namespaces);
-      state.namespaces = namespacesSet;
+      const uniqueNamespaces = [...new Set(namespaces)];
+      state.namespaces = uniqueNamespaces;
 
-      saveNamespaces([...namespacesSet]);
+      saveNamespaces(uniqueNamespaces);
     },
     /**
      * Resets the filter state.
      */
     resetFilter(state) {
-      state.namespaces = new Set();
+      state.namespaces = [];
       saveNamespaces([]);
     },
   },
@@ -169,6 +169,6 @@ export default filterSlice.reducer;
  * @returns An array of selected namespaces, empty means all namespaces are visible
  */
 export const useNamespaces = () => {
-  const namespacesSet = useSelector(({ filter }: { filter: FilterState }) => filter.namespaces);
-  return useMemo(() => [...namespacesSet], [namespacesSet]);
+  const namespaces = useSelector(({ filter }: { filter: FilterState }) => filter.namespaces);
+  return useMemo(() => namespaces.slice(), [namespaces]);
 };

--- a/frontend/src/redux/filterSlice.ts
+++ b/frontend/src/redux/filterSlice.ts
@@ -25,11 +25,11 @@ import { getSavedNamespaces, saveNamespaces } from '../lib/storage';
 
 export interface FilterState {
   /** The namespaces to filter on. */
-  namespaces: Set<string>;
+  namespaces: string[];
 }
 
 export const initialState: FilterState = {
-  namespaces: new Set(getSavedNamespaces()),
+  namespaces: getSavedNamespaces(),
 };
 
 /**
@@ -49,8 +49,8 @@ export function filterResource(
 ) {
   let matches: boolean = true;
 
-  if (item.metadata.namespace && filter.namespaces.size > 0) {
-    matches = filter.namespaces.has(item.metadata.namespace);
+  if (item.metadata.namespace && filter.namespaces.length > 0) {
+    matches = filter.namespaces.includes(item.metadata.namespace);
   }
 
   if (!matches) {
@@ -144,16 +144,16 @@ const filterSlice = createSlice({
         .map(ns => (typeof ns === 'string' ? ns.trim() : ''))
         .filter(Boolean);
 
-      const namespacesSet = new Set(namespaces);
-      state.namespaces = namespacesSet;
+      const uniqueNamespaces = [...new Set(namespaces)];
+      state.namespaces = uniqueNamespaces;
 
-      saveNamespaces([...namespacesSet]);
+      saveNamespaces(uniqueNamespaces);
     },
     /**
      * Resets the filter state.
      */
     resetFilter(state) {
-      state.namespaces = new Set();
+      state.namespaces = [];
       saveNamespaces([]);
     },
   },
@@ -169,6 +169,6 @@ export default filterSlice.reducer;
  * @returns An array of selected namespaces, empty means all namespaces are visible
  */
 export const useNamespaces = () => {
-  const namespacesSet = useSelector(({ filter }: { filter: FilterState }) => filter.namespaces);
-  return useMemo(() => [...namespacesSet], [namespacesSet]);
+  const namespaces = useSelector(({ filter }: { filter: FilterState }) => filter.namespaces);
+  return useMemo(() => namespaces, [namespaces]);
 };

--- a/frontend/src/redux/stores/store.test.tsx
+++ b/frontend/src/redux/stores/store.test.tsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { configureStore, createSlice } from '@reduxjs/toolkit';
+import { activityReducer, activitySlice } from '../../components/activity/activitySlice';
+import resourceTableReducer, {
+  addResourceTableColumnsProcessor,
+} from '../../components/common/Resource/resourceTableSlice';
+import type { Route } from '../../lib/router/Route';
+import pluginsReducer, { setPluginSettingsComponent } from '../../plugin/pluginsSlice';
+import filterReducer, { setNamespaceFilter } from '../filterSlice';
+import eventCallbackReducer, { addEventCallback, listenerMiddleware } from '../headlampEventSlice';
+import routesReducer, { setRoute, setRouteFilter } from '../routesSlice';
+import { serializableCheckOptions } from './store';
+
+const unrelatedSlice = createSlice({
+  name: 'unrelated',
+  initialState: {
+    value: null as unknown,
+  },
+  reducers: {
+    setValue(state, action: PayloadAction<unknown>) {
+      state.value = action.payload;
+    },
+  },
+});
+
+function createTestStore() {
+  return configureStore({
+    reducer: {
+      filter: filterReducer,
+      routes: routesReducer,
+      resourceTable: resourceTableReducer,
+      eventCallbackReducer,
+      plugins: pluginsReducer,
+      activity: activityReducer,
+      unrelated: unrelatedSlice.reducer,
+    },
+    middleware: getDefaultMiddleware =>
+      getDefaultMiddleware({
+        serializableCheck: serializableCheckOptions,
+      }).prepend(listenerMiddleware.middleware),
+  });
+}
+
+function consoleErrorCallsContain(consoleErrorSpy: ReturnType<typeof vi.spyOn>, expected: string) {
+  return consoleErrorSpy.mock.calls.some(call => call.some(arg => String(arg).includes(expected)));
+}
+
+describe('store serializable middleware', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('allows known route and event callback registrations without disabling the guard globally', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const store = createTestStore();
+    const route: Route = {
+      path: '/test',
+      component: () => <div>Test</div>,
+      sidebar: null,
+    };
+    const processor = () => [];
+    const routeFilter = (candidate: Route) => candidate;
+    const eventCallback = () => {};
+    const PluginSettings = () => <div>Plugin settings</div>;
+    const activityContent = <div>Activity</div>;
+
+    store.dispatch(setNamespaceFilter(['default']));
+    store.dispatch(setRoute(route));
+    store.dispatch(setRouteFilter(routeFilter));
+    store.dispatch(addResourceTableColumnsProcessor(processor));
+    store.dispatch(addEventCallback(eventCallback));
+    store.dispatch(
+      setPluginSettingsComponent({
+        name: 'plugin',
+        component: PluginSettings,
+        displaySaveButton: true,
+      })
+    );
+    store.dispatch(
+      activitySlice.actions.launchActivity({
+        id: 'activity',
+        title: 'Activity',
+        icon: null,
+        location: 'full',
+        content: activityContent,
+      })
+    );
+    store.dispatch(activitySlice.actions.update({ id: 'activity', content: activityContent }));
+    store.dispatch(unrelatedSlice.actions.setValue('serializable'));
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('still reports unrelated non-serializable state updates', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const store = createTestStore();
+    const nonSerializableValue = () => null;
+
+    store.dispatch(unrelatedSlice.actions.setValue(nonSerializableValue));
+
+    expect(
+      consoleErrorCallsContain(
+        consoleErrorSpy,
+        'A non-serializable value was detected in an action'
+      )
+    ).toBe(true);
+    expect(consoleErrorCallsContain(consoleErrorSpy, 'unrelated/setValue')).toBe(true);
+    expect(
+      consoleErrorCallsContain(
+        consoleErrorSpy,
+        'A non-serializable value was detected in the state'
+      )
+    ).toBe(true);
+  });
+});

--- a/frontend/src/redux/stores/store.tsx
+++ b/frontend/src/redux/stores/store.tsx
@@ -15,30 +15,152 @@
  */
 
 import { configureStore } from '@reduxjs/toolkit';
+import { activitySlice } from '../../components/activity/activitySlice';
+import { setBrandingAppLogoComponent } from '../../components/App/themeSlice';
+import { addResourceTableColumnsProcessor } from '../../components/common/Resource/resourceTableSlice';
+import {
+  addDetailsViewSectionsProcessor,
+  setDetailsView,
+  setDetailsViewSection,
+} from '../../components/DetailsViewSection/detailsViewSectionSlice';
+import {
+  addGraphSource,
+  addKindIcon,
+  setGlance,
+} from '../../components/resourceMap/graphViewSlice';
+import {
+  setHomeSidebarItemFilter,
+  setSidebarItem,
+  setSidebarItemFilter,
+} from '../../components/Sidebar/sidebarSlice';
+import { setPluginSettingsComponent } from '../../plugin/pluginsSlice';
+import {
+  addDetailsViewHeaderActionsProcessor,
+  setAppBarAction,
+  setAppBarActionsProcessor,
+  setDetailsViewHeaderAction,
+} from '../actionButtonsSlice';
 import { initialState as CLUSTER_ACTIONS_INITIAL_STATE } from '../clusterActionSlice';
+import {
+  addAddClusterProvider,
+  addClusterStatus,
+  addDialog,
+  addMenuItem,
+} from '../clusterProviderSlice';
 import { initialState as CLUSTER_PROVIDER_INITIAL_STATE } from '../clusterProviderSlice';
 import { initialState as CONFIG_INITIAL_STATE } from '../configSlice';
 import { initialState as FILTER_INITIAL_STATE } from '../filterSlice';
-import { listenerMiddleware } from '../headlampEventSlice';
+import { addEventCallback, listenerMiddleware } from '../headlampEventSlice';
+import { addOverviewChartsProcessor } from '../overviewChartsSlice';
+import {
+  addCustomCreateProject,
+  addDetailsTab,
+  addHeaderAction,
+  addOverviewSection,
+  setProjectDeleteButton,
+} from '../projectsSlice';
 import reducers from '../reducers/reducers';
+import { setRoute, setRouteFilter } from '../routesSlice';
+import { uiSlice } from '../uiSlice';
 
-const store = configureStore({
-  reducer: reducers,
-  preloadedState: {
-    filter: FILTER_INITIAL_STATE,
-    config: CONFIG_INITIAL_STATE,
-    clusterAction: CLUSTER_ACTIONS_INITIAL_STATE,
-    clusterProvider: CLUSTER_PROVIDER_INITIAL_STATE,
-  },
-  middleware: getDefaultMiddleware =>
-    getDefaultMiddleware({
-      serializableCheck: false,
-      thunk: true,
-    }).prepend(listenerMiddleware.middleware),
-});
+export const serializableCheckOptions = {
+  ignoredActions: [
+    setBrandingAppLogoComponent.type,
+    addDetailsViewSectionsProcessor.type,
+    setDetailsView.type,
+    setDetailsViewSection.type,
+    setHomeSidebarItemFilter.type,
+    setSidebarItem.type,
+    setSidebarItemFilter.type,
+    addResourceTableColumnsProcessor.type,
+    addGraphSource.type,
+    addKindIcon.type,
+    setGlance.type,
+    addDetailsViewHeaderActionsProcessor.type,
+    setAppBarAction.type,
+    setAppBarActionsProcessor.type,
+    setDetailsViewHeaderAction.type,
+    addAddClusterProvider.type,
+    addClusterStatus.type,
+    addDialog.type,
+    addMenuItem.type,
+    addEventCallback.type,
+    addOverviewChartsProcessor.type,
+    addCustomCreateProject.type,
+    addDetailsTab.type,
+    addHeaderAction.type,
+    addOverviewSection.type,
+    setProjectDeleteButton.type,
+    setRoute.type,
+    setRouteFilter.type,
+    setPluginSettingsComponent.type,
+    activitySlice.actions.launchActivity.type,
+    activitySlice.actions.update.type,
+    uiSlice.actions.addUIPanel.type,
+    uiSlice.actions.setClusterChooserButton.type,
+    uiSlice.actions.setFunctionsToOverride.type,
+  ],
+  ignoredPaths: [
+    'actionButtons.appBarActions',
+    'actionButtons.appBarActionsProcessors',
+    'actionButtons.headerActions',
+    'actionButtons.headerActionsProcessors',
+    'clusterProvider.clusterProviders',
+    'clusterProvider.clusterStatuses',
+    'clusterProvider.dialogs',
+    'clusterProvider.menuItems',
+    'detailsViewSection.detailViews',
+    'detailsViewSection.detailsViewSections',
+    'detailsViewSection.detailsViewSectionsProcessors',
+    'detailsViewSections.detailViews',
+    'detailsViewSections.detailsViewSections',
+    'detailsViewSections.detailsViewSectionsProcessors',
+    'routes.routes',
+    'routes.routeFilters',
+    'eventCallbackReducer.trackerFuncs',
+    'graphView.glances',
+    'graphView.graphSources',
+    'graphView.kindIcons',
+    'overviewCharts.processors',
+    'plugins.pluginSettings',
+    'projects.customCreateProject',
+    'projects.detailsTabs',
+    'projects.headerActions',
+    'projects.overviewSections',
+    'projects.projectDeleteButton',
+    'resourceTable.tableColumnsProcessors',
+    'sidebar.entries',
+    'sidebar.filters',
+    'sidebar.homeFilters',
+    'theme.logo',
+    'activity.activities',
+    'ui.clusterChooserButtonComponent',
+    'ui.functionsToOverride',
+    'ui.panels',
+  ],
+};
+
+export function createStore() {
+  return configureStore({
+    reducer: reducers,
+    preloadedState: {
+      filter: FILTER_INITIAL_STATE,
+      config: CONFIG_INITIAL_STATE,
+      clusterAction: CLUSTER_ACTIONS_INITIAL_STATE,
+      clusterProvider: CLUSTER_PROVIDER_INITIAL_STATE,
+    },
+    middleware: getDefaultMiddleware =>
+      getDefaultMiddleware({
+        serializableCheck: serializableCheckOptions,
+        thunk: true,
+      }).prepend(listenerMiddleware.middleware),
+  });
+}
+
+const store = createStore();
 
 export default store;
 
-export type AppDispatch = typeof store.dispatch;
-export type RootState = ReturnType<typeof store.getState>;
-export type AppStore = typeof store;
+export type AppStore = ReturnType<typeof createStore>;
+export type AppDispatch = AppStore['dispatch'];
+export type RootState = ReturnType<AppStore['getState']>;


### PR DESCRIPTION
## Summary
- restore Redux Toolkit serializability checks in the root store
- scope non-serializable exceptions to known plugin and UI registration paths
- add a store regression test proving known exceptions are allowed while unrelated non-serializable updates still warn

## Linked Issue
Fixes #6600

## What Changed
- replaced the global `serializableCheck: false` setting in `frontend/src/redux/stores/store.tsx` with a narrow allowlist of known registration actions and state paths
- exported a `createStore()` helper and serializable middleware options for focused verification
- added `frontend/src/redux/stores/store.test.tsx` to verify the store permits known route/resource-table/event registrations but still reports unrelated non-serializable updates

## Verification
- `cd frontend && npm test -- src/redux/stores/store.test.tsx` — passed
- `npm run frontend:tsc` — passed
- `npm run frontend:lint` — passed
- `npm run lint` — passed
- `npm run backend:test` — passed
- `npm run frontend:test` — failed: pre-existing Storybook failures unrelated to this change in `src/storybook.test.tsx` (`PersistentVolume/DetailsView > Base` timeout and `PersistentVolume/ListView > Items` missing MSW handler)
- `npm test` — failed: same pre-existing `npm run frontend:test` Storybook failures

## Scope
- unrelated files were not changed; only the Redux store configuration and its focused regression test are included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved namespace filtering and selection across the sidebar, autocomplete, resource map, and tables.
  * Preserved namespace filter behavior and reset handling while improving state consistency.
  * Maintained Redux serializability warnings for unexpected data while allowing supported callback-based actions.

* **Tests**
  * Expanded coverage for Redux serializability checks and updated namespace filtering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
