### PR TITLE
backend: helm: Skip invalid repository cache

### DIFF
--- a/backend/pkg/helm/charts.go
+++ b/backend/pkg/helm/charts.go
@@ -60,9 +60,17 @@ func listCharts(filter string, settings *cli.EnvSettings) ([]chartInfo, error) {
 
 		indexFile, err := repo.LoadIndexFile(repoIndexFile)
 		if err != nil {
-			logger.Log(logger.LevelWarn, map[string]string{"repo": name, "indexFile": repoIndexFile}, err, "skipping repo: failed to load cached index")
+			logger.Log(
+				logger.LevelWarn,
+				map[string]string{
+					"repo":      name,
+					"indexFile": repoIndexFile,
+				},
+				err,
+				"skipping repo: failed to load cached index",
+			)
+
 			continue
-		}
 
 		index.AddRepo(name, indexFile, true)
 

--- a/backend/pkg/helm/charts.go
+++ b/backend/pkg/helm/charts.go
@@ -60,7 +60,8 @@ func listCharts(filter string, settings *cli.EnvSettings) ([]chartInfo, error) {
 
 		indexFile, err := repo.LoadIndexFile(repoIndexFile)
 		if err != nil {
-			return nil, err
+			logger.Log(logger.LevelWarn, map[string]string{"repo": name, "indexFile": repoIndexFile}, err, "skipping repo: failed to load cached index")
+			continue
 		}
 
 		index.AddRepo(name, indexFile, true)

--- a/backend/pkg/helm/charts.go
+++ b/backend/pkg/helm/charts.go
@@ -71,6 +71,7 @@ func listCharts(filter string, settings *cli.EnvSettings) ([]chartInfo, error) {
 			)
 
 			continue
+		}
 
 		index.AddRepo(name, indexFile, true)
 

--- a/backend/pkg/helm/charts_test.go
+++ b/backend/pkg/helm/charts_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/helmpath"
 )
 
 var settings = cli.New()
@@ -112,4 +114,49 @@ func TestListChartContentType(t *testing.T) {
 
 	// Verify Content-Type header is correctly set.
 	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+}
+
+func TestListChartSkipsInvalidRepositoryCache(t *testing.T) {
+	ch := cache.New[interface{}]()
+	require.NotNil(t, ch)
+
+	tmpDir := t.TempDir()
+
+	customSettings := cli.New()
+	customSettings.RepositoryConfig = filepath.Join(tmpDir, "repositories.yaml")
+	customSettings.RepositoryCache = tmpDir
+
+	helmHandler, err := helm.NewHandlerWithSettings(ch, customSettings)
+	require.NoError(t, err)
+
+	testAddRepo(t, helmHandler, "valid_repo", "https://kubernetes-sigs.github.io/headlamp/")
+	testAddRepo(t, helmHandler, "broken_repo", "https://kubernetes-sigs.github.io/headlamp/")
+
+	cacheFile := filepath.Join(
+		customSettings.RepositoryCache,
+		helmpath.CacheIndexFile("broken_repo"),
+	)
+
+	err = os.WriteFile(cacheFile, []byte("invalid yaml"), 0o600)
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		"/clusters/minikube/helm/repositories/charts",
+		nil,
+	)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+
+	helmHandler.ListCharts(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	body := rr.Body.String()
+
+	assert.Contains(t, body, `"repository":"valid_repo"`)
+	assert.Contains(t, body, `"name":"valid_repo/headlamp"`)
+	assert.NotContains(t, body, `"repository":"broken_repo"`)
 }

--- a/backend/pkg/helm/repository.go
+++ b/backend/pkg/helm/repository.go
@@ -174,6 +174,8 @@ func addRepository(request AddUpdateRepoRequest, settings *cli.EnvSettings) erro
 	applyRequestFields(newRepo, request)
 
 	r, err := repo.NewChartRepository(newRepo, getter.All(settings))
+	r.CachePath = settings.RepositoryCache
+
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "creating chart repository")
 		return err

--- a/backend/pkg/helm/repository.go
+++ b/backend/pkg/helm/repository.go
@@ -174,12 +174,12 @@ func addRepository(request AddUpdateRepoRequest, settings *cli.EnvSettings) erro
 	applyRequestFields(newRepo, request)
 
 	r, err := repo.NewChartRepository(newRepo, getter.All(settings))
-	r.CachePath = settings.RepositoryCache
-
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "creating chart repository")
 		return err
 	}
+
+	r.CachePath = settings.RepositoryCache
 
 	_, err = r.DownloadIndexFile()
 	if err != nil {

--- a/backend/pkg/helm/repository_test.go
+++ b/backend/pkg/helm/repository_test.go
@@ -126,8 +126,8 @@ func testAddRepo(t *testing.T, helmHandler *helm.Handler, repoName, repoURL stri
 	t.Helper()
 
 	addRepo := helm.AddUpdateRepoRequest{
-		Name: "headlamp_test_repo",
-		URL:  "https://kubernetes-sigs.github.io/headlamp/",
+		Name: repoName,
+		URL:  repoURL,
 	}
 
 	addRepoRequest, err := http.NewRequestWithContext(context.Background(), "POST",
@@ -139,7 +139,7 @@ func testAddRepo(t *testing.T, helmHandler *helm.Handler, repoName, repoURL stri
 	helmHandler.AddRepo(rr, addRepoRequest)
 	assert.Equal(t, http.StatusOK, rr.Code)
 
-	assert.True(t, checkRepoExists(t, helmHandler, "headlamp_test_repo"))
+	assert.True(t, checkRepoExists(t, helmHandler, repoName))
 }
 
 // TestAddRepositoryToHelm.


### PR DESCRIPTION
## Summary

This PR makes the Helm chart listing endpoint resilient to partial
repository failures.

Previously, if `repo.LoadIndexFile()` failed for any configured
repository, the request returned an error and no charts were listed.

With this change, the backend logs a warning, skips the affected
repository, and continues listing charts from the remaining valid
repositories.

Fixes #6608 

## Changes

```go
indexFile, err := repo.LoadIndexFile(repoIndexFile)
if err != nil {
    logger.Log(logger.LevelWarn, map[string]string{"repo": name, "indexFile": repoIndexFile}, err, "skipping repo: failed to load cached index")
    continue
}
```
