### PR TITLE
app: MCP: Add permissions center

### DIFF
--- a/app/electron/mcp/MCPClient.ts
+++ b/app/electron/mcp/MCPClient.ts
@@ -21,6 +21,7 @@ import {
   hasClusterDependentServers,
   loadMCPSettings,
   makeMcpServersFromSettings,
+  mcpPermissionsCenter,
   MCPSettings,
   saveMCPSettings,
   showSettingsChangeDialog,
@@ -456,6 +457,25 @@ export default class MCPClient {
     }
   }
 
+  private async mcpGetPermissions() {
+    try {
+      const currentSettings = loadMCPSettings(this.settingsPath);
+      const toolsConfig = this.mcpToolState?.getConfig() || {};
+
+      return {
+        success: true,
+        permissions: mcpPermissionsCenter(currentSettings, toolsConfig),
+      };
+    } catch (error) {
+      console.error('Error getting MCP permissions:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+        permissions: [],
+      };
+    }
+  }
+
   private async mcpUpdateToolsConfig(toolsConfig: MCPToolsConfig) {
     console.log('Requested MCP tools configuration update:', toolsConfig);
     try {
@@ -551,6 +571,7 @@ export default class MCPClient {
     );
     ipcMain?.handle('mcp-get-config', async () => this.mcpGetConfig());
     ipcMain?.handle('mcp-get-tools-config', async () => this.mcpGetToolsConfig());
+    ipcMain?.handle('mcp-get-permissions', async () => this.mcpGetPermissions());
     ipcMain?.handle('mcp-update-tools-config', async (event, toolsConfig: MCPToolsConfig) =>
       this.mcpUpdateToolsConfig(toolsConfig)
     );

--- a/app/electron/mcp/MCPSettings.test.ts
+++ b/app/electron/mcp/MCPSettings.test.ts
@@ -28,11 +28,41 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
+// Mirrors the platform-dependent BASELINE_ENV_KEYS in MCPSettings.ts, but only keeps keys
+// that are actually present in this process's env so the assertions stay accurate on any OS.
+const EXPECTED_BASELINE_ENV_KEYS = (
+  process.platform === 'win32' ? ['PATH', 'SystemRoot', 'ComSpec', 'PATHEXT'] : ['PATH']
+).filter(key => process.env[key] !== undefined);
+
+function expectedBaselineEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of EXPECTED_BASELINE_ENV_KEYS) {
+    env[key] = process.env[key] as string;
+  }
+  return env;
+}
+
 describe('MCPSettings', () => {
-  it('loadMCPSettings returns mcp settings when present', () => {
+  it('loadMCPSettings returns mcp settings unchanged when already migrated', () => {
     const expected = {
       enabled: true,
-      servers: [{ name: 's1', command: 'cmd', args: ['-v'], enabled: true }],
+      permissionsMigrated: true,
+      servers: [
+        {
+          name: 's1',
+          command: 'cmd',
+          args: ['-v'],
+          enabled: true,
+          permissions: {
+            command: 'cmd',
+            args: ['-v'],
+            envKeys: [...EXPECTED_BASELINE_ENV_KEYS].sort(),
+            clusterDependent: false,
+            restart: { enabled: true, maxAttempts: 3, delayMs: 2000 },
+            approvedAt: '2026-01-01T00:00:00.000Z',
+          },
+        },
+      ],
     };
     (loadSettings as Mock).mockReturnValue({ mcp: expected });
 
@@ -40,6 +70,50 @@ describe('MCPSettings', () => {
 
     expect(loadSettings).toHaveBeenCalledWith('/path/to/settings.json');
     expect(result).toEqual(expected);
+    expect(saveSettings).not.toHaveBeenCalled();
+  });
+
+  it('loadMCPSettings migrates legacy servers with no permissions field to approved', () => {
+    const raw = {
+      mcp: {
+        enabled: true,
+        servers: [{ name: 'legacy', command: 'cmd', args: ['-v'], enabled: true }],
+      },
+    };
+    (loadSettings as Mock).mockReturnValue(raw);
+
+    const result = loadMCPSettings('/path/to/settings.json');
+
+    expect(result?.servers[0].permissions).toMatchObject({
+      command: 'cmd',
+      args: ['-v'],
+      envKeys: [...EXPECTED_BASELINE_ENV_KEYS].sort(),
+      clusterDependent: false,
+    });
+    expect(result?.servers[0].permissions?.approvedAt).toBeDefined();
+    expect(result?.permissionsMigrated).toBe(true);
+    // the migration is persisted so it only needs to run once
+    expect(saveSettings).toHaveBeenCalledWith('/path/to/settings.json', raw);
+  });
+
+  it('loadMCPSettings does not auto-approve a permissionless server added after migration', () => {
+    // Simulates a settings.json that already went through the legacy migration, and then
+    // had a new server added afterwards by directly editing the file (a supported
+    // workflow). That new server has no `permissions` field, but it must not be silently
+    // auto-approved the way pre-existing legacy servers were.
+    const raw = {
+      mcp: {
+        enabled: true,
+        permissionsMigrated: true,
+        servers: [{ name: 'added-later', command: 'cmd', args: ['-v'], enabled: true }],
+      },
+    };
+    (loadSettings as Mock).mockReturnValue(raw);
+
+    const result = loadMCPSettings('/path/to/settings.json');
+
+    expect(result?.servers[0].permissions).toBeUndefined();
+    expect(saveSettings).not.toHaveBeenCalled();
   });
 
   it('loadMCPSettings returns null when no mcp settings', () => {
@@ -63,8 +137,79 @@ describe('MCPSettings', () => {
     saveMCPSettings('/cfg', newMCP);
 
     expect(loadSettings).toHaveBeenCalledWith('/cfg');
-    expect((existing as any).mcp).toBe(newMCP);
+    expect((existing as any).mcp).toMatchObject(newMCP);
+    expect((existing as any).mcp.servers[0].permissions).toMatchObject({
+      command: 'c',
+      args: [],
+      envKeys: [...EXPECTED_BASELINE_ENV_KEYS].sort(),
+      clusterDependent: false,
+      restart: {
+        enabled: true,
+        maxAttempts: 3,
+        delayMs: 2000,
+      },
+    });
     expect(saveSettings).toHaveBeenCalledWith('/cfg', existing);
+  });
+
+  it('saveMCPSettings preserves approvedAt when effective permissions are unchanged', () => {
+    const existing = { someKey: 'value' };
+    (loadSettings as Mock).mockReturnValue(existing);
+
+    const originalApprovedAt = '2026-01-01T00:00:00.000Z';
+    const newMCP = {
+      enabled: true,
+      servers: [
+        {
+          name: 's',
+          command: 'c',
+          args: [],
+          enabled: true,
+          permissions: {
+            command: 'c',
+            args: [],
+            envKeys: [...EXPECTED_BASELINE_ENV_KEYS].sort(),
+            clusterDependent: false,
+            restart: { enabled: true, maxAttempts: 3, delayMs: 2000 },
+            approvedAt: originalApprovedAt,
+          },
+        },
+      ],
+    };
+
+    saveMCPSettings('/cfg', newMCP);
+
+    expect((existing as any).mcp.servers[0].permissions.approvedAt).toBe(originalApprovedAt);
+  });
+
+  it('saveMCPSettings stamps a fresh approvedAt when effective permissions changed', () => {
+    const existing = { someKey: 'value' };
+    (loadSettings as Mock).mockReturnValue(existing);
+
+    const originalApprovedAt = '2026-01-01T00:00:00.000Z';
+    const newMCP = {
+      enabled: true,
+      servers: [
+        {
+          name: 's',
+          command: 'c',
+          args: ['--new-arg'],
+          enabled: true,
+          permissions: {
+            command: 'c',
+            args: [],
+            envKeys: [...EXPECTED_BASELINE_ENV_KEYS].sort(),
+            clusterDependent: false,
+            restart: { enabled: true, maxAttempts: 3, delayMs: 2000 },
+            approvedAt: originalApprovedAt,
+          },
+        },
+      ],
+    };
+
+    saveMCPSettings('/cfg', newMCP);
+
+    expect((existing as any).mcp.servers[0].permissions.approvedAt).not.toBe(originalApprovedAt);
   });
 });
 
@@ -198,7 +343,9 @@ describe('MultiServerMCPClient', () => {
       ],
     };
 
-    (loadSettings as Mock).mockReturnValue({ mcp: mcpSettings });
+    (loadSettings as Mock).mockReturnValue({
+      mcp: MCP.withApprovedMCPPermissions(mcpSettings as any),
+    });
 
     const result = MCP.makeMcpServersFromSettings('/cfg', ['clusterA']);
 
@@ -209,14 +356,60 @@ describe('MultiServerMCPClient', () => {
     expect(entry.transport).toBe('stdio');
     expect(entry.command).toBe('cmd');
     expect(entry.args).toEqual(['arg1']);
-    // env should include process.env and server.env overrides
+    // env should include only approved explicit server.env values
     expect(entry.env.MCP_VAR).toBe('mcp');
-    expect(entry.env.TEST_ORIG_ENV).toBe('orig');
+    expect(entry.env.TEST_ORIG_ENV).toBeUndefined();
     // restart settings
     expect(entry.restart).toBeDefined();
     expect(entry.restart.enabled).toBe(true);
     expect(entry.restart.maxAttempts).toBe(3);
     expect(entry.restart.delayMs).toBe(2000);
+  });
+
+  it('skips enabled servers with unapproved broadened permissions', () => {
+    const approved = MCP.withApprovedMCPPermissions({
+      enabled: true,
+      servers: [
+        {
+          name: 'changed',
+          command: 'cmd',
+          args: ['old'],
+          enabled: true,
+          env: { SAFE_VAR: 'ok' },
+        },
+      ],
+    } as any);
+    approved.servers[0].env = { SAFE_VAR: 'ok', NEW_SECRET: 'secret' };
+
+    (loadSettings as Mock).mockReturnValue({ mcp: approved });
+
+    const result = MCP.makeMcpServersFromSettings('/cfg', ['clusterA']);
+
+    expect(result).toEqual({});
+  });
+
+  it('allows enabled servers with narrowed approved permissions', () => {
+    const approved = MCP.withApprovedMCPPermissions({
+      enabled: true,
+      servers: [
+        {
+          name: 'narrowed',
+          command: 'cmd',
+          args: ['run'],
+          enabled: true,
+          env: { SAFE_VAR: 'ok', OPTIONAL_VAR: 'ok' },
+        },
+      ],
+    } as any);
+    approved.servers[0].env = { SAFE_VAR: 'ok' };
+
+    (loadSettings as Mock).mockReturnValue({ mcp: approved });
+
+    const result = MCP.makeMcpServersFromSettings('/cfg', ['clusterA']);
+
+    expect(result).toHaveProperty('narrowed');
+    // env should include the inherited baseline env plus the approved explicit var
+    expect((result['narrowed'] as any).env).toEqual({ ...expectedBaselineEnv(), SAFE_VAR: 'ok' });
   });
 
   it('expands HEADLAMP_CURRENT_CLUSTER placeholder using provided clusters[0]', () => {
@@ -232,7 +425,9 @@ describe('MultiServerMCPClient', () => {
       ],
     };
 
-    (loadSettings as Mock).mockReturnValue({ mcp: mcpSettings });
+    (loadSettings as Mock).mockReturnValue({
+      mcp: MCP.withApprovedMCPPermissions(mcpSettings as any),
+    });
 
     const result = MCP.makeMcpServersFromSettings('/cfg', ['my-current-cluster']);
 
@@ -240,6 +435,68 @@ describe('MultiServerMCPClient', () => {
     const entry = result['withCluster'] as any;
     // the expand function should have replaced the placeholder
     expect(entry.args).toEqual(['connect', 'my-current-cluster']);
+  });
+});
+
+describe('mcpPermissionsCenter', () => {
+  it('reports effective server permissions and recent tool usage', () => {
+    const mcpSettings = MCP.withApprovedMCPPermissions({
+      enabled: true,
+      servers: [
+        {
+          name: 'cluster-tools',
+          command: 'node',
+          args: ['server.js', 'HEADLAMP_CURRENT_CLUSTER'],
+          enabled: true,
+          env: { TOKEN: 'value', PATH: '/bin' },
+        },
+      ],
+    } as any);
+
+    const result = MCP.mcpPermissionsCenter(mcpSettings, {
+      'cluster-tools': {
+        list: {
+          enabled: true,
+          lastUsed: '2026-07-23T10:00:00.000Z',
+          usageCount: 2,
+        },
+        get: {
+          enabled: true,
+          lastUsed: new Date('2026-07-23T11:00:00.000Z'),
+          usageCount: 1,
+        },
+      },
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        serverName: 'cluster-tools',
+        enabled: true,
+        approved: true,
+        command: 'node',
+        args: ['server.js', 'HEADLAMP_CURRENT_CLUSTER'],
+        envKeys: [...new Set([...EXPECTED_BASELINE_ENV_KEYS, 'TOKEN'])].sort(),
+        approvedAt: expect.any(String),
+        clusterDependent: true,
+        restart: {
+          enabled: true,
+          maxAttempts: 3,
+          delayMs: 2000,
+        },
+        recentToolUsage: [
+          {
+            toolName: 'get',
+            lastUsed: '2026-07-23T11:00:00.000Z',
+            usageCount: 1,
+          },
+          {
+            toolName: 'list',
+            lastUsed: '2026-07-23T10:00:00.000Z',
+            usageCount: 2,
+          },
+        ],
+      }),
+    ]);
   });
 });
 
@@ -325,10 +582,10 @@ describe('settingsChanges', () => {
   });
 
   it('returns empty array when there are no changes', () => {
-    const s = {
+    const s = MCP.withApprovedMCPPermissions({
       enabled: true,
       servers: [{ name: 's', command: 'c', args: ['x'], enabled: true, env: { K: 'v' } }],
-    };
+    } as any);
 
     const result = MCP.settingsChanges(s as any, s as any);
     expect(result).toEqual([]);

--- a/app/electron/mcp/MCPSettings.test.ts
+++ b/app/electron/mcp/MCPSettings.test.ts
@@ -28,11 +28,40 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
+// Mirrors the platform-dependent BASELINE_ENV_KEYS in MCPSettings.ts, but only keeps keys
+// that are actually present in this process's env so the assertions stay accurate on any OS.
+const EXPECTED_BASELINE_ENV_KEYS = (
+  process.platform === 'win32' ? ['PATH', 'SystemRoot', 'ComSpec', 'PATHEXT'] : ['PATH']
+).filter(key => process.env[key] !== undefined);
+
+function expectedBaselineEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of EXPECTED_BASELINE_ENV_KEYS) {
+    env[key] = process.env[key] as string;
+  }
+  return env;
+}
+
 describe('MCPSettings', () => {
-  it('loadMCPSettings returns mcp settings when present', () => {
+  it('loadMCPSettings returns mcp settings unchanged when servers already have permissions', () => {
     const expected = {
       enabled: true,
-      servers: [{ name: 's1', command: 'cmd', args: ['-v'], enabled: true }],
+      servers: [
+        {
+          name: 's1',
+          command: 'cmd',
+          args: ['-v'],
+          enabled: true,
+          permissions: {
+            command: 'cmd',
+            args: ['-v'],
+            envKeys: [...EXPECTED_BASELINE_ENV_KEYS].sort(),
+            clusterDependent: false,
+            restart: { enabled: true, maxAttempts: 3, delayMs: 2000 },
+            approvedAt: '2026-01-01T00:00:00.000Z',
+          },
+        },
+      ],
     };
     (loadSettings as Mock).mockReturnValue({ mcp: expected });
 
@@ -40,6 +69,29 @@ describe('MCPSettings', () => {
 
     expect(loadSettings).toHaveBeenCalledWith('/path/to/settings.json');
     expect(result).toEqual(expected);
+    expect(saveSettings).not.toHaveBeenCalled();
+  });
+
+  it('loadMCPSettings migrates legacy servers with no permissions field to approved', () => {
+    const raw = {
+      mcp: {
+        enabled: true,
+        servers: [{ name: 'legacy', command: 'cmd', args: ['-v'], enabled: true }],
+      },
+    };
+    (loadSettings as Mock).mockReturnValue(raw);
+
+    const result = loadMCPSettings('/path/to/settings.json');
+
+    expect(result?.servers[0].permissions).toMatchObject({
+      command: 'cmd',
+      args: ['-v'],
+      envKeys: [...EXPECTED_BASELINE_ENV_KEYS].sort(),
+      clusterDependent: false,
+    });
+    expect(result?.servers[0].permissions?.approvedAt).toBeDefined();
+    // the migration is persisted so it only needs to run once
+    expect(saveSettings).toHaveBeenCalledWith('/path/to/settings.json', raw);
   });
 
   it('loadMCPSettings returns null when no mcp settings', () => {
@@ -63,8 +115,79 @@ describe('MCPSettings', () => {
     saveMCPSettings('/cfg', newMCP);
 
     expect(loadSettings).toHaveBeenCalledWith('/cfg');
-    expect((existing as any).mcp).toBe(newMCP);
+    expect((existing as any).mcp).toMatchObject(newMCP);
+    expect((existing as any).mcp.servers[0].permissions).toMatchObject({
+      command: 'c',
+      args: [],
+      envKeys: [...EXPECTED_BASELINE_ENV_KEYS].sort(),
+      clusterDependent: false,
+      restart: {
+        enabled: true,
+        maxAttempts: 3,
+        delayMs: 2000,
+      },
+    });
     expect(saveSettings).toHaveBeenCalledWith('/cfg', existing);
+  });
+
+  it('saveMCPSettings preserves approvedAt when effective permissions are unchanged', () => {
+    const existing = { someKey: 'value' };
+    (loadSettings as Mock).mockReturnValue(existing);
+
+    const originalApprovedAt = '2026-01-01T00:00:00.000Z';
+    const newMCP = {
+      enabled: true,
+      servers: [
+        {
+          name: 's',
+          command: 'c',
+          args: [],
+          enabled: true,
+          permissions: {
+            command: 'c',
+            args: [],
+            envKeys: [...EXPECTED_BASELINE_ENV_KEYS].sort(),
+            clusterDependent: false,
+            restart: { enabled: true, maxAttempts: 3, delayMs: 2000 },
+            approvedAt: originalApprovedAt,
+          },
+        },
+      ],
+    };
+
+    saveMCPSettings('/cfg', newMCP);
+
+    expect((existing as any).mcp.servers[0].permissions.approvedAt).toBe(originalApprovedAt);
+  });
+
+  it('saveMCPSettings stamps a fresh approvedAt when effective permissions changed', () => {
+    const existing = { someKey: 'value' };
+    (loadSettings as Mock).mockReturnValue(existing);
+
+    const originalApprovedAt = '2026-01-01T00:00:00.000Z';
+    const newMCP = {
+      enabled: true,
+      servers: [
+        {
+          name: 's',
+          command: 'c',
+          args: ['--new-arg'],
+          enabled: true,
+          permissions: {
+            command: 'c',
+            args: [],
+            envKeys: [...EXPECTED_BASELINE_ENV_KEYS].sort(),
+            clusterDependent: false,
+            restart: { enabled: true, maxAttempts: 3, delayMs: 2000 },
+            approvedAt: originalApprovedAt,
+          },
+        },
+      ],
+    };
+
+    saveMCPSettings('/cfg', newMCP);
+
+    expect((existing as any).mcp.servers[0].permissions.approvedAt).not.toBe(originalApprovedAt);
   });
 });
 
@@ -198,7 +321,9 @@ describe('MultiServerMCPClient', () => {
       ],
     };
 
-    (loadSettings as Mock).mockReturnValue({ mcp: mcpSettings });
+    (loadSettings as Mock).mockReturnValue({
+      mcp: MCP.withApprovedMCPPermissions(mcpSettings as any),
+    });
 
     const result = MCP.makeMcpServersFromSettings('/cfg', ['clusterA']);
 
@@ -209,14 +334,60 @@ describe('MultiServerMCPClient', () => {
     expect(entry.transport).toBe('stdio');
     expect(entry.command).toBe('cmd');
     expect(entry.args).toEqual(['arg1']);
-    // env should include process.env and server.env overrides
+    // env should include only approved explicit server.env values
     expect(entry.env.MCP_VAR).toBe('mcp');
-    expect(entry.env.TEST_ORIG_ENV).toBe('orig');
+    expect(entry.env.TEST_ORIG_ENV).toBeUndefined();
     // restart settings
     expect(entry.restart).toBeDefined();
     expect(entry.restart.enabled).toBe(true);
     expect(entry.restart.maxAttempts).toBe(3);
     expect(entry.restart.delayMs).toBe(2000);
+  });
+
+  it('skips enabled servers with unapproved broadened permissions', () => {
+    const approved = MCP.withApprovedMCPPermissions({
+      enabled: true,
+      servers: [
+        {
+          name: 'changed',
+          command: 'cmd',
+          args: ['old'],
+          enabled: true,
+          env: { SAFE_VAR: 'ok' },
+        },
+      ],
+    } as any);
+    approved.servers[0].env = { SAFE_VAR: 'ok', NEW_SECRET: 'secret' };
+
+    (loadSettings as Mock).mockReturnValue({ mcp: approved });
+
+    const result = MCP.makeMcpServersFromSettings('/cfg', ['clusterA']);
+
+    expect(result).toEqual({});
+  });
+
+  it('allows enabled servers with narrowed approved permissions', () => {
+    const approved = MCP.withApprovedMCPPermissions({
+      enabled: true,
+      servers: [
+        {
+          name: 'narrowed',
+          command: 'cmd',
+          args: ['run'],
+          enabled: true,
+          env: { SAFE_VAR: 'ok', OPTIONAL_VAR: 'ok' },
+        },
+      ],
+    } as any);
+    approved.servers[0].env = { SAFE_VAR: 'ok' };
+
+    (loadSettings as Mock).mockReturnValue({ mcp: approved });
+
+    const result = MCP.makeMcpServersFromSettings('/cfg', ['clusterA']);
+
+    expect(result).toHaveProperty('narrowed');
+    // env should include the inherited baseline env plus the approved explicit var
+    expect((result['narrowed'] as any).env).toEqual({ ...expectedBaselineEnv(), SAFE_VAR: 'ok' });
   });
 
   it('expands HEADLAMP_CURRENT_CLUSTER placeholder using provided clusters[0]', () => {
@@ -232,7 +403,9 @@ describe('MultiServerMCPClient', () => {
       ],
     };
 
-    (loadSettings as Mock).mockReturnValue({ mcp: mcpSettings });
+    (loadSettings as Mock).mockReturnValue({
+      mcp: MCP.withApprovedMCPPermissions(mcpSettings as any),
+    });
 
     const result = MCP.makeMcpServersFromSettings('/cfg', ['my-current-cluster']);
 
@@ -240,6 +413,68 @@ describe('MultiServerMCPClient', () => {
     const entry = result['withCluster'] as any;
     // the expand function should have replaced the placeholder
     expect(entry.args).toEqual(['connect', 'my-current-cluster']);
+  });
+});
+
+describe('mcpPermissionsCenter', () => {
+  it('reports effective server permissions and recent tool usage', () => {
+    const mcpSettings = MCP.withApprovedMCPPermissions({
+      enabled: true,
+      servers: [
+        {
+          name: 'cluster-tools',
+          command: 'node',
+          args: ['server.js', 'HEADLAMP_CURRENT_CLUSTER'],
+          enabled: true,
+          env: { TOKEN: 'value', PATH: '/bin' },
+        },
+      ],
+    } as any);
+
+    const result = MCP.mcpPermissionsCenter(mcpSettings, {
+      'cluster-tools': {
+        list: {
+          enabled: true,
+          lastUsed: '2026-07-23T10:00:00.000Z',
+          usageCount: 2,
+        },
+        get: {
+          enabled: true,
+          lastUsed: new Date('2026-07-23T11:00:00.000Z'),
+          usageCount: 1,
+        },
+      },
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        serverName: 'cluster-tools',
+        enabled: true,
+        approved: true,
+        command: 'node',
+        args: ['server.js', 'HEADLAMP_CURRENT_CLUSTER'],
+        envKeys: [...new Set([...EXPECTED_BASELINE_ENV_KEYS, 'TOKEN'])].sort(),
+        approvedAt: expect.any(String),
+        clusterDependent: true,
+        restart: {
+          enabled: true,
+          maxAttempts: 3,
+          delayMs: 2000,
+        },
+        recentToolUsage: [
+          {
+            toolName: 'get',
+            lastUsed: '2026-07-23T11:00:00.000Z',
+            usageCount: 1,
+          },
+          {
+            toolName: 'list',
+            lastUsed: '2026-07-23T10:00:00.000Z',
+            usageCount: 2,
+          },
+        ],
+      }),
+    ]);
   });
 });
 
@@ -325,10 +560,10 @@ describe('settingsChanges', () => {
   });
 
   it('returns empty array when there are no changes', () => {
-    const s = {
+    const s = MCP.withApprovedMCPPermissions({
       enabled: true,
       servers: [{ name: 's', command: 'c', args: ['x'], enabled: true, env: { K: 'v' } }],
-    };
+    } as any);
 
     const result = MCP.settingsChanges(s as any, s as any);
     expect(result).toEqual([]);

--- a/app/electron/mcp/MCPSettings.ts
+++ b/app/electron/mcp/MCPSettings.ts
@@ -33,7 +33,33 @@ export interface MCPSettings {
   servers: MCPServer[];
 }
 
-interface MCPServer {
+export interface MCPServerRestartPolicy {
+  enabled: boolean;
+  maxAttempts: number;
+  delayMs: number;
+}
+
+export interface MCPServerPermissions {
+  command: string;
+  args: string[];
+  envKeys: string[];
+  clusterDependent: boolean;
+  restart: MCPServerRestartPolicy;
+  approvedAt?: string;
+}
+
+export interface MCPServerPermissionView extends MCPServerPermissions {
+  serverName: string;
+  enabled: boolean;
+  approved: boolean;
+  recentToolUsage: Array<{
+    toolName: string;
+    lastUsed?: string;
+    usageCount: number;
+  }>;
+}
+
+export interface MCPServer {
   /**
    * Server name
    */
@@ -54,7 +80,17 @@ interface MCPServer {
    * Environment variables for the MCP tool command
    */
   env?: Record<string, string>;
+  /**
+   * Last user-approved effective permissions for this server.
+   */
+  permissions?: MCPServerPermissions;
 }
+
+const DEFAULT_RESTART_POLICY: MCPServerRestartPolicy = {
+  enabled: true,
+  maxAttempts: 3,
+  delayMs: 2000,
+};
 
 /**
  * Load MCP server configuration from settings
@@ -69,7 +105,57 @@ export function loadMCPSettings(settingsPath: string): MCPSettings | null {
   }
 
   const mcp = (settings as any).mcp;
-  return mcp ? (mcp as MCPSettings) : null;
+  if (!mcp) {
+    return null;
+  }
+
+  return migrateLegacyMCPServerPermissions(settingsPath, settings, mcp as MCPSettings);
+}
+
+/**
+ * One-time migration for settings.json files written before the MCP permissions center
+ * existed. Servers configured back then have no `permissions` field, and
+ * hasApprovedMCPServerPermissions() treats a missing field as "not approved", which would
+ * silently skip every previously working server after upgrading.
+ *
+ * For any server missing `permissions`, this stamps its current effective permissions as
+ * already approved (the user already trusted this command by having configured it) and
+ * persists the result, so the migration only runs once per server.
+ *
+ * @param settingsPath - path to settings file
+ * @param settings - the raw settings object as loaded from disk
+ * @param mcpSettings - the mcp settings parsed from `settings`
+ *
+ * @returns mcpSettings, with legacy servers migrated to have approved permissions
+ */
+function migrateLegacyMCPServerPermissions(
+  settingsPath: string,
+  settings: Record<string, any>,
+  mcpSettings: MCPSettings
+): MCPSettings {
+  let migrated = false;
+  const servers = (mcpSettings.servers || []).map(server => {
+    if (server.permissions) {
+      return server;
+    }
+    migrated = true;
+    return {
+      ...server,
+      permissions: {
+        ...getMCPServerPermissions(server),
+        approvedAt: new Date().toISOString(),
+      },
+    };
+  });
+
+  if (!migrated) {
+    return mcpSettings;
+  }
+
+  const migratedSettings: MCPSettings = { ...mcpSettings, servers };
+  settings.mcp = migratedSettings;
+  saveSettings(settingsPath, settings);
+  return migratedSettings;
 }
 
 /**
@@ -80,8 +166,133 @@ export function loadMCPSettings(settingsPath: string): MCPSettings | null {
  */
 export function saveMCPSettings(settingsPath: string, mcpSettings: MCPSettings): void {
   const settings = loadSettings(settingsPath);
-  settings.mcp = mcpSettings;
+  settings.mcp = withApprovedMCPPermissions(mcpSettings);
   saveSettings(settingsPath, settings);
+}
+
+function usesCurrentCluster(args: string[] = []): boolean {
+  return args.some(arg => arg.includes('HEADLAMP_CURRENT_CLUSTER'));
+}
+
+function sortedEnvKeys(env?: Record<string, string>): string[] {
+  return Object.keys(env || {}).sort();
+}
+
+/**
+ * Environment variable keys that MCP servers need inherited from the host in order to
+ * resolve bare commands (e.g. `k8sgpt`) via PATH, and to spawn correctly on Windows.
+ * These are included explicitly (rather than passing through the whole process env)
+ * so the permissions center can still accurately report what a server can read.
+ */
+const BASELINE_ENV_KEYS =
+  process.platform === 'win32' ? ['PATH', 'SystemRoot', 'ComSpec', 'PATHEXT'] : ['PATH'];
+
+function baselineEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of BASELINE_ENV_KEYS) {
+    const value = process.env[key];
+    if (value !== undefined) {
+      env[key] = value;
+    }
+  }
+  return env;
+}
+
+function buildMcpServerEnv(server: MCPServer): Record<string, string> {
+  return { ...baselineEnv(), ...(server.env || {}) };
+}
+
+export function getMCPServerPermissions(server: MCPServer): MCPServerPermissions {
+  return {
+    command: server.command,
+    args: [...(server.args || [])],
+    envKeys: sortedEnvKeys(buildMcpServerEnv(server)),
+    clusterDependent: usesCurrentCluster(server.args),
+    restart: { ...DEFAULT_RESTART_POLICY },
+  };
+}
+
+function permissionArraysEqual(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function permissionArrayIncludes(approved: string[], effective: string[]): boolean {
+  return effective.every(value => approved.includes(value));
+}
+
+function restartPermissionIncludes(
+  approved?: MCPServerRestartPolicy,
+  effective?: MCPServerRestartPolicy
+): boolean {
+  if (!approved || !effective) {
+    return false;
+  }
+
+  if (!effective.enabled) {
+    return true;
+  }
+
+  return (
+    approved.enabled === effective.enabled &&
+    approved.maxAttempts >= effective.maxAttempts &&
+    approved.delayMs <= effective.delayMs
+  );
+}
+
+export function hasApprovedMCPServerPermissions(server: MCPServer): boolean {
+  if (!server.permissions) {
+    return false;
+  }
+
+  const effective = getMCPServerPermissions(server);
+  return (
+    server.permissions.command === effective.command &&
+    permissionArraysEqual(server.permissions.args || [], effective.args) &&
+    permissionArrayIncludes(server.permissions.envKeys || [], effective.envKeys) &&
+    (!effective.clusterDependent ||
+      server.permissions.clusterDependent === effective.clusterDependent) &&
+    restartPermissionIncludes(server.permissions.restart, effective.restart)
+  );
+}
+
+function permissionSnapshotsEqual(
+  left: MCPServerPermissions,
+  right: MCPServerPermissions
+): boolean {
+  return (
+    left.command === right.command &&
+    permissionArraysEqual(left.args || [], right.args || []) &&
+    permissionArraysEqual(left.envKeys || [], right.envKeys || []) &&
+    left.clusterDependent === right.clusterDependent &&
+    restartPermissionIncludes(left.restart, right.restart) &&
+    restartPermissionIncludes(right.restart, left.restart)
+  );
+}
+
+export function withApprovedMCPPermissions(mcpSettings: MCPSettings): MCPSettings {
+  return {
+    ...mcpSettings,
+    servers: (mcpSettings.servers || []).map(server => {
+      const effective = getMCPServerPermissions(server);
+      const previous = server.permissions;
+
+      // Preserve the original approval timestamp when the effective permissions
+      // for this server haven't actually changed, so unrelated saves (e.g. editing
+      // another server) don't reset it or mask when it was really approved.
+      const approvedAt =
+        previous?.approvedAt && permissionSnapshotsEqual(previous, effective)
+          ? previous.approvedAt
+          : new Date().toISOString();
+
+      return {
+        ...server,
+        permissions: {
+          ...effective,
+          approvedAt,
+        },
+      };
+    }),
+  };
 }
 
 /**
@@ -175,24 +386,23 @@ export function makeMcpServersFromSettings(
       continue;
     }
 
+    if (!hasApprovedMCPServerPermissions(server)) {
+      console.warn(`Skipping MCP server "${server.name}" because its permissions are not approved`);
+      continue;
+    }
+
     const expandedArgs = expandEnvAndResolvePaths(server.args || [], clusters[0] || null);
 
     if (DEBUG) {
       console.log(`Expanded args for ${server.name}:`, expandedArgs);
     }
 
-    const serverEnv = server.env ? { ...process.env, ...server.env } : process.env;
-
     mcpServers[server.name] = {
       transport: 'stdio',
       command: server.command,
       args: expandedArgs,
-      env: serverEnv as Record<string, string>,
-      restart: {
-        enabled: true,
-        maxAttempts: 3,
-        delayMs: 2000,
-      },
+      env: buildMcpServerEnv(server),
+      restart: { ...DEFAULT_RESTART_POLICY },
     };
   }
 
@@ -273,6 +483,19 @@ export function settingsChanges(
         serverChanges.push(`change environment variables`);
       }
 
+      const currentApproved = hasApprovedMCPServerPermissions(currentServer);
+      const nextPermissions = getMCPServerPermissions(nextServer);
+      const currentPermissions = currentServer.permissions;
+      if (
+        !currentPermissions ||
+        !currentApproved ||
+        currentPermissions.command !== nextPermissions.command ||
+        JSON.stringify(currentPermissions.args || []) !== JSON.stringify(nextPermissions.args) ||
+        JSON.stringify(currentPermissions.envKeys || []) !== JSON.stringify(nextPermissions.envKeys)
+      ) {
+        serverChanges.push(`request permission approval`);
+      }
+
       if (serverChanges.length > 0) {
         changes.push(`• MODIFY server "${nextServer.name}": ${serverChanges.join(', ')}`);
       }
@@ -280,6 +503,62 @@ export function settingsChanges(
   }
 
   return changes;
+}
+
+export function mcpPermissionsCenter(
+  mcpSettings: MCPSettings | null,
+  toolsConfig: Record<
+    string,
+    Record<string, { enabled?: boolean; lastUsed?: Date | string; usageCount?: number }>
+  > = {}
+): MCPServerPermissionView[] {
+  function normalizeLastUsed(lastUsed?: Date | string): string | undefined {
+    if (!lastUsed) {
+      return undefined;
+    }
+
+    const date = new Date(lastUsed);
+    if (Number.isNaN(date.getTime())) {
+      return undefined;
+    }
+
+    return date.toISOString();
+  }
+
+  return (mcpSettings?.servers || []).map(server => {
+    const permissions = getMCPServerPermissions(server);
+    const toolUsage = toolsConfig[server.name] || {};
+
+    return {
+      serverName: server.name,
+      enabled: server.enabled,
+      approved: hasApprovedMCPServerPermissions(server),
+      ...permissions,
+      approvedAt: server.permissions?.approvedAt,
+      recentToolUsage: Object.entries(toolUsage)
+        .filter(([, state]) => state.lastUsed || state.usageCount)
+        .map(([toolName, state]) => ({
+          toolName,
+          lastUsed: normalizeLastUsed(state.lastUsed),
+          usageCount: state.usageCount || 0,
+        }))
+        .sort((left, right) => {
+          const leftTime = left.lastUsed ? new Date(left.lastUsed).getTime() : 0;
+          const rightTime = right.lastUsed ? new Date(right.lastUsed).getTime() : 0;
+          return rightTime - leftTime;
+        }),
+    };
+  });
+}
+
+function permissionSummary(mcpSettings: MCPSettings | null): string[] {
+  return mcpPermissionsCenter(mcpSettings).map(server => {
+    const argsText = server.args.length > 0 ? server.args.join(' ') : 'none';
+    const envText = server.envKeys.length > 0 ? server.envKeys.join(', ') : 'none';
+    const clusterText = server.clusterDependent ? 'yes' : 'no';
+    const approvalText = server.approved ? 'approved' : 'needs approval';
+    return `• ${server.serverName}: command "${server.command}", args: ${argsText}, env: ${envText}, cluster-dependent: ${clusterText}, restart: ${server.restart.maxAttempts} attempt(s) after ${server.restart.delayMs}ms, ${approvalText}`;
+  });
 }
 
 /**
@@ -299,6 +578,7 @@ export async function showSettingsChangeDialog(
   nextSettings: MCPSettings
 ): Promise<boolean> {
   const changes = settingsChanges(currentSettings, nextSettings);
+  const permissions = permissionSummary(nextSettings);
   const result = await dialog.showMessageBox(mainWindow, {
     type: 'question',
     buttons: ['Apply Changes', 'Cancel'],
@@ -309,8 +589,12 @@ export async function showSettingsChangeDialog(
       changes.length > 0
         ? `The following changes will be applied:\n\n${changes.join(
             '\n'
+          )}\n\nEffective permissions:\n\n${permissions.join(
+            '\n'
           )}\n\nDo you want to apply these changes?`
-        : 'No changes detected in the MCP settings.\n\nDo you want to proceed anyway?',
+        : `No changes detected in the MCP settings.\n\nEffective permissions:\n\n${permissions.join(
+            '\n'
+          )}\n\nDo you want to proceed anyway?`,
   });
   return result.response === 0; // 0 is "Apply Changes"
 }

--- a/app/electron/mcp/MCPSettings.ts
+++ b/app/electron/mcp/MCPSettings.ts
@@ -31,9 +31,42 @@ export interface MCPSettings {
    * List of MCP servers
    */
   servers: MCPServer[];
+  /**
+   * Set once the one-time legacy permissions migration has run for this settings file.
+   * After this is set, servers found without a `permissions` field are treated as
+   * unapproved (rather than auto-approved), since they were added after the permissions
+   * center existed.
+   */
+  permissionsMigrated?: boolean;
 }
 
-interface MCPServer {
+export interface MCPServerRestartPolicy {
+  enabled: boolean;
+  maxAttempts: number;
+  delayMs: number;
+}
+
+export interface MCPServerPermissions {
+  command: string;
+  args: string[];
+  envKeys: string[];
+  clusterDependent: boolean;
+  restart: MCPServerRestartPolicy;
+  approvedAt?: string;
+}
+
+export interface MCPServerPermissionView extends MCPServerPermissions {
+  serverName: string;
+  enabled: boolean;
+  approved: boolean;
+  recentToolUsage: Array<{
+    toolName: string;
+    lastUsed?: string;
+    usageCount: number;
+  }>;
+}
+
+export interface MCPServer {
   /**
    * Server name
    */
@@ -54,7 +87,17 @@ interface MCPServer {
    * Environment variables for the MCP tool command
    */
   env?: Record<string, string>;
+  /**
+   * Last user-approved effective permissions for this server.
+   */
+  permissions?: MCPServerPermissions;
 }
+
+const DEFAULT_RESTART_POLICY: MCPServerRestartPolicy = {
+  enabled: true,
+  maxAttempts: 3,
+  delayMs: 2000,
+};
 
 /**
  * Load MCP server configuration from settings
@@ -69,7 +112,66 @@ export function loadMCPSettings(settingsPath: string): MCPSettings | null {
   }
 
   const mcp = (settings as any).mcp;
-  return mcp ? (mcp as MCPSettings) : null;
+  if (!mcp) {
+    return null;
+  }
+
+  return migrateLegacyMCPServerPermissions(settingsPath, settings, mcp as MCPSettings);
+}
+
+/**
+ * One-time migration for settings.json files written before the MCP permissions center
+ * existed. Servers configured back then have no `permissions` field, and
+ * hasApprovedMCPServerPermissions() treats a missing field as "not approved", which would
+ * silently skip every previously working server after upgrading.
+ *
+ * This only auto-approves permissionless servers the *first* time it runs for a given
+ * settings file (tracked via the persisted `permissionsMigrated` marker). Without that
+ * marker, a server added later by directly editing settings.json (a supported workflow)
+ * would also have no `permissions` field, and would otherwise be silently auto-approved
+ * and started on every load, bypassing the unapproved-permission block and the
+ * confirmation dialog. Once migrated, permissionless servers are left unapproved so they
+ * go through the normal approval flow.
+ *
+ * @param settingsPath - path to settings file
+ * @param settings - the raw settings object as loaded from disk
+ * @param mcpSettings - the mcp settings parsed from `settings`
+ *
+ * @returns mcpSettings, with legacy servers migrated to have approved permissions
+ */
+function migrateLegacyMCPServerPermissions(
+  settingsPath: string,
+  settings: Record<string, any>,
+  mcpSettings: MCPSettings
+): MCPSettings {
+  if (mcpSettings.permissionsMigrated) {
+    return mcpSettings;
+  }
+
+  const servers = (mcpSettings.servers || []).map(server => {
+    if (server.permissions) {
+      return server;
+    }
+    return {
+      ...server,
+      permissions: {
+        ...getMCPServerPermissions(server),
+        approvedAt: new Date().toISOString(),
+      },
+    };
+  });
+
+  const migratedSettings: MCPSettings = {
+    ...mcpSettings,
+    servers,
+    permissionsMigrated: true,
+  };
+  settings.mcp = migratedSettings;
+  saveSettings(settingsPath, settings);
+
+  // Persist the marker even when no server needed migrating (e.g. an empty server list),
+  // so a server added afterwards isn't mistaken for a pre-existing legacy one.
+  return migratedSettings;
 }
 
 /**
@@ -80,8 +182,133 @@ export function loadMCPSettings(settingsPath: string): MCPSettings | null {
  */
 export function saveMCPSettings(settingsPath: string, mcpSettings: MCPSettings): void {
   const settings = loadSettings(settingsPath);
-  settings.mcp = mcpSettings;
+  settings.mcp = withApprovedMCPPermissions(mcpSettings);
   saveSettings(settingsPath, settings);
+}
+
+function usesCurrentCluster(args: string[] = []): boolean {
+  return args.some(arg => arg.includes('HEADLAMP_CURRENT_CLUSTER'));
+}
+
+function sortedEnvKeys(env?: Record<string, string>): string[] {
+  return Object.keys(env || {}).sort();
+}
+
+/**
+ * Environment variable keys that MCP servers need inherited from the host in order to
+ * resolve bare commands (e.g. `k8sgpt`) via PATH, and to spawn correctly on Windows.
+ * These are included explicitly (rather than passing through the whole process env)
+ * so the permissions center can still accurately report what a server can read.
+ */
+const BASELINE_ENV_KEYS =
+  process.platform === 'win32' ? ['PATH', 'SystemRoot', 'ComSpec', 'PATHEXT'] : ['PATH'];
+
+function baselineEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of BASELINE_ENV_KEYS) {
+    const value = process.env[key];
+    if (value !== undefined) {
+      env[key] = value;
+    }
+  }
+  return env;
+}
+
+function buildMcpServerEnv(server: MCPServer): Record<string, string> {
+  return { ...baselineEnv(), ...(server.env || {}) };
+}
+
+export function getMCPServerPermissions(server: MCPServer): MCPServerPermissions {
+  return {
+    command: server.command,
+    args: [...(server.args || [])],
+    envKeys: sortedEnvKeys(buildMcpServerEnv(server)),
+    clusterDependent: usesCurrentCluster(server.args),
+    restart: { ...DEFAULT_RESTART_POLICY },
+  };
+}
+
+function permissionArraysEqual(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function permissionArrayIncludes(approved: string[], effective: string[]): boolean {
+  return effective.every(value => approved.includes(value));
+}
+
+function restartPermissionIncludes(
+  approved?: MCPServerRestartPolicy,
+  effective?: MCPServerRestartPolicy
+): boolean {
+  if (!approved || !effective) {
+    return false;
+  }
+
+  if (!effective.enabled) {
+    return true;
+  }
+
+  return (
+    approved.enabled === effective.enabled &&
+    approved.maxAttempts >= effective.maxAttempts &&
+    approved.delayMs <= effective.delayMs
+  );
+}
+
+export function hasApprovedMCPServerPermissions(server: MCPServer): boolean {
+  if (!server.permissions) {
+    return false;
+  }
+
+  const effective = getMCPServerPermissions(server);
+  return (
+    server.permissions.command === effective.command &&
+    permissionArraysEqual(server.permissions.args || [], effective.args) &&
+    permissionArrayIncludes(server.permissions.envKeys || [], effective.envKeys) &&
+    (!effective.clusterDependent ||
+      server.permissions.clusterDependent === effective.clusterDependent) &&
+    restartPermissionIncludes(server.permissions.restart, effective.restart)
+  );
+}
+
+function permissionSnapshotsEqual(
+  left: MCPServerPermissions,
+  right: MCPServerPermissions
+): boolean {
+  return (
+    left.command === right.command &&
+    permissionArraysEqual(left.args || [], right.args || []) &&
+    permissionArraysEqual(left.envKeys || [], right.envKeys || []) &&
+    left.clusterDependent === right.clusterDependent &&
+    restartPermissionIncludes(left.restart, right.restart) &&
+    restartPermissionIncludes(right.restart, left.restart)
+  );
+}
+
+export function withApprovedMCPPermissions(mcpSettings: MCPSettings): MCPSettings {
+  return {
+    ...mcpSettings,
+    servers: (mcpSettings.servers || []).map(server => {
+      const effective = getMCPServerPermissions(server);
+      const previous = server.permissions;
+
+      // Preserve the original approval timestamp when the effective permissions
+      // for this server haven't actually changed, so unrelated saves (e.g. editing
+      // another server) don't reset it or mask when it was really approved.
+      const approvedAt =
+        previous?.approvedAt && permissionSnapshotsEqual(previous, effective)
+          ? previous.approvedAt
+          : new Date().toISOString();
+
+      return {
+        ...server,
+        permissions: {
+          ...effective,
+          approvedAt,
+        },
+      };
+    }),
+  };
 }
 
 /**
@@ -175,24 +402,23 @@ export function makeMcpServersFromSettings(
       continue;
     }
 
+    if (!hasApprovedMCPServerPermissions(server)) {
+      console.warn(`Skipping MCP server "${server.name}" because its permissions are not approved`);
+      continue;
+    }
+
     const expandedArgs = expandEnvAndResolvePaths(server.args || [], clusters[0] || null);
 
     if (DEBUG) {
       console.log(`Expanded args for ${server.name}:`, expandedArgs);
     }
 
-    const serverEnv = server.env ? { ...process.env, ...server.env } : process.env;
-
     mcpServers[server.name] = {
       transport: 'stdio',
       command: server.command,
       args: expandedArgs,
-      env: serverEnv as Record<string, string>,
-      restart: {
-        enabled: true,
-        maxAttempts: 3,
-        delayMs: 2000,
-      },
+      env: buildMcpServerEnv(server),
+      restart: { ...DEFAULT_RESTART_POLICY },
     };
   }
 
@@ -273,6 +499,19 @@ export function settingsChanges(
         serverChanges.push(`change environment variables`);
       }
 
+      const currentApproved = hasApprovedMCPServerPermissions(currentServer);
+      const nextPermissions = getMCPServerPermissions(nextServer);
+      const currentPermissions = currentServer.permissions;
+      if (
+        !currentPermissions ||
+        !currentApproved ||
+        currentPermissions.command !== nextPermissions.command ||
+        JSON.stringify(currentPermissions.args || []) !== JSON.stringify(nextPermissions.args) ||
+        JSON.stringify(currentPermissions.envKeys || []) !== JSON.stringify(nextPermissions.envKeys)
+      ) {
+        serverChanges.push(`request permission approval`);
+      }
+
       if (serverChanges.length > 0) {
         changes.push(`• MODIFY server "${nextServer.name}": ${serverChanges.join(', ')}`);
       }
@@ -280,6 +519,62 @@ export function settingsChanges(
   }
 
   return changes;
+}
+
+export function mcpPermissionsCenter(
+  mcpSettings: MCPSettings | null,
+  toolsConfig: Record<
+    string,
+    Record<string, { enabled?: boolean; lastUsed?: Date | string; usageCount?: number }>
+  > = {}
+): MCPServerPermissionView[] {
+  function normalizeLastUsed(lastUsed?: Date | string): string | undefined {
+    if (!lastUsed) {
+      return undefined;
+    }
+
+    const date = new Date(lastUsed);
+    if (Number.isNaN(date.getTime())) {
+      return undefined;
+    }
+
+    return date.toISOString();
+  }
+
+  return (mcpSettings?.servers || []).map(server => {
+    const permissions = getMCPServerPermissions(server);
+    const toolUsage = toolsConfig[server.name] || {};
+
+    return {
+      serverName: server.name,
+      enabled: server.enabled,
+      approved: hasApprovedMCPServerPermissions(server),
+      ...permissions,
+      approvedAt: server.permissions?.approvedAt,
+      recentToolUsage: Object.entries(toolUsage)
+        .filter(([, state]) => state.lastUsed || state.usageCount)
+        .map(([toolName, state]) => ({
+          toolName,
+          lastUsed: normalizeLastUsed(state.lastUsed),
+          usageCount: state.usageCount || 0,
+        }))
+        .sort((left, right) => {
+          const leftTime = left.lastUsed ? new Date(left.lastUsed).getTime() : 0;
+          const rightTime = right.lastUsed ? new Date(right.lastUsed).getTime() : 0;
+          return rightTime - leftTime;
+        }),
+    };
+  });
+}
+
+function permissionSummary(mcpSettings: MCPSettings | null): string[] {
+  return mcpPermissionsCenter(mcpSettings).map(server => {
+    const argsText = server.args.length > 0 ? server.args.join(' ') : 'none';
+    const envText = server.envKeys.length > 0 ? server.envKeys.join(', ') : 'none';
+    const clusterText = server.clusterDependent ? 'yes' : 'no';
+    const approvalText = server.approved ? 'approved' : 'needs approval';
+    return `• ${server.serverName}: command "${server.command}", args: ${argsText}, env: ${envText}, cluster-dependent: ${clusterText}, restart: ${server.restart.maxAttempts} attempt(s) after ${server.restart.delayMs}ms, ${approvalText}`;
+  });
 }
 
 /**
@@ -299,6 +594,7 @@ export async function showSettingsChangeDialog(
   nextSettings: MCPSettings
 ): Promise<boolean> {
   const changes = settingsChanges(currentSettings, nextSettings);
+  const permissions = permissionSummary(nextSettings);
   const result = await dialog.showMessageBox(mainWindow, {
     type: 'question',
     buttons: ['Apply Changes', 'Cancel'],
@@ -309,8 +605,12 @@ export async function showSettingsChangeDialog(
       changes.length > 0
         ? `The following changes will be applied:\n\n${changes.join(
             '\n'
+          )}\n\nEffective permissions:\n\n${permissions.join(
+            '\n'
           )}\n\nDo you want to apply these changes?`
-        : 'No changes detected in the MCP settings.\n\nDo you want to proceed anyway?',
+        : `No changes detected in the MCP settings.\n\nEffective permissions:\n\n${permissions.join(
+            '\n'
+          )}\n\nDo you want to proceed anyway?`,
   });
   return result.response === 0; // 0 is "Apply Changes"
 }

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -103,6 +103,7 @@ contextBridge.exposeInMainWorld('desktopApi', {
     resetClient: () => ipcRenderer.invoke('mcp-reset-client'),
     getConfig: () => ipcRenderer.invoke('mcp-get-config'),
     updateConfig: (config: any) => ipcRenderer.invoke('mcp-update-config', config),
+    getPermissions: () => ipcRenderer.invoke('mcp-get-permissions'),
     getToolsConfig: () => ipcRenderer.invoke('mcp-get-tools-config'),
     updateToolsConfig: (config: any) => ipcRenderer.invoke('mcp-update-tools-config', config),
     setToolEnabled: (serverName: string, toolName: string, enabled: boolean) =>


### PR DESCRIPTION
## Summary

This PR adds an MCP permissions center by persisting approved effective permissions for desktop MCP servers and exposing those permissions through Electron IPC.

## Related Issue

Fixes #6617

## Changes

- Added persisted MCP server permission snapshots for command, args, granted environment variable names, cluster dependency, and restart policy.
- Added enforcement so enabled MCP servers with unapproved changed permissions are skipped before `mcpServers` are constructed.
- Updated the MCP settings confirmation dialog to show effective permission details before saving.
- Added an `mcp-get-permissions` IPC path exposed through preload so the desktop UI can inspect approved permissions and recent tool usage.
- Added focused tests for permission persistence, unapproved permission blocking, and permission-center output.

## Steps to Test

1. Run `cd app && npx vitest run electron/mcp/MCPSettings.test.ts`.
2. Run `npm run app:test:unit`.
3. Run `npm run app:tsc`.
4. Run `npm run app:lint`.
5. Run `npm run lint`.
6. Run `npm test`.
7. Run `npm run app:build`.

## Screenshots (if applicable)

There's no renderer-side UI, but the confirmation dialog itself is a real, user-facing surface (a native Electron `dialog.showMessageBox`), so here's a screen recording of it showing the effective permission summary before applying MCP settings changes:

Uploading demo.mp4…



## Notes for the Reviewer

- The issue and PR use the repository feature-request and pull-request templates.
- The permissions approval snapshot is stamped when MCP settings are saved after the existing confirmation dialog. If settings are edited outside that flow to broaden command, args, env keys, cluster dependency, or restart policy, the server is skipped until re-approved.
- `npm run app:test:e2e` was attempted but could not run because `app/e2e-tests` currently has no `test` script.
- The first aggregate `npm run lint` attempt hit stale golangci-lint cache entries from another local checkout; rerunning with an isolated `GOLANGCI_LINT_CACHE` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP permission management with approval tracking and restart policies.
  * Added visibility into effective access, approval status, restart behavior, and recent tool usage.
  * Added an API for retrieving MCP permission information.

* **Bug Fixes**
  * MCP servers now start only when permissions are approved.
  * Restricted MCP environment variables to approved baseline and configured values.
  * Improved validation for broadened and narrowed permission changes.
  * Added support for cluster placeholder expansion in MCP permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


