### PR TITLE
ci: push-release-assets: Add cosign keyless signing for checksums

### DIFF
--- a/.github/workflows/push-release-assets.yml
+++ b/.github/workflows/push-release-assets.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # need to write to releases and download artifacts
+      id-token: write # needed for cosign keyless signing via GitHub OIDC
     steps:
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -156,5 +157,24 @@ jobs:
           gh release upload ${{ inputs.release_name }} ./temp-checksums/checksums.txt.asc --clobber
 
           echo "Checksums signature created and uploaded successfully"
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_UPDATE_TOKEN }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign checksums.txt with cosign (keyless)
+        run: |
+          cosign sign-blob --yes \
+            --output-signature ./temp-checksums/checksums.txt.sig \
+            --output-certificate ./temp-checksums/checksums.txt.pem \
+            ./temp-checksums/checksums.txt
+
+          gh release upload ${{ inputs.release_name }} \
+            ./temp-checksums/checksums.txt.sig \
+            ./temp-checksums/checksums.txt.pem \
+            --clobber
+
+          echo "Cosign signature and certificate uploaded successfully"
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_UPDATE_TOKEN }}

--- a/.github/workflows/push-release-assets.yml
+++ b/.github/workflows/push-release-assets.yml
@@ -166,15 +166,13 @@ jobs:
       - name: Sign checksums.txt with cosign (keyless)
         run: |
           cosign sign-blob --yes \
-            --output-signature ./temp-checksums/checksums.txt.sig \
-            --output-certificate ./temp-checksums/checksums.txt.pem \
+            --bundle ./temp-checksums/checksums.txt.sigstore.json \
             ./temp-checksums/checksums.txt
 
           gh release upload ${{ inputs.release_name }} \
-            ./temp-checksums/checksums.txt.sig \
-            ./temp-checksums/checksums.txt.pem \
+            ./temp-checksums/checksums.txt.sigstore.json \
             --clobber
 
-          echo "Cosign signature and certificate uploaded successfully"
+          echo "Cosign bundle uploaded successfully"
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_UPDATE_TOKEN }}


### PR DESCRIPTION
## Summary
This PR adds cosign keyless signing of the release checksums.txt file to the push-release-assets workflow. It attaches a checksums.txt.sigstore.json bundle to each release, giving OpenSSF Scorecard a recognized signature file to detect, which should raise the Signed-Releases check score from the current 0/10 on future releases where this workflow runs.

## Related Issue
Relates to the OpenSSF Scorecard report for this repo showing a 0/10 Signed-Releases score. No existing tracked issue.

## Changes
- Added an id-token: write permission to the publish job, needed for cosign keyless signing via GitHub OIDC
- Added a step to install cosign using sigstore/cosign-installer pinned by SHA
- Added a step that signs checksums.txt with cosign in keyless mode, producing a checksums.txt.sigstore.json bundle, and uploads it to the release as an additional asset

## Steps to Test
1. Checked out this branch in a personal fork and confirmed cosign keyless signing works end to end in an isolated test workflow, since the real push-release-assets workflow needs release secrets and a real release to run against
2. The test workflow installed cosign, signed a sample file with cosign sign-blob --bundle, and ran cosign verify-blob --new-bundle-format against it
3. The run succeeded, ending in Verified OK, confirming the OIDC permission and cosign invocation are correct before applying the same pattern to checksums.txt in this workflow
4. Once merged, the real verification step is to confirm checksums.txt.sigstore.json appears as a release asset the next time push-release-assets is dispatched for an actual release, then re-run the OpenSSF Scorecard analysis against the repo to confirm the Signed-Releases score improves

## Screenshots 
Verified cosign keyless signing in an isolated test run on my fork: https://github.com/Athang69/headlamp/actions/runs/30211522217/job/89818442024

The run shows "Wrote bundle to file test.txt.sigstore.json" followed by "Verified OK" for the cosign verify-blob step, confirming the OIDC signing and verification flow works correctly.

<img width="1864" height="1049" alt="image" src="https://github.com/user-attachments/assets/4c887248-0423-4ce4-b728-6ed433736266" />



## Notes for the Reviewer
This only affects future releases where push-release-assets is dispatched, it cannot retroactively sign already published releases, so the Scorecard score will not update until the next real release runs through this workflow. Also worth checking separately why this workflow was not dispatched for the last couple of releases, since the existing GPG signing step for checksums.txt.asc has the same gap today.