### PR TITLE
frontend: pluginManager: Guard against malformed IPC JSON responses

### DIFF
--- a/frontend/src/components/App/pluginManager.ts
+++ b/frontend/src/components/App/pluginManager.ts
@@ -50,7 +50,16 @@ export class PluginManager {
 
     return new Promise((resolve, reject) => {
       const handleResponse = (response: string) => {
-        const parsedResponse = JSON.parse(response);
+        let parsedResponse;
+        try {
+          parsedResponse = JSON.parse(response);
+        } catch (error) {
+          clearTimeout(timeoutId);
+          window.desktopApi.removeListener('plugin-manager', handleResponse);
+          reject(error);
+          return;
+        }
+
         if (parsedResponse.identifier === identifier) {
           clearTimeout(timeoutId);
           window.desktopApi.removeListener('plugin-manager', handleResponse);


### PR DESCRIPTION
## Summary

Frontend pluginManager used bare JSON.parse on IPC replies. Bad JSON could throw and skip cleanup. App was fixed in #6471 this adds the same guard on the frontend.

## Related Issue

Related to #6456 / #6471 (frontend only).

## Changes

- pluginManager.ts: try/catch on JSON.parse; on failure clear timeout, remove listener, reject

## Steps to Test

1. Open desktop Headlamp > Plugin Manager.
2. List plugins or start a normal install - should work as before.

## Screenshots

N/A

## Notes for the Reviewer

Small follow-up to #6471. Diff is the try/catch path only.