### PR TITLE
frontend: util: Fix normalizeUnit rendering "undefined" for sub-1-byte memory

### DIFF
--- a/frontend/src/lib/util.test.ts
+++ b/frontend/src/lib/util.test.ts
@@ -332,6 +332,27 @@ describe('normalizeUnit', () => {
     });
   });
 
+  describe('memory — sub-1-byte values (regression for #6628)', () => {
+    it('formats a milli-suffixed quantity as Bytes, not "undefined"', () => {
+      expect(normalizeUnit('memory', '500m')).toBe('0.5 Bytes');
+    });
+
+    it('formats a plain fractional quantity as Bytes', () => {
+      expect(normalizeUnit('memory', '0.5')).toBe('0.5 Bytes');
+    });
+
+    it('never emits the literal string "undefined" for tiny quantities', () => {
+      expect(normalizeUnit('memory', '1m')).not.toContain('undefined');
+      expect(normalizeUnit('memory', '1u')).not.toContain('undefined');
+      expect(normalizeUnit('memory', '1n')).not.toContain('undefined');
+    });
+
+    it('handles negative quantities gracefully instead of "NaN undefined"', () => {
+      expect(normalizeUnit('memory', '-1')).toBe('-1 Bytes');
+      expect(normalizeUnit('memory', '-1Gi')).toBe('-1.07 GB');
+    });
+  });
+
   describe('cpu', () => {
     it('converts millicores', () => {
       expect(normalizeUnit('cpu', '500m')).toBe('0.5 cores');

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -583,7 +583,7 @@ export function normalizeUnit(resourceType: string, quantity: string) {
         const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
         const k = 1000;
         const dm = 2;
-        const i = Math.floor(Math.log(bytes) / Math.log(k));
+        const i = Math.max(0, Math.floor(Math.log(Math.abs(bytes)) / Math.log(k)));
         normalizedQuantity = parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
       }
       break;


### PR DESCRIPTION
## Related Issue

Fixes 6628

## Changes

- Fixed `normalizeUnit()` in `frontend/src/lib/util.ts` producing the literal string `"undefined"` (and `"NaN undefined"`) for memory quantities below 1 byte. The size-unit index `Math.floor(Math.log(bytes) / Math.log(1000))` goes negative when `bytes < 1` (e.g. Kubernetes milli-suffixed values like `500m`, or plain fractions like `0.5`), so `sizes[-1]` was `undefined`. Clamped the index to a minimum of `0` and used `Math.abs(bytes)` inside the log; the signed value is still used for the displayed number.
- Added regression tests in `frontend/src/lib/util.test.ts` covering milli/micro/nano suffixes, a plain fraction, and negative quantities.

## Steps to Test

1. Run the unit tests: `cd frontend && npx vitest run src/lib/util.test.ts` — all pass (includes the new `memory — sub-1-byte values (regression for #6628)` block).
2. Or verify the function directly:
   - `normalizeUnit('memory', '500m')` → `"0.5 Bytes"` (was `"500 undefined"`)
   - `normalizeUnit('memory', '0.5')` → `"0.5 Bytes"` (was `"500 undefined"`)
   - `normalizeUnit('memory', '-1')` → `"-1 Bytes"` (was `"NaN undefined"`)
   - `normalizeUnit('memory', '-1Gi')` → `"-1.07 GB"` (was `"NaN undefined"`)
   - Regression check: `normalizeUnit('memory', '1024')` → `"1.02 KB"` (unchanged)

## Screenshots (if applicable)

N/A — internal formatting logic, no UI-visual change beyond correcting the displayed unit string.

## Notes for the Reviewer

- Minimal one-line change to the memory branch; no behavioral change for values ≥ 1 byte (verified by existing tests, all 117 in the file pass).
- `Math.abs` is applied **only** inside the index calculation so negative quantities don't yield `NaN` from `Math.log`; the division still uses the signed `bytes`, so negatives render with their sign (e.g. `-1.07 GB`).
- Note: sub-milli-byte values like `1m` (0.001 bytes) render as `0 Bytes` due to the existing 2-decimal (`toFixed(2)`) precision — this is intentional and out of scope; the fix's goal is eliminating the invalid `"undefined"`/`"NaN"` output. Happy to add dynamic precision in a follow-up if desired.
- `prettier` and `eslint` are clean on the changed files.