### PR TITLE
backend: k8cache: Add configurable cache watch resources allowlist

### DIFF
--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -78,6 +78,31 @@ func main() {
 	StartHeadlampServer(headlampConfig)
 }
 
+// parseCacheWatchResources splits, trims, lowercases, and deduplicates
+// the comma-separated resource list. Returns nil for empty input so that
+// the caller falls back to the default (watch all resources).
+func parseCacheWatchResources(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+
+	parts := strings.Split(raw, ",")
+	resources := make([]string, 0, len(parts))
+
+	for _, p := range parts {
+		r := strings.ToLower(strings.TrimSpace(p))
+		if r != "" {
+			resources = append(resources, r)
+		}
+	}
+
+	if len(resources) == 0 {
+		return nil
+	}
+
+	return resources
+}
+
 // buildHeadlampCFG maps the parsed config into the struct the backend uses.
 func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextStore) *headlampconfig.HeadlampCFG {
 	return &headlampconfig.HeadlampCFG{
@@ -87,6 +112,7 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 		SkippedKubeContexts:    conf.SkippedKubeContexts,
 		ListenAddr:             conf.ListenAddr,
 		CacheEnabled:           conf.CacheEnabled,
+		CacheWatchResources:    parseCacheWatchResources(conf.CacheWatchResources),
 		Port:                   conf.Port,
 		DevMode:                conf.DevMode,
 		StaticDir:              conf.StaticDir,
@@ -321,7 +347,7 @@ func cacheMiddlewareHandler(c *HeadlampConfig, next http.Handler, w http.Respons
 		return
 	}
 
-	k8cache.CheckForChanges(k8sResponseCache, contextKey, *kContext)
+	k8cache.CheckForChanges(k8sResponseCache, contextKey, *kContext, c.CacheWatchResources)
 
 	next.ServeHTTP(rcw, r)
 

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -79,6 +79,31 @@ func main() {
 	StartHeadlampServer(headlampConfig)
 }
 
+// parseCacheWatchResources splits, trims, lowercases, and deduplicates
+// the comma-separated resource list. Returns nil for empty input so that
+// the caller falls back to the default (watch all resources).
+func parseCacheWatchResources(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+
+	parts := strings.Split(raw, ",")
+	resources := make([]string, 0, len(parts))
+
+	for _, p := range parts {
+		r := strings.ToLower(strings.TrimSpace(p))
+		if r != "" {
+			resources = append(resources, r)
+		}
+	}
+
+	if len(resources) == 0 {
+		return nil
+	}
+
+	return resources
+}
+
 // buildHeadlampCFG maps the parsed config into the struct the backend uses.
 func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextStore) *headlampconfig.HeadlampCFG {
 	return &headlampconfig.HeadlampCFG{
@@ -90,6 +115,7 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 		SkippedKubeContexts:    conf.SkippedKubeContexts,
 		ListenAddr:             conf.ListenAddr,
 		CacheEnabled:           conf.CacheEnabled,
+		CacheWatchResources:    parseCacheWatchResources(conf.CacheWatchResources),
 		Port:                   conf.Port,
 		DevMode:                conf.DevMode,
 		StaticDir:              conf.StaticDir,
@@ -325,7 +351,7 @@ func cacheMiddlewareHandler(c *HeadlampConfig, next http.Handler, w http.Respons
 		return
 	}
 
-	k8cache.CheckForChanges(k8sResponseCache, contextKey, *kContext)
+	k8cache.CheckForChanges(k8sResponseCache, contextKey, *kContext, c.CacheWatchResources)
 
 	next.ServeHTTP(rcw, r)
 

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	// It has no effect in in-cluster mode or when running without embedded frontend.
 	NoBrowser              bool   `koanf:"no-browser"`
 	CacheEnabled           bool   `koanf:"cache-enabled"`
+	CacheWatchResources    string `koanf:"cache-watch-resources"`
 	EnableHelm             bool   `koanf:"enable-helm"`
 	EnableDynamicClusters  bool   `koanf:"enable-dynamic-clusters"`
 	EnableClusterInventory bool   `koanf:"enable-cluster-inventory"`
@@ -544,6 +545,9 @@ func addGeneralFlags(f *flag.FlagSet) {
 	f.String("in-cluster-context-name", "main", "Name to use for the in-cluster Kubernetes context")
 	f.Bool("dev", false, "Allow connections from other origins")
 	f.Bool("cache-enabled", false, "K8s cache in backend")
+	f.String("cache-watch-resources", "",
+		"Comma-separated list of resource names to watch for cache invalidation "+
+			"(e.g. pods,deployments,ingresses). Empty means use built-in defaults")
 	f.Bool("no-browser", false, "Disable automatically opening the browser when using embedded frontend")
 	f.Bool("insecure-ssl", false, "Accept/Ignore all server SSL certificates")
 	f.String("log-level", "info", "Set backend log verbosity. Options: debug, info (default), warn, error")

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -48,6 +48,7 @@ type Config struct {
 	// It has no effect in in-cluster mode or when running without embedded frontend.
 	NoBrowser              bool   `koanf:"no-browser"`
 	CacheEnabled           bool   `koanf:"cache-enabled"`
+	CacheWatchResources    string `koanf:"cache-watch-resources"`
 	EnableHelm             bool   `koanf:"enable-helm"`
 	EnableDynamicClusters  bool   `koanf:"enable-dynamic-clusters"`
 	EnableClusterInventory bool   `koanf:"enable-cluster-inventory"`
@@ -582,6 +583,7 @@ func flagset(appName string) *flag.FlagSet {
 	f := flag.NewFlagSet("config", flag.ContinueOnError)
 
 	addGeneralFlags(f, appName)
+	addCacheFlags(f)
 	addOIDCFlags(f)
 	addProxyAuthFlags(f)
 	addTelemetryFlags(f)
@@ -603,7 +605,6 @@ func addGeneralFlags(f *flag.FlagSet, appName string) {
 			"If unset, it is derived from the kube-system/kubeadm-config ConfigMap (treating \"kubernetes\" as unset), "+
 			"falling back to \"main\"")
 	f.Bool("dev", false, "Allow connections from other origins")
-	f.Bool("cache-enabled", false, "K8s cache in backend")
 	f.Bool("no-browser", false, "Disable automatically opening the browser when using embedded frontend")
 	f.Bool("insecure-ssl", false, "Accept/Ignore all server SSL certificates")
 	f.String("log-level", "info", "Set backend log verbosity. Options: debug, info (default), warn, error")
@@ -651,6 +652,13 @@ func addGeneralFlags(f *flag.FlagSet, appName string) {
 	f.String("service-account-token-path", "",
 		"Path to the service account token. "+
 			"Only used when --unsafe-use-service-account-token is set and in-cluster")
+}
+
+func addCacheFlags(f *flag.FlagSet) {
+	f.Bool("cache-enabled", false, "K8s cache in backend")
+	f.String("cache-watch-resources", "",
+		"Comma-separated list of resource names to watch for cache invalidation "+
+			"(e.g. pods,deployments,ingresses). Empty means use built-in defaults")
 }
 
 func addOIDCFlags(f *flag.FlagSet) {

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -132,6 +132,30 @@ func TestParseBasic(t *testing.T) {
 	}
 }
 
+func TestParseCacheWatchResources(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		expect string
+	}{
+		{"default_empty", nil, ""},
+		{
+			"custom_list",
+			[]string{"go run ./cmd", "--cache-watch-resources=pods,ingresses,networkpolicies"},
+			"pods,ingresses,networkpolicies",
+		},
+		{"single_resource", []string{"go run ./cmd", "--cache-watch-resources=ingresses"}, "ingresses"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf, err := config.Parse(tt.args)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expect, conf.CacheWatchResources)
+		})
+	}
+}
+
 var ParseWithEnvTests = []struct {
 	name   string
 	args   []string

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -231,6 +231,30 @@ func TestParseInvalidAppName(t *testing.T) {
 	}
 }
 
+func TestParseCacheWatchResources(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		expect string
+	}{
+		{"default_empty", nil, ""},
+		{
+			"custom_list",
+			[]string{"go run ./cmd", "--cache-watch-resources=pods,ingresses,networkpolicies"},
+			"pods,ingresses,networkpolicies",
+		},
+		{"single_resource", []string{"go run ./cmd", "--cache-watch-resources=ingresses"}, "ingresses"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf, err := config.Parse(tt.args)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expect, conf.CacheWatchResources)
+		})
+	}
+}
+
 var ParseWithEnvTests = []struct {
 	name   string
 	args   []string

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -51,6 +51,7 @@ type HeadlampCFG struct {
 	InClusterContextName   string
 	ListenAddr             string
 	CacheEnabled           bool
+	CacheWatchResources    []string
 	DevMode                bool
 	Insecure               bool
 	EnableHelm             bool

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -52,6 +52,7 @@ type HeadlampCFG struct {
 	InClusterContextName   string
 	ListenAddr             string
 	CacheEnabled           bool
+	CacheWatchResources    []string
 	DevMode                bool
 	Insecure               bool
 	EnableHelm             bool

--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -117,7 +117,10 @@ func SkipWebSocket(r *http.Request, next http.Handler, w http.ResponseWriter) bo
 
 // returnGVRList returns list+watch GroupVersionResources filtered to an allowlisted set of
 // API resource names (e.g. pods, deployments) used for cache invalidation watchers.
-func returnGVRList(apiResourceLists []*metav1.APIResourceList) []schema.GroupVersionResource {
+func returnGVRList(
+	apiResourceLists []*metav1.APIResourceList,
+	watchResources []string,
+) []schema.GroupVersionResource {
 	skipKinds := map[string]bool{
 		"Lease": true,
 		"Event": true,
@@ -146,26 +149,42 @@ func returnGVRList(apiResourceLists []*metav1.APIResourceList) []schema.GroupVer
 		}
 	}
 
-	filtered := filterImportantResources(gvrList)
+	filtered := filterImportantResources(gvrList, watchResources)
 
 	return filtered
 }
 
+// defaultWatchResources is the built-in set of resource names watched for
+// cache invalidation when no custom list is configured.
+var defaultWatchResources = []string{
+	"pods",
+	"services",
+	"deployments",
+	"replicasets",
+	"statefulsets",
+	"daemonsets",
+	"nodes",
+	"configmaps",
+	"secrets",
+	"jobs",
+	"cronjobs",
+}
+
 // filterImportantResources filters the provided list of GroupVersionResources to
 // include only those that are deemed important for caching and watching.
-func filterImportantResources(gvrList []schema.GroupVersionResource) []schema.GroupVersionResource {
-	allowed := map[string]struct{}{
-		"pods":         {},
-		"services":     {},
-		"deployments":  {},
-		"replicasets":  {},
-		"statefulsets": {},
-		"daemonsets":   {},
-		"nodes":        {},
-		"configmaps":   {},
-		"secrets":      {},
-		"jobs":         {},
-		"cronjobs":     {},
+// When watchResources is nil or empty, the built-in defaultWatchResources are used.
+func filterImportantResources(
+	gvrList []schema.GroupVersionResource,
+	watchResources []string,
+) []schema.GroupVersionResource {
+	resources := watchResources
+	if len(resources) == 0 {
+		resources = defaultWatchResources
+	}
+
+	allowed := make(map[string]struct{}, len(resources))
+	for _, r := range resources {
+		allowed[r] = struct{}{}
 	}
 
 	filtered := make([]schema.GroupVersionResource, 0, len(allowed))
@@ -192,6 +211,7 @@ func CheckForChanges(
 	k8scache cache.Cache[string],
 	contextKey string,
 	kContext kubeconfig.Context,
+	watchResources []string,
 ) {
 	if _, loaded := watcherRegistry.LoadOrStore(contextKey, struct{}{}); loaded {
 		return
@@ -201,7 +221,7 @@ func CheckForChanges(
 
 	contextCancel.Store(contextKey, cancel)
 
-	go runWatcher(ctx, k8scache, contextKey, kContext)
+	go runWatcher(ctx, k8scache, contextKey, kContext, watchResources)
 }
 
 // SyncWatchers stops watchers for contexts that are no longer active and purges
@@ -258,6 +278,7 @@ func runWatcher(
 	k8scache cache.Cache[string],
 	contextKey string,
 	kContext kubeconfig.Context,
+	watchResources []string,
 ) {
 	defer func() {
 		watcherRegistry.Delete(contextKey)
@@ -286,7 +307,7 @@ func runWatcher(
 		return
 	}
 
-	gvrList := returnGVRList(apiResourceLists)
+	gvrList := returnGVRList(apiResourceLists, watchResources)
 	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, 0, "", nil)
 
 	RunInformerToWatch(gvrList, factory, contextKey, k8scache)

--- a/backend/pkg/k8cache/cacheInvalidation_internal_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_internal_test.go
@@ -85,6 +85,6 @@ func TestReturnGVRList(t *testing.T) {
 		{Group: "apps", Version: "v1", Resource: "deployments"},
 	}
 
-	result := returnGVRList(apiResourceLists)
+	result := returnGVRList(apiResourceLists, nil)
 	assert.ElementsMatch(t, expected, result)
 }

--- a/backend/pkg/k8cache/cacheInvalidation_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_test.go
@@ -808,10 +808,87 @@ func TestFilterImportantResources(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := k8cache.ExportedFilterImportantResources(tt.input)
+			got := k8cache.ExportedFilterImportantResources(tt.input, nil)
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestFilterImportantResources_CustomWatchResources(t *testing.T) {
+	t.Parallel()
+
+	input := []schema.GroupVersionResource{
+		{Group: "", Version: "v1", Resource: "pods"},
+		{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
+		{Group: "apps", Version: "v1", Resource: "deployments"},
+		{Group: "", Version: "v1", Resource: "namespaces"},
+	}
+
+	tests := []struct {
+		name           string
+		watchResources []string
+		want           []schema.GroupVersionResource
+	}{
+		{
+			name:           "custom list selects only specified resources",
+			watchResources: []string{"pods", "ingresses"},
+			want: []schema.GroupVersionResource{
+				{Group: "", Version: "v1", Resource: "pods"},
+				{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
+			},
+		},
+		{
+			name:           "single custom resource",
+			watchResources: []string{"namespaces"},
+			want: []schema.GroupVersionResource{
+				{Group: "", Version: "v1", Resource: "namespaces"},
+			},
+		},
+		{
+			name:           "custom resource not in input returns empty",
+			watchResources: []string{"networkpolicies"},
+			want:           []schema.GroupVersionResource{},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := k8cache.ExportedFilterImportantResources(input, tt.watchResources)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestReturnGVRList_CustomWatchResources(t *testing.T) {
+	t.Parallel()
+
+	apiResourceLists := []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", Kind: "Pod", Verbs: []string{"list", "watch", "get"}},
+				{Name: "namespaces", Kind: "Namespace", Verbs: []string{"list", "watch", "get"}},
+			},
+		},
+		{
+			GroupVersion: "networking.k8s.io/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "ingresses", Kind: "Ingress", Verbs: []string{"list", "watch", "get"}},
+			},
+		},
+	}
+
+	got := k8cache.ExportedReturnGVRList(apiResourceLists, []string{"ingresses", "namespaces"})
+
+	want := []schema.GroupVersionResource{
+		{Group: "", Version: "v1", Resource: "namespaces"},
+		{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
+	}
+
+	assert.Equal(t, want, got)
 }
 
 func TestReturnGVRList_FiltersImportantResources(t *testing.T) {
@@ -840,7 +917,7 @@ func TestReturnGVRList_FiltersImportantResources(t *testing.T) {
 		},
 	}
 
-	got := k8cache.ExportedReturnGVRList(apiResourceLists)
+	got := k8cache.ExportedReturnGVRList(apiResourceLists, nil)
 
 	want := []schema.GroupVersionResource{
 		{Group: "", Version: "v1", Resource: "pods"},

--- a/backend/pkg/k8cache/export_test.go
+++ b/backend/pkg/k8cache/export_test.go
@@ -17,8 +17,9 @@ func ExportedRunWatcher(
 	k8scache cache.Cache[string],
 	contextKey string,
 	kContext kubeconfig.Context,
+	watchResources []string,
 ) {
-	runWatcher(ctx, k8scache, contextKey, kContext)
+	runWatcher(ctx, k8scache, contextKey, kContext, watchResources)
 }
 
 // ResetRegistries clears both registries for test isolation.
@@ -163,13 +164,19 @@ func ExportedRedactCacheKey(key string) string {
 }
 
 // ExportedFilterImportantResources exposes filterImportantResources for testing.
-func ExportedFilterImportantResources(gvrList []schema.GroupVersionResource) []schema.GroupVersionResource {
-	return filterImportantResources(gvrList)
+func ExportedFilterImportantResources(
+	gvrList []schema.GroupVersionResource,
+	watchResources []string,
+) []schema.GroupVersionResource {
+	return filterImportantResources(gvrList, watchResources)
 }
 
 // ExportedReturnGVRList exposes returnGVRList for testing.
-func ExportedReturnGVRList(apiResourceLists []*metav1.APIResourceList) []schema.GroupVersionResource {
-	return returnGVRList(apiResourceLists)
+func ExportedReturnGVRList(
+	apiResourceLists []*metav1.APIResourceList,
+	watchResources []string,
+) []schema.GroupVersionResource {
+	return returnGVRList(apiResourceLists, watchResources)
 }
 
 // ExportedInvalidateCacheKeysForResourceEvent exposes invalidateCacheKeysForResourceEvent for testing.

--- a/backend/pkg/k8cache/registry_cleanup_test.go
+++ b/backend/pkg/k8cache/registry_cleanup_test.go
@@ -23,7 +23,7 @@ func TestRunWatcherCleansUpRegistryOnFailure(t *testing.T) {
 
 	// An empty Context causes RESTConfig() to return an error,
 	// which makes runWatcher exit on its first error path.
-	k8cache.ExportedRunWatcher(ctx, nil, key, kubeconfig.Context{})
+	k8cache.ExportedRunWatcher(ctx, nil, key, kubeconfig.Context{}, nil)
 
 	// After the early return, both registry entries must be cleaned up
 	// so that a subsequent CheckForChanges call can start a new watcher.


### PR DESCRIPTION
## Summary

This PR adds a configurable allowlist for cache invalidation watchers by introducing a new `--cache-watch-resources` CLI flag. Previously, the backend only invalidated the cache for 11 hardcoded resource types (like pods, deployments, etc.), leaving resources like Ingresses or CRDs stale when mutated. This change allows users to specify an exact list of resources they want to monitor for cache invalidation.

## Related Issue

Fixes #6635 

## Changes

- Added `CacheWatchResources` field to `Config` struct and registered the `--cache-watch-resources` CLI flag.
- Updated `headlampConfig` and `server.go` to parse the comma-separated flag into a slice of strings.
- Modified `filterImportantResources` in `cacheInvalidation.go` to accept the configurable allowlist. When left empty, it falls back to the original 11 default resources for backward compatibility.
- Updated all related tests in `config_test.go`, `cacheInvalidation_test.go`, and internal cache test files to cover the new flag and configurable allowlist logic.

## Steps to Test

1. Build the backend using `npm run backend:build`.
2. Start the backend with the new flag: `./backend/headlamp-server --cache-enabled=true --cache-watch-resources=pods,ingresses,deployments`.
3. Verify that the backend successfully starts and only sets up informers for the specified resources.
4. Modify an Ingress resource (or whichever resource you added to the list) via kubectl.
5. Verify in the Headlamp UI or via API that the cache for that resource is immediately invalidated and reflects the updated state.
6. Run `npm run backend:test` to ensure all new unit tests pass successfully.

## Notes for the Reviewer

This PR modifies the core Kubernetes cache invalidation watcher logic. The default behavior is strictly preserved when the `--cache-watch-resources` flag is omitted, ensuring no breaking changes for existing users. Full test coverage has been added for the new configuration layer and resource filtering logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration to select which resource types are monitored for cache changes.
  * Supports comma-separated resource names with automatic trimming and case normalization.
  * Built-in default resources remain active when no selections are specified.
  * Resource monitoring can be customized independently for each context.

* **Bug Fixes**
  * Improved cache invalidation filtering for configured and unavailable resources.

* **Tests**
  * Added coverage for default and custom resource selections, including unavailable resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->