### PR TITLE
backend: k8cache: Use JSON status probe to prevent false-positive Failure cache drops

### DIFF
--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -302,10 +302,14 @@ func StoreK8sResponseInCache(k8scache cache.Cache[string],
 	headersToCache := FilterHeaderForCache(capturedHeaders, encoding)
 
 	if !strings.Contains(url.Path, "selfsubjectrulesreviews") {
-		// Check the decompressed body for Kubernetes error status before
-		// marshalling the full CachedResponseData. This avoids allocating
-		// the JSON envelope for responses that will be discarded anyway.
-		if strings.Contains(dcmpBody, "Failure") {
+		// Only skip caching for actual Kubernetes error Status objects.
+		var statusProbe struct {
+			Kind   string `json:"kind"`
+			Status string `json:"status"`
+		}
+
+		if json.Unmarshal([]byte(dcmpBody), &statusProbe) == nil &&
+			statusProbe.Kind == "Status" && statusProbe.Status == "Failure" {
 			return nil
 		}
 

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -308,7 +308,7 @@ func StoreK8sResponseInCache(k8scache cache.Cache[string],
 			Status string `json:"status"`
 		}
 
-		if json.Unmarshal([]byte(dcmpBody), &statusProbe) == nil &&
+		if err := json.NewDecoder(strings.NewReader(dcmpBody)).Decode(&statusProbe); err == nil &&
 			statusProbe.Kind == "Status" && statusProbe.Status == "Failure" {
 			return nil
 		}

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -302,11 +302,19 @@ func StoreK8sResponseInCache(k8scache cache.Cache[string],
 	headersToCache := FilterHeaderForCache(capturedHeaders, encoding)
 
 	if !strings.Contains(url.Path, "selfsubjectrulesreviews") {
-		// Check the decompressed body for Kubernetes error status before
-		// marshalling the full CachedResponseData. This avoids allocating
-		// the JSON envelope for responses that will be discarded anyway.
+		// Only skip caching for actual Kubernetes error Status objects.
+		// Use a fast substring pre-check so non-error responses (the common
+		// case) skip the JSON decode entirely.
 		if strings.Contains(dcmpBody, "Failure") {
-			return nil
+			var statusProbe struct {
+				Kind   string `json:"kind"`
+				Status string `json:"status"`
+			}
+
+			if err := json.NewDecoder(strings.NewReader(dcmpBody)).Decode(&statusProbe); err == nil &&
+				statusProbe.Kind == "Status" && statusProbe.Status == "Failure" {
+				return nil
+			}
 		}
 
 		cachedData := CachedResponseData{

--- a/backend/pkg/k8cache/cacheStore_bench_test.go
+++ b/backend/pkg/k8cache/cacheStore_bench_test.go
@@ -39,7 +39,7 @@ func BenchmarkStoreK8sResponseInCache(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		b.StopTimer()
 
 		rw := httptest.NewRecorder()
@@ -72,7 +72,7 @@ func BenchmarkStoreK8sResponseInCache_FailureSkip(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		b.StopTimer()
 
 		rw := httptest.NewRecorder()
@@ -108,7 +108,7 @@ func BenchmarkGenerateKey(b *testing.B) {
 
 	var err error
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		benchBuildCacheKeySink, err = k8cache.GenerateKey(
 			targetURL, contextID,
 		)

--- a/backend/pkg/k8cache/cacheStore_test.go
+++ b/backend/pkg/k8cache/cacheStore_test.go
@@ -925,6 +925,29 @@ func TestStoreK8sResponseInCache_FailureBodyNotCached(t *testing.T) {
 	assert.Error(t, getErr, "Failure responses should never be cached")
 }
 
+// TestStoreK8sResponseInCache_ValidResourceContainingFailureStringIsCached verifies that
+// valid Kubernetes resources (like ConfigMaps or Pods) containing the word "Failure" in their
+// data or spec are cached normally, rather than being discarded by a false-positive substring check.
+func TestStoreK8sResponseInCache_ValidResourceContainingFailureStringIsCached(t *testing.T) {
+	mockCache := NewMockCache()
+	targetURL := &url.URL{Path: "/api/v1/namespaces/default/configmaps"}
+
+	rw := httptest.NewRecorder()
+	rcw := k8cache.NewResponseCapture(rw)
+
+	validBody := `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"error-codes"},"data":{"reason":"Failure"}}`
+
+	rcw.WriteHeader(http.StatusOK)
+	_, _ = rcw.Write([]byte(validBody))
+
+	err := k8cache.StoreK8sResponseInCache(mockCache, targetURL, rcw, "valid-cm-key")
+	assert.NoError(t, err)
+
+	stored, getErr := mockCache.Get(context.Background(), "valid-cm-key")
+	assert.NoError(t, getErr, "Valid ConfigMap with data containing 'Failure' SHOULD be cached")
+	assert.NotEmpty(t, stored)
+}
+
 // TestExtractNamespace_QueryStringOnNamespacedURL verifies that query
 // parameters are stripped correctly even when a namespace is present.
 func TestExtractNamespace_QueryStringOnNamespacedURL(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR fixes a bug in `backend/pkg/k8cache/cacheStore.go` where valid Kubernetes resources returning `HTTP 200 OK` (such as ConfigMaps, Pods, Secrets, Deployments, and Events) were incorrectly excluded from the response cache if their payload contained the string `"Failure"`.

Previously, the cache skipped any response whose decompressed body contained the substring `"Failure"`, resulting in false positives for legitimate resources. This PR replaces that check with a schema-aware probe that only excludes Kubernetes `Status` error objects (`kind: "Status"` and `status: "Failure"`).

## Related Issue

Fixes #6626 

## Changes

- **`backend/pkg/k8cache/cacheStore.go`**
  - Replaced the unscoped `strings.Contains(dcmpBody, "Failure")` check with a lightweight JSON `Status` probe that skips caching only when:
    - `kind == "Status"`
    - `status == "Failure"`

- **`backend/pkg/k8cache/cacheStore_test.go`**
  - Added `TestStoreK8sResponseInCache_ValidResourceContainingFailureStringIsCached` to ensure valid resources containing `"Failure"` are cached.
  - Verified existing behavior with `TestStoreK8sResponseInCache_FailureBodyNotCached`.

- **`backend/pkg/k8cache/cacheStore_bench_test.go`**
  - Modernized benchmark loops by using Go's `b.Loop()` API.

## Steps to Test

1. Run the backend test suite:

```bash
cd backend
go test -v ./pkg/k8cache/...
```

2. Verify that the following tests pass:

- `TestStoreK8sResponseInCache_ValidResourceContainingFailureStringIsCached`
- `TestStoreK8sResponseInCache_FailureBodyNotCached`

3. Confirm that all existing tests in `pkg/k8cache` continue to pass.

## Screenshots (if applicable)

N/A (backend-only change)

## Notes for the Reviewer

- Kubernetes API error responses represented as `Status` objects with `status: "Failure"` continue to be excluded from the cache as intended.
- Valid Kubernetes resources containing the string `"Failure"` in their data, labels, annotations, or other fields are now cached correctly.
- The implementation unmarshals only the `kind` and `status` fields into a lightweight struct, avoiding unnecessary allocations while keeping the cache filtering schema-aware.
```