### PR TITLE
Drop removed-in-1.22 v1beta1 API versions (Ingress, CRD)

### DIFF
--- a/frontend/src/lib/k8s/crd.ts
+++ b/frontend/src/lib/k8s/crd.ts
@@ -67,7 +67,7 @@ export interface KubeCRD extends KubeObjectInterface {
 class CustomResourceDefinition extends KubeObject<KubeCRD> {
   static kind = 'CustomResourceDefinition';
   static apiName = 'customresourcedefinitions';
-  static apiVersion = ['apiextensions.k8s.io/v1', 'apiextensions.k8s.io/v1beta1'];
+  static apiVersion = ['apiextensions.k8s.io/v1'];
   static isNamespaced = false;
 
   static readOnlyFields = ['metadata.managedFields'];

--- a/frontend/src/lib/k8s/ingress.ts
+++ b/frontend/src/lib/k8s/ingress.ts
@@ -93,7 +93,7 @@ export interface KubeIngress extends KubeObjectInterface {
 class Ingress extends KubeObject<KubeIngress> {
   static kind = 'Ingress';
   static apiName = 'ingresses';
-  static apiVersion = ['networking.k8s.io/v1', 'extensions/v1beta1'];
+  static apiVersion = ['networking.k8s.io/v1'];
   static isNamespaced = true;
 
   static getBaseObject(): KubeIngress {


### PR DESCRIPTION
## Problem
Two resource classes declare API versions that were **removed in Kubernetes 1.22**, alongside the current version. Headlamp queries every declared apiVersion, so on any cluster >= 1.22 it always requests the removed version, which 404s — filling the browser console with errors (and the "Unable to parse error json" path, since the 404 body isn't JSON) on every modern cluster:

- `Ingress` (`ingress.ts`): `extensions/v1beta1` → `GET /apis/extensions/v1beta1/ingresses` 404s.
- `CustomResourceDefinition` (`crd.ts`): `apiextensions.k8s.io/v1beta1` → `GET /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions` 404s.

## Fix
Drop the removed API versions. `networking.k8s.io/v1` (Ingress) is available since 1.19 and `apiextensions.k8s.io/v1` (CRD) since 1.16; releases that only serve the removed versions are long EOL.

## Note
Left the `gateway.networking.k8s.io/v1beta1` declarations untouched — that version is *deprecated* but still served by current Gateway API, so it remains a valid fallback.
