### PR TITLE
backend: kubeconfig: Resolve relative PKI paths against file dir

### DIFF
--- a/backend/pkg/kubeconfig/export_test.go
+++ b/backend/pkg/kubeconfig/export_test.go
@@ -10,6 +10,9 @@ var BuildUserAgent = buildUserAgent
 
 var DeriveInClusterName = deriveInClusterName
 
+// ResolveKubeconfigPaths is exported for testing.
+var ResolveKubeconfigPaths = resolveKubeconfigPaths
+
 // UserAgentRoundTripper is exported for testing.
 type UserAgentRoundTripper struct {
 	Base      roundTripperInterface

--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -485,7 +486,7 @@ func LoadContextsFromFile(kubeConfigPath string, source int) ([]Context, []Conte
 
 	skipProxySetup := source != KubeConfig
 
-	contexts, contextErrors, err := loadContextsFromData(data, source, skipProxySetup)
+	contexts, contextErrors, err := loadContextsFromData(data, source, skipProxySetup, kubeConfigPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error loading contexts from file: %w", err)
 	}
@@ -512,7 +513,9 @@ func LoadContextsFromBase64String(kubeConfig string, source int) ([]Context, []C
 
 	skipProxySetup := source != KubeConfig
 
-	return loadContextsFromData(kubeConfigByte, source, skipProxySetup)
+	// Base64 kubeconfigs have no filesystem origin, so relative certificate
+	// and key paths cannot be resolved against a parent directory.
+	return loadContextsFromData(kubeConfigByte, source, skipProxySetup, "")
 }
 
 // LoadContextsFromMultipleFiles loads contexts from the given kubeconfig files.
@@ -537,8 +540,15 @@ func LoadContextsFromMultipleFiles(kubeConfigs string, source int) ([]Context, [
 
 // loadContextsFromData loads contexts from a kubeconfig data.
 // It unmarshals the kubeconfig data, extracts the contexts, and processes each context.
+// kubeConfigPath is the filesystem path of the source kubeconfig when known; an empty
+// string means the data has no filesystem origin (for example base64 payloads).
 // It returns valid contexts, contextLoadErrors and any errors that occurred during the process.
-func loadContextsFromData(data []byte, source int, skipProxySetup bool) ([]Context, []ContextLoadError, error) {
+func loadContextsFromData(
+	data []byte,
+	source int,
+	skipProxySetup bool,
+	kubeConfigPath string,
+) ([]Context, []ContextLoadError, error) {
 	var contexts []Context
 
 	var contextErrors []ContextLoadError
@@ -557,7 +567,7 @@ func loadContextsFromData(data []byte, source int, skipProxySetup bool) ([]Conte
 
 	// Process each context
 	for _, rawContext := range rawContexts {
-		context, err := ProcessContext(rawContext, kubeconfig, source, skipProxySetup)
+		context, err := processContext(rawContext, kubeconfig, source, skipProxySetup, kubeConfigPath)
 		if err != nil {
 			contextErrors = append(contextErrors, ContextLoadError{
 				ContextName: context.Name,
@@ -604,11 +614,28 @@ func GetContextsFromKubeconfig(kubeconfig map[string]interface{}) ([]interface{}
 // source is the source of the kubeconfig, i.e where the kubeconfig came from.
 // It can be KubeConfig, DynamicCluster, or InCluster.
 // skipProxySetup is a flag to skip proxy setup.
+// Relative certificate and key paths are left unresolved because no filesystem
+// origin is available through this entry point.
 func ProcessContext(
 	rawContext interface{},
 	kubeconfig map[string]interface{},
 	source int,
 	skipProxySetup bool,
+) (Context, error) {
+	return processContext(rawContext, kubeconfig, source, skipProxySetup, "")
+}
+
+// processContext processes a context from the kubeconfig.
+// kubeConfigPath is the source kubeconfig file path when known. Relative PKI
+// paths (certificate-authority, client-certificate, client-key, tokenFile, and
+// path-based exec commands) are resolved against that file's directory, matching
+// kubectl / client-go LoadFromFile behavior. See issue #2413.
+func processContext(
+	rawContext interface{},
+	kubeconfig map[string]interface{},
+	source int,
+	skipProxySetup bool,
+	kubeConfigPath string,
 ) (Context, error) {
 	var errs []error
 
@@ -647,6 +674,19 @@ func ProcessContext(
 		return context, errors.Join(errs...)
 	}
 
+	if err := resolveKubeconfigPaths(singleConfig, kubeConfigPath); err != nil {
+		errs = append(errs, ContextError{
+			ContextName: contextName,
+			Reason:      err.Error(),
+		})
+		context = Context{
+			Name:  contextName,
+			Error: err.Error(),
+		}
+
+		return context, errors.Join(errs...)
+	}
+
 	// Convert the config to a context
 	context, err = convertToContext(contextName, singleConfig, source, skipProxySetup)
 	if err != nil {
@@ -659,6 +699,44 @@ func ProcessContext(
 	}
 
 	return context, errors.Join(errs...)
+}
+
+// resolveKubeconfigPaths makes relative certificate and key paths absolute using
+// the directory of the source kubeconfig file, matching client-go's
+// LoadFromFile + ResolveLocalPaths behavior. kubeConfigPath may be empty when
+// the config has no filesystem origin (for example base64 payloads); in that
+// case paths are left unchanged.
+func resolveKubeconfigPaths(config *api.Config, kubeConfigPath string) error {
+	if config == nil || kubeConfigPath == "" {
+		return nil
+	}
+
+	absPath, err := filepath.Abs(kubeConfigPath)
+	if err != nil {
+		return fmt.Errorf("could not determine absolute path of kubeconfig %q: %w", kubeConfigPath, err)
+	}
+
+	// ResolveLocalPaths resolves each relative path against filepath.Dir of
+	// that stanza's LocationOfOrigin and skips stanzas where it is empty.
+	// clientcmd.Load (used above) never sets LocationOfOrigin, so assign the
+	// source kubeconfig path here first — matching LoadFromFile.
+	for _, cluster := range config.Clusters {
+		cluster.LocationOfOrigin = absPath
+	}
+
+	for _, authInfo := range config.AuthInfos {
+		authInfo.LocationOfOrigin = absPath
+	}
+
+	for _, ctx := range config.Contexts {
+		ctx.LocationOfOrigin = absPath
+	}
+
+	if err := clientcmd.ResolveLocalPaths(config); err != nil {
+		return fmt.Errorf("resolving relative paths in kubeconfig %q: %w", absPath, err)
+	}
+
+	return nil
 }
 
 // extractContextInfo extracts the context information from the raw context.

--- a/backend/pkg/kubeconfig/kubeconfig_test.go
+++ b/backend/pkg/kubeconfig/kubeconfig_test.go
@@ -1089,3 +1089,268 @@ func TestContextAuthType(t *testing.T) {
 		})
 	}
 }
+
+// writeRelativePKIFixture creates a kubeconfig with relative certificate paths
+// under dir/pki/, matching the layout reported in issue #2413.
+func writeRelativePKIFixture(t *testing.T, dir, contextName string) string {
+	t.Helper()
+
+	pkiDir := filepath.Join(dir, "pki")
+	require.NoError(t, os.MkdirAll(pkiDir, 0o750))
+
+	caPath := filepath.Join(pkiDir, "ca.pem")
+	certPath := filepath.Join(pkiDir, "admin.pem")
+	keyPath := filepath.Join(pkiDir, "admin.key")
+	tokenPath := filepath.Join(pkiDir, "token")
+
+	for _, path := range []string{caPath, certPath, keyPath, tokenPath} {
+		require.NoError(t, os.WriteFile(path, []byte("test-pki-material\n"), 0o600))
+	}
+
+	kubeconfigPath := filepath.Join(dir, "config")
+	content := fmt.Sprintf(`apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: pki/ca.pem
+    server: https://127.0.0.1:6443
+  name: %s
+contexts:
+- context:
+    cluster: %s
+    user: %s-admin
+  name: %s
+current-context: %s
+kind: Config
+preferences: {}
+users:
+- name: %s-admin
+  user:
+    client-certificate: pki/admin.pem
+    client-key: pki/admin.key
+    tokenFile: pki/token
+`, contextName, contextName, contextName, contextName, contextName, contextName)
+	require.NoError(t, os.WriteFile(kubeconfigPath, []byte(content), 0o600))
+
+	return kubeconfigPath
+}
+
+func TestResolveKubeconfigPathsNoopForEmptyOrigin(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, kubeconfig.ResolveKubeconfigPaths(nil, "ignored-kubeconfig-path"))
+
+	cfg := api.NewConfig()
+	cfg.Clusters["c"] = &api.Cluster{
+		Server:               "https://127.0.0.1:6443",
+		CertificateAuthority: "pki/ca.pem",
+	}
+	cfg.AuthInfos["u"] = &api.AuthInfo{
+		ClientCertificate: "pki/admin.pem",
+		ClientKey:         "pki/admin.key",
+		TokenFile:         "pki/token",
+	}
+
+	require.NoError(t, kubeconfig.ResolveKubeconfigPaths(cfg, ""))
+	assert.Equal(t, "pki/ca.pem", cfg.Clusters["c"].CertificateAuthority)
+	assert.Equal(t, "pki/admin.pem", cfg.AuthInfos["u"].ClientCertificate)
+	assert.Equal(t, "pki/admin.key", cfg.AuthInfos["u"].ClientKey)
+	assert.Equal(t, "pki/token", cfg.AuthInfos["u"].TokenFile)
+}
+
+func TestLoadContextsFromFileResolvesRelativePKIPaths(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	kubeconfigPath := writeRelativePKIFixture(t, dir, "kubernetes80")
+
+	absCA := filepath.Join(dir, "pki", "ca.pem")
+	absCert := filepath.Join(dir, "pki", "admin.pem")
+	absKey := filepath.Join(dir, "pki", "admin.key")
+	absToken := filepath.Join(dir, "pki", "token")
+
+	contexts, contextErrors, err := kubeconfig.LoadContextsFromFile(kubeconfigPath, kubeconfig.KubeConfig)
+	require.NoError(t, err)
+	require.Empty(t, contextErrors)
+	require.Len(t, contexts, 1)
+
+	ctx := contexts[0]
+	require.NotNil(t, ctx.Cluster)
+	require.NotNil(t, ctx.AuthInfo)
+
+	assert.Equal(t, absCA, ctx.Cluster.CertificateAuthority)
+	assert.Equal(t, absCert, ctx.AuthInfo.ClientCertificate)
+	assert.Equal(t, absKey, ctx.AuthInfo.ClientKey)
+	assert.Equal(t, absToken, ctx.AuthInfo.TokenFile)
+	assert.True(t, filepath.IsAbs(ctx.Cluster.CertificateAuthority))
+	assert.True(t, filepath.IsAbs(ctx.AuthInfo.ClientCertificate))
+	assert.True(t, filepath.IsAbs(ctx.AuthInfo.ClientKey))
+	assert.True(t, filepath.IsAbs(ctx.AuthInfo.TokenFile))
+}
+
+func TestLoadContextsFromFileKeepsAbsolutePKIPaths(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pkiDir := filepath.Join(dir, "certs")
+	require.NoError(t, os.MkdirAll(pkiDir, 0o750))
+
+	absCA := filepath.Join(pkiDir, "ca.pem")
+	absCert := filepath.Join(pkiDir, "admin.pem")
+	absKey := filepath.Join(pkiDir, "admin.key")
+	absToken := filepath.Join(pkiDir, "token")
+
+	for _, path := range []string{absCA, absCert, absKey, absToken} {
+		require.NoError(t, os.WriteFile(path, []byte("test-pki-material\n"), 0o600))
+	}
+
+	kubeconfigPath := filepath.Join(dir, "config")
+	content := fmt.Sprintf(`apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: '%s'
+    server: https://127.0.0.1:6443
+  name: abs-cluster
+contexts:
+- context:
+    cluster: abs-cluster
+    user: abs-admin
+  name: abs-context
+current-context: abs-context
+kind: Config
+users:
+- name: abs-admin
+  user:
+    client-certificate: '%s'
+    client-key: '%s'
+    tokenFile: '%s'
+`, absCA, absCert, absKey, absToken)
+	require.NoError(t, os.WriteFile(kubeconfigPath, []byte(content), 0o600))
+
+	contexts, contextErrors, err := kubeconfig.LoadContextsFromFile(kubeconfigPath, kubeconfig.KubeConfig)
+	require.NoError(t, err)
+	require.Empty(t, contextErrors)
+	require.Len(t, contexts, 1)
+
+	ctx := contexts[0]
+	assert.Equal(t, absCA, ctx.Cluster.CertificateAuthority)
+	assert.Equal(t, absCert, ctx.AuthInfo.ClientCertificate)
+	assert.Equal(t, absKey, ctx.AuthInfo.ClientKey)
+	assert.Equal(t, absToken, ctx.AuthInfo.TokenFile)
+}
+
+func TestLoadContextsFromMultipleFilesResolvesRelativeToEachFile(t *testing.T) {
+	t.Parallel()
+
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	pathA := writeRelativePKIFixture(t, dirA, "cluster-a")
+	pathB := writeRelativePKIFixture(t, dirB, "cluster-b")
+
+	combined := pathA + string(os.PathListSeparator) + pathB
+	contexts, contextErrors, err := kubeconfig.LoadContextsFromMultipleFiles(combined, kubeconfig.KubeConfig)
+	require.NoError(t, err)
+	require.Empty(t, contextErrors)
+	require.Len(t, contexts, 2)
+
+	byName := map[string]kubeconfig.Context{}
+	for _, ctx := range contexts {
+		byName[ctx.Name] = ctx
+	}
+
+	require.Contains(t, byName, "cluster-a")
+	require.Contains(t, byName, "cluster-b")
+
+	assert.Equal(t, filepath.Join(dirA, "pki", "ca.pem"), byName["cluster-a"].Cluster.CertificateAuthority)
+	assert.Equal(t, filepath.Join(dirA, "pki", "admin.pem"), byName["cluster-a"].AuthInfo.ClientCertificate)
+	assert.Equal(t, filepath.Join(dirA, "pki", "admin.key"), byName["cluster-a"].AuthInfo.ClientKey)
+	assert.Equal(t, filepath.Join(dirA, "pki", "token"), byName["cluster-a"].AuthInfo.TokenFile)
+
+	assert.Equal(t, filepath.Join(dirB, "pki", "ca.pem"), byName["cluster-b"].Cluster.CertificateAuthority)
+	assert.Equal(t, filepath.Join(dirB, "pki", "admin.pem"), byName["cluster-b"].AuthInfo.ClientCertificate)
+	assert.Equal(t, filepath.Join(dirB, "pki", "admin.key"), byName["cluster-b"].AuthInfo.ClientKey)
+	assert.Equal(t, filepath.Join(dirB, "pki", "token"), byName["cluster-b"].AuthInfo.TokenFile)
+}
+
+func TestLoadContextsFromBase64StringLeavesRelativePKIPathsUnresolved(t *testing.T) {
+	t.Parallel()
+
+	content := `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: pki/ca.pem
+    server: https://127.0.0.1:6443
+  name: b64-cluster
+contexts:
+- context:
+    cluster: b64-cluster
+    user: b64-admin
+  name: b64-context
+current-context: b64-context
+kind: Config
+users:
+- name: b64-admin
+  user:
+    client-certificate: pki/admin.pem
+    client-key: pki/admin.key
+    tokenFile: pki/token
+`
+	encoded := base64.StdEncoding.EncodeToString([]byte(content))
+
+	contexts, contextErrors, err := kubeconfig.LoadContextsFromBase64String(encoded, kubeconfig.DynamicCluster)
+	require.NoError(t, err)
+	require.Empty(t, contextErrors)
+	require.Len(t, contexts, 1)
+
+	ctx := contexts[0]
+	assert.Equal(t, "pki/ca.pem", ctx.Cluster.CertificateAuthority)
+	assert.Equal(t, "pki/admin.pem", ctx.AuthInfo.ClientCertificate)
+	assert.Equal(t, "pki/admin.key", ctx.AuthInfo.ClientKey)
+	assert.Equal(t, "pki/token", ctx.AuthInfo.TokenFile)
+}
+
+func TestLoadContextsFromFileResolvesParentRelativePKIPaths(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	pkiDir := filepath.Join(root, "pki")
+	configDir := filepath.Join(root, "kube")
+
+	require.NoError(t, os.MkdirAll(pkiDir, 0o750))
+	require.NoError(t, os.MkdirAll(configDir, 0o750))
+
+	require.NoError(t, os.WriteFile(filepath.Join(pkiDir, "ca.pem"), []byte("ca\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(pkiDir, "admin.pem"), []byte("cert\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(pkiDir, "admin.key"), []byte("key\n"), 0o600))
+
+	kubeconfigPath := filepath.Join(configDir, "config")
+	content := `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: ../pki/ca.pem
+    server: https://127.0.0.1:6443
+  name: parent-rel
+contexts:
+- context:
+    cluster: parent-rel
+    user: parent-rel-admin
+  name: parent-rel
+current-context: parent-rel
+kind: Config
+users:
+- name: parent-rel-admin
+  user:
+    client-certificate: ../pki/admin.pem
+    client-key: ../pki/admin.key
+`
+	require.NoError(t, os.WriteFile(kubeconfigPath, []byte(content), 0o600))
+
+	contexts, contextErrors, err := kubeconfig.LoadContextsFromFile(kubeconfigPath, kubeconfig.KubeConfig)
+	require.NoError(t, err)
+	require.Empty(t, contextErrors)
+	require.Len(t, contexts, 1)
+
+	ctx := contexts[0]
+	assert.Equal(t, filepath.Join(root, "pki", "ca.pem"), filepath.Clean(ctx.Cluster.CertificateAuthority))
+	assert.Equal(t, filepath.Join(root, "pki", "admin.pem"), filepath.Clean(ctx.AuthInfo.ClientCertificate))
+	assert.Equal(t, filepath.Join(root, "pki", "admin.key"), filepath.Clean(ctx.AuthInfo.ClientKey))
+}


### PR DESCRIPTION
## Summary

Kubeconfigs that use relative `certificate-authority`, `client-certificate`, and `client-key` paths work with kubectl but failed in Headlamp Desktop. Headlamp loaded kubeconfig bytes via `clientcmd.Load` without recording `LocationOfOrigin`, so relative PKI paths were never resolved against the kubeconfig file directory.

This matches client-go's `LoadFromFile` + `ResolveLocalPaths` behavior: when a kubeconfig comes from disk, relative paths are absolutized before `SetupProxy`. Base64 / in-memory configs have no filesystem origin and are left unchanged.

## Related Issue

Fixes #2413

## Changes

- Thread the source kubeconfig path through the file load path
- Resolve relative PKI paths with `clientcmd.ResolveLocalPaths` before proxy setup
- Keep the exported `ProcessContext` API unchanged (no origin → no resolution)
- Add regression tests for relative, absolute, parent-relative, multi-file, and base64 cases

## Steps to Test

1. Create a kubeconfig with relative PKI paths, e.g.:
   ```yaml
   apiVersion: v1
   clusters:
   - cluster:
       certificate-authority: pki/ca.pem
       server: https://<api>:6443
     name: kubernetes80
   contexts:
   - context:
       cluster: kubernetes80
       user: kubernetes-admin1
     name: kubernetes-80
   current-context: kubernetes-80
   kind: Config
   users:
   - name: kubernetes-admin1
     user:
       client-certificate: pki/admin.pem
       client-key: pki/admin.key
   ```
   with the PEM files under `pki/` next to the kubeconfig.
2. Confirm `kubectl` can use that config.
3. Point Headlamp Desktop at the same kubeconfig and select the context.
4. Confirm the cluster connects (no Bad Gateway from unresolved relative cert paths).
5. Confirm absolute-path kubeconfigs and base64/dynamic cluster configs still behave as before.

## Notes for the Reviewer

- Regression test fails on the old code with paths left as `pki/...` and passes after the fix.
- Validated locally with `npm run backend:lint` and `npm run backend:test`.
- Opaque Bad Gateway when cert files are missing after resolution is a separate concern (`SetupProxy` still swallows transport setup errors); this PR only fixes the relative-path resolution gap reported in #2413.