### PR TITLE
make: build-plugins-container: Follow host platform by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ else
         DOCKER_PLATFORM ?= local
     endif
 endif
+# The plugins container follows the host platform by default, like the main
+# image. Override to cross-build, e.g. DOCKER_PLUGINS_PLATFORM=linux/amd64.
+DOCKER_PLUGINS_PLATFORM ?= $(DOCKER_PLATFORM)
 DOCKER_PUSH ?= false
 EMBED_BINARY_NAME := headlamp_app
 # Get version and app name from app/package.json
@@ -399,7 +402,7 @@ image-verify-digests:
 build-plugins-container:
 	$(DOCKER_CMD) $(DOCKER_BUILDX_CMD) build \
 	--pull \
-	--platform=linux/amd64 \
+	--platform=$(DOCKER_PLUGINS_PLATFORM) \
 	--push=$(DOCKER_PUSH) \
 	-t $(DOCKER_REPO)/$(DOCKER_PLUGINS_IMAGE_NAME):$(DOCKER_IMAGE_VERSION) -f \
 	Dockerfile.plugins \


### PR DESCRIPTION
## Summary

This PR fixes the plugins container build ignoring the host architecture. `build-plugins-container` hardcoded `--platform=linux/amd64`, so on an Apple Silicon Mac it produced an amd64 image while `make image` correctly produced arm64. Because the flag was written inline rather than through a variable, it could not be overridden from the environment either.

This is the same defect as #4578, which was fixed for the `image` target in #4657 by adding host detection. That change did not cover `build-plugins-container`.

The failure mode is quiet and easy to misread. `kind load docker-image` exits 0 and prints its usual loading message, but the mismatched-architecture image is never added to the node. The problem only surfaces later as `ErrImageNeverPull` on the pod, which looks like a tagging or pull-policy mistake rather than an architecture mismatch. The practical effect is that the CI e2e run cannot be reproduced locally on an Apple Silicon Mac, because the plugins image is an init container in `e2e-tests/kubernetes-headlamp-ci.yaml` and the Headlamp pod never becomes ready.

## Related Issue

Fixes #6632

## Changes

- Added `DOCKER_PLUGINS_PLATFORM ?= $(DOCKER_PLATFORM)`, defaulting to the platform already derived from the host in Makefile:13-28
- Updated `build-plugins-container` to use `--platform=$(DOCKER_PLUGINS_PLATFORM)` instead of the hardcoded `linux/amd64`

Four lines changed in one file.

## Steps to Test

Resolution of the platform value, which can be checked on any host without building:

```
# 1. Default now follows the host (linux/arm64 on Apple Silicon, previously linux/amd64)
make -n build-plugins-container | tr -s ' \\\n' ' ' | grep -o '\-\-platform=[^ ]*'

# 2. Explicitly pinnable, which was not possible before
DOCKER_PLUGINS_PLATFORM=linux/amd64 make -n build-plugins-container | tr -s ' \\\n' ' ' | grep -o '\-\-platform=[^ ]*'

# 3. Also inherits an existing DOCKER_PLATFORM override
DOCKER_PLATFORM=linux/amd64 make -n build-plugins-container | tr -s ' \\\n' ' ' | grep -o '\-\-platform=[^ ]*'

# 4. Linux/CI path is unchanged: resolves to `local`, which is what the image target already passes there
make -n build-plugins-container DOCKER_PLATFORM=local | tr -s ' \\\n' ' ' | grep -o '\-\-platform=[^ ]*'
```

Expected: `linux/arm64`, `linux/amd64`, `linux/amd64`, `local`.

End to end on an Apple Silicon Mac:

```
# 5. Build and confirm the image architecture
DOCKER_IMAGE_VERSION=fixtest DOCKER_PLUGINS_IMAGE_NAME=headlamp-plugins-fixtest make build-plugins-container
docker image inspect ghcr.io/headlamp-k8s/headlamp-plugins-fixtest:fixtest --format '{{.Os}}/{{.Architecture}}'
# -> linux/arm64   (before this change: linux/amd64)

# 6. Confirm it actually lands on an arm64 kind node, which the amd64 build did not
kind create cluster --name test
kind load docker-image ghcr.io/headlamp-k8s/headlamp-plugins-fixtest:fixtest --name test
docker exec test-control-plane crictl images | grep fixtest
# -> present. With the previous amd64 build this grep returned nothing, despite kind load exiting 0.
```

I ran all six of the above on macOS 26.5.2 arm64 with Docker 27.5.1 and kind 0.32.0. With the corrected image in place the full e2e suite passes locally: 35 passed, 11 skipped.

## Screenshots (if applicable)

Not applicable, build tooling change.

## Notes for the Reviewer

- CI behaviour should be unchanged. On Linux the detection in Makefile:13-28 resolves `DOCKER_PLATFORM` to `local`, which is exactly what the `image` target already passes on those runners, so the plugins build gets the same value it effectively had before. Worth a second opinion on whether `local` is what you want there, or whether that build should stay explicitly pinned to `linux/amd64`; if the latter is preferred I am happy to set `DOCKER_PLUGINS_PLATFORM=linux/amd64` in `build-container.yml` instead of relying on the default.
- `build-plugins-container` is invoked from exactly one place, the e2e job at `.github/workflows/build-container.yml:137`. It is not used by any release or publish workflow, so there is no impact on published images.
- I deliberately used a separate `DOCKER_PLUGINS_PLATFORM` variable rather than reusing `DOCKER_PLATFORM` directly in the target, so the plugins image can still be cross-built independently of the main image.