### PR TITLE
e2e-tests: Document the setup the tests actually require

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -101,33 +101,60 @@ absolute, because the test resolves them relative to its own working directory:
 
 ```bash
 mkdir -p ~/headlamp-e2e-certs
-kubectl config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' | base64 --decode > ~/headlamp-e2e-certs/ca.crt
+kubectl config view --raw --minify --context=test -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' | base64 --decode > ~/headlamp-e2e-certs/ca.crt
 kubectl config set-cluster kind-test --certificate-authority="$HOME/headlamp-e2e-certs/ca.crt" --embed-certs=false
 kubectl config unset clusters.kind-test.certificate-authority-data
 ```
 
 Do the same for the `client-certificate-data` and `client-key-data` fields on
-the user entry.
+the user entry. To update the second cluster, use `--context=test2` and the
+`kind-test2` cluster entry.
 
-### Optional suites
+### Additional suites
 
-Two spec files skip unless their variable is set, so a normal run does not
-exercise them:
+`tests/incluster-api.spec.ts` tests a separate Headlamp deployment running in
+in-cluster mode. CI runs it in a dedicated step after deploying
+`kubernetes-headlamp-incluster-ci.yaml` to the `test2` cluster. To reproduce
+that setup locally:
 
 ```bash
-# tests/incluster-api.spec.ts
-export HEADLAMP_SA_TOKEN=$(kubectl create token headlamp --duration=1h -n kube-system)
+kubectl config use-context test2
+kubectl create serviceaccount headlamp --namespace kube-system
+kubectl create clusterrolebinding headlamp \
+  --serviceaccount=kube-system:headlamp --clusterrole=cluster-admin
+kubectl apply -f e2e-tests/kubernetes-headlamp-incluster-ci.yaml
+kubectl wait deployment -n kube-system headlamp \
+  --for condition=Available=True --timeout=120s
 
-# tests/clusterInventory.spec.ts
-export HEADLAMP_CLUSTER_INVENTORY_E2E=true
-
-# Optional, only read by clusterInventory.spec.ts. Defaults to "headlamp".
-export HEADLAMP_TEST_BACKEND_TOKEN=...
+kubectl port-forward -n kube-system service/headlamp 8080:80
 ```
 
-Neither is set in CI, so both suites are skipped there as well.
+Leave the port-forward running, then use a second terminal to set the URL and
+service account token before running the spec:
 
-IMPORTANT: Make sure that the following npx commands are ran in the same terminal session as the environment variables were set.
+```bash
+export HEADLAMP_TEST_URL=http://localhost:8080
+export HEADLAMP_SA_TOKEN=$(kubectl create token headlamp --duration=1h -n kube-system)
+
+cd e2e-tests
+npx playwright test tests/incluster-api.spec.ts
+```
+
+`tests/clusterInventory.spec.ts` requires Headlamp to be configured with a
+working cluster inventory source. It is skipped unless explicitly enabled and
+is not run in CI:
+
+```bash
+export HEADLAMP_CLUSTER_INVENTORY_E2E=true
+
+# Optional. This defaults to "headlamp".
+export HEADLAMP_TEST_BACKEND_TOKEN=...
+
+cd e2e-tests
+npx playwright test tests/clusterInventory.spec.ts
+```
+
+IMPORTANT: Make sure that the following npx commands are run in the same terminal session as the environment variables were set.
 
 ## Run all tests
 

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -1,35 +1,131 @@
-# end to end tests with playwright and minikube
+# end to end tests with playwright
 
-```
+These tests run against Headlamp deployed **in-cluster**, across **two**
+clusters whose kubectl contexts are named `test` and `test2`.
+
+Those names are not arbitrary. The specs hardcode them: `podsPage.spec.ts`
+navigates to `/c/test/pods`, and `multiCluster.spec.ts` asserts a home page
+listing both `test` and `test2`. `headlamp.spec.ts` also asserts on a
+`headlamp-admin` service account and on the `headlamp` Service, both of which
+come from the in-cluster deployment rather than from a dev server.
+
+The setup below mirrors what CI does in `.github/workflows/build-container.yml`,
+which is the reference if anything here drifts.
+
+## Setup
+
+Install the test dependencies:
+
+```bash
+cd e2e-tests
+npm ci
 npx playwright install
 ```
 
-The instructions below assume Headlamp is running locally in-cluster with minikube.
+Create the two clusters and rename their contexts to what the specs expect:
 
 ```bash
-# Determine if the headlamp addon is enabled
-minikube addons list
+kind create cluster --name test
+kubectl config rename-context kind-test test
 
-# If the addon is not already enabled run the following command
-minikube addons enable headlamp
-
-# Generate the URL needed for the HEADLAMP_TEST_URL environment variable
-# note: Make sure to use the URL created after the " Starting tunnel for service headlamp. " message
-minikube service headlamp -n headlamp
-
-# Open the browser to the URL generated above, it should direct you to a page waiting for a token
-
-# run in a separate terminal...
-export HEADLAMP_TEST_URL= # from the "minikube service headlamp -n headlamp" command directly above.
-
-# Create a token for the tests to use
-export HEADLAMP_TOKEN=$(kubectl create token headlamp --duration 24h -n headlamp)
-
-# To see the token to login via the web browser
-echo $HEADLAMP_TOKEN
+kind create cluster --name test2
+kubectl config rename-context kind-test2 test2
 ```
 
-Now with those two environment variables set we can run the tests.
+Give each cluster a `headlamp-admin` service account with cluster-admin:
+
+```bash
+for ctx in test test2; do
+  kubectl --context="$ctx" -n kube-system create serviceaccount headlamp-admin
+  kubectl --context="$ctx" create clusterrolebinding headlamp-admin \
+    --serviceaccount=kube-system:headlamp-admin --clusterrole=cluster-admin
+done
+```
+
+Build the images and load them into the `test` cluster. The plugins image is
+used as an init container by the manifest below:
+
+```bash
+# from the repository root
+DOCKER_IMAGE_VERSION=latest make image
+DOCKER_IMAGE_VERSION=latest DOCKER_PLUGINS_IMAGE_NAME=headlamp-plugins-test make build-plugins-container
+
+kind load docker-image ghcr.io/headlamp-k8s/headlamp:latest --name test
+kind load docker-image ghcr.io/headlamp-k8s/headlamp-plugins-test:latest --name test
+```
+
+Deploy Headlamp into the `test` cluster. The manifest is templated, so the
+cluster addresses and CA data have to be substituted in:
+
+```bash
+kubectl config use-context test
+export TEST_CA_DATA=$(kubectl config view --raw --minify -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
+export TEST_SERVER="https://$(kubectl get nodes -o=jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'):6443"
+
+kubectl config use-context test2
+export TEST2_CA_DATA=$(kubectl config view --raw --minify -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
+export TEST2_SERVER="https://$(kubectl get nodes -o=jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'):6443"
+
+kubectl config use-context test
+envsubst < e2e-tests/kubernetes-headlamp-ci.yaml | kubectl --context=test apply -f -
+kubectl wait deployment -n kube-system headlamp --for condition=Available=True --timeout=180s
+```
+
+Finally, export the URL and the tokens the specs read:
+
+```bash
+export HEADLAMP_TEST_URL="http://<address of the headlamp Service>"
+export HEADLAMP_TEST_TOKEN=$(kubectl --context=test  create token headlamp-admin --duration 24h -n kube-system)
+export HEADLAMP_TEST2_TOKEN=$(kubectl --context=test2 create token headlamp-admin --duration 24h -n kube-system)
+```
+
+CI reaches the Service on its NodePort, at
+`http://<node InternalIP>:<nodePort>`. That address is reachable from the host
+on Linux, but not on every platform; if it is not reachable on yours, any means
+of exposing the Service will do, as long as `HEADLAMP_TEST_URL` points at it.
+
+`HEADLAMP_TEST_URL` defaults to `http://localhost:3000` if unset
+(`playwright.config.ts`), so an unset variable shows up as connection errors
+rather than as an obvious configuration problem.
+
+### Kubeconfig with certificates on disk
+
+`dynamicCluster.spec.ts` reads your kubeconfig with `kubectl config view`, which
+redacts embedded `certificate-authority-data` and the client certificate fields,
+and then reads the referenced files from disk. If those fields are embedded
+rather than file paths, six tests in that file fail with `ENOENT`.
+
+CI works around this by rewriting the kubeconfig so the certificates live in
+files. If you hit those failures, do the same, and note that the paths must be
+absolute, because the test resolves them relative to its own working directory:
+
+```bash
+mkdir -p ~/headlamp-e2e-certs
+kubectl config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' | base64 --decode > ~/headlamp-e2e-certs/ca.crt
+kubectl config set-cluster kind-test --certificate-authority="$HOME/headlamp-e2e-certs/ca.crt" --embed-certs=false
+kubectl config unset clusters.kind-test.certificate-authority-data
+```
+
+Do the same for the `client-certificate-data` and `client-key-data` fields on
+the user entry.
+
+### Optional suites
+
+Two spec files skip unless their variable is set, so a normal run does not
+exercise them:
+
+```bash
+# tests/incluster-api.spec.ts
+export HEADLAMP_SA_TOKEN=$(kubectl create token headlamp --duration=1h -n kube-system)
+
+# tests/clusterInventory.spec.ts
+export HEADLAMP_CLUSTER_INVENTORY_E2E=true
+
+# Optional, only read by clusterInventory.spec.ts. Defaults to "headlamp".
+export HEADLAMP_TEST_BACKEND_TOKEN=...
+```
+
+Neither is set in CI, so both suites are skipped there as well.
 
 IMPORTANT: Make sure that the following npx commands are ran in the same terminal session as the environment variables were set.
 
@@ -92,6 +188,10 @@ npx playwright test -g "404 page is present" --headed
   - within the playwright.config.ts file locate the `const config: PlaywrightTestConfig` object. within the object, modify the use object to contain a field for `launchOptions: { slowMo: }` set to a number of milliseconds ex. `use: { ..., launchOptions: { slowMo: 1000 }` property to slow down the tests to take 1 second between each step.
 
 ## Running Playwright through a Virtual Machine (VM)
+
+> Note: this section predates the two-cluster kind setup described above and has
+> not been updated for it. It still refers to a single minikube cluster and to
+> `kubernetes-headlamp-ci.yml`, which is now `kubernetes-headlamp-ci.yaml`.
 
 ### Log into Azure CLI
 


### PR DESCRIPTION
## Summary

`e2e-tests/README.md` described a single minikube cluster with the headlamp addon, but the specs in that directory cannot pass against it. They hardcode two kubectl contexts named `test` and `test2`, which is what CI creates with kind, and they assert on an in-cluster deployment rather than on the addon.

Following the README as written produces failures that look like product bugs rather than a setup mismatch.

## Related Issue

Fixes #6634

## Changes

Rewrote the setup section around what CI does in `.github/workflows/build-container.yml`, which was the only place the working configuration was recorded.

Three concrete mismatches are fixed:

- **Cluster names.** `podsPage.spec.ts` navigates to `/c/test/pods`, and `multiCluster.spec.ts` asserts a home page listing both `test` and `test2`. A single cluster named `minikube` cannot satisfy those.
- **Token variable.** The README exported `HEADLAMP_TOKEN`. Nothing reads that. The specs read `HEADLAMP_TEST_TOKEN` and `HEADLAMP_TEST2_TOKEN`.
- **Deployment shape.** The addon installs into the `headlamp` namespace; the tests expect the layout in `kubernetes-headlamp-ci.yaml`, which deploys into `kube-system` with a `headlamp-admin` service account. `headlamp.spec.ts` asserts on that service account by name.

It also documents three things that were not written down anywhere, each of which cost me time to rediscover:

- `HEADLAMP_TEST_URL` defaults to `http://localhost:3000` (`playwright.config.ts`), so leaving it unset surfaces as connection errors rather than as an obvious missing setting.
- `dynamicCluster.spec.ts` reads certificates from disk via `kubectl config view`, which redacts embedded certificate data. An embedded-certificate kubeconfig fails six tests in that file with `ENOENT`, and the paths must be absolute because the test resolves them relative to its own working directory.
- `incluster-api.spec.ts` and `clusterInventory.spec.ts` skip unless their variables are set. Neither is set in CI, so those suites do not run there either. That is worth knowing before assuming they provide coverage.

Every environment variable the specs read is now documented, including the optional `HEADLAMP_TEST_BACKEND_TOKEN`.

## Steps to Test

Follow the README from a clean checkout and confirm you reach a passing run. I did this and got `35 passed, 11 skipped` in about 1.2 minutes. The 11 skips are the two gated suites plus `themedXterm.spec.ts`, which skips for a separate reason tracked in #6631.

The two mismatches can also be confirmed without running anything:

```bash
# Nothing reads HEADLAMP_TOKEN
grep -ro "process\.env\.HEADLAMP[A-Z_0-9]*" e2e-tests/tests/ | sed 's/.*env\.//' | sort -u

# The specs hardcode test / test2
grep -ro "'/c/test2\?[^']*'" e2e-tests/tests/ | sort -u
```

## Screenshots (if applicable)

Not applicable, documentation only.

## Notes for the Reviewer

- **I documented the kind setup rather than making minikube work**, because that is what the specs require today and what CI exercises. Whether minikube should also be supported is a separate question: it would mean the specs no longer hardcoding `test` and `test2`, which is a code change rather than a docs one. I have left that open in #6634 rather than deciding it here.
- **On the Service URL.** CI uses `http://<node InternalIP>:<nodePort>`, which is reachable from the host on Linux runners but not on every platform. Rather than document a platform-specific workaround, the README says any means of exposing the Service is fine as long as `HEADLAMP_TEST_URL` points at it. Happy to add platform-specific guidance if you would rather it be concrete.
- **The Azure VM section is unchanged**, with a note that it predates this setup. It refers to a single minikube cluster and to `kubernetes-headlamp-ci.yml`, which is now `.yaml`. I could not verify those steps, so I did not want to rewrite them speculatively. Removing or updating that section seems worth a separate decision.
- The certificate workaround is described as a workaround, not a recommended step, since it modifies the reader's kubeconfig. It is only needed if `dynamicCluster.spec.ts` fails.
