### PR TITLE
backend: helm: Skip invalid repository cache

### DIFF
--- a/backend/pkg/helm/charts.go
+++ b/backend/pkg/helm/charts.go
@@ -60,7 +60,8 @@ func listCharts(filter string, settings *cli.EnvSettings) ([]chartInfo, error) {
 
 		indexFile, err := repo.LoadIndexFile(repoIndexFile)
 		if err != nil {
-			return nil, err
+			logger.Log(logger.LevelWarn, nil, err, "loading repo index")
+			continue
 		}
 
 		index.AddRepo(name, indexFile, true)

--- a/backend/pkg/helm/charts.go
+++ b/backend/pkg/helm/charts.go
@@ -60,7 +60,7 @@ func listCharts(filter string, settings *cli.EnvSettings) ([]chartInfo, error) {
 
 		indexFile, err := repo.LoadIndexFile(repoIndexFile)
 		if err != nil {
-logger.Log(logger.LevelWarn, map[string]string{"repo": name, "indexFile": repoIndexFile}, err, "skipping repo: failed to load cached index")
+            logger.Log(logger.LevelWarn, map[string]string{"repo": name, "indexFile": repoIndexFile}, err, "skipping repo: failed to load cached index")
 			continue
 		}
 

--- a/backend/pkg/helm/charts.go
+++ b/backend/pkg/helm/charts.go
@@ -60,7 +60,7 @@ func listCharts(filter string, settings *cli.EnvSettings) ([]chartInfo, error) {
 
 		indexFile, err := repo.LoadIndexFile(repoIndexFile)
 		if err != nil {
-			logger.Log(logger.LevelWarn, nil, err, "loading repo index")
+logger.Log(logger.LevelWarn, map[string]string{"repo": name, "indexFile": repoIndexFile}, err, "skipping repo: failed to load cached index")
 			continue
 		}
 


### PR DESCRIPTION
## Summary

This PR makes the Helm chart listing endpoint resilient to partial
repository failures.

Previously, if `repo.LoadIndexFile()` failed for any configured
repository, the request returned an error and no charts were listed.

With this change, the backend logs a warning, skips the affected
repository, and continues listing charts from the remaining valid
repositories.

Fixes #6608 

## Changes

```go
indexFile, err := repo.LoadIndexFile(repoIndexFile)
if err != nil {
    logger.Log(logger.LevelWarn, nil, err, "loading repo index")
    continue
}
```
