### PR TITLE
frontend: DataField: Prevent editor layout collapse on fractional zoom

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -462,22 +462,25 @@ export function DataField(props: DataFieldProps) {
     }
   };
 
-  function handleEditorDidMount(editor: any) {
-    const editorElement: HTMLElement | null = editor.getDomNode();
-    if (!editorElement) {
-      return;
+  const editorHeight = React.useMemo(() => {
+    let lineCount = 1;
+    const str = data ?? '';
+    for (let i = 0; i < str.length; i++) {
+      if (str[i] === '\n') {
+        lineCount++;
+        if (lineCount > 10) {
+          break;
+        }
+      }
     }
-
-    const lineCount = editor.getModel()?.getLineCount() || 1;
     if (lineCount < 2) {
-      editorElement.style.height = '3vh';
+      return '3vh';
     } else if (lineCount <= 10) {
-      editorElement.style.height = '10vh';
-    } else {
-      editorElement.style.height = '40vh';
+      return '10vh';
     }
-    editor.layout();
-  }
+    return '40vh';
+  }, [data]);
+
   let language = (label as string).split('.').pop() as string;
   if (language !== 'json') {
     language = 'yaml';
@@ -485,10 +488,10 @@ export function DataField(props: DataFieldProps) {
 
   const editorComponent = (
     <Editor
+      height={editorHeight}
       value={data}
       language={language}
       onChange={handleChange}
-      onMount={handleEditorDidMount}
       options={{ lineNumbers: 'off', automaticLayout: true }}
       theme={theme.palette.mode === 'dark' ? 'vs-dark' : 'light'}
     />
@@ -505,7 +508,7 @@ export function DataField(props: DataFieldProps) {
           <Box width="100%" borderTop={1} height={'1px'}></Box>
         </Box>
       )}
-      <Box mt={1} px={1} pb={1}>
+      <Box mt={1} px={1} pb={1} sx={{ minHeight: editorHeight }}>
         {editorComponent}
       </Box>
     </Box>

--- a/frontend/src/components/configmap/__snapshots__/Details.WithBinaryData.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/Details.WithBinaryData.stories.storyshot
@@ -270,7 +270,7 @@
                       class="MuiBox-root css-1rsqta2"
                     >
                       <div
-                        class="MuiBox-root css-1y5kcuw"
+                        class="MuiBox-root css-1disxx1"
                       >
                         <div
                           class="mock-monaco-editor"
@@ -294,7 +294,7 @@
                       class="MuiBox-root css-1rsqta2"
                     >
                       <div
-                        class="MuiBox-root css-1y5kcuw"
+                        class="MuiBox-root css-1disxx1"
                       >
                         <div
                           class="mock-monaco-editor"

--- a/frontend/src/components/configmap/__snapshots__/Details.WithBinaryDataAndData.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/Details.WithBinaryDataAndData.stories.storyshot
@@ -233,7 +233,7 @@
                       class="MuiBox-root css-1rsqta2"
                     >
                       <div
-                        class="MuiBox-root css-1y5kcuw"
+                        class="MuiBox-root css-1disxx1"
                       >
                         <div
                           class="mock-monaco-editor"
@@ -257,7 +257,7 @@
                       class="MuiBox-root css-1rsqta2"
                     >
                       <div
-                        class="MuiBox-root css-1y5kcuw"
+                        class="MuiBox-root css-1disxx1"
                       >
                         <div
                           class="mock-monaco-editor"
@@ -281,7 +281,7 @@
                       class="MuiBox-root css-1rsqta2"
                     >
                       <div
-                        class="MuiBox-root css-1y5kcuw"
+                        class="MuiBox-root css-1disxx1"
                       >
                         <div
                           class="mock-monaco-editor"
@@ -337,7 +337,7 @@
                       class="MuiBox-root css-1rsqta2"
                     >
                       <div
-                        class="MuiBox-root css-1y5kcuw"
+                        class="MuiBox-root css-1disxx1"
                       >
                         <div
                           class="mock-monaco-editor"
@@ -361,7 +361,7 @@
                       class="MuiBox-root css-1rsqta2"
                     >
                       <div
-                        class="MuiBox-root css-1y5kcuw"
+                        class="MuiBox-root css-1disxx1"
                       >
                         <div
                           class="mock-monaco-editor"

--- a/frontend/src/components/configmap/__snapshots__/Details.WithData.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/Details.WithData.stories.storyshot
@@ -233,7 +233,7 @@
                       class="MuiBox-root css-1rsqta2"
                     >
                       <div
-                        class="MuiBox-root css-1y5kcuw"
+                        class="MuiBox-root css-1disxx1"
                       >
                         <div
                           class="mock-monaco-editor"
@@ -257,7 +257,7 @@
                       class="MuiBox-root css-1rsqta2"
                     >
                       <div
-                        class="MuiBox-root css-1y5kcuw"
+                        class="MuiBox-root css-1disxx1"
                       >
                         <div
                           class="mock-monaco-editor"
@@ -281,7 +281,7 @@
                       class="MuiBox-root css-1rsqta2"
                     >
                       <div
-                        class="MuiBox-root css-1y5kcuw"
+                        class="MuiBox-root css-1disxx1"
                       >
                         <div
                           class="mock-monaco-editor"


### PR DESCRIPTION
Fixes #6551

### What this PR does / why we need it
At non-100% browser zoom levels (such as 90% in Chromium engines), imperative DOM height mutations inside `onMount` (`editorElement.style.height = ...`) interact badly with Monaco's `automaticLayout` `ResizeObserver` loop, causing the editor container to collapse down to 5px.

This PR moves the height calculation into React via `useMemo` based on line count, passing it cleanly to `<Editor height={editorHeight}>` and setting `minHeight: editorHeight` on the container Box to prevent layout collapse.

### How to test it
1. Open a ConfigMap details view.
2. Adjust browser zoom to 90% in Chrome or Edge.
3. Verify the editor height remains intact and readable without collapsing.
