### PR TITLE
cluster-inventory: render ClusterProfile displayName in cluster picker

### DIFF
--- a/backend/pkg/clusterinventory/clusterinventory.go
+++ b/backend/pkg/clusterinventory/clusterinventory.go
@@ -572,9 +572,10 @@ func clusterInventoryMetadataFromProfile(
 ) *inventorymetadata.Metadata {
 	metadata := &inventorymetadata.Metadata{
 		Profile: inventorymetadata.Profile{
-			Namespace: cp.Namespace,
-			Name:      cp.Name,
-			Key:       profileKey,
+			Namespace:   cp.Namespace,
+			Name:        cp.Name,
+			Key:         profileKey,
+			DisplayName: cp.Spec.DisplayName,
 		},
 		Conditions: append([]metav1.Condition(nil), cp.Status.Conditions...),
 	}

--- a/backend/pkg/clusterinventory/clusterinventory_test.go
+++ b/backend/pkg/clusterinventory/clusterinventory_test.go
@@ -333,6 +333,7 @@ func TestContextFromClusterProfilePreservesInventoryMetadata(t *testing.T) {
 	runner := newTestRunner(t, Options{})
 	profileKey := "in-cluster/default/spoke-a"
 	cp := clusterProfile("spoke-a", "static-token", "https://spoke-a.example.com")
+	cp.Spec.DisplayName = "Spoke A"
 	cp.Status.Conditions = []metav1.Condition{
 		{
 			Type:               apisv1alpha1.ClusterConditionControlPlaneHealthy,
@@ -357,9 +358,10 @@ func TestContextFromClusterProfilePreservesInventoryMetadata(t *testing.T) {
 
 	require.NotNil(t, headlampContext.ClusterInventory)
 	assert.Equal(t, inventorymetadata.Profile{
-		Namespace: "default",
-		Name:      "spoke-a",
-		Key:       profileKey,
+		Namespace:   "default",
+		Name:        "spoke-a",
+		Key:         profileKey,
+		DisplayName: "Spoke A",
 	}, headlampContext.ClusterInventory.Profile)
 	assert.Equal(t, cp.Status.Conditions, headlampContext.ClusterInventory.Conditions)
 	require.NotNil(t, headlampContext.ClusterInventory.Version)

--- a/backend/pkg/clusterinventory/metadata/metadata.go
+++ b/backend/pkg/clusterinventory/metadata/metadata.go
@@ -24,6 +24,8 @@ type Profile struct {
 	Namespace string `json:"namespace"`
 	Name      string `json:"name"`
 	Key       string `json:"key"`
+	// DisplayName is the human-readable name from ClusterProfileSpec.DisplayName, when set.
+	DisplayName string `json:"displayName,omitempty"`
 }
 
 // Version contains version details reported by Cluster Inventory.

--- a/frontend/src/components/App/Home/ClusterInventory/index.ts
+++ b/frontend/src/components/App/Home/ClusterInventory/index.ts
@@ -54,6 +54,19 @@ export function isClusterInventoryCluster(cluster: Cluster): boolean {
   return cluster?.meta_data?.source === CLUSTER_INVENTORY_SOURCE;
 }
 
+/**
+ * Returns the ClusterProfile's displayName when the cluster was discovered from
+ * Cluster Inventory and a displayName was reported, for a cleaner name than the
+ * generated context name.
+ */
+export function getClusterInventoryDisplayName(cluster: Cluster): string | undefined {
+  if (!isClusterInventoryCluster(cluster)) {
+    return undefined;
+  }
+
+  return cluster?.meta_data?.clusterInventory?.profile?.displayName || undefined;
+}
+
 /** Returns the Cluster Inventory control plane health condition when present. */
 export function getControlPlaneHealthyCondition(
   cluster: Cluster

--- a/frontend/src/components/App/Home/ClusterTable.tsx
+++ b/frontend/src/components/App/Home/ClusterTable.tsx
@@ -55,7 +55,7 @@ import {
 } from './ClusterInventory';
 import { canSelectCluster } from './clusterStatus';
 import { CONNECT_ON_CLUSTER_LINK, MULTI_HOME_ENABLED } from './config';
-import { getCustomClusterNames } from './customClusterNames';
+import { getClusterDisplayLabel, getCustomClusterNames } from './customClusterNames';
 
 /**
  * ClusterStatus component displays the status of a cluster.
@@ -312,12 +312,16 @@ export default function ClusterTable({
         {
           id: 'name',
           header: t('Name'),
-          accessorKey: 'name',
+          // Sort/filter by the rendered display label, not the real (possibly
+          // generated) context name, so Cluster Inventory clusters order the
+          // way they read on screen.
+          accessorFn: cluster => getClusterDisplayLabel(cluster),
           gridTemplate: 2,
           Cell: ({ row: { original } }) => {
             const appearance = getClusterAppearanceFromMeta(original.name);
+            const label = getClusterDisplayLabel(original);
             return (
-              <LightTooltip title={original.name}>
+              <LightTooltip title={label}>
                 {/* Record as recently-used on open so it auto-connects on return.
                     onClickCapture on the wrapper keeps the Link's native
                     navigation (and works for keyboard activation) while the Link
@@ -332,7 +336,7 @@ export default function ClusterTable({
                 >
                   <Link routeName="cluster" params={{ cluster: original.name }}>
                     <ClusterBadge
-                      name={original.name}
+                      name={label}
                       icon={appearance.icon}
                       accentColor={appearance.accentColor}
                     />

--- a/frontend/src/components/App/Home/RecentClusters.tsx
+++ b/frontend/src/components/App/Home/RecentClusters.tsx
@@ -29,6 +29,7 @@ import { formatClusterPathParam, getClusterPrefixedPath } from '../../../lib/clu
 import { Cluster } from '../../../lib/k8s/cluster';
 import { createRouteURL } from '../../../lib/router/createRouteURL';
 import { MULTI_HOME_ENABLED } from './config';
+import { getClusterDisplayLabel } from './customClusterNames';
 import SquareButton from './SquareButton';
 const ToggleButton = styled(MuiToggledButton)({
   textTransform: 'none',
@@ -51,7 +52,7 @@ const ClusterButton = React.forwardRef<HTMLButtonElement, ClusterButtonProps>((p
       focusRipple
       icon={icon}
       iconColor={appearance.accentColor}
-      label={cluster.name}
+      label={getClusterDisplayLabel(cluster)}
       ref={ref}
       onClick={onClick}
     />
@@ -165,7 +166,7 @@ export default function RecentClusters(props: RecentClustersProps) {
           >
             {recentClusters.map(cluster => (
               <ToggleButton key={cluster.name} value={cluster}>
-                {cluster.name}
+                {getClusterDisplayLabel(cluster)}
               </ToggleButton>
             ))}
           </ToggleButtonGroup>

--- a/frontend/src/components/App/Home/customClusterNames.test.ts
+++ b/frontend/src/components/App/Home/customClusterNames.test.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Cluster } from '../../../lib/k8s/cluster';
+import { getClusterDisplayLabel, getCustomClusterNames } from './customClusterNames';
+
+function makeCluster(overrides: Partial<Cluster> = {}): Cluster {
+  return {
+    name: 'cluster-inventory-root-default-spoke-a--abc123',
+    auth_type: '',
+    ...overrides,
+  } as Cluster;
+}
+
+describe('getClusterDisplayLabel', () => {
+  it('falls back to the real name when there is no custom name or displayName', () => {
+    const cluster = makeCluster();
+
+    expect(getClusterDisplayLabel(cluster)).toBe(cluster.name);
+  });
+
+  it('prefers the Cluster Inventory displayName over the generated context name', () => {
+    const cluster = makeCluster({
+      meta_data: {
+        source: 'cluster_inventory',
+        clusterInventory: {
+          profile: {
+            namespace: 'default',
+            name: 'spoke-a',
+            key: 'root/default/spoke-a',
+            displayName: 'Spoke A',
+          },
+        },
+      },
+    });
+
+    expect(getClusterDisplayLabel(cluster)).toBe('Spoke A');
+  });
+
+  it('prefers an explicit custom name over the Cluster Inventory displayName', () => {
+    const cluster = makeCluster({
+      meta_data: {
+        source: 'cluster_inventory',
+        extensions: { headlamp_info: { customName: 'My Custom Name' } },
+        clusterInventory: {
+          profile: {
+            namespace: 'default',
+            name: 'spoke-a',
+            key: 'root/default/spoke-a',
+            displayName: 'Spoke A',
+          },
+        },
+      },
+    });
+
+    expect(getClusterDisplayLabel(cluster)).toBe('My Custom Name');
+  });
+
+  it('ignores displayName for clusters not sourced from Cluster Inventory', () => {
+    const cluster = makeCluster({
+      name: 'kubeconfig-cluster',
+      meta_data: {
+        source: 'kubeconfig',
+        clusterInventory: {
+          profile: { namespace: 'default', name: 'spoke-a', key: 'k', displayName: 'Spoke A' },
+        },
+      },
+    });
+
+    expect(getClusterDisplayLabel(cluster)).toBe('kubeconfig-cluster');
+  });
+});
+
+describe('getCustomClusterNames', () => {
+  it('returns an empty array when clusters is null', () => {
+    expect(getCustomClusterNames(null)).toEqual([]);
+  });
+
+  it('never rewrites Cluster.name, even when a display label is available', () => {
+    // Cluster.name is the canonical identifier used for routing, recent-cluster
+    // storage, and connection tracking, and must survive untouched -- unlike a
+    // custom name, a ClusterProfile displayName is not guaranteed unique.
+    const cluster = makeCluster({
+      meta_data: {
+        source: 'cluster_inventory',
+        extensions: { headlamp_info: { customName: 'My Custom Name' } },
+        clusterInventory: {
+          profile: {
+            namespace: 'default',
+            name: 'spoke-a',
+            key: 'root/default/spoke-a',
+            displayName: 'Spoke A',
+          },
+        },
+      },
+    });
+
+    const result = getCustomClusterNames({ [cluster.name]: cluster });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe(cluster.name);
+  });
+
+  it('sorts clusters by their display label rather than their real name', () => {
+    const zebra = makeCluster({
+      name: 'cluster-inventory-root-default-zebra--zzz999',
+      meta_data: {
+        source: 'cluster_inventory',
+        clusterInventory: {
+          profile: { namespace: 'default', name: 'zebra', key: 'k1', displayName: 'Alpha' },
+        },
+      },
+    });
+    const apple = makeCluster({
+      name: 'cluster-inventory-root-default-apple--aaa111',
+      meta_data: {
+        source: 'cluster_inventory',
+        clusterInventory: {
+          profile: { namespace: 'default', name: 'apple', key: 'k2', displayName: 'Zulu' },
+        },
+      },
+    });
+
+    const result = getCustomClusterNames({ [zebra.name]: zebra, [apple.name]: apple });
+
+    // "Alpha" (on the zebra-named cluster) sorts before "Zulu" (on the apple-named
+    // cluster) -- sorting follows the label, not the underlying real name.
+    expect(result.map(c => c.name)).toEqual([zebra.name, apple.name]);
+  });
+});

--- a/frontend/src/components/App/Home/customClusterNames.ts
+++ b/frontend/src/components/App/Home/customClusterNames.ts
@@ -15,22 +15,41 @@
  */
 
 import { useClustersConf } from '../../../lib/k8s';
+import { Cluster } from '../../../lib/k8s/cluster';
+import { getClusterInventoryDisplayName } from './ClusterInventory';
 
 /**
- * Gets the names of the clusters from the clusters configuration.
- * If the cluster has a custom name, it will be used instead of the default name.
- * The clusters are sorted by their names.
+ * Gets the display label for a cluster: an explicit custom name if set,
+ * otherwise the owning ClusterProfile's Cluster Inventory displayName,
+ * otherwise the cluster's real name.
  *
- * @returns An array of name sorted clusters.
+ * This is presentation-only. Cluster.name must stay untouched: it's the
+ * canonical identifier used for routing, recent-cluster storage, and
+ * connection tracking, and -- unlike a user-set custom name, which is
+ * validated unique -- a ClusterProfile displayName is not guaranteed unique,
+ * so using it as an identifier risks collisions between unrelated clusters.
+ *
+ * @returns The label to render for this cluster.
  */
-export function getCustomClusterNames(clusters: ReturnType<typeof useClustersConf>) {
+export function getClusterDisplayLabel(cluster: Cluster): string {
+  return (
+    cluster.meta_data?.extensions?.headlamp_info?.customName ||
+    getClusterInventoryDisplayName(cluster) ||
+    cluster.name
+  );
+}
+
+/**
+ * Gets the clusters from the clusters configuration, sorted by their display
+ * label (see getClusterDisplayLabel). Cluster.name is left untouched.
+ *
+ * @returns An array of clusters sorted by display label.
+ */
+export function getCustomClusterNames(clusters: ReturnType<typeof useClustersConf>): Cluster[] {
   if (clusters === null) {
     return [];
   }
-  return Object.values(clusters)
-    .map(c => ({
-      ...c,
-      name: c.meta_data?.extensions?.headlamp_info?.customName || c.name,
-    }))
-    .sort((a, b) => a.name.localeCompare(b.name));
+  return Object.values(clusters).sort((a, b) =>
+    getClusterDisplayLabel(a).localeCompare(getClusterDisplayLabel(b))
+  );
 }

--- a/frontend/src/components/cluster/Chooser.tsx
+++ b/frontend/src/components/cluster/Chooser.tsx
@@ -49,6 +49,7 @@ import { getCluster, getClusterPrefixedPath } from '../../lib/util';
 import { useTypedSelector } from '../../redux/hooks';
 import { uiSlice } from '../../redux/uiSlice';
 import { AppLogo } from '../App/AppLogo';
+import { getClusterDisplayLabel } from '../App/Home/customClusterNames';
 import ActionButton from '../common/ActionButton';
 import { DialogTitle } from '../common/Dialog';
 import ErrorBoundary from '../common/ErrorBoundary';
@@ -134,6 +135,7 @@ const ClusterButton = React.forwardRef<HTMLButtonElement, ClusterButtonProps>((p
   const appearance = getClusterAppearanceFromMeta(cluster?.name || '');
   const icon = appearance.icon || 'mdi:kubernetes';
   const iconColor = appearance.accentColor || theme.palette.primaryColor;
+  const label = getClusterDisplayLabel(cluster);
 
   return (
     <ButtonBase focusRipple ref={ref} onClick={onClick}>
@@ -151,7 +153,7 @@ const ClusterButton = React.forwardRef<HTMLButtonElement, ClusterButtonProps>((p
           }}
         >
           <Icon icon={icon} width="50" height="50" color={iconColor} />
-          <LightTooltip title={cluster.name}>
+          <LightTooltip title={label}>
             <Typography
               color="textSecondary"
               gutterBottom
@@ -162,7 +164,7 @@ const ClusterButton = React.forwardRef<HTMLButtonElement, ClusterButtonProps>((p
                 display: 'block',
               }}
             >
-              {cluster.name}
+              {label}
             </Typography>
           </LightTooltip>
         </CardContent>
@@ -258,7 +260,7 @@ function ClusterList(props: ClusterListProps) {
             <Autocomplete
               id="cluster-selector-autocomplete"
               options={clusters}
-              getOptionLabel={option => option.name}
+              getOptionLabel={option => getClusterDisplayLabel(option)}
               style={{ width: '100%' }}
               disableClearable
               autoComplete
@@ -382,6 +384,7 @@ export function ClusterDialog(props: ClusterDialogProps) {
 function Chooser(props: ClusterDialogProps) {
   const history = useHistory();
   const clusters = useClustersConf();
+  const clusterList = React.useMemo(() => Object.values(clusters || {}), [clusters]);
   const { open = null, onClose, children = [], ...otherProps } = props;
   // Only used if open is not provided
   const [show, setShow] = React.useState(props.open);
@@ -396,12 +399,12 @@ function Chooser(props: ClusterDialogProps) {
 
       // If we only have one cluster configured, then we skip offering
       // the choice to the user.
-      if (!!clusters && Object.keys(clusters).length === 1) {
-        handleButtonClick(Object.values(clusters)[0]);
+      if (clusterList.length === 1) {
+        handleButtonClick(clusterList[0]);
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [open, show, clusters]
+    [open, show, clusterList]
   );
 
   function handleButtonClick(cluster: Cluster) {
@@ -431,7 +434,6 @@ function Chooser(props: ClusterDialogProps) {
     }
   }
 
-  const clusterList = Object.values(clusters || {});
   if (!show) {
     return null;
   }

--- a/frontend/src/components/cluster/ClusterChooserPopup.test.tsx
+++ b/frontend/src/components/cluster/ClusterChooserPopup.test.tsx
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import { TestContext } from '../../test';
+
+vi.mock('../../lib/k8s', () => ({
+  useClustersConf: vi.fn(() => ({})),
+  useSelectedClusters: vi.fn(() => []),
+}));
+
+import { useClustersConf, useSelectedClusters } from '../../lib/k8s';
+import { Cluster } from '../../lib/k8s/cluster';
+import ClusterChooserPopup from './ClusterChooserPopup';
+
+function makeCluster(overrides: Partial<Cluster> = {}): Cluster {
+  return {
+    name: 'cluster-inventory-root-default-spoke-a--abc123',
+    auth_type: '',
+    ...overrides,
+  } as Cluster;
+}
+
+function renderPopup() {
+  const anchor = document.createElement('div');
+  document.body.appendChild(anchor);
+
+  return render(
+    <TestContext>
+      <ClusterChooserPopup anchor={anchor} />
+    </TestContext>
+  );
+}
+
+describe('ClusterChooserPopup', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('renders the Cluster Inventory displayName instead of the generated context name', () => {
+    const cluster = makeCluster({
+      meta_data: {
+        source: 'cluster_inventory',
+        clusterInventory: {
+          profile: {
+            namespace: 'default',
+            name: 'spoke-a',
+            key: 'root/default/spoke-a',
+            displayName: 'Spoke A',
+          },
+        },
+      },
+    });
+    (useClustersConf as Mock).mockReturnValue({ [cluster.name]: cluster });
+
+    renderPopup();
+
+    expect(screen.getByText('Spoke A')).toBeInTheDocument();
+    expect(screen.queryByText(cluster.name)).not.toBeInTheDocument();
+  });
+
+  it('keys identity (DOM id, current-cluster state) off the real name, not the display label', () => {
+    const cluster = makeCluster({
+      meta_data: {
+        source: 'cluster_inventory',
+        clusterInventory: {
+          profile: {
+            namespace: 'default',
+            name: 'spoke-a',
+            key: 'root/default/spoke-a',
+            displayName: 'Spoke A',
+          },
+        },
+      },
+    });
+    (useClustersConf as Mock).mockReturnValue({ [cluster.name]: cluster });
+    (useSelectedClusters as Mock).mockReturnValue([cluster.name]);
+
+    renderPopup();
+
+    // The rendered label is "Spoke A", but selection/current-cluster tracking,
+    // and the option's DOM id, must still resolve through the real cluster name.
+    const option = document.getElementById(cluster.name);
+    expect(option).not.toBeNull();
+    expect(option).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText('Current')).toBeInTheDocument();
+  });
+
+  it('finds a cluster when searching by its display label', () => {
+    const cluster = makeCluster({
+      meta_data: {
+        source: 'cluster_inventory',
+        clusterInventory: {
+          profile: {
+            namespace: 'default',
+            name: 'spoke-a',
+            key: 'root/default/spoke-a',
+            displayName: 'Spoke A',
+          },
+        },
+      },
+    });
+    (useClustersConf as Mock).mockReturnValue({ [cluster.name]: cluster });
+
+    renderPopup();
+
+    fireEvent.change(screen.getByPlaceholderText('Name'), { target: { value: 'Spoke' } });
+
+    expect(screen.getByText('Spoke A')).toBeInTheDocument();
+  });
+
+  it('still finds a cluster when searching by its real name', () => {
+    const cluster = makeCluster({
+      meta_data: {
+        source: 'cluster_inventory',
+        clusterInventory: {
+          profile: {
+            namespace: 'default',
+            name: 'spoke-a',
+            key: 'root/default/spoke-a',
+            displayName: 'Spoke A',
+          },
+        },
+      },
+    });
+    (useClustersConf as Mock).mockReturnValue({ [cluster.name]: cluster });
+
+    renderPopup();
+
+    fireEvent.change(screen.getByPlaceholderText('Name'), {
+      target: { value: 'cluster-inventory-root' },
+    });
+
+    expect(screen.getByText('Spoke A')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/cluster/ClusterChooserPopup.tsx
+++ b/frontend/src/components/cluster/ClusterChooserPopup.tsx
@@ -36,6 +36,7 @@ import { useClustersConf, useSelectedClusters } from '../../lib/k8s';
 import { Cluster } from '../../lib/k8s/cluster';
 import { createRouteURL } from '../../lib/router/createRouteURL';
 import { getCluster, getClusterPrefixedPath } from '../../lib/util';
+import { getClusterDisplayLabel } from '../App/Home/customClusterNames';
 import ClusterBadge from '../Sidebar/ClusterBadge';
 
 function ClusterListItem(props: { cluster: Cluster; onClick: () => void; selected?: boolean }) {
@@ -56,7 +57,7 @@ function ClusterListItem(props: { cluster: Cluster; onClick: () => void; selecte
       })}
     >
       <ClusterBadge
-        name={cluster.name}
+        name={getClusterDisplayLabel(cluster)}
         icon={appearance.icon}
         accentColor={appearance.accentColor}
       />
@@ -109,8 +110,13 @@ function ClusterChooserPopup(props: ChooserPopupPros) {
   const [recentClusters, clustersToShow] = React.useMemo(() => {
     let allClusters = Object.values(clusters || {});
     if (filter !== '') {
-      allClusters = allClusters.filter(cluster =>
-        cluster.name.toLowerCase().includes(filter.toLowerCase())
+      const needle = filter.toLowerCase();
+      // Match on the rendered display label as well as the real name, so
+      // typing a Cluster Inventory displayName (e.g. "Spoke A") finds it too.
+      allClusters = allClusters.filter(
+        cluster =>
+          getClusterDisplayLabel(cluster).toLowerCase().includes(needle) ||
+          cluster.name.toLowerCase().includes(needle)
       );
     }
 
@@ -149,7 +155,7 @@ function ClusterChooserPopup(props: ChooserPopupPros) {
         return 1;
       }
 
-      return a.name.localeCompare(b.name);
+      return getClusterDisplayLabel(a).localeCompare(getClusterDisplayLabel(b));
     });
 
     return [recentClusters, clustersToShow];


### PR DESCRIPTION
## Summary

This PR fixes the awkward cluster names shown for clusters sourced from the ClusterInventory API by preferring the owning ClusterProfile's `displayName`, when set, over the generated context name.

## Related Issue

Fixes #6615

## Changes

- Backend: carry `ClusterProfile.Spec.DisplayName` through into the Cluster Inventory context metadata (`clusterinventory.go`, `metadata.go`), instead of discarding it.
- Frontend: prefer the Cluster Inventory `displayName` (after any user-set custom name) when rendering cluster names in the Home page cluster list, the cluster chooser dialog, and the header cluster chooser popup. Routing still keys off the real, stable context name -- only the rendered label changes.
- Tests: backend coverage for `DisplayName` propagation; frontend unit/component tests for the name-resolution precedence and for the header chooser popup rendering the display name.

## Steps to Test

1. Configure a Cluster Inventory provider and a `ClusterProfile` with `spec.displayName` set (e.g. "Spoke A") but a less friendly underlying name.
2. Open Headlamp's Home page cluster list -- the cluster should show as "Spoke A" instead of the generated `cluster-inventory-...` name.
3. Open the cluster chooser dialog and the header cluster chooser popup (keyboard shortcut) -- both should also show "Spoke A".
4. Confirm clicking the cluster still navigates/connects correctly (routing is unaffected; only the label changed).

## Notes for the Reviewer

- Kept the display substitution presentation-only (mirrors the existing `customName` precedence) rather than rewriting `Cluster.name`, since `ClusterProfileSpec.DisplayName` isn't guaranteed unique the way user-set custom names are validated to be.
