### PR TITLE
frontend: Activity: Add accessible aria-labels to icon buttons

### DIFF
--- a/frontend/src/components/App/Settings/ShortcutsSettings.tsx
+++ b/frontend/src/components/App/Settings/ShortcutsSettings.tsx
@@ -203,7 +203,7 @@ function ShortcutEditor({
       </Button>
       {isModified && (
         <Tooltip title={t('Reset to default')}>
-          <IconButton size="small" onClick={onReset}>
+          <IconButton size="small" onClick={onReset} aria-label={t('Reset to default')}>
             <Icon icon="mdi:restore" width={16} />
           </IconButton>
         </Tooltip>

--- a/frontend/src/components/activity/Activity.tsx
+++ b/frontend/src/components/activity/Activity.tsx
@@ -669,15 +669,19 @@ export function SingleActivityRenderer({
                     </ClickAwayListener>
                   </Popper>
                   <IconButton
-                    onClick={() => {
-                      Activity.update(id, { minimized: true });
-                    }}
+                    onClick={() => Activity.update(id, { minimized: true })}
                     size="small"
                     title={t('Minimize')}
+                    aria-label={t('Minimize')}
                   >
                     <Icon icon="mdi:minimize" />
                   </IconButton>
-                  <IconButton onClick={() => Activity.close(id)} size="small" title={t('Close')}>
+                  <IconButton
+                    onClick={() => Activity.close(id)}
+                    size="small"
+                    title={t('Close')}
+                    aria-label={t('Close')}
+                  >
                     <Icon icon="mdi:close" />
                   </IconButton>
                 </>

--- a/frontend/src/components/activity/__snapshots__/Activity.Basic.stories.storyshot
+++ b/frontend/src/components/activity/__snapshots__/Activity.Basic.stories.storyshot
@@ -42,6 +42,7 @@
               />
             </button>
             <button
+              aria-label="Minimize"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
               tabindex="0"
               title="Minimize"
@@ -52,6 +53,7 @@
               />
             </button>
             <button
+              aria-label="Close"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
               tabindex="0"
               title="Close"
@@ -110,6 +112,7 @@
               </span>
             </button>
             <button
+              aria-label="Minimize"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
               tabindex="0"
               title="Minimize"
@@ -120,6 +123,7 @@
               />
             </button>
             <button
+              aria-label="Close"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
               tabindex="0"
               title="Close"


### PR DESCRIPTION
## Summary

This PR improves accessibility (a11y) for keyboard-only and screen-reader users by adding explicit `aria-label` attributes to icon-only action buttons in `Activity.tsx` and `ShortcutsSettings.tsx`.

## Related Issue

N/A

## Changes

- Added `aria-label={t('Minimize')}` and `aria-label={t('Close')}` to header `<IconButton>` components in `Activity.tsx`.
- Added `aria-label={t('Reset to default')}` to shortcut key reset `<IconButton>` in `ShortcutsSettings.tsx`.

## Steps to Test

1. Open Headlamp and trigger an Activity panel (e.g., Create/Apply or Log Viewer).
2. Inspect the minimize and close icon buttons in the top-right header using Chrome DevTools Accessibility inspector or a screen reader.
3. Verify that the accessible name announces as "Minimize" and "Close".
4. Navigate to Settings > Shortcuts and modify a shortcut key to display the reset button.
5. Verify that the reset button announces as "Reset to default".

## Screenshots (if applicable)

*N/A - Accessibility attribute additions.*

## Notes for the Reviewer

- Clean 6-line diff touching frontend accessibility compliance.
- Passes `npm run frontend:lint:fix` and `npm run frontend:test`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added accessible labels to shortcut reset, activity minimize, and activity close buttons.
  * Improved screen reader clarity for window controls in activity panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->