### PR TITLE
backend: speed up serviceproxy timeout test cleanup

### DIFF
--- a/backend/pkg/serviceproxy/http_test.go
+++ b/backend/pkg/serviceproxy/http_test.go
@@ -117,21 +117,40 @@ func TestHTTPGetStreamContextCancellation(t *testing.T) {
 }
 
 func TestHTTPGetStreamTimeout(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(15 * time.Second)
+	requestStarted := make(chan struct{})
+	requestFinished := make(chan struct{})
 
-		if _, err := w.Write([]byte("Hello, World!")); err != nil {
-			t.Fatalf("write test: %v", err)
-		}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		<-r.Context().Done()
+		close(requestFinished)
 	}))
 	defer ts.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
+	start := time.Now()
+
 	err := serviceproxy.HTTPGetStream(ctx, ts.URL, &countingResponseWriter{})
 	if err == nil {
 		t.Errorf("HTTPGetStream() error = nil, want error")
+	}
+
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("HTTPGetStream() took %v, want under %v", elapsed, 5*time.Second)
+	}
+
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("HTTPGetStream() did not reach the test server")
+	}
+
+	select {
+	case <-requestFinished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("test server handler did not exit after context cancellation")
 	}
 }
 

--- a/backend/pkg/serviceproxy/http_test.go
+++ b/backend/pkg/serviceproxy/http_test.go
@@ -117,21 +117,41 @@ func TestHTTPGetStreamContextCancellation(t *testing.T) {
 }
 
 func TestHTTPGetStreamTimeout(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(15 * time.Second)
+	requestStarted := make(chan struct{})
+	requestFinished := make(chan struct{})
 
-		if _, err := w.Write([]byte("Hello, World!")); err != nil {
-			t.Fatalf("write test: %v", err)
-		}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		<-r.Context().Done()
+		close(requestFinished)
 	}))
 	defer ts.Close()
+	defer ts.CloseClientConnections()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
+	start := time.Now()
+
 	err := serviceproxy.HTTPGetStream(ctx, ts.URL, &countingResponseWriter{})
 	if err == nil {
 		t.Errorf("HTTPGetStream() error = nil, want error")
+	}
+
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("HTTPGetStream() took %v, want under %v", elapsed, 5*time.Second)
+	}
+
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("HTTPGetStream() did not reach the test server")
+	}
+
+	select {
+	case <-requestFinished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("test server handler did not exit after context cancellation")
 	}
 }
 


### PR DESCRIPTION
## Summary
- speed up `TestHTTPGetStreamTimeout` by replacing its fixed 15-second sleep with a request-context-aware handler
- keep the timeout regression covered while ensuring the test server exits promptly after cancellation

## Linked Issue
Fixes #6610

## What Changed
- updated `backend/pkg/serviceproxy/http_test.go` to wait on `r.Context().Done()` instead of sleeping
- added assertions that the request reaches the test server, the handler exits after cancellation, and the timeout case stays fast

## Verification
- `npm run backend:format` — passed
- `npm run backend:build` — passed
- `cd backend && go test ./pkg/serviceproxy -run TestHTTPGetStreamTimeout -count=1 -v` — passed
- `npm run backend:lint` — passed
- `npm run backend:test` — passed
- `npm test` — passed
- `npm run lint` — passed

## Scope
- only `backend/pkg/serviceproxy/http_test.go` was changed for this issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of timed-out streaming requests.
  * Requests now cancel promptly when a timeout occurs, reducing unnecessary waiting and server activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
