### PR TITLE
frontend: stateless: Fix IndexedDB cursor error registration

### DIFF
--- a/frontend/src/stateless/updateStatelessClusterKubeconfig.ts
+++ b/frontend/src/stateless/updateStatelessClusterKubeconfig.ts
@@ -60,8 +60,9 @@ export function updateStatelessClusterKubeconfig(
 
         // variable to track if we found and updated the context
         let updated = false;
+        const cursorRequest = store.openCursor();
 
-        store.openCursor().onsuccess = function onCursor(event: Event) {
+        cursorRequest.onsuccess = function onCursor(event: Event) {
           const e = event as CursorSuccessEvent;
           const cursor = e.target?.result;
 
@@ -115,7 +116,7 @@ export function updateStatelessClusterKubeconfig(
             reject(`Failed to update kubeconfig: ${err.target.error}`);
           };
 
-          store.openCursor().onerror = function onCursorError(event: Event) {
+          cursorRequest.onerror = function onCursorError(event: Event) {
             const de = event as DatabaseErrorEvent;
             reject(de.target ? de.target.error : 'Error during the cursor operation');
           };

--- a/frontend/src/stateless/updateStatelessClusterKubeconfig.ts
+++ b/frontend/src/stateless/updateStatelessClusterKubeconfig.ts
@@ -61,6 +61,10 @@ export function updateStatelessClusterKubeconfig(
         // variable to track if we found and updated the context
         let updated = false;
         const cursorRequest = store.openCursor();
+        cursorRequest.onerror = function onCursorError(event: Event) {
+          const de = event as DatabaseErrorEvent;
+          reject(de.target ? de.target.error : 'Error during the cursor operation');
+        };
 
         cursorRequest.onsuccess = function onCursor(event: Event) {
           const e = event as CursorSuccessEvent;
@@ -114,11 +118,6 @@ export function updateStatelessClusterKubeconfig(
 
           putRequest.onerror = (err: any) => {
             reject(`Failed to update kubeconfig: ${err.target.error}`);
-          };
-
-          cursorRequest.onerror = function onCursorError(event: Event) {
-            const de = event as DatabaseErrorEvent;
-            reject(de.target ? de.target.error : 'Error during the cursor operation');
           };
         };
       };


### PR DESCRIPTION
## Summary

Register the IndexedDB cursor `onsuccess` and `onerror` handlers on the same
`IDBRequest` returned by `openCursor()`.

## Problem

The current implementation calls `store.openCursor()` twice:

- once to register the `onsuccess` handler
- again to register the `onerror` handler

Since each call to `openCursor()` creates a new cursor request, the error
handler is attached to a different request than the one being processed.

Fix #6659 

## Solution

Store the result of `store.openCursor()` in a local variable and register both
`onsuccess` and `onerror` handlers on that same request.

This avoids creating an unnecessary second cursor request and ensures both
callbacks correspond to the same IndexedDB operation.