### PR TITLE
app: e2e-tests: Fix the desktop suite and stop it mutating the kubeconfig

### DIFF
--- a/app/e2e-tests/playwright.config.ts
+++ b/app/e2e-tests/playwright.config.ts
@@ -46,7 +46,9 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  // 'list' streams progress; the html report is still written but never
+  // auto-opened, which otherwise blocks the run on `open --wait-apps`.
+  reporter: [['list'], ['html', { open: 'never' }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/app/e2e-tests/tests/clusterAutoConnect.spec.ts
+++ b/app/e2e-tests/tests/clusterAutoConnect.spec.ts
@@ -34,7 +34,7 @@
  */
 
 import { expect, test } from '@playwright/test';
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -56,7 +56,17 @@ function shell(cmd: string): string {
   return execSync(cmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'inherit'] }).trim();
 }
 
+// `minikube delete` clears current-context in the user's kubeconfig, which
+// leaves kubectl unusable afterwards. Remember it so teardown can put it back.
+let previousContext = '';
+
 function setupExecCluster(): void {
+  try {
+    previousContext = shell('kubectl config current-context');
+  } catch {
+    /* no current context set; nothing to restore */
+  }
+
   // Start (or reconnect to) the dedicated minikube profile.
   // minikube automatically adds the context to the kubeconfig in ORIGINAL_KUBECONFIG.
   shell(`minikube start --profile ${CLUSTER_NAME}`);
@@ -72,7 +82,7 @@ function setupExecCluster(): void {
   // Use the kubeconfig that minikube already wrote (cert-based auth, proven to work).
   // Export it to a standalone file so the test doesn't inherit unrelated contexts.
   const exported = shell(`kubectl --context ${CLUSTER_NAME} config view --minify --raw --flatten`);
-  fs.writeFileSync(MERGED_KUBECONFIG, exported);
+  fs.writeFileSync(MERGED_KUBECONFIG, exported, { mode: 0o600 });
 }
 function teardownExecCluster(): void {
   // Stop and delete the minikube profile (also removes its kubeconfig entries).
@@ -84,6 +94,17 @@ function teardownExecCluster(): void {
   for (const f of [EXEC_KUBECONFIG, MERGED_KUBECONFIG]) {
     try {
       fs.unlinkSync(f);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  // Restore the context `minikube delete` cleared.
+  if (previousContext) {
+    try {
+      execFileSync('kubectl', ['config', 'use-context', previousContext], {
+        stdio: ['pipe', 'pipe', 'inherit'],
+      });
     } catch {
       /* ignore */
     }

--- a/app/e2e-tests/tests/clusterRename.spec.ts
+++ b/app/e2e-tests/tests/clusterRename.spec.ts
@@ -15,6 +15,9 @@
  */
 
 import { expect, test } from '@playwright/test';
+import { execSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { _electron, Page } from 'playwright';
 import { HeadlampPage } from './headlampPage';
@@ -23,6 +26,21 @@ import { HeadlampPage } from './headlampPage';
 const electronExecutable = process.platform === 'win32' ? 'electron.cmd' : 'electron';
 const electronPath = path.resolve(__dirname, `../../node_modules/.bin/${electronExecutable}`);
 const appPath = path.resolve(__dirname, '../../');
+
+// Renaming a cluster persists a headlamp_info customName extension into the
+// kubeconfig. Run against a throwaway copy so the developer's real kubeconfig
+// is never modified and the suite stays repeatable.
+const ISOLATED_KUBECONFIG = path.join(os.tmpdir(), `headlamp-e2e-rename-${process.pid}.kubeconfig`);
+
+function writeIsolatedKubeconfig(context: string, target: string): void {
+  fs.writeFileSync(
+    target,
+    execSync(`kubectl --context ${context} config view --minify --raw --flatten`, {
+      encoding: 'utf8',
+    }),
+    { mode: 0o600 }
+  );
+}
 let electronApp;
 let electronPage: Page;
 
@@ -56,13 +74,17 @@ async function renameCluster(
 ) {
   await page.fill(`input[placeholder="${fromName}"]`, toName);
   await page.getByRole('button', { name: 'Apply' }).click();
-  await page.getByRole('button', { name: confirm ? 'Yes' : 'No' }).click();
+  // ConfirmDialog sets aria-label="confirm-button"/"cancel-button", which becomes
+  // the accessible name and overrides the visible "Yes"/"No" text.
+  await page.getByRole('button', { name: confirm ? 'confirm-button' : 'cancel-button' }).click();
   await page.waitForLoadState('load');
   await page.locator(`a[href="#/c/${toName}/"]`).click();
 }
 
 // Setup
 test.beforeAll(async () => {
+  writeIsolatedKubeconfig(TEST_CONFIG.originalName, ISOLATED_KUBECONFIG);
+
   electronApp = await _electron.launch({
     cwd: appPath,
     executablePath: electronPath,
@@ -71,14 +93,22 @@ test.beforeAll(async () => {
       ...process.env,
       NODE_ENV: 'development',
       ELECTRON_DEV: 'true',
+      KUBECONFIG: ISOLATED_KUBECONFIG,
     },
   });
 
   electronPage = await electronApp.firstWindow();
 });
 
+// The app holds a single-instance lock, so it must be closed or the next spec
+// file's launch is denied the lock and quits immediately.
+test.afterAll(async () => {
+  await electronApp?.close();
+  fs.rmSync(ISOLATED_KUBECONFIG, { force: true });
+});
+
 test.beforeEach(async ({ page }) => {
-  page.close();
+  await page.close();
 });
 
 // Tests
@@ -105,5 +135,7 @@ test.describe('Cluster rename functionality', () => {
     // Test successful rename
     await renameCluster(page, TEST_CONFIG.originalName, TEST_CONFIG.newName);
     await verifyClusterName(page, TEST_CONFIG.newName);
+    // No need to rename back: the rename is written to ISOLATED_KUBECONFIG,
+    // which is discarded in afterAll.
   });
 });

--- a/app/e2e-tests/tests/namespaces.spec.ts
+++ b/app/e2e-tests/tests/namespaces.spec.ts
@@ -15,6 +15,9 @@
  */
 
 import { test } from '@playwright/test';
+import { execSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { _electron, Page } from 'playwright';
 import { HeadlampPage } from './headlampPage';
@@ -23,6 +26,13 @@ import { NamespacesPage } from './namespacesPage';
 const electronExecutable = process.platform === 'win32' ? 'electron.cmd' : 'electron';
 const electronPath = path.resolve(__dirname, `../../node_modules/.bin/${electronExecutable}`);
 
+// Run against a throwaway copy of the kubeconfig so the developer's real one is
+// never modified by anything the app persists, and the suite stays repeatable.
+const ISOLATED_KUBECONFIG = path.join(
+  os.tmpdir(),
+  `headlamp-e2e-namespaces-${process.pid}.kubeconfig`
+);
+
 const electron = _electron;
 const appPath = path.resolve(__dirname, '../../');
 let electronApp;
@@ -30,6 +40,14 @@ let electronPage: Page;
 
 if (process.env.PLAYWRIGHT_TEST_MODE === 'app') {
   test.beforeAll(async () => {
+    fs.writeFileSync(
+      ISOLATED_KUBECONFIG,
+      execSync('kubectl --context minikube config view --minify --raw --flatten', {
+        encoding: 'utf8',
+      }),
+      { mode: 0o600 }
+    );
+
     electronApp = await electron.launch({
       cwd: appPath,
       executablePath: electronPath,
@@ -38,15 +56,23 @@ if (process.env.PLAYWRIGHT_TEST_MODE === 'app') {
         ...process.env,
         NODE_ENV: 'development',
         ELECTRON_DEV: 'true',
+        KUBECONFIG: ISOLATED_KUBECONFIG,
       },
     });
 
     electronPage = await electronApp.firstWindow();
   });
 
+  // The app holds a single-instance lock, so it must be closed or a later
+  // launch in the same run is denied the lock and quits immediately.
+  test.afterAll(async () => {
+    await electronApp?.close();
+    fs.rmSync(ISOLATED_KUBECONFIG, { force: true });
+  });
+
   test.beforeEach(async ({ page }) => {
     if (process.env.PLAYWRIGHT_TEST_MODE === 'app') {
-      page.close();
+      await page.close();
     }
   });
 }
@@ -55,7 +81,8 @@ if (process.env.PLAYWRIGHT_TEST_MODE === 'app') {
 // - a running minikube cluster named 'minikube'
 // - an ENV variable of PLAYWRIGHT_TEST_MODE=app
 test.describe('create a namespace with the minimal editor', async () => {
-  test.setTimeout(0);
+  // A real timeout, so a failure surfaces as a failure rather than hanging forever.
+  test.setTimeout(3 * 60 * 1000);
   test('create a namespace with the minimal editor then delete it', async ({
     page: browserPage,
   }) => {

--- a/app/e2e-tests/tests/namespacesPage.ts
+++ b/app/e2e-tests/tests/namespacesPage.ts
@@ -21,8 +21,8 @@ export class NamespacesPage {
 
   async navigateToNamespaces() {
     await this.page.waitForLoadState('load');
-    await this.page.waitForSelector('span:has-text("Cluster")');
-    await this.page.getByText('Cluster', { exact: true }).click();
+    // Namespaces is a top-level sidebar entry. It used to be nested under a
+    // "Cluster" group, which no longer exists.
     await this.page.waitForSelector('span:has-text("Namespaces")');
     await this.page.click('span:has-text("Namespaces")');
     await this.page.waitForLoadState('load');
@@ -68,8 +68,9 @@ export class NamespacesPage {
     await expect(page.getByRole('textbox', { name: 'yaml Code' })).toBeVisible();
     await page.fill('textarea[aria-label="yaml Code"]', yaml);
 
-    await expect(page.getByRole('button', { name: 'Apply' })).toBeVisible();
-    await page.getByRole('button', { name: 'Apply' }).click();
+    // exact: true, otherwise this also matches the "Create / Apply" button.
+    await expect(page.getByRole('button', { name: 'Apply', exact: true })).toBeVisible();
+    await page.getByRole('button', { name: 'Apply', exact: true }).click();
 
     await page.waitForSelector(`a:has-text("${name}")`);
     await expect(page.locator(`a:has-text("${name}")`)).toBeVisible();
@@ -88,11 +89,13 @@ export class NamespacesPage {
 
     await page.waitForLoadState('load');
 
-    await page.waitForSelector('button:has-text("Yes")');
+    // This is a ConfirmDialog. Its confirm button reads "Delete" here and "Yes"
+    // in other places, so key off the stable aria-label instead of the text.
+    await page.waitForSelector('button[aria-label="confirm-button"]');
 
     await page.waitForLoadState('load');
 
-    await page.click('button:has-text("Yes")');
+    await page.click('button[aria-label="confirm-button"]');
 
     await page.waitForSelector('h1:has-text("Namespaces")');
     await page.waitForSelector('td:has-text("Terminating")');


### PR DESCRIPTION
## Summary

This PR fixes the app-mode e2e suite in `app/e2e-tests`, which did not pass and which modified the developer's real kubeconfig as a side effect. Because that mutation was never reverted, the suite could only ever pass once on a given machine; every run after the first found a cluster named `test-cluster` instead of `minikube`.

Before: 2 of 4 tests failing, roughly 1.8 minutes, with a failure mode that looked like an indefinite hang.
After: 4 of 4 passing in about a minute, repeatable, and leaving no state behind.

There were seven distinct problems. They had to be fixed together, because each one masked the next.

## Related Issue

Fixes #6648

Also related to #6639, which asks whether this suite should run in CI and lists what that would take. Two of the fixes here (the disabled timeout and the cross-spec state mutation) are the robustness problems that issue identifies as worth fixing first, so this is a prerequisite rather than the CI change itself.

This PR does not add a workflow. That decision is still open in #6639.

## Changes

**Test isolation and reporting**

- `clusterRename` persisted `customName` as a `headlamp_info` extension in `~/.kube/config` and never reverted it. Both `clusterRename` and `namespaces` now run against a throwaway copy of the kubeconfig in `os.tmpdir()`, which is the approach `clusterAutoConnect` already used. The user's kubeconfig is no longer written to at all.
- `minikube delete` clears `current-context`, which left `kubectl` unusable after a run (`connection refused to localhost:8080`). `clusterAutoConnect` now records and restores it.
- `clusterRename` and `namespaces` never closed their Electron app. The app takes a single-instance lock (`app/electron/main.ts:1634`), so the next spec file's launch was denied the lock and quit immediately, surfacing as `electron.launch: Process failed to launch!`. Both now close the app in `afterAll`.
- `namespaces.spec.ts` used `test.setTimeout(0)`, disabling the test timeout entirely, so any failure in that file hung forever instead of failing. In CI that would burn a job to the workflow limit rather than reporting a failure. It now has a real timeout.
- The html reporter blocked the run on `open --wait-apps` after a failure. I lost 85 minutes to a run that had actually finished in 40 seconds. Reporting is now `list` plus `html` with `open: 'never'`, so runs stream progress and always terminate. This does not change CI behaviour, where Playwright already suppresses auto-open.

**Selectors that had drifted from the UI**

- `ConfirmDialog` sets `aria-label="confirm-button"` / `"cancel-button"`, which becomes the accessible name and overrides the visible text, so `getByRole('button', { name: 'Yes' })` matched nothing. These now query the same accessible name that the component's own unit tests use (`frontend/src/components/common/ConfirmButton.test.tsx`).
- The namespace delete confirmation reads "Cancel"/"Delete" rather than "No"/"Yes", so keying off the aria-label covers both dialogs.
- Namespaces is a top-level sidebar entry now. The page object still clicked through a "Cluster" group, which no longer exists outside Storybook stories.
- `getByRole('button', { name: 'Apply' })` matched both "Apply" and "Create / Apply", a strict mode violation. Made exact.

## Steps to Test

Requires a running minikube cluster named `minikube`, plus the prerequisites the suite needs (these are not currently documented; see #6640):

```
# 1. Build what the app loads in dev mode
make frontend                       # -> frontend/build/index.html
make backend                        # -> backend/headlamp-server
cd app && npm install
npm run compile-electron -- --dev   # -> app/build/main.js
cd e2e-tests && npm install && npx playwright install chromium

# 2. Run it
PLAYWRIGHT_TEST_MODE=app npx playwright test
```

Expected: `4 passed`, exit 0, in roughly a minute.

To confirm the isolation actually holds, which is the main point of this PR:

```
# Before and after a run, all three should be unchanged:
grep -c customName ~/.kube/config     # 0
kubectl config current-context        # minikube
kubectl get ns testing-e2e            # not found

# And it should be repeatable, which it was not before:
PLAYWRIGHT_TEST_MODE=app npx playwright test   # 4 passed
PLAYWRIGHT_TEST_MODE=app npx playwright test   # 4 passed again
```

I also ran it with `CI=true` to exercise `retries: 2` and `forbidOnly`; it passes and terminates cleanly.

## Screenshots (if applicable)

Not applicable, test-only change.

## Notes for the Reviewer

- **The aria-label queries look odd on purpose.** `getByRole('button', { name: 'confirm-button' })` reads strangely, but it is the actual accessible name, and it is what the component's unit tests already assert against. Worth flagging separately: `aria-label="confirm-button"` overriding the visible "Yes" means a screen reader announces "confirm button" rather than "Yes". That looks like a real accessibility problem in `ConfirmDialog`, not just a test inconvenience. I have not filed that, and did not want to change component behaviour inside a test-only PR. Happy to open an issue if you agree it is one.
- **The kubeconfig isolation changes what the specs talk to.** They now see a minified, flattened copy of the `minikube` context rather than the developer's full kubeconfig. That is deliberate: it stops the suite mutating a real file, and it means the specs no longer depend on whatever else happens to be in the developer's config. The context is still named `minikube`, so the specs' expectations are unchanged.
- **Not validated on Linux.** Everything here was verified on macOS/arm64. The suite has never run in CI, so there may be Linux-specific issues (Electron sandbox flags, missing GTK/NSS libraries, xvfb behaviour) that only appear the first time it runs on a runner. That is one reason this PR deliberately stops short of adding a workflow.
- `app/e2e-tests` is outside the scope of `npm run app:lint` and its `format-check`, though the pre-commit hook does cover `app/**/*.{ts,tsx}`. These files were also checked directly against the same Prettier config.
