### PR TITLE
frontend: ReleaseNotesModal: Render HTML images from GitHub release notes

### DIFF
--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.stories.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.stories.tsx
@@ -25,7 +25,7 @@ export default {
 export const Show = {
   args: {
     releaseNotes:
-      '# Release Notes\n\n## Hello\n\n### Sub-heading\n\nworld\n\n## Changes\n\n| Feature | Status | Notes |\n|---------|--------|-------|\n| Dark mode | ✅ Done | Available in settings |\n| Tables | ✅ Done | Now rendered properly |\n| Images | ✅ Done | Bounded to container |\n\n## Code Example\n\n```yaml\napiVersion: v1\nkind: Pod\n```\n\n> **Note:** This is a blockquote with important information.',
+      '# Release Notes\n\n## Hello\n\n### Sub-heading\n\nworld\n\n## Changes\n\n| Feature | Status | Notes |\n|---------|--------|-------|\n| Dark mode | ✅ Done | Available in settings |\n| Tables | ✅ Done | Now rendered properly |\n| Images | ✅ Done | Bounded to container |\n\n## Screenshot\n\n<img width="800" height="352" alt="Example release screenshot" src="https://github.com/user-attachments/assets/674137f5-99db-4d7f-ab50-d91b19202704" />\n\n## Code Example\n\n```yaml\napiVersion: v1\nkind: Pod\n```\n\n> **Note:** This is a blockquote with important information.',
     appVersion: '1.9.9',
   },
 };

--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.stories.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.stories.tsx
@@ -30,6 +30,22 @@ export const Show = {
   },
 };
 
+export const Table = {
+  args: {
+    releaseNotes:
+      '## Changes\n\n| Feature | Status | Notes |\n| ------- | ------ | ----- |\n| Tables | Done | Rendered with GFM |',
+    appVersion: '1.9.9',
+  },
+};
+
+export const HtmlImage = {
+  args: {
+    releaseNotes:
+      '## Screenshot\n\n<img width="800" height="352" alt="Example release screenshot" src="https://github.com/user-attachments/assets/674137f5-99db-4d7f-ab50-d91b19202704" />',
+    appVersion: '1.9.9',
+  },
+};
+
 export const Closed = {
   args: {
     releaseNotes: undefined,

--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.test.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen, within } from '@testing-library/react';
+import ReleaseNotesModal from './ReleaseNotesModal';
+
+vi.mock('@iconify/react', () => ({ Icon: () => null }));
+
+describe('ReleaseNotesModal', () => {
+  it('renders GitHub release-note tables and HTML images', () => {
+    const releaseNotes = `## Changes
+
+| Feature | Status |
+| ------- | ------ |
+| Tables | Ready |
+
+<img alt="Release preview" src="https://example.com/release.png" />`;
+
+    render(<ReleaseNotesModal releaseNotes={releaseNotes} appVersion="1.2.3" />);
+
+    const table = screen.getByRole('table');
+    expect(within(table).getByRole('columnheader', { name: 'Feature' })).toBeInTheDocument();
+    expect(within(table).getByRole('cell', { name: 'Tables' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Release preview' })).toHaveAttribute(
+      'src',
+      'https://example.com/release.png'
+    );
+  });
+});

--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.tsx
@@ -25,6 +25,7 @@ import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { DialogTitle } from '../Dialog';
+import { htmlImagesToMarkdown } from './htmlImagesToMarkdown';
 
 export interface ReleaseNotesModalProps {
   releaseNotes: string;
@@ -35,6 +36,7 @@ export default function ReleaseNotesModal(props: ReleaseNotesModalProps) {
   const { releaseNotes, appVersion } = props;
   const [showReleaseNotes, setShowReleaseNotes] = React.useState(Boolean(releaseNotes));
   const { t } = useTranslation();
+  const notesMarkdown = React.useMemo(() => htmlImagesToMarkdown(releaseNotes), [releaseNotes]);
 
   return (
     <Dialog open={showReleaseNotes} maxWidth="xl">
@@ -100,7 +102,7 @@ export default function ReleaseNotesModal(props: ReleaseNotesModalProps) {
               ),
             }}
           >
-            {releaseNotes}
+            {notesMarkdown}
           </ReactMarkdown>
         </Box>
       </DialogContent>

--- a/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.HtmlImage.stories.storyshot
+++ b/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.HtmlImage.stories.storyshot
@@ -1,0 +1,93 @@
+<body>
+  <div
+    aria-hidden="true"
+  />
+  <div
+    class="MuiDialog-root MuiModal-root css-zw3mfo-MuiModal-root-MuiDialog-root"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root MuiModal-backdrop css-yiavyu-MuiBackdrop-root-MuiDialog-backdrop"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-testid="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiDialog-container MuiDialog-scrollPaper css-hz1bth-MuiDialog-container"
+      role="presentation"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      tabindex="-1"
+    >
+      <div
+        aria-labelledby=":mock-test-id:"
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthXl css-h0fqyc-MuiPaper-root-MuiDialog-paper"
+        role="dialog"
+      >
+        <h2
+          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-8yphvn-MuiTypography-root-MuiDialogTitle-root"
+          id=":mock-test-id:"
+          style="display: flex;"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-container css-9cyib4-MuiGrid-root"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <h1
+                class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
+              >
+                Release Notes (1.9.9)
+              </h1>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-0"
+              >
+                <button
+                  aria-label="Close"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+        </h2>
+        <div
+          class="MuiDialogContent-root MuiDialogContent-dividers css-1t4vnk2-MuiDialogContent-root"
+        >
+          <div
+            class="MuiBox-root css-wicc6q"
+          >
+            <h2>
+              Screenshot
+            </h2>
+            
+
+            <p>
+              <img
+                alt="Example release screenshot"
+                src="https://github.com/user-attachments/assets/674137f5-99db-4d7f-ab50-d91b19202704"
+              />
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      data-testid="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>

--- a/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.Show.stories.storyshot
+++ b/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.Show.stories.storyshot
@@ -148,6 +148,19 @@
             
 
             <h2>
+              Screenshot
+            </h2>
+            
+
+            <p>
+              <img
+                alt="Example release screenshot"
+                src="https://github.com/user-attachments/assets/674137f5-99db-4d7f-ab50-d91b19202704"
+              />
+            </p>
+            
+
+            <h2>
               Code Example
             </h2>
             

--- a/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.Table.stories.storyshot
+++ b/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.Table.stories.storyshot
@@ -1,0 +1,115 @@
+<body>
+  <div
+    aria-hidden="true"
+  />
+  <div
+    class="MuiDialog-root MuiModal-root css-zw3mfo-MuiModal-root-MuiDialog-root"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root MuiModal-backdrop css-yiavyu-MuiBackdrop-root-MuiDialog-backdrop"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-testid="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiDialog-container MuiDialog-scrollPaper css-hz1bth-MuiDialog-container"
+      role="presentation"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      tabindex="-1"
+    >
+      <div
+        aria-labelledby=":mock-test-id:"
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthXl css-h0fqyc-MuiPaper-root-MuiDialog-paper"
+        role="dialog"
+      >
+        <h2
+          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-8yphvn-MuiTypography-root-MuiDialogTitle-root"
+          id=":mock-test-id:"
+          style="display: flex;"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-container css-9cyib4-MuiGrid-root"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <h1
+                class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
+              >
+                Release Notes (1.9.9)
+              </h1>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-0"
+              >
+                <button
+                  aria-label="Close"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+        </h2>
+        <div
+          class="MuiDialogContent-root MuiDialogContent-dividers css-1t4vnk2-MuiDialogContent-root"
+        >
+          <div
+            class="MuiBox-root css-wicc6q"
+          >
+            <h2>
+              Changes
+            </h2>
+            
+
+            <table>
+              <thead>
+                <tr>
+                  <th>
+                    Feature
+                  </th>
+                  <th>
+                    Status
+                  </th>
+                  <th>
+                    Notes
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    Tables
+                  </td>
+                  <td>
+                    Done
+                  </td>
+                  <td>
+                    Rendered with GFM
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      data-testid="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>

--- a/frontend/src/components/common/ReleaseNotes/htmlImagesToMarkdown.test.ts
+++ b/frontend/src/components/common/ReleaseNotes/htmlImagesToMarkdown.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 The Kubernetes Authors
+ * Copyright 2025 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,9 @@ describe('htmlImagesToMarkdown', () => {
       '## Feature\n\n<img width="800" height="352" alt="Cluster inventory" src="https://github.com/user-attachments/assets/abc123" />\n\nMore text';
     const result = htmlImagesToMarkdown(input);
 
-    expect(result).toContain('![Cluster inventory](https://github.com/user-attachments/assets/abc123)');
+    expect(result).toContain(
+      '![Cluster inventory](https://github.com/user-attachments/assets/abc123)'
+    );
     expect(result).not.toContain('<img');
   });
 

--- a/frontend/src/components/common/ReleaseNotes/htmlImagesToMarkdown.test.ts
+++ b/frontend/src/components/common/ReleaseNotes/htmlImagesToMarkdown.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { htmlImagesToMarkdown } from './htmlImagesToMarkdown';
+
+describe('htmlImagesToMarkdown', () => {
+  it('returns markdown unchanged when there are no img tags', () => {
+    const input = '## Hello\n\nNo images here.';
+    expect(htmlImagesToMarkdown(input)).toBe(input);
+  });
+
+  it('converts GitHub-style HTML img tags to markdown images', () => {
+    const input =
+      '## Feature\n\n<img width="800" height="352" alt="Cluster inventory" src="https://github.com/user-attachments/assets/abc123" />\n\nMore text';
+    const result = htmlImagesToMarkdown(input);
+
+    expect(result).toContain('![Cluster inventory](https://github.com/user-attachments/assets/abc123)');
+    expect(result).not.toContain('<img');
+  });
+
+  it('handles src before alt and single quotes', () => {
+    const input = `<img src='https://example.com/a.png' alt='Demo' />`;
+    expect(htmlImagesToMarkdown(input)).toContain('![Demo](https://example.com/a.png)');
+  });
+
+  it('drops non-http(s) image sources', () => {
+    const input = `<img src="javascript:alert(1)" alt="x" /><img src="https://example.com/ok.png" alt="ok" />`;
+    const result = htmlImagesToMarkdown(input);
+
+    expect(result).not.toContain('javascript:');
+    expect(result).toContain('![ok](https://example.com/ok.png)');
+  });
+});

--- a/frontend/src/components/common/ReleaseNotes/htmlImagesToMarkdown.ts
+++ b/frontend/src/components/common/ReleaseNotes/htmlImagesToMarkdown.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 The Kubernetes Authors
+ * Copyright 2025 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/components/common/ReleaseNotes/htmlImagesToMarkdown.ts
+++ b/frontend/src/components/common/ReleaseNotes/htmlImagesToMarkdown.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * GitHub release notes often embed screenshots as raw HTML <img> tags.
+ * react-markdown does not render raw HTML by default, so convert those
+ * tags into markdown image syntax before rendering.
+ */
+export function htmlImagesToMarkdown(markdown: string): string {
+  if (!markdown || !markdown.includes('<img')) {
+    return markdown;
+  }
+
+  return markdown.replace(/<img\b[^>]*>/gi, tag => {
+    const srcMatch = tag.match(/\bsrc\s*=\s*(["'])(.*?)\1/i);
+    if (!srcMatch) {
+      return '';
+    }
+
+    const src = srcMatch[2].trim();
+    // Only allow http(s) image URLs from release notes.
+    if (!/^https?:\/\//i.test(src)) {
+      return '';
+    }
+
+    const altMatch = tag.match(/\balt\s*=\s*(["'])(.*?)\1/i);
+    const alt = (altMatch ? altMatch[2] : '').replace(/[[\]]/g, '');
+
+    return `\n\n![${alt}](${src})\n\n`;
+  });
+}

--- a/frontend/src/components/common/Resource/DeleteButton.test.tsx
+++ b/frontend/src/components/common/Resource/DeleteButton.test.tsx
@@ -138,7 +138,7 @@ describe('DeleteButton', () => {
     renderButton(makeNamespace({ name: 'kube-system' }));
     const dialog = await openDialog();
 
-    const confirmButton = within(dialog).getByLabelText('confirm-button');
+    const confirmButton = within(dialog).getByTestId('confirm-button');
     const input = within(dialog).getByLabelText('translation|Namespace name');
 
     expect(confirmButton).toBeDisabled();
@@ -162,7 +162,7 @@ describe('DeleteButton', () => {
     );
     const dialog = await openDialog();
 
-    const confirmButton = within(dialog).getByLabelText('confirm-button');
+    const confirmButton = within(dialog).getByTestId('confirm-button');
     const input = within(dialog).getByLabelText('translation|Namespace name');
 
     // The object's metadata.name should NOT unlock deletion.
@@ -186,7 +186,7 @@ describe('DeleteButton', () => {
     expect(within(dialog).queryByLabelText('translation|Namespace name')).not.toBeInTheDocument();
 
     // Confirm is enabled right away — no type-to-confirm step.
-    expect(within(dialog).getByLabelText('confirm-button')).toBeEnabled();
+    expect(within(dialog).getByTestId('confirm-button')).toBeEnabled();
   });
 
   it('stays in sync with the production protected namespace list', async () => {

--- a/frontend/src/components/common/Resource/DeleteMultipleButton.test.tsx
+++ b/frontend/src/components/common/Resource/DeleteMultipleButton.test.tsx
@@ -136,7 +136,7 @@ describe('DeleteMultipleButton', () => {
     ]);
     const dialog = await openDialog();
 
-    const confirmButton = within(dialog).getByLabelText('confirm-button');
+    const confirmButton = within(dialog).getByTestId('confirm-button');
     const input = within(dialog).getByLabelText('translation|Namespace name(s)');
 
     expect(confirmButton).toBeDisabled();
@@ -164,7 +164,7 @@ describe('DeleteMultipleButton', () => {
     ).not.toBeInTheDocument();
 
     // Confirm is enabled right away — no type-to-confirm step.
-    expect(within(dialog).getByLabelText('confirm-button')).toBeEnabled();
+    expect(within(dialog).getByTestId('confirm-button')).toBeEnabled();
   });
 
   it('stays in sync with the production protected namespace list', async () => {


### PR DESCRIPTION
## Summary
- Fix Release Notes dialog so screenshots from GitHub releases actually show.
- GitHub release bodies often use raw HTML `<img>` tags; `react-markdown` ignores raw HTML by default, so images were missing (#6158).
- Convert http(s) `<img>` tags into markdown images before render (non-http(s) sources are dropped).
- Add unit tests and a Storybook example with an HTML screenshot.

Fixes #6158

## Test plan
- [x] `npx vitest run src/components/common/ReleaseNotes/htmlImagesToMarkdown.test.ts` (4/4 pass)
- [x] Storybook → `common/ReleaseNotes/ReleaseNotesModal` → **Show** → **Screenshot** section shows a real image
<img width="1895" height="915" alt="image" src="https://github.com/user-attachments/assets/8e41e6e6-bdf5-4a3f-b17a-64f586309132" />

