### PR TITLE
app: e2e-tests: Make the desktop suite runnable as documented

### DIFF
--- a/app/e2e-tests/README.md
+++ b/app/e2e-tests/README.md
@@ -1,69 +1,105 @@
-# e2e test for local playwright app mode
+# e2e tests for the desktop (Electron) app
 
-Currently we have the original e2e tests for the web mode in the `e2e-tests` directory. We are adding new tests for the app mode in the `app-e2e-tests` directory for local testing. Unlike the other tests, these tests do not require a token to run so the setup is as followed:
+These are the Playwright tests for the desktop app. The web-mode tests for
+in-cluster Headlamp live in the top-level `e2e-tests` directory.
 
-## Running app mode tests
+There are two modes:
 
-## Setup
+- **app mode** (`npm run test-app`) drives the Electron app directly. This is
+  the mode most of these tests are written for; three of the four skip unless
+  `PLAYWRIGHT_TEST_MODE=app`.
+- **web mode** (`npm run test-web`) drives a browser against a separately
+  running backend and frontend.
 
-- Before running the tests, be sure to have an instance of Minikube running with the name `minikube`
+## Prerequisites
 
-### Running the tests
+Both modes need a running minikube cluster named `minikube`:
 
-To run the tests for the app mode, follow the steps below:
+```bash
+minikube start
+kubectl config current-context   # should print: minikube
+```
 
-- cd into the e2e-tests directory within the headlamp repository
-  `cd headlamp/app/e2e-tests`
+The name matters. `clusterRename.spec.ts` expects a cluster called `minikube`,
+and `clusterAutoConnect.spec.ts` shells out to `minikube` directly to create and
+delete its own throwaway profile, so `minikube` and `kubectl` must both be on
+`PATH`.
 
-- npm install the needed packages
-  `npm install`
+App mode runs the app from source rather than from a packaged build, so the
+things the app loads in dev mode have to exist first:
 
-- run the following command
-  `npm run test-app`
-  (optional: include `-- --headed` to run the tests in headed mode)
-  (optional: include `-- --ui` to run the tests in ui mode)
+```bash
+# from the repository root
+npm run frontend:install
+npm run frontend:build   # -> frontend/build/index.html
+npm run backend:build    # -> backend/headlamp-server
+npm run app:install
+```
 
-## Running web mode tests
+`app/build/main.js`, the Electron entry point, is built automatically by the
+`pretest-app` script, so there is no separate step for it.
 
-Running the tests for the web mode requires the backend and frontend to be running. Follow the steps below to run the tests for the web mode:
+Then install the test dependencies:
 
-Note: You may encouter issues switching from the app mode tests to the web mode tests. If you do, search for any running headlamp server processes and end them before running the web mode tests or app mode tests.
+```bash
+cd app/e2e-tests
+npm install
+npx playwright install chromium
+```
 
-## Setup
+Chromium is required even though these are Electron tests. The specs request
+Playwright's `page` fixture before switching to the Electron window, and
+requesting it launches a browser.
 
-- Before running the tests, be sure to have an instance of Minikube running with the name `minikube`
+## Running the tests
 
-### Backend
+### App mode
 
-To run the tests for the web mode, you will need to have the backend running. Follow the steps below to run the backend:
+```bash
+cd app/e2e-tests
+npm run test-app
+```
 
-- cd into the headlamp directory in a singular terminal
-  `cd headlamp`
+Or from the repository root:
 
-- run the following command
-  `npm run backend:build` followed by `npm run backend:start`
+```bash
+npm run app:test:e2e
+```
 
-### Frontend
+Optional flags can be passed from either directory:
 
-To run the tests for the web mode, you will need to have the frontend running. Follow the steps below to run the frontend:
+```bash
+# from app/e2e-tests
+npm run test-app -- --headed   # watch it run
+npm run test-app -- --ui       # Playwright UI mode
 
-- cd into the headlamp directory in a separate terminal
-  `cd headlamp`
+# from the repository root
+npm run app:test:e2e -- --headed
+npm run app:test:e2e -- --ui
+```
 
-- run the following command
-  `npm run frontend:build` followed by `npm run frontend:start`
+### Web mode
 
-### Running the tests
+Web mode needs the backend and frontend running in separate terminals first:
 
-To run the tests for the web mode, follow the steps below:
+```bash
+# terminal 1, from the repository root
+npm run backend:build && npm run backend:start
 
-- cd into the e2e-tests directory within the headlamp repository in a separate terminal
-  `cd headlamp/app/e2e-tests`
+# terminal 2, from the repository root
+npm run frontend:build && npm run frontend:start
 
-- npm install the needed packages
-  `npm install`
+# terminal 3
+cd app/e2e-tests
+npm run test-web
+```
 
-- run the following command
-  `npm run test-web`
-  (optional: include `-- --headed` to run the tests in headed mode)
-  (optional: include `-- --ui` to run the tests in ui mode)
+## Troubleshooting
+
+**`electron.launch: Process failed to launch!`** The app takes a
+single-instance lock, so only one instance can run at a time. Check for a
+leftover Electron process from an earlier interrupted run.
+
+**Switching between app and web mode.** If a run misbehaves after switching
+modes, look for a leftover `headlamp-server` process from the previous mode and
+stop it before trying again.

--- a/app/e2e-tests/package.json
+++ b/app/e2e-tests/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "pretest-app": "npm --prefix .. run compile-electron -- --dev",
     "test-app": "PLAYWRIGHT_TEST_MODE=app playwright test",
     "test-web": "PLAYWRIGHT_TEST_MODE=web playwright test"
   },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "app:package:mac": "npm run app:build && cd app && npm run package -- --mac",
     "app:test": "npm run app:test:unit && npm run app:test:e2e",
     "app:test:unit": "cd app && npm run test",
-    "app:test:e2e": "cd app/e2e-tests && npm run test",
+    "app:test:e2e": "cd app/e2e-tests && npm run test-app --",
     "app:tsc": "cd app && npm run tsc",
     "app:i18n-check": "cd app && npm run i18n-check",
     "app:format": "cd app && npm run format",


### PR DESCRIPTION
## Summary

Two problems stopped the desktop e2e suite from being runnable by following the documentation.

`npm run app:test:e2e` failed immediately with `Missing script: "test"`. The root script delegated to a `test` script in `app/e2e-tests` that does not exist; that package only defines `test-app` and `test-web`.

Separately, the README omitted a required setup step. `app/package.json` declares `"main": "build/main.js"` and the specs launch the app with `electron .`, which resolves that field, but nothing in the README or the specs created it.

## Related Issue

Fixes #6633
Fixes #6640

## Changes

- **Root `app:test:e2e` now points at `test-app`**, the mode these tests are written for. Adding a delegating `test` script to `app/e2e-tests` would also have fixed the error, but it puts another `npm run` in the chain and arguments are not forwarded across those, so flags would be silently dropped.
- **Added a `pretest-app` hook** that runs `compile-electron -- --dev`, so the Electron entry point is built automatically and the suite cannot be run against a missing one. That seemed better than documenting one more manual step people can skip.
- **Rewrote `app/e2e-tests/README.md`** around what the suite actually requires.

The README changes are based on getting the suite running rather than on reading the source. The previously undocumented requirements:

- A minikube cluster named **`minikube`**. The name matters: `clusterRename.spec.ts` expects it, and `clusterAutoConnect.spec.ts` shells out to `minikube` directly to create and delete its own throwaway profile, so both `minikube` and `kubectl` must be on `PATH`.
- The **frontend and backend built**, because app mode runs the app from source. With `ELECTRON_DEV=true`, `app/electron/main.ts` resolves `../frontend/build/index.html` (main.ts:91) and `../backend/headlamp-server` (main.ts:772).
- **Chromium installed**, even though these are Electron tests. Every spec requests Playwright's `page` fixture before switching to the Electron window, and requesting it launches a browser. This one is easy to miss.

It also documents that flags cannot be passed through `npm run app:test:e2e` from the repository root, because that delegates to a second `npm run`; run the script from `app/e2e-tests` when you need flags.

## Steps to Test

The script fix, which needs no cluster:

```
# Before: Missing script: "test"
# After: resolves and starts Playwright
node -p "require('./package.json').scripts['app:test:e2e']"
# -> cd app/e2e-tests && npm run test-app
```

The pre-hook, which is the point of the second fix:

```
rm -f app/build/main.js
cd app/e2e-tests && npm run pretest-app
ls -la ../build/main.js     # rebuilt
```

That the suite is discoverable, without running it:

```
cd app/e2e-tests
PLAYWRIGHT_TEST_MODE=app npx playwright test --list
# -> Total: 4 tests in 3 files
```

Then follow the README from a clean checkout and confirm you reach a running suite.

## Screenshots (if applicable)

Not applicable, docs and npm scripts only.

## Notes for the Reviewer

- **This does not make the suite pass.** It currently fails for unrelated reasons, tracked in #6648 and fixed in #6641. This PR only makes it possible to invoke it by following the docs. I have kept the two separate because they are different problems with different reviewers in mind, and #6641 is test-code while this is scripts and documentation.
- **On `pretest-app` versus documenting the step.** npm runs `pre<script>` automatically for `npm run test-app`, so this costs nothing at the call site. The alternative was a README line saying "remember to run compile-electron first", which is the kind of step people skip and which produced a confusing failure. Happy to switch to documentation only if you would rather the scripts stay minimal.
- **Web mode is unchanged.** Only `test-app` gets the pre-hook, because web mode does not launch Electron and so does not need `build/main.js`.
- I did not touch the top-level `e2e-tests` README, which has a similar but separate mismatch tracked in #6634.
