### PR TITLE
backend: Scope ClusterProfile discovery by namespace

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -176,42 +176,20 @@ jobs:
         fi
     - name: Multi-Cluster Setup
       run: |
-        # Use Cluster 1 context
-        kubectl config use-context test
-        export TEST_CA_DATA=$(kubectl config view --raw --minify -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
-        export TEST_SERVER="https://$(kubectl get nodes -o=jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'):6443"
-        kubectl create serviceaccount headlamp-admin --namespace kube-system
-        kubectl create clusterrolebinding headlamp-admin --serviceaccount=kube-system:headlamp-admin --clusterrole=cluster-admin
-        echo "HEADLAMP_TEST_TOKEN=$(kubectl create token headlamp-admin --duration 24h -n kube-system)" >> $GITHUB_ENV
-
-        # Use Cluster 2 context
-        kubectl config use-context test2
-        export TEST2_CA_DATA=$(kubectl config view --raw --minify -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
-        export TEST2_SERVER="https://$(kubectl get nodes -o=jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'):6443"
-        kubectl create serviceaccount headlamp-admin --namespace kube-system
-        kubectl create clusterrolebinding headlamp-admin --serviceaccount=kube-system:headlamp-admin --clusterrole=cluster-admin
-        echo "HEADLAMP_TEST2_TOKEN=$(kubectl create token headlamp-admin --duration 24h -n kube-system)" >> $GITHUB_ENV
-
-        envsubst < e2e-tests/kubernetes-headlamp-ci.yaml | kubectl --context=test apply -f -
+        ./e2e-tests/scripts/setup-multicluster.sh --skip-image-build
     - name: Run e2e tests
       run: |
-        echo "------------------------------------sleeping 12...------------------------------------"
-        sleep 12
         kubectl config use-context test
         kubectl get services --all-namespaces
         kubectl get deployments -n kube-system
-        echo "------------------Waiting for headlamp deployment to be available...------------------"
-        kubectl wait deployment -n kube-system headlamp --for condition=Available=True --timeout=30s
         echo "----------------------------------Opening the service----------------------------------"
-        IP_ADDRESS=$(kubectl get nodes -o=jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
-        SERVICE_PORT=$(kubectl get services headlamp -n kube-system -o=jsonpath='{.spec.ports[0].nodePort}')
-        export SERVICE_URL="http://${IP_ADDRESS}:${SERVICE_PORT}"
-        echo $SERVICE_URL
-        curl -L $SERVICE_URL | grep -q "Headlamp: Kubernetes Web UI"        
-        echo "--------------------------------Export Tokens Received From Previous Step--------------------------------"
-        export HEADLAMP_TEST_TOKEN=${HEADLAMP_TEST_TOKEN}
-        export HEADLAMP_TEST2_TOKEN=${HEADLAMP_TEST2_TOKEN}
+        echo "${HEADLAMP_TEST_URL}"
+        curl -fL --connect-timeout 5 --max-time 30 "${HEADLAMP_TEST_URL}" | grep -q "Headlamp: Kubernetes Web UI"
         echo "---------------------------------Certificate handling---------------------------------"
+        # The Multi-Cluster Setup step already resolved the node address and NodePort.
+        AUTHORITY="${HEADLAMP_TEST_URL#http://}"
+        IP_ADDRESS="${AUTHORITY%%:*}"
+        SERVICE_PORT="${AUTHORITY##*:}"
         export KUBECONFIG=$HOME/.kube/config
         ca_data=$(yq e '.clusters[0].cluster."certificate-authority-data"' $KUBECONFIG | base64 --decode)
         echo "$ca_data" > ca.crt
@@ -230,7 +208,7 @@ jobs:
         cd e2e-tests
         npm ci
         npx playwright install --with-deps
-        HEADLAMP_TEST_URL=$SERVICE_URL npx playwright test
+        npx playwright test
         exit_code=$?
         if [ $exit_code -ne 0 ]; then
           echo "Playwright tests failed with exit code $exit_code"

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -502,24 +502,36 @@ func startClusterInventory(ctx context.Context, config *HeadlampConfig) error {
 		return nil
 	}
 
-	var hubConfig *rest.Config
+	var (
+		hubConfig    *rest.Config
+		hubNamespace string
+	)
 
 	if config.UseInCluster {
-		inClusterConfig, err := rest.InClusterConfig()
+		var err error
+
+		hubConfig, err = rest.InClusterConfig()
 		if err != nil {
 			return fmt.Errorf("get in-cluster config for cluster inventory: %w", err)
 		}
 
-		hubConfig = inClusterConfig
+		hubNamespace, _, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			&clientcmd.ClientConfigLoadingRules{}, &clientcmd.ConfigOverrides{},
+		).Namespace()
+		if err != nil {
+			return fmt.Errorf("get pod namespace for cluster inventory: %w", err)
+		}
 	}
 
 	runner, err := clusterinventory.NewRunner(clusterinventory.Options{
 		Store:                 config.KubeConfigStore,
 		ProviderFile:          config.ClusterInventoryProviderFile,
 		LabelSelector:         config.ClusterInventoryLabelSelector,
+		Namespaces:            config.ClusterInventoryNamespaces,
 		RootReconcileInterval: config.ClusterInventoryRootReconcileInterval,
 		NoCRDCacheTTL:         config.ClusterInventoryNoCRDCacheTTL,
 		HubConfig:             hubConfig,
+		HubNamespace:          hubNamespace,
 		DiscoverFromStore:     !config.UseInCluster,
 	})
 	if err != nil {

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -68,6 +68,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -145,6 +146,8 @@ const (
 	serverReadHeaderTimeout = 10 * time.Second
 	// serverIdleTimeout is the maximum time to wait for the next request on a keep-alive connection.
 	serverIdleTimeout = 120 * time.Second
+	// serviceAccountNamespacePath contains the namespace of an in-cluster pod.
+	serviceAccountNamespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 )
 
 // maxProxyResponseSize is the maximum size (in bytes) for proxied responses.
@@ -501,29 +504,57 @@ func addPluginListRoute(config *HeadlampConfig, r *mux.Router) {
 	}).Methods("GET")
 }
 
+func readServiceAccountNamespace() (string, error) {
+	data, err := os.ReadFile(serviceAccountNamespacePath)
+	if err != nil {
+		return "", fmt.Errorf("read service account namespace: %w", err)
+	}
+
+	return validateServiceAccountNamespace(data)
+}
+
+func validateServiceAccountNamespace(data []byte) (string, error) {
+	namespace := strings.TrimSpace(string(data))
+	if errs := validation.IsDNS1123Label(namespace); len(errs) > 0 {
+		return "", fmt.Errorf("invalid service account namespace %q: %s", namespace, strings.Join(errs, "; "))
+	}
+
+	return namespace, nil
+}
+
 func startClusterInventory(ctx context.Context, config *HeadlampConfig) error {
 	if !config.EnableClusterInventory {
 		return nil
 	}
 
-	var hubConfig *rest.Config
+	var (
+		hubConfig    *rest.Config
+		hubNamespace string
+	)
 
 	if config.UseInCluster {
-		inClusterConfig, err := rest.InClusterConfig()
+		var err error
+
+		hubConfig, err = rest.InClusterConfig()
 		if err != nil {
 			return fmt.Errorf("get in-cluster config for cluster inventory: %w", err)
 		}
 
-		hubConfig = inClusterConfig
+		hubNamespace, err = readServiceAccountNamespace()
+		if err != nil {
+			return fmt.Errorf("get pod namespace for cluster inventory: %w", err)
+		}
 	}
 
 	runner, err := clusterinventory.NewRunner(clusterinventory.Options{
 		Store:                 config.KubeConfigStore,
 		ProviderFile:          config.ClusterInventoryProviderFile,
 		LabelSelector:         config.ClusterInventoryLabelSelector,
+		Namespaces:            config.ClusterInventoryNamespaces,
 		RootReconcileInterval: config.ClusterInventoryRootReconcileInterval,
 		NoCRDCacheTTL:         config.ClusterInventoryNoCRDCacheTTL,
 		HubConfig:             hubConfig,
+		HubNamespace:          hubNamespace,
 		DiscoverFromStore:     !config.UseInCluster,
 	})
 	if err != nil {

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -92,6 +92,41 @@ func writeTestTokenFile(t *testing.T) string {
 	return tokenFile
 }
 
+func TestValidateServiceAccountNamespace(t *testing.T) {
+	tests := []struct {
+		name        string
+		contents    string
+		want        string
+		wantErrText string
+	}{
+		{name: "valid namespace is trimmed", contents: " team-a\n", want: "team-a"},
+		{
+			name:        "empty namespace is rejected",
+			contents:    " \n",
+			wantErrText: "invalid service account namespace",
+		},
+		{
+			name:        "invalid namespace is rejected",
+			contents:    "Team_A",
+			wantErrText: "invalid service account namespace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateServiceAccountNamespace([]byte(tt.contents))
+			if tt.wantErrText != "" {
+				require.ErrorContains(t, err, tt.wantErrText)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestCreateHeadlampHandlerSkipsInClusterContextWhenConfigUnavailable(t *testing.T) {
 	t.Setenv("KUBERNETES_SERVICE_HOST", "")
 	t.Setenv("KUBERNETES_SERVICE_PORT", "")

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -109,6 +109,7 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 		}(),
 		ClusterInventoryProviderFile:          conf.ClusterInventoryProviderFile,
 		ClusterInventoryLabelSelector:         conf.ClusterInventoryLabelSelector,
+		ClusterInventoryNamespaces:            conf.ClusterInventoryNamespaces,
 		ClusterInventoryRootReconcileInterval: conf.ClusterInventoryRootReconcileInterval,
 		ClusterInventoryNoCRDCacheTTL:         conf.ClusterInventoryNoCRDCacheTTL,
 		TLSCertPath:                           conf.TLSCertPath,

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -110,6 +110,7 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 		}(),
 		ClusterInventoryProviderFile:          conf.ClusterInventoryProviderFile,
 		ClusterInventoryLabelSelector:         conf.ClusterInventoryLabelSelector,
+		ClusterInventoryNamespaces:            conf.ClusterInventoryNamespaces,
 		ClusterInventoryRootReconcileInterval: conf.ClusterInventoryRootReconcileInterval,
 		ClusterInventoryNoCRDCacheTTL:         conf.ClusterInventoryNoCRDCacheTTL,
 		TLSCertPath:                           conf.TLSCertPath,

--- a/backend/cmd/server_config_test.go
+++ b/backend/cmd/server_config_test.go
@@ -29,16 +29,17 @@ func TestBuildHeadlampCFG(t *testing.T) {
 
 	t.Run("maps basic fields and splits proxy urls", func(t *testing.T) {
 		conf := &config.Config{
-			Port:                   4444,
-			InCluster:              true,
-			InClusterContextName:   "test-incluster",
-			InsecureSsl:            true,
-			PluginsDir:             "/plugins",
-			UserPluginsDir:         "/user-plugins",
-			AllowKubeconfigChanges: true,
-			WatchPluginsChanges:    false,
-			BaseURL:                "/headlamp",
-			ProxyURLs:              "http://proxy1,http://proxy2",
+			Port:                       4444,
+			InCluster:                  true,
+			InClusterContextName:       "test-incluster",
+			InsecureSsl:                true,
+			PluginsDir:                 "/plugins",
+			UserPluginsDir:             "/user-plugins",
+			AllowKubeconfigChanges:     true,
+			WatchPluginsChanges:        false,
+			BaseURL:                    "/headlamp",
+			ProxyURLs:                  "http://proxy1,http://proxy2",
+			ClusterInventoryNamespaces: "team-a,team-b",
 		}
 
 		headlampCFG := buildHeadlampCFG(conf, store)
@@ -54,6 +55,7 @@ func TestBuildHeadlampCFG(t *testing.T) {
 		assert.Equal(t, "/headlamp", headlampCFG.BaseURL)
 		assert.Equal(t, []string{"http://proxy1", "http://proxy2"}, headlampCFG.ProxyURLs)
 		assert.Equal(t, store, headlampCFG.KubeConfigStore)
+		assert.Equal(t, "team-a,team-b", headlampCFG.ClusterInventoryNamespaces)
 	})
 
 	t.Run("empty proxy urls yields empty slice", func(t *testing.T) {

--- a/backend/cmd/server_config_test.go
+++ b/backend/cmd/server_config_test.go
@@ -29,17 +29,18 @@ func TestBuildHeadlampCFG(t *testing.T) {
 
 	t.Run("maps basic fields and splits proxy urls", func(t *testing.T) {
 		conf := &config.Config{
-			Port:                   4444,
-			InCluster:              true,
-			InClusterContextName:   "test-incluster",
-			InsecureSsl:            true,
-			KubeConfigDir:          "/kubeconfigs",
-			PluginsDir:             "/plugins",
-			UserPluginsDir:         "/user-plugins",
-			AllowKubeconfigChanges: true,
-			WatchPluginsChanges:    false,
-			BaseURL:                "/headlamp",
-			ProxyURLs:              "http://proxy1,http://proxy2",
+			Port:                       4444,
+			InCluster:                  true,
+			InClusterContextName:       "test-incluster",
+			InsecureSsl:                true,
+			KubeConfigDir:              "/kubeconfigs",
+			PluginsDir:                 "/plugins",
+			UserPluginsDir:             "/user-plugins",
+			AllowKubeconfigChanges:     true,
+			WatchPluginsChanges:        false,
+			BaseURL:                    "/headlamp",
+			ProxyURLs:                  "http://proxy1,http://proxy2",
+			ClusterInventoryNamespaces: "team-a,team-b",
 		}
 
 		headlampCFG := buildHeadlampCFG(conf, store)
@@ -56,6 +57,7 @@ func TestBuildHeadlampCFG(t *testing.T) {
 		assert.Equal(t, "/headlamp", headlampCFG.BaseURL)
 		assert.Equal(t, []string{"http://proxy1", "http://proxy2"}, headlampCFG.ProxyURLs)
 		assert.Equal(t, store, headlampCFG.KubeConfigStore)
+		assert.Equal(t, "team-a,team-b", headlampCFG.ClusterInventoryNamespaces)
 	})
 
 	t.Run("empty proxy urls yields empty slice", func(t *testing.T) {

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -49,7 +49,7 @@ require (
 	golang.org/x/term v0.44.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/klog/v2 v2.140.0
-	sigs.k8s.io/cluster-inventory-api v0.1.2
+	sigs.k8s.io/cluster-inventory-api v0.1.3
 )
 
 require (

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -801,8 +801,8 @@ k8s.io/utils v0.0.0-20260507154919-ff6756f316d2 h1:wU4tMEhLGgIbLvXQb1cfN+EcM0wf7
 k8s.io/utils v0.0.0-20260507154919-ff6756f316d2/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 oras.land/oras-go/v2 v2.6.2 h1:N04RXngAp1LJKTG6ifz3xHPipasEkWr+hFmInja5YKo=
 oras.land/oras-go/v2 v2.6.2/go.mod h1:PlTtg4JTDJkDe8yVHpM2wz7/YDc00GVas+i4jAW2TZ4=
-sigs.k8s.io/cluster-inventory-api v0.1.2 h1:rH8Xh6NW5u0WXarjDJeYLSrCLQkwJnSUnyb74eyAXFY=
-sigs.k8s.io/cluster-inventory-api v0.1.2/go.mod h1:7J3M6srZ1I4snZR+p5zxgEBdXnia3tlHo5ODMHJpEUk=
+sigs.k8s.io/cluster-inventory-api v0.1.3 h1:E7GY85hOIIPdALNdTO9Cbs2PXqjotWq6afe/NTwgCJo=
+sigs.k8s.io/cluster-inventory-api v0.1.3/go.mod h1:7J3M6srZ1I4snZR+p5zxgEBdXnia3tlHo5ODMHJpEUk=
 sigs.k8s.io/controller-runtime v0.24.1 h1:miPEwrmirImAvgME1L9qebGHrOnGJoVmVdtOU9fRfo4=
 sigs.k8s.io/controller-runtime v0.24.1/go.mod h1:vFkfY5fGt5xAC/sKb8IBFKgWPNKG9OUG29dR8Y2wImw=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=

--- a/backend/pkg/clusterinventory/clusterinventory.go
+++ b/backend/pkg/clusterinventory/clusterinventory.go
@@ -28,6 +28,7 @@ import (
 	"hash"
 	"net/http"
 	"net/url"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -38,6 +39,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -70,6 +72,7 @@ const (
 	logFieldRoot           = "root"
 	logFieldClusterProfile = "clusterprofile"
 	logFieldServer         = "server"
+	logFieldNamespace      = "namespace"
 )
 
 // Options controls Cluster Inventory discovery.
@@ -80,6 +83,9 @@ type Options struct {
 	ProviderFile string
 	// LabelSelector filters ClusterProfile resources before they are synced.
 	LabelSelector string
+	// Namespaces limits ClusterProfile discovery to a comma-separated list of namespaces.
+	// A value of "*" watches all namespaces; empty watches each root's default namespace.
+	Namespaces string
 	// RootReconcileInterval controls how often root clusters are reconciled.
 	// Values less than or equal to zero use DefaultRootReconcileInterval.
 	RootReconcileInterval time.Duration
@@ -88,6 +94,8 @@ type Options struct {
 	NoCRDCacheTTL time.Duration
 	// HubConfig enables discovery from the in-cluster root when set.
 	HubConfig *rest.Config
+	// HubNamespace is the default namespace for the in-cluster root.
+	HubNamespace string
 	// DiscoverFromStore enables discovery from non-internal contexts already in Store.
 	DiscoverFromStore bool
 }
@@ -99,7 +107,9 @@ type Runner struct {
 	rootReconcileInterval time.Duration
 	noCRDCacheTTL         time.Duration
 	labelSelector         labels.Selector
+	namespaces            []string
 	hubConfig             *rest.Config
+	hubNamespace          string
 	discoverFromStore     bool
 
 	clientForConfig func(*rest.Config) (ciaclient.Interface, error)
@@ -112,20 +122,26 @@ type Runner struct {
 	noCRD             map[string]time.Time
 }
 
-// rootState tracks the active informer and identity for one discovery root.
+// rootState tracks the active informers and identity for one discovery root.
 type rootState struct {
 	rootID      string
 	serverURL   string
 	fingerprint string
 	ctx         context.Context
 	cancel      context.CancelFunc
-	informer    cache.SharedIndexInformer
+	watches     []rootWatch
 }
 
-// rootInformer bundles a root state with its informer factory before activation.
-type rootInformer struct {
-	state   *rootState
-	factory externalversions.SharedInformerFactory
+// rootWatch pairs a ClusterProfile informer with the factory that owns it.
+type rootWatch struct {
+	factory  externalversions.SharedInformerFactory
+	informer cache.SharedIndexInformer
+}
+
+// rootConfig contains the Kubernetes client config and watched namespaces for one root.
+type rootConfig struct {
+	restConfig *rest.Config
+	namespaces []string
 }
 
 // profileState tracks the Headlamp context created from one ClusterProfile.
@@ -153,6 +169,11 @@ func NewRunner(opts Options) (*Runner, error) {
 		return nil, err
 	}
 
+	namespaces, err := normalizeNamespaces(opts.Namespaces)
+	if err != nil {
+		return nil, err
+	}
+
 	rootReconcileInterval := opts.RootReconcileInterval
 	if rootReconcileInterval <= 0 {
 		rootReconcileInterval = DefaultRootReconcileInterval
@@ -169,7 +190,9 @@ func NewRunner(opts Options) (*Runner, error) {
 		rootReconcileInterval: rootReconcileInterval,
 		noCRDCacheTTL:         noCRDCacheTTL,
 		labelSelector:         labelSelector,
+		namespaces:            namespaces,
 		hubConfig:             opts.HubConfig,
+		hubNamespace:          opts.HubNamespace,
 		discoverFromStore:     opts.DiscoverFromStore,
 		clientForConfig: func(config *rest.Config) (ciaclient.Interface, error) {
 			return ciaclient.NewForConfig(config)
@@ -208,12 +231,15 @@ func (r *Runner) reconcileRoots(ctx context.Context) {
 	}
 
 	presentRoots := map[string]struct{}{}
-	desiredRoots := map[string]*rest.Config{}
+	desiredRoots := map[string]rootConfig{}
 	storeRootsLoaded := true
 
 	if r.hubConfig != nil {
 		presentRoots[inClusterRootID] = struct{}{}
-		desiredRoots[inClusterRootID] = r.hubConfig
+		desiredRoots[inClusterRootID] = rootConfig{
+			restConfig: r.hubConfig,
+			namespaces: r.namespacesForRoot(r.hubNamespace),
+		}
 	}
 
 	if r.discoverFromStore {
@@ -236,7 +262,7 @@ func (r *Runner) reconcileRoots(ctx context.Context) {
 
 // collectStoreSeedRoots adds existing non-internal Headlamp contexts as discovery roots.
 func (r *Runner) collectStoreSeedRoots(
-	desiredRoots map[string]*rest.Config,
+	desiredRoots map[string]rootConfig,
 	presentRoots map[string]struct{},
 ) bool {
 	contexts, err := r.store.GetContexts()
@@ -270,15 +296,18 @@ func (r *Runner) collectStoreSeedRoots(
 			continue
 		}
 
-		desiredRoots[rootID] = seedConfig
+		desiredRoots[rootID] = rootConfig{
+			restConfig: seedConfig,
+			namespaces: r.namespacesForRoot(headlampContext.KubeContext.Namespace),
+		}
 	}
 
 	return true
 }
 
 // reconcileRoot ensures one discovery root has a matching active ClusterProfile informer.
-func (r *Runner) reconcileRoot(ctx context.Context, rootID string, config *rest.Config) {
-	if config == nil {
+func (r *Runner) reconcileRoot(ctx context.Context, rootID string, root rootConfig) {
+	if root.restConfig == nil {
 		return
 	}
 
@@ -286,26 +315,26 @@ func (r *Runner) reconcileRoot(ctx context.Context, rootID string, config *rest.
 		return
 	}
 
-	serverURL := normalizeServerURL(config.Host)
+	serverURL := normalizeServerURL(root.restConfig.Host)
 	if r.hasNoCRD(serverURL) {
 		r.stopRoot(rootID, true)
 
 		return
 	}
 
-	fingerprint := restConfigFingerprint(config)
+	fingerprint := rootFingerprint(root)
 	if r.rootMatches(rootID, serverURL, fingerprint) {
 		return
 	}
 
-	rootInformer, ok := r.newRootInformer(ctx, rootID, serverURL, fingerprint, config)
+	state, ok := r.newRootState(ctx, rootID, serverURL, fingerprint, root)
 	if !ok {
 		return
 	}
 
-	previous, current := r.activateRoot(rootInformer.state)
+	previous, current := r.activateRoot(state)
 	if current {
-		rootInformer.state.cancel()
+		state.cancel()
 
 		return
 	}
@@ -314,7 +343,7 @@ func (r *Runner) reconcileRoot(ctx context.Context, rootID string, config *rest.
 		previous.cancel()
 	}
 
-	go r.runRootInformer(rootInformer.state, rootInformer.factory)
+	go r.runRootInformer(state)
 }
 
 // rootMatches reports whether the active root already matches the given connection identity.
@@ -327,35 +356,57 @@ func (r *Runner) rootMatches(rootID, serverURL, fingerprint string) bool {
 	return current != nil && current.serverURL == serverURL && current.fingerprint == fingerprint
 }
 
-// newRootInformer creates an unstarted ClusterProfile informer for a discovery root.
-func (r *Runner) newRootInformer(
+// newRootState creates unstarted ClusterProfile informers for a discovery root.
+func (r *Runner) newRootState(
 	ctx context.Context,
 	rootID string,
 	serverURL string,
 	fingerprint string,
-	config *rest.Config,
-) (*rootInformer, bool) {
-	client, err := r.clientForConfig(rest.CopyConfig(config))
+	root rootConfig,
+) (*rootState, bool) {
+	client, err := r.clientForConfig(rest.CopyConfig(root.restConfig))
 	if err != nil {
-		logger.Log(logger.LevelWarn, map[string]string{logFieldRoot: rootID, logFieldServer: config.Host}, err,
+		logger.Log(logger.LevelWarn, map[string]string{logFieldRoot: rootID, logFieldServer: serverURL}, err,
 			"cluster-inventory: failed to create client")
 
 		return nil, false
 	}
 
 	rootCtx, cancel := context.WithCancel(ctx)
-	factory := r.newClusterProfileInformerFactory(client)
-	informer := factory.Apis().V1alpha1().ClusterProfiles().Informer()
 	state := &rootState{
 		rootID:      rootID,
 		serverURL:   serverURL,
 		fingerprint: fingerprint,
 		ctx:         rootCtx,
 		cancel:      cancel,
-		informer:    informer,
+		watches:     make([]rootWatch, 0, len(root.namespaces)),
 	}
 
-	_, err = informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	for _, namespace := range root.namespaces {
+		watch, ok := r.newRootWatch(state, client, namespace)
+		if !ok {
+			cancel()
+
+			return nil, false
+		}
+
+		state.watches = append(state.watches, watch)
+	}
+
+	return state, true
+}
+
+// newRootWatch creates an unstarted ClusterProfile informer for one namespace of a root.
+func (r *Runner) newRootWatch(
+	state *rootState,
+	client ciaclient.Interface,
+	namespace string,
+) (rootWatch, bool) {
+	options := r.clusterProfileInformerOptions(namespace)
+	factory := externalversions.NewSharedInformerFactoryWithOptions(client, 0, options...)
+	informer := factory.Apis().V1alpha1().ClusterProfiles().Informer()
+
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			r.handleClusterProfileUpsert(state, obj)
 		},
@@ -367,44 +418,38 @@ func (r *Runner) newRootInformer(
 		},
 	})
 	if err != nil {
-		cancel()
-		logger.Log(logger.LevelWarn, map[string]string{logFieldRoot: rootID, logFieldServer: config.Host}, err,
+		logger.Log(logger.LevelWarn, map[string]string{logFieldRoot: state.rootID, logFieldServer: state.serverURL}, err,
 			"cluster-inventory: failed to add ClusterProfile event handler")
 
-		return nil, false
+		return rootWatch{}, false
 	}
 
 	if err := informer.SetWatchErrorHandler(func(_ *cache.Reflector, err error) {
-		r.handleRootWatchError(state, err)
+		r.handleRootWatchError(state, namespace, err)
 	}); err != nil {
-		cancel()
-		logger.Log(logger.LevelWarn, map[string]string{logFieldRoot: rootID, logFieldServer: config.Host}, err,
+		logger.Log(logger.LevelWarn, map[string]string{logFieldRoot: state.rootID, logFieldServer: state.serverURL}, err,
 			"cluster-inventory: failed to set ClusterProfile watch error handler")
 
-		return nil, false
+		return rootWatch{}, false
 	}
 
-	return &rootInformer{state: state, factory: factory}, true
+	return rootWatch{factory: factory, informer: informer}, true
 }
 
-// newClusterProfileInformerFactory creates an informer factory for ClusterProfiles.
-func (r *Runner) newClusterProfileInformerFactory(client ciaclient.Interface) externalversions.SharedInformerFactory {
-	return externalversions.NewSharedInformerFactoryWithOptions(client, 0, r.clusterProfileInformerOptions()...)
-}
+// clusterProfileInformerOptions returns informer options for one namespace of a root.
+func (r *Runner) clusterProfileInformerOptions(namespace string) []externalversions.SharedInformerOption {
+	options := make([]externalversions.SharedInformerOption, 0, 2)
+	options = append(options, externalversions.WithNamespace(namespace))
 
-// clusterProfileInformerOptions returns informer options derived from the label selector.
-func (r *Runner) clusterProfileInformerOptions() []externalversions.SharedInformerOption {
 	if r.labelSelector == nil {
-		return nil
+		return options
 	}
 
 	selector := r.labelSelector.String()
 
-	return []externalversions.SharedInformerOption{
-		externalversions.WithTweakListOptions(func(options *metav1.ListOptions) {
-			options.LabelSelector = selector
-		}),
-	}
+	return append(options, externalversions.WithTweakListOptions(func(listOptions *metav1.ListOptions) {
+		listOptions.LabelSelector = selector
+	}))
 }
 
 // activateRoot records a root as active and returns any previous active root.
@@ -422,13 +467,23 @@ func (r *Runner) activateRoot(state *rootState) (*rootState, bool) {
 	return previous, false
 }
 
-// runRootInformer starts a root informer and prunes profiles missing after the initial sync.
-func (r *Runner) runRootInformer(state *rootState, factory externalversions.SharedInformerFactory) {
-	defer factory.Shutdown()
+// runRootInformer starts root informers and prunes profiles missing after the initial sync.
+func (r *Runner) runRootInformer(state *rootState) {
+	defer func() {
+		for _, watch := range state.watches {
+			watch.factory.Shutdown()
+		}
+	}()
 
-	factory.Start(state.ctx.Done())
+	synced := make([]cache.InformerSynced, 0, len(state.watches))
 
-	if !cache.WaitForCacheSync(state.ctx.Done(), state.informer.HasSynced) {
+	for _, watch := range state.watches {
+		watch.factory.Start(state.ctx.Done())
+
+		synced = append(synced, watch.informer.HasSynced)
+	}
+
+	if !cache.WaitForCacheSync(state.ctx.Done(), synced...) {
 		return
 	}
 
@@ -475,18 +530,19 @@ func (r *Runner) handleClusterProfileDelete(state *rootState, obj interface{}) {
 	r.pruneClusterProfile(state, profileKey)
 }
 
-// handleRootWatchError reacts to ClusterProfile watch errors for a discovery root.
-func (r *Runner) handleRootWatchError(state *rootState, err error) {
+// handleRootWatchError reacts to ClusterProfile watch errors for one namespace of a root.
+func (r *Runner) handleRootWatchError(state *rootState, namespace string, err error) {
 	if isNoCRDError(err) {
 		r.markRootNoCRD(state)
-		logger.Log(logger.LevelInfo, map[string]string{logFieldRoot: state.rootID, logFieldServer: state.serverURL}, nil,
-			"cluster-inventory: ClusterProfile CRD is not available")
 
 		return
 	}
 
-	logger.Log(logger.LevelWarn, map[string]string{logFieldRoot: state.rootID, logFieldServer: state.serverURL}, err,
-		"cluster-inventory: ClusterProfile watch error")
+	logger.Log(logger.LevelWarn, map[string]string{
+		logFieldRoot:      state.rootID,
+		logFieldServer:    state.serverURL,
+		logFieldNamespace: namespace,
+	}, err, "cluster-inventory: ClusterProfile watch error")
 }
 
 // syncClusterProfile converts a ClusterProfile to a Headlamp context and stores it.
@@ -615,18 +671,20 @@ func (r *Runner) recordSyncedProfile(state *rootState, profileKey string, contex
 func (r *Runner) completeRootSyncFromCache(state *rootState) {
 	seen := map[string]struct{}{}
 
-	for _, obj := range state.informer.GetIndexer().List() {
-		cp, ok := clusterProfileFromObject(obj)
-		if !ok {
-			continue
-		}
+	for _, watch := range state.watches {
+		for _, obj := range watch.informer.GetIndexer().List() {
+			cp, ok := clusterProfileFromObject(obj)
+			if !ok {
+				continue
+			}
 
-		if !r.clusterProfileMatchesSelector(cp) {
-			continue
-		}
+			if !r.clusterProfileMatchesSelector(cp) {
+				continue
+			}
 
-		profileKey := makeProfileKey(state.rootID, cp.Namespace+"/"+cp.Name)
-		seen[profileKey] = struct{}{}
+			profileKey := makeProfileKey(state.rootID, cp.Namespace+"/"+cp.Name)
+			seen[profileKey] = struct{}{}
+		}
 	}
 
 	r.mu.Lock()
@@ -829,7 +887,7 @@ func (r *Runner) markNoCRD(serverURL string) {
 	r.noCRD[serverURL] = r.now().Add(r.noCRDCacheTTL)
 }
 
-// markRootNoCRD stops a root and caches its server as missing the ClusterProfile CRD.
+// markRootNoCRD stops a root once and caches its server as missing the ClusterProfile CRD.
 func (r *Runner) markRootNoCRD(state *rootState) {
 	var (
 		cancel       context.CancelFunc
@@ -849,6 +907,8 @@ func (r *Runner) markRootNoCRD(state *rootState) {
 
 	if cancel != nil {
 		cancel()
+		logger.Log(logger.LevelInfo, map[string]string{logFieldRoot: state.rootID, logFieldServer: state.serverURL}, nil,
+			"cluster-inventory: ClusterProfile CRD is not available")
 	}
 }
 
@@ -880,6 +940,61 @@ func normalizeLabelSelector(selector string) (labels.Selector, error) {
 	return parsed, nil
 }
 
+// normalizeNamespaces parses a user-provided comma-separated namespace list.
+func normalizeNamespaces(value string) ([]string, error) {
+	if strings.TrimSpace(value) == "" {
+		return nil, nil
+	}
+
+	var (
+		namespaces    = make([]string, 0, strings.Count(value, ",")+1)
+		allNamespaces bool
+	)
+
+	for _, namespace := range strings.Split(value, ",") {
+		namespace = strings.TrimSpace(namespace)
+
+		switch namespace {
+		case "":
+			return nil, errors.New("invalid cluster-inventory-namespaces: namespace must not be empty")
+		case "*":
+			allNamespaces = true
+		default:
+			if errs := validation.IsDNS1123Label(namespace); len(errs) > 0 {
+				return nil, fmt.Errorf("invalid cluster-inventory-namespaces: %q: %s",
+					namespace, strings.Join(errs, "; "))
+			}
+
+			namespaces = append(namespaces, namespace)
+		}
+	}
+
+	if allNamespaces {
+		if len(namespaces) > 0 {
+			return nil, errors.New(`invalid cluster-inventory-namespaces: "*" must be used on its own`)
+		}
+
+		return []string{metav1.NamespaceAll}, nil
+	}
+
+	slices.Sort(namespaces)
+
+	return slices.Compact(namespaces), nil
+}
+
+// namespacesForRoot returns the configured namespaces, or the root's default namespace.
+func (r *Runner) namespacesForRoot(defaultNamespace string) []string {
+	if len(r.namespaces) > 0 {
+		return r.namespaces
+	}
+
+	if defaultNamespace == "" {
+		defaultNamespace = metav1.NamespaceDefault
+	}
+
+	return []string{defaultNamespace}
+}
+
 // contextNameFromProfileKey builds a stable Headlamp context name for a profile key.
 func contextNameFromProfileKey(profileKey string) string {
 	return clusterInventoryContextPrefix +
@@ -909,14 +1024,18 @@ func normalizeServerURL(host string) string {
 	return strings.TrimRight(parsed.String(), "/")
 }
 
-// restConfigFingerprint hashes the REST config fields that affect root identity.
-func restConfigFingerprint(config *rest.Config) string {
+// rootFingerprint hashes the connection and namespace settings that affect root identity.
+func rootFingerprint(root rootConfig) string {
 	fingerprintHash := sha256.New()
 
-	writeRestConfigFingerprint(fingerprintHash, config)
-	writeTLSConfigFingerprint(fingerprintHash, config)
-	writeImpersonateFingerprint(fingerprintHash, config)
-	writeExecFingerprint(fingerprintHash, config.ExecProvider)
+	writeRestConfigFingerprint(fingerprintHash, root.restConfig)
+	writeTLSConfigFingerprint(fingerprintHash, root.restConfig)
+	writeImpersonateFingerprint(fingerprintHash, root.restConfig)
+	writeExecFingerprint(fingerprintHash, root.restConfig.ExecProvider)
+
+	for _, namespace := range root.namespaces {
+		writeHashString(fingerprintHash, namespace)
+	}
 
 	return hex.EncodeToString(fingerprintHash.Sum(nil))
 }

--- a/backend/pkg/clusterinventory/clusterinventory.go
+++ b/backend/pkg/clusterinventory/clusterinventory.go
@@ -28,6 +28,7 @@ import (
 	"hash"
 	"net/http"
 	"net/url"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -38,6 +39,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -70,6 +72,7 @@ const (
 	logFieldRoot           = "root"
 	logFieldClusterProfile = "clusterprofile"
 	logFieldServer         = "server"
+	logFieldNamespace      = "namespace"
 )
 
 // Options controls Cluster Inventory discovery.
@@ -80,6 +83,9 @@ type Options struct {
 	ProviderFile string
 	// LabelSelector filters ClusterProfile resources before they are synced.
 	LabelSelector string
+	// Namespaces limits ClusterProfile discovery to a comma-separated list of namespaces.
+	// A value of "*" watches all namespaces; empty watches each root's default namespace.
+	Namespaces string
 	// RootReconcileInterval controls how often root clusters are reconciled.
 	// Values less than or equal to zero use DefaultRootReconcileInterval.
 	RootReconcileInterval time.Duration
@@ -88,6 +94,8 @@ type Options struct {
 	NoCRDCacheTTL time.Duration
 	// HubConfig enables discovery from the in-cluster root when set.
 	HubConfig *rest.Config
+	// HubNamespace is the default namespace for the in-cluster root.
+	HubNamespace string
 	// DiscoverFromStore enables discovery from non-internal contexts already in Store.
 	DiscoverFromStore bool
 }
@@ -99,7 +107,9 @@ type Runner struct {
 	rootReconcileInterval time.Duration
 	noCRDCacheTTL         time.Duration
 	labelSelector         labels.Selector
+	namespaces            []string
 	hubConfig             *rest.Config
+	hubNamespace          string
 	discoverFromStore     bool
 
 	clientForConfig func(*rest.Config) (ciaclient.Interface, error)
@@ -108,24 +118,31 @@ type Runner struct {
 	mu                sync.Mutex
 	roots             map[string]*rootState
 	profiles          map[string]profileState
-	profileKeysByRoot map[string]map[string]struct{}
+	profileKeysByRoot map[string]map[string]string
 	noCRD             map[string]time.Time
 }
 
-// rootState tracks the active informer and identity for one discovery root.
+// rootState tracks the active informers and identity for one discovery root.
 type rootState struct {
 	rootID      string
 	serverURL   string
 	fingerprint string
 	ctx         context.Context
 	cancel      context.CancelFunc
-	informer    cache.SharedIndexInformer
+	watches     []rootWatch
 }
 
-// rootInformer bundles a root state with its informer factory before activation.
-type rootInformer struct {
-	state   *rootState
-	factory externalversions.SharedInformerFactory
+// rootWatch pairs a ClusterProfile informer with the factory that owns it.
+type rootWatch struct {
+	namespace string
+	factory   externalversions.SharedInformerFactory
+	informer  cache.SharedIndexInformer
+}
+
+// rootConfig contains the Kubernetes client config and watched namespaces for one root.
+type rootConfig struct {
+	restConfig *rest.Config
+	namespaces []string
 }
 
 // profileState tracks the Headlamp context created from one ClusterProfile.
@@ -153,6 +170,11 @@ func NewRunner(opts Options) (*Runner, error) {
 		return nil, err
 	}
 
+	namespaces, err := normalizeNamespaces(opts.Namespaces)
+	if err != nil {
+		return nil, err
+	}
+
 	rootReconcileInterval := opts.RootReconcileInterval
 	if rootReconcileInterval <= 0 {
 		rootReconcileInterval = DefaultRootReconcileInterval
@@ -169,7 +191,9 @@ func NewRunner(opts Options) (*Runner, error) {
 		rootReconcileInterval: rootReconcileInterval,
 		noCRDCacheTTL:         noCRDCacheTTL,
 		labelSelector:         labelSelector,
+		namespaces:            namespaces,
 		hubConfig:             opts.HubConfig,
+		hubNamespace:          opts.HubNamespace,
 		discoverFromStore:     opts.DiscoverFromStore,
 		clientForConfig: func(config *rest.Config) (ciaclient.Interface, error) {
 			return ciaclient.NewForConfig(config)
@@ -177,7 +201,7 @@ func NewRunner(opts Options) (*Runner, error) {
 		now:               time.Now,
 		roots:             map[string]*rootState{},
 		profiles:          map[string]profileState{},
-		profileKeysByRoot: map[string]map[string]struct{}{},
+		profileKeysByRoot: map[string]map[string]string{},
 		noCRD:             map[string]time.Time{},
 	}, nil
 }
@@ -208,12 +232,15 @@ func (r *Runner) reconcileRoots(ctx context.Context) {
 	}
 
 	presentRoots := map[string]struct{}{}
-	desiredRoots := map[string]*rest.Config{}
+	desiredRoots := map[string]rootConfig{}
 	storeRootsLoaded := true
 
 	if r.hubConfig != nil {
 		presentRoots[inClusterRootID] = struct{}{}
-		desiredRoots[inClusterRootID] = r.hubConfig
+		desiredRoots[inClusterRootID] = rootConfig{
+			restConfig: r.hubConfig,
+			namespaces: r.namespacesForRoot(r.hubNamespace),
+		}
 	}
 
 	if r.discoverFromStore {
@@ -236,7 +263,7 @@ func (r *Runner) reconcileRoots(ctx context.Context) {
 
 // collectStoreSeedRoots adds existing non-internal Headlamp contexts as discovery roots.
 func (r *Runner) collectStoreSeedRoots(
-	desiredRoots map[string]*rest.Config,
+	desiredRoots map[string]rootConfig,
 	presentRoots map[string]struct{},
 ) bool {
 	contexts, err := r.store.GetContexts()
@@ -270,15 +297,18 @@ func (r *Runner) collectStoreSeedRoots(
 			continue
 		}
 
-		desiredRoots[rootID] = seedConfig
+		desiredRoots[rootID] = rootConfig{
+			restConfig: seedConfig,
+			namespaces: r.namespacesForRoot(headlampContext.KubeContext.Namespace),
+		}
 	}
 
 	return true
 }
 
 // reconcileRoot ensures one discovery root has a matching active ClusterProfile informer.
-func (r *Runner) reconcileRoot(ctx context.Context, rootID string, config *rest.Config) {
-	if config == nil {
+func (r *Runner) reconcileRoot(ctx context.Context, rootID string, root rootConfig) {
+	if root.restConfig == nil {
 		return
 	}
 
@@ -286,26 +316,26 @@ func (r *Runner) reconcileRoot(ctx context.Context, rootID string, config *rest.
 		return
 	}
 
-	serverURL := normalizeServerURL(config.Host)
+	serverURL := normalizeServerURL(root.restConfig.Host)
 	if r.hasNoCRD(serverURL) {
 		r.stopRoot(rootID, true)
 
 		return
 	}
 
-	fingerprint := restConfigFingerprint(config)
+	fingerprint := rootFingerprint(root)
 	if r.rootMatches(rootID, serverURL, fingerprint) {
 		return
 	}
 
-	rootInformer, ok := r.newRootInformer(ctx, rootID, serverURL, fingerprint, config)
+	state, ok := r.newRootState(ctx, rootID, serverURL, fingerprint, root)
 	if !ok {
 		return
 	}
 
-	previous, current := r.activateRoot(rootInformer.state)
+	previous, current := r.activateRoot(state)
 	if current {
-		rootInformer.state.cancel()
+		state.cancel()
 
 		return
 	}
@@ -314,7 +344,7 @@ func (r *Runner) reconcileRoot(ctx context.Context, rootID string, config *rest.
 		previous.cancel()
 	}
 
-	go r.runRootInformer(rootInformer.state, rootInformer.factory)
+	go r.runRootInformer(state)
 }
 
 // rootMatches reports whether the active root already matches the given connection identity.
@@ -327,35 +357,57 @@ func (r *Runner) rootMatches(rootID, serverURL, fingerprint string) bool {
 	return current != nil && current.serverURL == serverURL && current.fingerprint == fingerprint
 }
 
-// newRootInformer creates an unstarted ClusterProfile informer for a discovery root.
-func (r *Runner) newRootInformer(
+// newRootState creates unstarted ClusterProfile informers for a discovery root.
+func (r *Runner) newRootState(
 	ctx context.Context,
 	rootID string,
 	serverURL string,
 	fingerprint string,
-	config *rest.Config,
-) (*rootInformer, bool) {
-	client, err := r.clientForConfig(rest.CopyConfig(config))
+	root rootConfig,
+) (*rootState, bool) {
+	client, err := r.clientForConfig(rest.CopyConfig(root.restConfig))
 	if err != nil {
-		logger.Log(logger.LevelWarn, map[string]string{logFieldRoot: rootID, logFieldServer: config.Host}, err,
+		logger.Log(logger.LevelWarn, map[string]string{logFieldRoot: rootID, logFieldServer: serverURL}, err,
 			"cluster-inventory: failed to create client")
 
 		return nil, false
 	}
 
 	rootCtx, cancel := context.WithCancel(ctx)
-	factory := r.newClusterProfileInformerFactory(client)
-	informer := factory.Apis().V1alpha1().ClusterProfiles().Informer()
 	state := &rootState{
 		rootID:      rootID,
 		serverURL:   serverURL,
 		fingerprint: fingerprint,
 		ctx:         rootCtx,
 		cancel:      cancel,
-		informer:    informer,
+		watches:     make([]rootWatch, 0, len(root.namespaces)),
 	}
 
-	_, err = informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	for _, namespace := range root.namespaces {
+		watch, ok := r.newRootWatch(state, client, namespace)
+		if !ok {
+			cancel()
+
+			return nil, false
+		}
+
+		state.watches = append(state.watches, watch)
+	}
+
+	return state, true
+}
+
+// newRootWatch creates an unstarted ClusterProfile informer for one namespace of a root.
+func (r *Runner) newRootWatch(
+	state *rootState,
+	client ciaclient.Interface,
+	namespace string,
+) (rootWatch, bool) {
+	options := r.clusterProfileInformerOptions(namespace)
+	factory := externalversions.NewSharedInformerFactoryWithOptions(client, 0, options...)
+	informer := factory.Apis().V1alpha1().ClusterProfiles().Informer()
+
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			r.handleClusterProfileUpsert(state, obj)
 		},
@@ -367,44 +419,38 @@ func (r *Runner) newRootInformer(
 		},
 	})
 	if err != nil {
-		cancel()
-		logger.Log(logger.LevelWarn, map[string]string{logFieldRoot: rootID, logFieldServer: config.Host}, err,
+		logger.Log(logger.LevelWarn, map[string]string{logFieldRoot: state.rootID, logFieldServer: state.serverURL}, err,
 			"cluster-inventory: failed to add ClusterProfile event handler")
 
-		return nil, false
+		return rootWatch{}, false
 	}
 
 	if err := informer.SetWatchErrorHandler(func(_ *cache.Reflector, err error) {
-		r.handleRootWatchError(state, err)
+		r.handleRootWatchError(state, namespace, err)
 	}); err != nil {
-		cancel()
-		logger.Log(logger.LevelWarn, map[string]string{logFieldRoot: rootID, logFieldServer: config.Host}, err,
+		logger.Log(logger.LevelWarn, map[string]string{logFieldRoot: state.rootID, logFieldServer: state.serverURL}, err,
 			"cluster-inventory: failed to set ClusterProfile watch error handler")
 
-		return nil, false
+		return rootWatch{}, false
 	}
 
-	return &rootInformer{state: state, factory: factory}, true
+	return rootWatch{namespace: namespace, factory: factory, informer: informer}, true
 }
 
-// newClusterProfileInformerFactory creates an informer factory for ClusterProfiles.
-func (r *Runner) newClusterProfileInformerFactory(client ciaclient.Interface) externalversions.SharedInformerFactory {
-	return externalversions.NewSharedInformerFactoryWithOptions(client, 0, r.clusterProfileInformerOptions()...)
-}
+// clusterProfileInformerOptions returns informer options for one namespace of a root.
+func (r *Runner) clusterProfileInformerOptions(namespace string) []externalversions.SharedInformerOption {
+	options := make([]externalversions.SharedInformerOption, 0, 2)
+	options = append(options, externalversions.WithNamespace(namespace))
 
-// clusterProfileInformerOptions returns informer options derived from the label selector.
-func (r *Runner) clusterProfileInformerOptions() []externalversions.SharedInformerOption {
 	if r.labelSelector == nil {
-		return nil
+		return options
 	}
 
 	selector := r.labelSelector.String()
 
-	return []externalversions.SharedInformerOption{
-		externalversions.WithTweakListOptions(func(options *metav1.ListOptions) {
-			options.LabelSelector = selector
-		}),
-	}
+	return append(options, externalversions.WithTweakListOptions(func(listOptions *metav1.ListOptions) {
+		listOptions.LabelSelector = selector
+	}))
 }
 
 // activateRoot records a root as active and returns any previous active root.
@@ -422,19 +468,35 @@ func (r *Runner) activateRoot(state *rootState) (*rootState, bool) {
 	return previous, false
 }
 
-// runRootInformer starts a root informer and prunes profiles missing after the initial sync.
-func (r *Runner) runRootInformer(state *rootState, factory externalversions.SharedInformerFactory) {
-	defer factory.Shutdown()
+// runRootInformer starts each namespace informer and waits for shutdown.
+func (r *Runner) runRootInformer(state *rootState) {
+	defer func() {
+		for _, watch := range state.watches {
+			watch.factory.Shutdown()
+		}
+	}()
 
-	factory.Start(state.ctx.Done())
+	for _, watch := range state.watches {
+		logger.Log(logger.LevelInfo, map[string]string{
+			logFieldRoot:      state.rootID,
+			logFieldServer:    state.serverURL,
+			logFieldNamespace: namespaceLogValue(watch.namespace),
+		}, nil, "cluster-inventory: starting ClusterProfile watch")
 
-	if !cache.WaitForCacheSync(state.ctx.Done(), state.informer.HasSynced) {
+		watch.factory.Start(state.ctx.Done())
+		go r.waitForRootWatchSync(state, watch)
+	}
+
+	<-state.ctx.Done()
+}
+
+// waitForRootWatchSync prunes stale profiles after one namespace cache has synced.
+func (r *Runner) waitForRootWatchSync(state *rootState, watch rootWatch) {
+	if !cache.WaitForCacheSync(state.ctx.Done(), watch.informer.HasSynced) {
 		return
 	}
 
-	r.completeRootSyncFromCache(state)
-
-	<-state.ctx.Done()
+	r.completeRootWatchSyncFromCache(state, watch)
 }
 
 // handleClusterProfileUpsert syncs an added or updated ClusterProfile into the context store.
@@ -454,7 +516,7 @@ func (r *Runner) handleClusterProfileUpsert(state *rootState, obj interface{}) {
 		return
 	}
 
-	if !r.recordRootProfile(state, profileKey) {
+	if !r.recordRootProfile(state, profileKey, cp.Namespace) {
 		return
 	}
 
@@ -475,18 +537,19 @@ func (r *Runner) handleClusterProfileDelete(state *rootState, obj interface{}) {
 	r.pruneClusterProfile(state, profileKey)
 }
 
-// handleRootWatchError reacts to ClusterProfile watch errors for a discovery root.
-func (r *Runner) handleRootWatchError(state *rootState, err error) {
+// handleRootWatchError reacts to ClusterProfile watch errors for one namespace of a root.
+func (r *Runner) handleRootWatchError(state *rootState, namespace string, err error) {
 	if isNoCRDError(err) {
 		r.markRootNoCRD(state)
-		logger.Log(logger.LevelInfo, map[string]string{logFieldRoot: state.rootID, logFieldServer: state.serverURL}, nil,
-			"cluster-inventory: ClusterProfile CRD is not available")
 
 		return
 	}
 
-	logger.Log(logger.LevelWarn, map[string]string{logFieldRoot: state.rootID, logFieldServer: state.serverURL}, err,
-		"cluster-inventory: ClusterProfile watch error")
+	logger.Log(logger.LevelWarn, map[string]string{
+		logFieldRoot:      state.rootID,
+		logFieldServer:    state.serverURL,
+		logFieldNamespace: namespace,
+	}, err, "cluster-inventory: ClusterProfile watch error")
 }
 
 // syncClusterProfile converts a ClusterProfile to a Headlamp context and stores it.
@@ -611,35 +674,55 @@ func (r *Runner) recordSyncedProfile(state *rootState, profileKey string, contex
 	r.profiles[profileKey] = profileState{contextName: contextName}
 }
 
-// completeRootSyncFromCache prunes profiles no longer present after a root cache sync.
-func (r *Runner) completeRootSyncFromCache(state *rootState) {
-	seen := map[string]struct{}{}
-
-	for _, obj := range state.informer.GetIndexer().List() {
-		cp, ok := clusterProfileFromObject(obj)
-		if !ok {
-			continue
-		}
-
-		if !r.clusterProfileMatchesSelector(cp) {
-			continue
-		}
-
-		profileKey := makeProfileKey(state.rootID, cp.Namespace+"/"+cp.Name)
-		seen[profileKey] = struct{}{}
-	}
+// completeRootWatchSyncFromCache prunes profiles missing from one synced namespace cache.
+func (r *Runner) completeRootWatchSyncFromCache(state *rootState, watch rootWatch) {
+	seen := r.profileKeysFromRootWatch(state.rootID, watch)
 
 	r.mu.Lock()
-
 	if r.roots[state.rootID] != state {
 		r.mu.Unlock()
+
 		return
 	}
 
 	previous := r.profileKeysByRoot[state.rootID]
-	r.profileKeysByRoot[state.rootID] = seen
 
 	var contextNames []string
+
+	if watch.namespace == metav1.NamespaceAll {
+		contextNames = r.syncAllNamespaceProfilesLocked(state.rootID, previous, seen)
+	} else {
+		contextNames = r.syncNamedNamespaceProfilesLocked(state, watch.namespace, previous, seen)
+	}
+
+	r.mu.Unlock()
+
+	r.removeContexts(contextNames)
+}
+
+func (r *Runner) profileKeysFromRootWatch(rootID string, watch rootWatch) map[string]string {
+	seen := map[string]string{}
+
+	for _, obj := range watch.informer.GetIndexer().List() {
+		cp, ok := clusterProfileFromObject(obj)
+		if !ok || !r.clusterProfileMatchesSelector(cp) {
+			continue
+		}
+
+		profileKey := makeProfileKey(rootID, cp.Namespace+"/"+cp.Name)
+		seen[profileKey] = cp.Namespace
+	}
+
+	return seen
+}
+
+func (r *Runner) syncAllNamespaceProfilesLocked(
+	rootID string,
+	previous map[string]string,
+	seen map[string]string,
+) []string {
+	r.profileKeysByRoot[rootID] = seen
+	contextNames := []string{}
 
 	for profileKey := range previous {
 		if _, ok := seen[profileKey]; ok {
@@ -648,13 +731,60 @@ func (r *Runner) completeRootSyncFromCache(state *rootState) {
 
 		contextNames = append(contextNames, r.pruneProfileLocked(profileKey)...)
 	}
-	r.mu.Unlock()
 
-	r.removeContexts(contextNames)
+	return contextNames
+}
+
+func (r *Runner) syncNamedNamespaceProfilesLocked(
+	state *rootState,
+	namespace string,
+	previous map[string]string,
+	seen map[string]string,
+) []string {
+	next := make(map[string]string, len(previous)+len(seen))
+	for profileKey, profileNamespace := range previous {
+		next[profileKey] = profileNamespace
+	}
+
+	contextNames := []string{}
+
+	for profileKey, profileNamespace := range previous {
+		_, stillPresent := seen[profileKey]
+
+		if profileNamespace != namespace && r.rootWatchesNamespace(state, profileNamespace) {
+			continue
+		}
+
+		if profileNamespace == namespace && stillPresent {
+			continue
+		}
+
+		delete(next, profileKey)
+		contextNames = append(contextNames, r.pruneProfileLocked(profileKey)...)
+	}
+
+	for profileKey, profileNamespace := range seen {
+		next[profileKey] = profileNamespace
+	}
+
+	r.profileKeysByRoot[state.rootID] = next
+
+	return contextNames
+}
+
+// rootWatchesNamespace reports whether a root state intentionally watches a namespace.
+func (r *Runner) rootWatchesNamespace(state *rootState, namespace string) bool {
+	for _, watch := range state.watches {
+		if watch.namespace == metav1.NamespaceAll || watch.namespace == namespace {
+			return true
+		}
+	}
+
+	return false
 }
 
 // recordRootProfile records that a current root has seen a ClusterProfile.
-func (r *Runner) recordRootProfile(state *rootState, profileKey string) bool {
+func (r *Runner) recordRootProfile(state *rootState, profileKey string, namespace string) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -663,10 +793,10 @@ func (r *Runner) recordRootProfile(state *rootState, profileKey string) bool {
 	}
 
 	if r.profileKeysByRoot[state.rootID] == nil {
-		r.profileKeysByRoot[state.rootID] = map[string]struct{}{}
+		r.profileKeysByRoot[state.rootID] = map[string]string{}
 	}
 
-	r.profileKeysByRoot[state.rootID][profileKey] = struct{}{}
+	r.profileKeysByRoot[state.rootID][profileKey] = namespace
 
 	return true
 }
@@ -829,7 +959,7 @@ func (r *Runner) markNoCRD(serverURL string) {
 	r.noCRD[serverURL] = r.now().Add(r.noCRDCacheTTL)
 }
 
-// markRootNoCRD stops a root and caches its server as missing the ClusterProfile CRD.
+// markRootNoCRD stops a root once and caches its server as missing the ClusterProfile CRD.
 func (r *Runner) markRootNoCRD(state *rootState) {
 	var (
 		cancel       context.CancelFunc
@@ -849,6 +979,8 @@ func (r *Runner) markRootNoCRD(state *rootState) {
 
 	if cancel != nil {
 		cancel()
+		logger.Log(logger.LevelInfo, map[string]string{logFieldRoot: state.rootID, logFieldServer: state.serverURL}, nil,
+			"cluster-inventory: ClusterProfile CRD is not available")
 	}
 }
 
@@ -880,6 +1012,81 @@ func normalizeLabelSelector(selector string) (labels.Selector, error) {
 	return parsed, nil
 }
 
+// normalizeNamespaces parses a user-provided comma-separated namespace list.
+func normalizeNamespaces(value string) ([]string, error) {
+	if strings.TrimSpace(value) == "" {
+		return nil, nil
+	}
+
+	var (
+		namespaces    = make([]string, 0, strings.Count(value, ",")+1)
+		allNamespaces bool
+	)
+
+	for _, namespace := range strings.Split(value, ",") {
+		namespace = strings.TrimSpace(namespace)
+
+		switch namespace {
+		case "":
+			return nil, errors.New("invalid cluster-inventory-namespaces: namespace must not be empty")
+		case "*":
+			if allNamespaces {
+				return nil, errors.New(`invalid cluster-inventory-namespaces: "*" must be used on its own`)
+			}
+
+			allNamespaces = true
+		default:
+			if errs := validation.IsDNS1123Label(namespace); len(errs) > 0 {
+				return nil, fmt.Errorf("invalid cluster-inventory-namespaces: %q: %s",
+					namespace, strings.Join(errs, "; "))
+			}
+
+			namespaces = append(namespaces, namespace)
+		}
+	}
+
+	if allNamespaces {
+		if len(namespaces) > 0 {
+			return nil, errors.New(`invalid cluster-inventory-namespaces: "*" must be used on its own`)
+		}
+
+		return []string{metav1.NamespaceAll}, nil
+	}
+
+	slices.Sort(namespaces)
+
+	return slices.Compact(namespaces), nil
+}
+
+// ValidateNamespaces validates a comma-separated Cluster Inventory namespace list.
+func ValidateNamespaces(value string) error {
+	_, err := normalizeNamespaces(value)
+
+	return err
+}
+
+// namespacesForRoot returns the configured namespaces, or the root's default namespace.
+func (r *Runner) namespacesForRoot(defaultNamespace string) []string {
+	if len(r.namespaces) > 0 {
+		return r.namespaces
+	}
+
+	if defaultNamespace == "" {
+		defaultNamespace = metav1.NamespaceDefault
+	}
+
+	return []string{defaultNamespace}
+}
+
+// namespaceLogValue renders the all-namespace sentinel in a human-readable form.
+func namespaceLogValue(namespace string) string {
+	if namespace == metav1.NamespaceAll {
+		return "*"
+	}
+
+	return namespace
+}
+
 // contextNameFromProfileKey builds a stable Headlamp context name for a profile key.
 func contextNameFromProfileKey(profileKey string) string {
 	return clusterInventoryContextPrefix +
@@ -909,14 +1116,18 @@ func normalizeServerURL(host string) string {
 	return strings.TrimRight(parsed.String(), "/")
 }
 
-// restConfigFingerprint hashes the REST config fields that affect root identity.
-func restConfigFingerprint(config *rest.Config) string {
+// rootFingerprint hashes the connection and namespace settings that affect root identity.
+func rootFingerprint(root rootConfig) string {
 	fingerprintHash := sha256.New()
 
-	writeRestConfigFingerprint(fingerprintHash, config)
-	writeTLSConfigFingerprint(fingerprintHash, config)
-	writeImpersonateFingerprint(fingerprintHash, config)
-	writeExecFingerprint(fingerprintHash, config.ExecProvider)
+	writeRestConfigFingerprint(fingerprintHash, root.restConfig)
+	writeTLSConfigFingerprint(fingerprintHash, root.restConfig)
+	writeImpersonateFingerprint(fingerprintHash, root.restConfig)
+	writeExecFingerprint(fingerprintHash, root.restConfig.ExecProvider)
+
+	for _, namespace := range root.namespaces {
+		writeHashString(fingerprintHash, namespace)
+	}
 
 	return hex.EncodeToString(fingerprintHash.Sum(nil))
 }

--- a/backend/pkg/clusterinventory/clusterinventory_test.go
+++ b/backend/pkg/clusterinventory/clusterinventory_test.go
@@ -55,32 +55,22 @@ const (
 	clusterInventoryTestEventuallyTick    = 20 * time.Millisecond
 )
 
-func writeProviderFile(t *testing.T, providers ...string) string {
+func writeProviderFile(t *testing.T) string {
 	t.Helper()
 
-	if len(providers) == 0 {
-		providers = []string{"static-token"}
-	}
-
-	providerJSON := ""
-
-	for i, provider := range providers {
-		if i > 0 {
-			providerJSON += ","
-		}
-
-		providerJSON += `{
-			"name": "` + provider + `",
+	providerJSON := `{
+		"providers": [{
+			"name": "static-token",
 			"execConfig": {
 				"apiVersion": "client.authentication.k8s.io/v1",
 				"command": "/bin/echo",
 				"provideClusterInfo": true
 			}
-		}`
-	}
+		}]
+	}`
 
 	path := filepath.Join(t.TempDir(), "providers.json")
-	err := os.WriteFile(path, []byte(`{"providers":[`+providerJSON+`]}`), 0o600)
+	err := os.WriteFile(path, []byte(providerJSON), 0o600)
 	require.NoError(t, err)
 
 	return path
@@ -153,6 +143,16 @@ func listErrorClient(err error) *ciafake.Clientset {
 	return client
 }
 
+func namespacedProfileClient() *ciafake.Clientset {
+	fromDefault := clusterProfile("from-default", "static-token", "https://default.example.com")
+	fromA := clusterProfile("from-a", "static-token", "https://a.example.com")
+	fromA.Namespace = "team-a"
+	fromB := clusterProfile("from-b", "static-token", "https://b.example.com")
+	fromB.Namespace = "team-b"
+
+	return ciafake.NewSimpleClientset(fromDefault, fromA, fromB)
+}
+
 func getProfileContext(store kubeconfig.ContextStore, profileKey string) (*kubeconfig.Context, error) {
 	return store.GetContext(contextNameFromProfileKey(profileKey))
 }
@@ -196,7 +196,17 @@ func waitForRootSync(t *testing.T, runner *Runner, rootID string) {
 		state := runner.roots[rootID]
 		runner.mu.Unlock()
 
-		return state != nil && state.informer.HasSynced()
+		if state == nil {
+			return false
+		}
+
+		for _, watch := range state.watches {
+			if !watch.informer.HasSynced() {
+				return false
+			}
+		}
+
+		return true
 	}, clusterInventoryTestEventuallyTimeout, clusterInventoryTestEventuallyTick)
 }
 
@@ -280,6 +290,66 @@ func TestNewRunnerValidatesProviderFile(t *testing.T) {
 		LabelSelector: "headlamp.dev/ignore in (",
 	})
 	require.ErrorContains(t, err, "invalid cluster-inventory-label-selector")
+
+	_, err = NewRunner(Options{
+		Store:        store,
+		ProviderFile: writeProviderFile(t),
+		Namespaces:   "team-a,Team B",
+	})
+	require.ErrorContains(t, err, "invalid cluster-inventory-namespaces")
+
+	_, err = NewRunner(Options{
+		Store:        store,
+		ProviderFile: writeProviderFile(t),
+		Namespaces:   "team-a,*",
+	})
+	require.ErrorContains(t, err, `"*" must be used on its own`)
+}
+
+func TestNormalizeNamespaces(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    []string
+		wantErr string
+	}{
+		{name: "unset", value: "  "},
+		{
+			name:  "trimmed, sorted and deduplicated",
+			value: " team-b,team-a, team-b ",
+			want:  []string{"team-a", "team-b"},
+		},
+		{name: "all namespaces", value: "*", want: []string{metav1.NamespaceAll}},
+		{
+			name:    "all namespaces cannot be combined with a listed namespace",
+			value:   "team-a,*",
+			wantErr: `"*" must be used on its own`,
+		},
+		{
+			name:    "empty entries are rejected",
+			value:   "team-a,,team-b",
+			wantErr: "namespace must not be empty",
+		},
+		{
+			name:    "invalid namespaces are rejected",
+			value:   "Team-A",
+			wantErr: "invalid cluster-inventory-namespaces",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeNamespaces(tt.value)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestRestConfigToContextPreservesConfig(t *testing.T) {
@@ -459,6 +529,64 @@ func TestInformerInitialSyncUsesAccessProviders(t *testing.T) {
 
 	requireProfileContextEventually(t, store, "in-cluster/default/spoke-a")
 	requireNoProfileContextEventually(t, store, "in-cluster/default/no-access")
+}
+
+func TestInformerWatchesNamespaces(t *testing.T) {
+	tests := []struct {
+		name         string
+		hubNamespace string
+		namespaces   string
+		want         []string
+		wantAbsent   []string
+	}{
+		{
+			name:         "defaults to the hub namespace",
+			hubNamespace: "team-a",
+			want:         []string{"in-cluster/team-a/from-a"},
+			wantAbsent:   []string{"in-cluster/default/from-default", "in-cluster/team-b/from-b"},
+		},
+		{
+			name:       "watches the configured namespaces",
+			namespaces: "team-a,team-b",
+			want:       []string{"in-cluster/team-a/from-a", "in-cluster/team-b/from-b"},
+			wantAbsent: []string{"in-cluster/default/from-default"},
+		},
+		{
+			name:       "watches all namespaces",
+			namespaces: "*",
+			want: []string{
+				"in-cluster/default/from-default",
+				"in-cluster/team-a/from-a",
+				"in-cluster/team-b/from-b",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := kubeconfig.NewContextStore()
+			runner := newTestRunner(t, Options{
+				Store:        store,
+				HubConfig:    &rest.Config{Host: "https://hub.example.com"},
+				HubNamespace: tt.hubNamespace,
+				Namespaces:   tt.namespaces,
+			})
+			runner.clientForConfig = func(*rest.Config) (ciaclient.Interface, error) {
+				return namespacedProfileClient(), nil
+			}
+
+			ctx := testRunnerContext(t, runner)
+			reconcileAndWaitForRoot(t, ctx, runner, inClusterRootID)
+
+			for _, profileKey := range tt.want {
+				requireProfileContextEventually(t, store, profileKey)
+			}
+
+			for _, profileKey := range tt.wantAbsent {
+				requireNoProfileContextEventually(t, store, profileKey)
+			}
+		})
+	}
 }
 
 func TestInformerInitialSyncIgnoresLabelSelectedProfiles(t *testing.T) {
@@ -771,7 +899,38 @@ func TestStoreSeedConfigChangeRestartsWatcher(t *testing.T) {
 	requireProfileContextEventually(t, store, "store/seed-a/default/from-b")
 }
 
-func TestRestConfigFingerprintIncludesExecConfig(t *testing.T) {
+func TestStoreSeedNamespaceChangeRestartsWatcher(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+	seed := testStoreContext("seed-a", kubeconfig.KubeConfig, "https://seed.example.com", "token", false)
+	seed.KubeContext.Namespace = "team-a"
+	require.NoError(t, store.AddContext(seed))
+
+	runner := newTestRunner(t, Options{
+		Store:             store,
+		DiscoverFromStore: true,
+	})
+
+	client := namespacedProfileClient()
+	runner.clientForConfig = func(*rest.Config) (ciaclient.Interface, error) {
+		return client, nil
+	}
+
+	ctx := testRunnerContext(t, runner)
+	reconcileAndWaitForRoot(t, ctx, runner, "store/seed-a")
+	requireProfileContextEventually(t, store, "store/seed-a/team-a/from-a")
+	requireNoProfileContextEventually(t, store, "store/seed-a/team-b/from-b")
+
+	seed = testStoreContext("seed-a", kubeconfig.KubeConfig, "https://seed.example.com", "token", false)
+	seed.KubeContext.Namespace = "team-b"
+	require.NoError(t, store.AddContext(seed))
+
+	reconcileAndWaitForRoot(t, ctx, runner, "store/seed-a")
+
+	requireNoProfileContextEventually(t, store, "store/seed-a/team-a/from-a")
+	requireProfileContextEventually(t, store, "store/seed-a/team-b/from-b")
+}
+
+func TestRootFingerprintIncludesExecConfig(t *testing.T) {
 	execConfig := func(raw string) *clientcmdapi.ExecConfig {
 		return &clientcmdapi.ExecConfig{
 			APIVersion: "client.authentication.k8s.io/v1",
@@ -793,8 +952,20 @@ func TestRestConfigFingerprintIncludesExecConfig(t *testing.T) {
 		ExecProvider: execConfig(`{"audience":"b"}`),
 	}
 
-	assert.Equal(t, restConfigFingerprint(configA), restConfigFingerprint(configAAgain))
-	assert.NotEqual(t, restConfigFingerprint(configA), restConfigFingerprint(configB))
+	fingerprint := func(config *rest.Config) string {
+		return rootFingerprint(rootConfig{restConfig: config})
+	}
+
+	assert.Equal(t, fingerprint(configA), fingerprint(configAAgain))
+	assert.NotEqual(t, fingerprint(configA), fingerprint(configB))
+}
+
+func TestRootFingerprintIncludesNamespaces(t *testing.T) {
+	config := &rest.Config{Host: "https://seed.example.com"}
+
+	assert.NotEqual(t,
+		rootFingerprint(rootConfig{restConfig: config, namespaces: []string{"team-a"}}),
+		rootFingerprint(rootConfig{restConfig: config, namespaces: []string{"team-b"}}))
 }
 
 func TestSelfReferencingProfileDoesNotTriggerChildWatcher(t *testing.T) {

--- a/backend/pkg/clusterinventory/clusterinventory_test.go
+++ b/backend/pkg/clusterinventory/clusterinventory_test.go
@@ -55,32 +55,22 @@ const (
 	clusterInventoryTestEventuallyTick    = 20 * time.Millisecond
 )
 
-func writeProviderFile(t *testing.T, providers ...string) string {
+func writeProviderFile(t *testing.T) string {
 	t.Helper()
 
-	if len(providers) == 0 {
-		providers = []string{"static-token"}
-	}
-
-	providerJSON := ""
-
-	for i, provider := range providers {
-		if i > 0 {
-			providerJSON += ","
-		}
-
-		providerJSON += `{
-			"name": "` + provider + `",
+	providerJSON := `{
+		"providers": [{
+			"name": "static-token",
 			"execConfig": {
 				"apiVersion": "client.authentication.k8s.io/v1",
 				"command": "/bin/echo",
 				"provideClusterInfo": true
 			}
-		}`
-	}
+		}]
+	}`
 
 	path := filepath.Join(t.TempDir(), "providers.json")
-	err := os.WriteFile(path, []byte(`{"providers":[`+providerJSON+`]}`), 0o600)
+	err := os.WriteFile(path, []byte(providerJSON), 0o600)
 	require.NoError(t, err)
 
 	return path
@@ -153,6 +143,16 @@ func listErrorClient(err error) *ciafake.Clientset {
 	return client
 }
 
+func namespacedProfileClient() *ciafake.Clientset {
+	fromDefault := clusterProfile("from-default", "static-token", "https://default.example.com")
+	fromA := clusterProfile("from-a", "static-token", "https://a.example.com")
+	fromA.Namespace = "team-a"
+	fromB := clusterProfile("from-b", "static-token", "https://b.example.com")
+	fromB.Namespace = "team-b"
+
+	return ciafake.NewSimpleClientset(fromDefault, fromA, fromB)
+}
+
 func getProfileContext(store kubeconfig.ContextStore, profileKey string) (*kubeconfig.Context, error) {
 	return store.GetContext(contextNameFromProfileKey(profileKey))
 }
@@ -196,7 +196,17 @@ func waitForRootSync(t *testing.T, runner *Runner, rootID string) {
 		state := runner.roots[rootID]
 		runner.mu.Unlock()
 
-		return state != nil && state.informer.HasSynced()
+		if state == nil {
+			return false
+		}
+
+		for _, watch := range state.watches {
+			if !watch.informer.HasSynced() {
+				return false
+			}
+		}
+
+		return true
 	}, clusterInventoryTestEventuallyTimeout, clusterInventoryTestEventuallyTick)
 }
 
@@ -280,6 +290,71 @@ func TestNewRunnerValidatesProviderFile(t *testing.T) {
 		LabelSelector: "headlamp.dev/ignore in (",
 	})
 	require.ErrorContains(t, err, "invalid cluster-inventory-label-selector")
+
+	_, err = NewRunner(Options{
+		Store:        store,
+		ProviderFile: writeProviderFile(t),
+		Namespaces:   "team-a,Team B",
+	})
+	require.ErrorContains(t, err, "invalid cluster-inventory-namespaces")
+
+	_, err = NewRunner(Options{
+		Store:        store,
+		ProviderFile: writeProviderFile(t),
+		Namespaces:   "team-a,*",
+	})
+	require.ErrorContains(t, err, `"*" must be used on its own`)
+}
+
+func TestNormalizeNamespaces(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    []string
+		wantErr string
+	}{
+		{name: "unset", value: "  "},
+		{
+			name:  "trimmed, sorted and deduplicated",
+			value: " team-b,team-a, team-b ",
+			want:  []string{"team-a", "team-b"},
+		},
+		{name: "all namespaces", value: "*", want: []string{metav1.NamespaceAll}},
+		{
+			name:    "repeated all namespaces are rejected",
+			value:   "*,*",
+			wantErr: `"*" must be used on its own`,
+		},
+		{
+			name:    "all namespaces cannot be combined with a listed namespace",
+			value:   "team-a,*",
+			wantErr: `"*" must be used on its own`,
+		},
+		{
+			name:    "empty entries are rejected",
+			value:   "team-a,,team-b",
+			wantErr: "namespace must not be empty",
+		},
+		{
+			name:    "invalid namespaces are rejected",
+			value:   "Team-A",
+			wantErr: "invalid cluster-inventory-namespaces",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeNamespaces(tt.value)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestRestConfigToContextPreservesConfig(t *testing.T) {
@@ -388,7 +463,7 @@ func TestClusterProfileDeletePrunesContextOutsideRunnerLock(t *testing.T) {
 
 	runner.mu.Lock()
 	runner.roots[state.rootID] = state
-	runner.profileKeysByRoot[state.rootID] = map[string]struct{}{profileKey: {}}
+	runner.profileKeysByRoot[state.rootID] = map[string]string{profileKey: "default"}
 	runner.profiles[profileKey] = profileState{contextName: contextName}
 	runner.mu.Unlock()
 
@@ -459,6 +534,64 @@ func TestInformerInitialSyncUsesAccessProviders(t *testing.T) {
 
 	requireProfileContextEventually(t, store, "in-cluster/default/spoke-a")
 	requireNoProfileContextEventually(t, store, "in-cluster/default/no-access")
+}
+
+func TestInformerWatchesNamespaces(t *testing.T) {
+	tests := []struct {
+		name         string
+		hubNamespace string
+		namespaces   string
+		want         []string
+		wantAbsent   []string
+	}{
+		{
+			name:         "defaults to the hub namespace",
+			hubNamespace: "team-a",
+			want:         []string{"in-cluster/team-a/from-a"},
+			wantAbsent:   []string{"in-cluster/default/from-default", "in-cluster/team-b/from-b"},
+		},
+		{
+			name:       "watches the configured namespaces",
+			namespaces: "team-a,team-b",
+			want:       []string{"in-cluster/team-a/from-a", "in-cluster/team-b/from-b"},
+			wantAbsent: []string{"in-cluster/default/from-default"},
+		},
+		{
+			name:       "watches all namespaces",
+			namespaces: "*",
+			want: []string{
+				"in-cluster/default/from-default",
+				"in-cluster/team-a/from-a",
+				"in-cluster/team-b/from-b",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := kubeconfig.NewContextStore()
+			runner := newTestRunner(t, Options{
+				Store:        store,
+				HubConfig:    &rest.Config{Host: "https://hub.example.com"},
+				HubNamespace: tt.hubNamespace,
+				Namespaces:   tt.namespaces,
+			})
+			runner.clientForConfig = func(*rest.Config) (ciaclient.Interface, error) {
+				return namespacedProfileClient(), nil
+			}
+
+			ctx := testRunnerContext(t, runner)
+			reconcileAndWaitForRoot(t, ctx, runner, inClusterRootID)
+
+			for _, profileKey := range tt.want {
+				requireProfileContextEventually(t, store, profileKey)
+			}
+
+			for _, profileKey := range tt.wantAbsent {
+				requireNoProfileContextEventually(t, store, profileKey)
+			}
+		})
+	}
 }
 
 func TestInformerInitialSyncIgnoresLabelSelectedProfiles(t *testing.T) {
@@ -535,6 +668,61 @@ func TestInitialSyncFailureDoesNotPrunePreviousContexts(t *testing.T) {
 	runner.reconcileRoots(ctx)
 
 	requireProfileContextEventually(t, store, "in-cluster/default/spoke-a")
+}
+
+func TestNamespaceSyncFailureOnlyPreservesFailedNamespace(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+	runner := newTestRunner(t, Options{
+		Store:      store,
+		HubConfig:  &rest.Config{Host: "https://hub.example.com"},
+		Namespaces: "team-a,team-b",
+	})
+
+	runner.clientForConfig = func(config *rest.Config) (ciaclient.Interface, error) {
+		if config.Host != "https://partial-outage.example.com" {
+			return namespacedProfileClient(), nil
+		}
+
+		client := ciafake.NewSimpleClientset()
+		client.PrependReactor("list", "clusterprofiles", func(action k8stesting.Action) (bool, k8sruntime.Object, error) {
+			if action.GetNamespace() == "team-b" {
+				return true, nil, errors.New("team-b is unavailable")
+			}
+
+			return false, nil, nil
+		})
+
+		return client, nil
+	}
+
+	ctx := testRunnerContext(t, runner)
+	reconcileAndWaitForRoot(t, ctx, runner, inClusterRootID)
+	requireProfileContextEventually(t, store, "in-cluster/team-a/from-a")
+	requireProfileContextEventually(t, store, "in-cluster/team-b/from-b")
+
+	runner.hubConfig = &rest.Config{Host: "https://partial-outage.example.com"}
+	runner.reconcileRoots(ctx)
+
+	require.Eventually(t, func() bool {
+		runner.mu.Lock()
+		defer runner.mu.Unlock()
+
+		state := runner.roots[inClusterRootID]
+		if state == nil || state.serverURL != "https://partial-outage.example.com" {
+			return false
+		}
+
+		for _, watch := range state.watches {
+			if watch.namespace == "team-a" {
+				return watch.informer.HasSynced()
+			}
+		}
+
+		return false
+	}, clusterInventoryTestEventuallyTimeout, clusterInventoryTestEventuallyTick)
+
+	requireNoProfileContextEventually(t, store, "in-cluster/team-a/from-a")
+	requireProfileContextEventually(t, store, "in-cluster/team-b/from-b")
 }
 
 func TestProviderFailureDoesNotPrunePreviousContext(t *testing.T) {
@@ -771,7 +959,38 @@ func TestStoreSeedConfigChangeRestartsWatcher(t *testing.T) {
 	requireProfileContextEventually(t, store, "store/seed-a/default/from-b")
 }
 
-func TestRestConfigFingerprintIncludesExecConfig(t *testing.T) {
+func TestStoreSeedNamespaceChangeRestartsWatcher(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+	seed := testStoreContext("seed-a", kubeconfig.KubeConfig, "https://seed.example.com", "token", false)
+	seed.KubeContext.Namespace = "team-a"
+	require.NoError(t, store.AddContext(seed))
+
+	runner := newTestRunner(t, Options{
+		Store:             store,
+		DiscoverFromStore: true,
+	})
+
+	client := namespacedProfileClient()
+	runner.clientForConfig = func(*rest.Config) (ciaclient.Interface, error) {
+		return client, nil
+	}
+
+	ctx := testRunnerContext(t, runner)
+	reconcileAndWaitForRoot(t, ctx, runner, "store/seed-a")
+	requireProfileContextEventually(t, store, "store/seed-a/team-a/from-a")
+	requireNoProfileContextEventually(t, store, "store/seed-a/team-b/from-b")
+
+	seed = testStoreContext("seed-a", kubeconfig.KubeConfig, "https://seed.example.com", "token", false)
+	seed.KubeContext.Namespace = "team-b"
+	require.NoError(t, store.AddContext(seed))
+
+	reconcileAndWaitForRoot(t, ctx, runner, "store/seed-a")
+
+	requireNoProfileContextEventually(t, store, "store/seed-a/team-a/from-a")
+	requireProfileContextEventually(t, store, "store/seed-a/team-b/from-b")
+}
+
+func TestRootFingerprintIncludesExecConfig(t *testing.T) {
 	execConfig := func(raw string) *clientcmdapi.ExecConfig {
 		return &clientcmdapi.ExecConfig{
 			APIVersion: "client.authentication.k8s.io/v1",
@@ -793,8 +1012,20 @@ func TestRestConfigFingerprintIncludesExecConfig(t *testing.T) {
 		ExecProvider: execConfig(`{"audience":"b"}`),
 	}
 
-	assert.Equal(t, restConfigFingerprint(configA), restConfigFingerprint(configAAgain))
-	assert.NotEqual(t, restConfigFingerprint(configA), restConfigFingerprint(configB))
+	fingerprint := func(config *rest.Config) string {
+		return rootFingerprint(rootConfig{restConfig: config})
+	}
+
+	assert.Equal(t, fingerprint(configA), fingerprint(configAAgain))
+	assert.NotEqual(t, fingerprint(configA), fingerprint(configB))
+}
+
+func TestRootFingerprintIncludesNamespaces(t *testing.T) {
+	config := &rest.Config{Host: "https://seed.example.com"}
+
+	assert.NotEqual(t,
+		rootFingerprint(rootConfig{restConfig: config, namespaces: []string{"team-a"}}),
+		rootFingerprint(rootConfig{restConfig: config, namespaces: []string{"team-b"}}))
 }
 
 func TestSelfReferencingProfileDoesNotTriggerChildWatcher(t *testing.T) {

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -68,6 +68,7 @@ type Config struct {
 
 	ClusterInventoryProviderFile          string        `koanf:"cluster-inventory-provider-file"`
 	ClusterInventoryLabelSelector         string        `koanf:"cluster-inventory-label-selector"`
+	ClusterInventoryNamespaces            string        `koanf:"cluster-inventory-namespaces"`
 	ClusterInventoryRootReconcileInterval time.Duration `koanf:"cluster-inventory-root-reconcile-interval"`
 	ClusterInventoryNoCRDCacheTTL         time.Duration `koanf:"cluster-inventory-no-crd-cache-ttl"`
 
@@ -578,6 +579,8 @@ func addGeneralFlags(f *flag.FlagSet) {
 		"Path to the JSON configuration file for experimental/alpha Cluster Inventory access providers")
 	f.String("cluster-inventory-label-selector", "",
 		"Label selector used to filter ClusterProfile resources for experimental/alpha Cluster Inventory")
+	f.String("cluster-inventory-namespaces", "",
+		"Comma-separated namespaces watched for experimental/alpha ClusterProfile resources; \"*\" watches all")
 	f.Duration("cluster-inventory-root-reconcile-interval", clusterinventory.DefaultRootReconcileInterval,
 		"Interval for reconciling experimental/alpha Cluster Inventory roots")
 	f.Duration("cluster-inventory-no-crd-cache-ttl", clusterinventory.DefaultNoCRDCacheTTL,

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -69,6 +69,7 @@ type Config struct {
 
 	ClusterInventoryProviderFile          string        `koanf:"cluster-inventory-provider-file"`
 	ClusterInventoryLabelSelector         string        `koanf:"cluster-inventory-label-selector"`
+	ClusterInventoryNamespaces            string        `koanf:"cluster-inventory-namespaces"`
 	ClusterInventoryRootReconcileInterval time.Duration `koanf:"cluster-inventory-root-reconcile-interval"`
 	ClusterInventoryNoCRDCacheTTL         time.Duration `koanf:"cluster-inventory-no-crd-cache-ttl"`
 
@@ -232,6 +233,10 @@ func (c *Config) validateClusterInventory() error {
 	}
 
 	c.ClusterInventoryLabelSelector = labelSelector
+
+	if err := clusterinventory.ValidateNamespaces(c.ClusterInventoryNamespaces); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -605,6 +610,8 @@ func addGeneralFlags(f *flag.FlagSet) {
 		"Path to the JSON configuration file for experimental/alpha Cluster Inventory access providers")
 	f.String("cluster-inventory-label-selector", "",
 		"Label selector used to filter ClusterProfile resources for experimental/alpha Cluster Inventory")
+	f.String("cluster-inventory-namespaces", "",
+		"Comma-separated namespaces watched for experimental/alpha ClusterProfile resources; \"*\" watches all")
 	f.Duration("cluster-inventory-root-reconcile-interval", clusterinventory.DefaultRootReconcileInterval,
 		"Interval for reconciling experimental/alpha Cluster Inventory roots")
 	f.Duration("cluster-inventory-no-crd-cache-ttl", clusterinventory.DefaultNoCRDCacheTTL,

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -19,6 +19,7 @@ func TestMain(m *testing.M) {
 		"HEADLAMP_CONFIG_ENABLE_CLUSTER_INVENTORY",
 		"HEADLAMP_CONFIG_CLUSTER_INVENTORY_PROVIDER_FILE",
 		"HEADLAMP_CONFIG_CLUSTER_INVENTORY_LABEL_SELECTOR",
+		"HEADLAMP_CONFIG_CLUSTER_INVENTORY_NAMESPACES",
 		"HEADLAMP_CONFIG_CLUSTER_INVENTORY_ROOT_RECONCILE_INTERVAL",
 		"HEADLAMP_CONFIG_CLUSTER_INVENTORY_NO_CRD_CACHE_TTL",
 	}
@@ -488,6 +489,7 @@ func TestParseClusterInventoryFlags(t *testing.T) {
 		"--enable-cluster-inventory",
 		"--cluster-inventory-provider-file=" + providerFile,
 		"--cluster-inventory-label-selector=environment=prod,!headlamp.dev/ignore",
+		"--cluster-inventory-namespaces=team-a,team-b",
 		"--cluster-inventory-root-reconcile-interval=15s",
 		"--cluster-inventory-no-crd-cache-ttl=1m",
 	})
@@ -496,6 +498,7 @@ func TestParseClusterInventoryFlags(t *testing.T) {
 	assert.True(t, conf.EnableClusterInventory)
 	assert.Equal(t, providerFile, conf.ClusterInventoryProviderFile)
 	assert.Equal(t, "environment=prod,!headlamp.dev/ignore", conf.ClusterInventoryLabelSelector)
+	assert.Equal(t, "team-a,team-b", conf.ClusterInventoryNamespaces)
 	assert.Equal(t, 15*time.Second, conf.ClusterInventoryRootReconcileInterval)
 	assert.Equal(t, time.Minute, conf.ClusterInventoryNoCRDCacheTTL)
 }
@@ -505,6 +508,7 @@ func TestParseClusterInventoryEnv(t *testing.T) {
 	t.Setenv("HEADLAMP_CONFIG_ENABLE_CLUSTER_INVENTORY", "true")
 	t.Setenv("HEADLAMP_CONFIG_CLUSTER_INVENTORY_PROVIDER_FILE", providerFile)
 	t.Setenv("HEADLAMP_CONFIG_CLUSTER_INVENTORY_LABEL_SELECTOR", "!headlamp.dev/ignore")
+	t.Setenv("HEADLAMP_CONFIG_CLUSTER_INVENTORY_NAMESPACES", "*")
 
 	conf, err := config.Parse([]string{"go run ./cmd"})
 	require.NoError(t, err)
@@ -512,6 +516,7 @@ func TestParseClusterInventoryEnv(t *testing.T) {
 	assert.True(t, conf.EnableClusterInventory)
 	assert.Equal(t, providerFile, conf.ClusterInventoryProviderFile)
 	assert.Equal(t, "!headlamp.dev/ignore", conf.ClusterInventoryLabelSelector)
+	assert.Equal(t, "*", conf.ClusterInventoryNamespaces)
 }
 
 func TestParseClusterInventoryDefaultIntervals(t *testing.T) {
@@ -527,6 +532,7 @@ func TestParseClusterInventoryDefaultIntervals(t *testing.T) {
 	assert.Equal(t, clusterinventory.DefaultRootReconcileInterval, conf.ClusterInventoryRootReconcileInterval)
 	assert.Equal(t, clusterinventory.DefaultNoCRDCacheTTL, conf.ClusterInventoryNoCRDCacheTTL)
 	assert.Empty(t, conf.ClusterInventoryLabelSelector)
+	assert.Empty(t, conf.ClusterInventoryNamespaces)
 }
 
 func TestClusterInventoryValidation(t *testing.T) {

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -19,6 +19,7 @@ func TestMain(m *testing.M) {
 		"HEADLAMP_CONFIG_ENABLE_CLUSTER_INVENTORY",
 		"HEADLAMP_CONFIG_CLUSTER_INVENTORY_PROVIDER_FILE",
 		"HEADLAMP_CONFIG_CLUSTER_INVENTORY_LABEL_SELECTOR",
+		"HEADLAMP_CONFIG_CLUSTER_INVENTORY_NAMESPACES",
 		"HEADLAMP_CONFIG_CLUSTER_INVENTORY_ROOT_RECONCILE_INTERVAL",
 		"HEADLAMP_CONFIG_CLUSTER_INVENTORY_NO_CRD_CACHE_TTL",
 	}
@@ -501,6 +502,7 @@ func TestParseClusterInventoryFlags(t *testing.T) {
 		"--enable-cluster-inventory",
 		"--cluster-inventory-provider-file=" + providerFile,
 		"--cluster-inventory-label-selector=environment=prod,!headlamp.dev/ignore",
+		"--cluster-inventory-namespaces=team-a,team-b",
 		"--cluster-inventory-root-reconcile-interval=15s",
 		"--cluster-inventory-no-crd-cache-ttl=1m",
 	})
@@ -509,6 +511,7 @@ func TestParseClusterInventoryFlags(t *testing.T) {
 	assert.True(t, conf.EnableClusterInventory)
 	assert.Equal(t, providerFile, conf.ClusterInventoryProviderFile)
 	assert.Equal(t, "environment=prod,!headlamp.dev/ignore", conf.ClusterInventoryLabelSelector)
+	assert.Equal(t, "team-a,team-b", conf.ClusterInventoryNamespaces)
 	assert.Equal(t, 15*time.Second, conf.ClusterInventoryRootReconcileInterval)
 	assert.Equal(t, time.Minute, conf.ClusterInventoryNoCRDCacheTTL)
 }
@@ -518,6 +521,7 @@ func TestParseClusterInventoryEnv(t *testing.T) {
 	t.Setenv("HEADLAMP_CONFIG_ENABLE_CLUSTER_INVENTORY", "true")
 	t.Setenv("HEADLAMP_CONFIG_CLUSTER_INVENTORY_PROVIDER_FILE", providerFile)
 	t.Setenv("HEADLAMP_CONFIG_CLUSTER_INVENTORY_LABEL_SELECTOR", "!headlamp.dev/ignore")
+	t.Setenv("HEADLAMP_CONFIG_CLUSTER_INVENTORY_NAMESPACES", "*")
 
 	conf, err := config.Parse([]string{"go run ./cmd"})
 	require.NoError(t, err)
@@ -525,6 +529,7 @@ func TestParseClusterInventoryEnv(t *testing.T) {
 	assert.True(t, conf.EnableClusterInventory)
 	assert.Equal(t, providerFile, conf.ClusterInventoryProviderFile)
 	assert.Equal(t, "!headlamp.dev/ignore", conf.ClusterInventoryLabelSelector)
+	assert.Equal(t, "*", conf.ClusterInventoryNamespaces)
 }
 
 func TestParseClusterInventoryDefaultIntervals(t *testing.T) {
@@ -540,6 +545,7 @@ func TestParseClusterInventoryDefaultIntervals(t *testing.T) {
 	assert.Equal(t, clusterinventory.DefaultRootReconcileInterval, conf.ClusterInventoryRootReconcileInterval)
 	assert.Equal(t, clusterinventory.DefaultNoCRDCacheTTL, conf.ClusterInventoryNoCRDCacheTTL)
 	assert.Empty(t, conf.ClusterInventoryLabelSelector)
+	assert.Empty(t, conf.ClusterInventoryNamespaces)
 }
 
 func TestClusterInventoryValidation(t *testing.T) {
@@ -592,6 +598,32 @@ func TestClusterInventoryValidation(t *testing.T) {
 		require.Nil(t, conf)
 		assert.Contains(t, err.Error(), "invalid cluster-inventory-provider-file")
 	})
+}
+
+func TestClusterInventoryRejectsInvalidNamespaces(t *testing.T) {
+	invalidNamespaces := []struct {
+		name       string
+		namespaces string
+	}{
+		{name: "invalid DNS label", namespaces: "Team_A"},
+		{name: "empty list entry", namespaces: "team-a,,team-b"},
+		{name: "repeated wildcard", namespaces: "*,*"},
+	}
+
+	for _, tt := range invalidNamespaces {
+		t.Run("enabled rejects "+tt.name, func(t *testing.T) {
+			providerFile := writeClusterInventoryProviderFile(t)
+			conf, err := config.Parse([]string{
+				"go run ./cmd",
+				"--enable-cluster-inventory",
+				"--cluster-inventory-provider-file=" + providerFile,
+				"--cluster-inventory-namespaces=" + tt.namespaces,
+			})
+			require.Error(t, err)
+			require.Nil(t, conf)
+			assert.Contains(t, err.Error(), "invalid cluster-inventory-namespaces")
+		})
+	}
 }
 
 func TestClusterInventoryRejectsInvalidLabelSelector(t *testing.T) {

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -86,6 +86,7 @@ type HeadlampCFG struct {
 	EnableClusterInventory                bool
 	ClusterInventoryProviderFile          string
 	ClusterInventoryLabelSelector         string
+	ClusterInventoryNamespaces            string
 	ClusterInventoryRootReconcileInterval time.Duration
 	ClusterInventoryNoCRDCacheTTL         time.Duration
 }

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -87,6 +87,7 @@ type HeadlampCFG struct {
 	EnableClusterInventory                bool
 	ClusterInventoryProviderFile          string
 	ClusterInventoryLabelSelector         string
+	ClusterInventoryNamespaces            string
 	ClusterInventoryRootReconcileInterval time.Duration
 	ClusterInventoryNoCRDCacheTTL         time.Duration
 }

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -142,6 +142,7 @@ config:
 | config.clusterInventory.accessProvidersConfig | object | `{}` | Experimental/alpha Cluster Inventory access providers config. Required when Cluster Inventory is enabled |
 | config.clusterInventory.plugins | list | `[]` | Kubernetes image volumes that provide experimental/alpha Cluster Inventory access provider binaries |
 | config.clusterInventory.labelSelector | string | `"!headlamp.dev/ignore"` | Kubernetes label selector used to filter experimental/alpha ClusterProfile resources |
+| config.clusterInventory.namespaces | list | `[]` | Namespaces watched for experimental/alpha ClusterProfile resources. Empty uses the Headlamp pod namespace for in-cluster roots and the kubeconfig context namespace for kubeconfig roots; `["*"]` watches all and requires equivalent cluster-wide RBAC permissions |
 | config.clusterInventory.rootReconcileInterval | string | `""` | Override the experimental/alpha Cluster Inventory root reconcile interval. Empty uses the Headlamp default |
 | config.clusterInventory.noCRDCacheTTL | string | `""` | Override the experimental/alpha Cluster Inventory no-CRD cache TTL. Empty uses the Headlamp default |
 | config.extraArgs   | array  | `[]`                  | Additional arguments for Headlamp server                                  |

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -303,6 +303,9 @@ spec:
             {{- with $clusterInventory.labelSelector }}
             - "-cluster-inventory-label-selector={{ . }}"
             {{- end }}
+            {{- with $clusterInventory.namespaces }}
+            - "-cluster-inventory-namespaces={{ join "," . }}"
+            {{- end }}
             {{- with $clusterInventory.rootReconcileInterval }}
             - "-cluster-inventory-root-reconcile-interval={{ . }}"
             {{- end }}

--- a/charts/headlamp/tests/expected_templates/cluster-inventory.yaml
+++ b/charts/headlamp/tests/expected_templates/cluster-inventory.yaml
@@ -131,6 +131,7 @@ spec:
             - "-enable-cluster-inventory"
             - "-cluster-inventory-provider-file=/etc/cluster-inventory/config.json"
             - "-cluster-inventory-label-selector=!headlamp.dev/ignore"
+            - "-cluster-inventory-namespaces=inventory-e2e,shared-inventory"
             - "-cluster-inventory-root-reconcile-interval=10s"
             - "-cluster-inventory-no-crd-cache-ttl=30s"
             # Check if externalSecret is disabled

--- a/charts/headlamp/tests/failing_test_cases/cluster-inventory-namespaces-invalid.yaml
+++ b/charts/headlamp/tests/failing_test_cases/cluster-inventory-namespaces-invalid.yaml
@@ -5,7 +5,4 @@ config:
       providers:
         - name: static-provider
     namespaces:
-      - inventory-e2e
-      - shared-inventory
-    rootReconcileInterval: 10s
-    noCRDCacheTTL: 30s
+      - Team-A

--- a/charts/headlamp/tests/failing_test_cases/cluster-inventory-namespaces-wildcard-mixed.yaml
+++ b/charts/headlamp/tests/failing_test_cases/cluster-inventory-namespaces-wildcard-mixed.yaml
@@ -5,7 +5,5 @@ config:
       providers:
         - name: static-provider
     namespaces:
+      - "*"
       - inventory-e2e
-      - shared-inventory
-    rootReconcileInterval: 10s
-    noCRDCacheTTL: 30s

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -328,6 +328,27 @@
               "description": "Kubernetes label selector used to filter experimental/alpha ClusterProfile resources",
               "default": "!headlamp.dev/ignore"
             },
+            "namespaces": {
+              "type": "array",
+              "description": "Namespaces watched for experimental/alpha ClusterProfile resources. Empty uses the Headlamp pod namespace for in-cluster roots and the kubeconfig context namespace for kubeconfig roots; [\"*\"] watches all and requires equivalent cluster-wide RBAC permissions",
+              "uniqueItems": true,
+              "default": [],
+              "anyOf": [
+                {
+                  "description": "\"*\" must be used on its own",
+                  "items": { "enum": ["*"] },
+                  "maxItems": 1
+                },
+                {
+                  "items": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 63,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                  }
+                }
+              ]
+            },
             "rootReconcileInterval": {
               "type": "string",
               "description": "Override the experimental/alpha Cluster Inventory root reconcile interval. Empty uses the Headlamp default",

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -170,6 +170,8 @@ config:
     #     mountPath: /access-plugins/kubeconfig-secretreader
     # -- Kubernetes label selector used to filter experimental/alpha ClusterProfile resources.
     labelSelector: "!headlamp.dev/ignore"
+    # -- Namespaces watched for experimental/alpha ClusterProfile resources. Empty uses the Headlamp pod namespace for in-cluster roots and the kubeconfig context namespace for kubeconfig roots; ["*"] watches all and requires equivalent cluster-wide RBAC permissions.
+    namespaces: []
     # -- Override the experimental/alpha Cluster Inventory root reconcile interval. Empty uses the Headlamp default.
     rootReconcileInterval: ""
     # -- Override the experimental/alpha Cluster Inventory no-CRD cache TTL. Empty uses the Headlamp default.

--- a/docs/development/cluster-inventory.md
+++ b/docs/development/cluster-inventory.md
@@ -14,7 +14,7 @@ Headlamp integration uses the `v0.1.x` API, so fields and behavior may change.
 
 Headlamp can discover additional clusters from Cluster Inventory API
 `ClusterProfile` resources when started with Cluster Inventory enabled. The
-backend uses `sigs.k8s.io/cluster-inventory-api v0.1.0`, the `pkg/access`
+backend uses `sigs.k8s.io/cluster-inventory-api v0.1.3`, the `pkg/access`
 provider configuration package, and `ClusterProfile.status.accessProviders`.
 
 The provider configuration file is not a `ClusterProfile` status object. It uses
@@ -63,16 +63,16 @@ In another terminal:
 npm run frontend:start
 ```
 
-Install the `v0.1.0` CRD on clusters that publish inventory:
+Install the `v0.1.3` CRD on clusters that publish inventory:
 
 ```bash
 kubectl --context kind-ci-hub apply -f \
-  https://raw.githubusercontent.com/kubernetes-sigs/cluster-inventory-api/v0.1.0/config/crd/bases/multicluster.x-k8s.io_clusterprofiles.yaml
+  https://raw.githubusercontent.com/kubernetes-sigs/cluster-inventory-api/v0.1.3/config/crd/bases/multicluster.x-k8s.io_clusterprofiles.yaml
 ```
 
 Patch sample status with `status.accessProviders` and health conditions:
 
-`ClusterProfile.spec.clusterManager.name` is required by the v0.1.0 CRD, even
+`ClusterProfile.spec.clusterManager.name` is required by the v0.1.3 CRD, even
 when the access details are patched later through the status subresource. The
 CRD also requires `reason` on each condition, so include it even when adapting
 examples that omit the field.

--- a/docs/development/cluster-inventory.md
+++ b/docs/development/cluster-inventory.md
@@ -46,9 +46,16 @@ HEADLAMP_CONFIG_ENABLE_DYNAMIC_CLUSTERS=true \
   --enable-cluster-inventory \
   --cluster-inventory-provider-file "$WORK/provider-config.json" \
   --cluster-inventory-label-selector='!headlamp.dev/ignore' \
+  --cluster-inventory-namespaces=inventory-e2e \
   --cluster-inventory-root-reconcile-interval=10s \
   --cluster-inventory-no-crd-cache-ttl=30s
 ```
+
+Without `--cluster-inventory-namespaces`, each root is watched in its own
+default namespace: the pod namespace when running in-cluster, and the
+kubecontext namespace (or `default`) for roots seeded from the kubeconfig.
+Pass a comma-separated list to watch more than one namespace. Use `*` on its
+own to watch all namespaces.
 
 In another terminal:
 

--- a/docs/development/cluster-inventory.md
+++ b/docs/development/cluster-inventory.md
@@ -17,6 +17,18 @@ Headlamp can discover additional clusters from Cluster Inventory API
 backend uses `sigs.k8s.io/cluster-inventory-api v0.1.3`, the `pkg/access`
 provider configuration package, and `ClusterProfile.status.accessProviders`.
 
+For a local end-to-end environment, follow the setup in
+[`e2e-tests/README.md`](https://github.com/kubernetes-sigs/headlamp/blob/main/e2e-tests/README.md).
+It uses the regular E2E `test` and `test2` kind clusters and deploys Cluster
+Inventory into the same Headlamp instance as the multi-cluster tests.
+
+Explicit namespace lists, all-namespace discovery, label filtering, and
+kubeconfig context namespace changes are covered by the backend tests:
+
+```bash
+npm run backend:test
+```
+
 The provider configuration file is not a `ClusterProfile` status object. It uses
 the upstream access configuration shape with a top-level `providers` array:
 

--- a/docs/installation/in-cluster/index.md
+++ b/docs/installation/in-cluster/index.md
@@ -76,7 +76,25 @@ Cluster Inventory access provider. The `plugins` entries are Kubernetes `image`
 volumes that mount provider binaries into the Headlamp container, not Headlamp
 UI plugins. By default, Headlamp watches `ClusterProfile` resources that do not
 have the `headlamp.dev/ignore` label because the chart sets
-`config.clusterInventory.labelSelector` to `!headlamp.dev/ignore`.
+`config.clusterInventory.labelSelector` to `!headlamp.dev/ignore`. Discovery is
+scoped to the Headlamp pod's namespace. This follows the namespaced consumer
+model for ClusterProfile: give each consumer its own namespace and expose only
+the clusters that consumer needs.
+
+To watch specific namespaces, set:
+
+```yaml
+config:
+  clusterInventory:
+    namespaces:
+      - inventory-team-a
+      - inventory-team-b
+```
+
+Each selected namespace requires permission to get, list, and watch
+ClusterProfiles. Set `namespaces` to `["*"]` to watch all namespaces. `*`
+cannot be combined with named namespaces, and all-namespace discovery requires
+equivalent cluster-wide access.
 
 ## Using simple yaml
 

--- a/docs/installation/in-cluster/index.md
+++ b/docs/installation/in-cluster/index.md
@@ -76,7 +76,25 @@ Cluster Inventory access provider. The `plugins` entries are Kubernetes `image`
 volumes that mount provider binaries into the Headlamp container, not Headlamp
 UI plugins. By default, Headlamp watches `ClusterProfile` resources that do not
 have the `headlamp.dev/ignore` label because the chart sets
-`config.clusterInventory.labelSelector` to `!headlamp.dev/ignore`.
+`config.clusterInventory.labelSelector` to `!headlamp.dev/ignore`. Discovery is
+scoped to the Headlamp pod's namespace. This follows the namespaced consumer
+model for ClusterProfile: each Headlamp instance reads the profiles published
+for that consumer's namespace.
+
+To watch specific namespaces, set:
+
+```yaml
+config:
+  clusterInventory:
+    namespaces:
+      - inventory-team-a
+      - inventory-team-b
+```
+
+Each selected namespace requires permission to get, list, and watch
+ClusterProfiles. Set `namespaces` to `["*"]` to watch all namespaces. `*`
+cannot be combined with named namespaces, and all-namespace discovery requires
+equivalent cluster-wide access.
 
 ## Using simple yaml
 

--- a/e2e-tests/.gitignore
+++ b/e2e-tests/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+/.env
 /test-results/
 /playwright-report/
 /playwright/.cache/

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -14,69 +14,59 @@ which is the reference if anything here drifts.
 
 ## Setup
 
-Install the test dependencies:
+Run these commands from the repository root on Linux with Docker running and
+Node.js `>=22.0.0`, npm `>=11.0.0`, `curl`, `envsubst`, `grep`, `kind`, `kubectl`,
+`jq`, and `make` installed.
+
+Install the Playwright dependencies:
 
 ```bash
 cd e2e-tests
 npm ci
-npx playwright install
+npx playwright install --with-deps
+cd ..
 ```
 
-Create the two clusters and rename their contexts to what the specs expect:
+Set up the two clusters, Headlamp, and the Cluster Inventory fixture:
 
 ```bash
-kind create cluster --name test
-kubectl config rename-context kind-test test
-
-kind create cluster --name test2
-kubectl config rename-context kind-test2 test2
+./e2e-tests/scripts/setup-multicluster.sh
 ```
 
-Give each cluster a `headlamp-admin` service account with cluster-admin:
+The script writes the URL and credentials needed by Playwright to
+`e2e-tests/.env`. Load them and run the multi-cluster and Cluster Inventory
+specs:
 
 ```bash
-for ctx in test test2; do
-  kubectl --context="$ctx" -n kube-system create serviceaccount headlamp-admin
-  kubectl --context="$ctx" create clusterrolebinding headlamp-admin \
-    --serviceaccount=kube-system:headlamp-admin --clusterrole=cluster-admin
-done
+set -a
+source e2e-tests/.env
+set +a
+cd e2e-tests
+npx playwright test tests/multiCluster.spec.ts tests/clusterInventory.spec.ts
+cd ..
 ```
 
-Build the images and load them into the `test` cluster. The plugins image is
-used as an init container by the manifest below:
+The setup is idempotent. It creates `test` and `test2` when neither exists,
+reuses them when both exist, and fails without deleting anything when the
+environment is only partially present. Clusters created by a successful setup
+stay running for subsequent tests. The setup log reports whether it created or
+reused the clusters.
+
+If the setup reused the clusters, leave both clusters and contexts intact and
+remove only the generated environment file:
 
 ```bash
-# from the repository root
-DOCKER_IMAGE_VERSION=latest make image
-DOCKER_IMAGE_VERSION=latest DOCKER_PLUGINS_IMAGE_NAME=headlamp-plugins-test make build-plugins-container
-
-kind load docker-image ghcr.io/headlamp-k8s/headlamp:latest --name test
-kind load docker-image ghcr.io/headlamp-k8s/headlamp-plugins-test:latest --name test
+rm -f e2e-tests/.env
 ```
 
-Deploy Headlamp into the `test` cluster. The manifest is templated, so the
-cluster addresses and CA data have to be substituted in:
+If the setup created both clusters, remove that environment when finished:
 
 ```bash
-kubectl config use-context test
-export TEST_CA_DATA=$(kubectl config view --raw --minify -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
-export TEST_SERVER="https://$(kubectl get nodes -o=jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'):6443"
-
-kubectl config use-context test2
-export TEST2_CA_DATA=$(kubectl config view --raw --minify -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
-export TEST2_SERVER="https://$(kubectl get nodes -o=jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'):6443"
-
-kubectl config use-context test
-envsubst < e2e-tests/kubernetes-headlamp-ci.yaml | kubectl --context=test apply -f -
-kubectl wait deployment -n kube-system headlamp --for condition=Available=True --timeout=180s
-```
-
-Finally, export the URL and the tokens the specs read:
-
-```bash
-export HEADLAMP_TEST_URL="http://<address of the headlamp Service>"
-export HEADLAMP_TEST_TOKEN=$(kubectl --context=test  create token headlamp-admin --duration 24h -n kube-system)
-export HEADLAMP_TEST2_TOKEN=$(kubectl --context=test2 create token headlamp-admin --duration 24h -n kube-system)
+kind delete cluster --name test
+kind delete cluster --name test2
+kubectl config delete-context test 2>/dev/null || true
+kubectl config delete-context test2 2>/dev/null || true
+rm -f e2e-tests/.env
 ```
 
 CI reaches the Service on its NodePort, at
@@ -140,21 +130,14 @@ cd e2e-tests
 npx playwright test tests/incluster-api.spec.ts
 ```
 
-`tests/clusterInventory.spec.ts` requires Headlamp to be configured with a
-working cluster inventory source. It is skipped unless explicitly enabled and
-is not run in CI:
+### Cluster Inventory
 
-```bash
-export HEADLAMP_CLUSTER_INVENTORY_E2E=true
-
-# Optional. This defaults to "headlamp".
-export HEADLAMP_TEST_BACKEND_TOKEN=...
-
-cd e2e-tests
-npx playwright test tests/clusterInventory.spec.ts
-```
-
-IMPORTANT: Make sure that the following npx commands are run in the same terminal session as the environment variables were set.
+The Cluster Inventory E2E uses the same `test` and `test2` clusters and the same
+Headlamp Deployment as the regular multi-cluster tests. It installs the v0.1.3
+Cluster Inventory API CRD on `test`, publishes one `ClusterProfile` for
+`test2`, and verifies both discovery and proxy access to a running pod in
+`tests/clusterInventory.spec.ts`. The generated `.env` enables this spec; it is
+otherwise skipped unless `HEADLAMP_CLUSTER_INVENTORY_E2E=true`.
 
 ## Run all tests
 
@@ -201,6 +184,15 @@ npx playwright test -g "404 page is present" --headed
 - This will open a browser window that will show the test running in real-time, this can be ran as a substitute or in pair with the VS code extension.
 
 ## Optional configuration
+
+### System Chromium
+
+Playwright downloads a supported Chromium build by default. On an unsupported
+Linux distribution, use an existing Chromium executable instead:
+
+```bash
+export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH="$(command -v chromium)"
+```
 
 ### Headed vs Headless
 

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -14,69 +14,59 @@ which is the reference if anything here drifts.
 
 ## Setup
 
-Install the test dependencies:
+Run these commands from the repository root on Linux with Docker running and
+Node.js `>=22.0.0`, npm `>=11.0.0`, `curl`, `envsubst`, `grep`, `kind`, `kubectl`,
+`jq`, and `make` installed.
+
+Install the Playwright dependencies:
 
 ```bash
 cd e2e-tests
 npm ci
-npx playwright install
+npx playwright install --with-deps
+cd ..
 ```
 
-Create the two clusters and rename their contexts to what the specs expect:
+Set up the two clusters, Headlamp, and the Cluster Inventory fixture:
 
 ```bash
-kind create cluster --name test
-kubectl config rename-context kind-test test
-
-kind create cluster --name test2
-kubectl config rename-context kind-test2 test2
+./e2e-tests/scripts/setup-multicluster.sh
 ```
 
-Give each cluster a `headlamp-admin` service account with cluster-admin:
+The script writes the URL and credentials needed by Playwright to
+`e2e-tests/.env`. Load them and run the multi-cluster and Cluster Inventory
+specs:
 
 ```bash
-for ctx in test test2; do
-  kubectl --context="$ctx" -n kube-system create serviceaccount headlamp-admin
-  kubectl --context="$ctx" create clusterrolebinding headlamp-admin \
-    --serviceaccount=kube-system:headlamp-admin --clusterrole=cluster-admin
-done
+set -a
+source e2e-tests/.env
+set +a
+cd e2e-tests
+npx playwright test tests/multiCluster.spec.ts tests/clusterInventory.spec.ts
+cd ..
 ```
 
-Build the images and load them into the `test` cluster. The plugins image is
-used as an init container by the manifest below:
+The setup is idempotent. It creates `test` and `test2` when neither exists,
+reuses them when both exist, and fails without deleting anything when the
+environment is only partially present. Clusters created by a successful setup
+stay running for subsequent tests. The setup log reports whether it created or
+reused the clusters.
+
+If the setup reused the clusters, leave both clusters and contexts intact and
+remove only the generated environment file:
 
 ```bash
-# from the repository root
-DOCKER_IMAGE_VERSION=latest make image
-DOCKER_IMAGE_VERSION=latest DOCKER_PLUGINS_IMAGE_NAME=headlamp-plugins-test make build-plugins-container
-
-kind load docker-image ghcr.io/headlamp-k8s/headlamp:latest --name test
-kind load docker-image ghcr.io/headlamp-k8s/headlamp-plugins-test:latest --name test
+rm -f e2e-tests/.env
 ```
 
-Deploy Headlamp into the `test` cluster. The manifest is templated, so the
-cluster addresses and CA data have to be substituted in:
+If the setup created both clusters, remove that environment when finished:
 
 ```bash
-kubectl config use-context test
-export TEST_CA_DATA=$(kubectl config view --raw --minify -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
-export TEST_SERVER="https://$(kubectl get nodes -o=jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'):6443"
-
-kubectl config use-context test2
-export TEST2_CA_DATA=$(kubectl config view --raw --minify -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
-export TEST2_SERVER="https://$(kubectl get nodes -o=jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'):6443"
-
-kubectl config use-context test
-envsubst < e2e-tests/kubernetes-headlamp-ci.yaml | kubectl --context=test apply -f -
-kubectl wait deployment -n kube-system headlamp --for condition=Available=True --timeout=180s
-```
-
-Finally, export the URL and the tokens the specs read:
-
-```bash
-export HEADLAMP_TEST_URL="http://<address of the headlamp Service>"
-export HEADLAMP_TEST_TOKEN=$(kubectl --context=test  create token headlamp-admin --duration 24h -n kube-system)
-export HEADLAMP_TEST2_TOKEN=$(kubectl --context=test2 create token headlamp-admin --duration 24h -n kube-system)
+kind delete cluster --name test
+kind delete cluster --name test2
+kubectl config delete-context test 2>/dev/null || true
+kubectl config delete-context test2 2>/dev/null || true
+rm -f e2e-tests/.env
 ```
 
 CI reaches the Service on its NodePort, at
@@ -140,21 +130,14 @@ cd e2e-tests
 npx playwright test tests/incluster-api.spec.ts
 ```
 
-`tests/clusterInventory.spec.ts` requires Headlamp to be configured with a
-working cluster inventory source. It is skipped unless explicitly enabled and
-is not run in CI:
+### Cluster Inventory
 
-```bash
-export HEADLAMP_CLUSTER_INVENTORY_E2E=true
-
-# Optional. This defaults to "headlamp".
-export HEADLAMP_TEST_BACKEND_TOKEN=...
-
-cd e2e-tests
-npx playwright test tests/clusterInventory.spec.ts
-```
-
-IMPORTANT: Make sure that the following npx commands are run in the same terminal session as the environment variables were set.
+The Cluster Inventory E2E uses the same `test` and `test2` clusters and the same
+Headlamp Deployment as the regular multi-cluster tests. It installs the v0.1.3
+Cluster Inventory API CRD on `test`, publishes one `ClusterProfile` for
+`test2`, and verifies both discovery and proxy access to a running pod in
+`tests/clusterInventory.spec.ts`. The generated `.env` enables this spec; it is
+otherwise skipped unless `HEADLAMP_CLUSTER_INVENTORY_E2E=true`.
 
 ## Run all tests
 
@@ -250,6 +233,15 @@ port-forwards to OAuth2-Proxy) and signs in to Dex as
 - This will open a browser window that will show the test running in real-time, this can be ran as a substitute or in pair with the VS code extension.
 
 ## Optional configuration
+
+### System Chromium
+
+Playwright downloads a supported Chromium build by default. On an unsupported
+Linux distribution, use an existing Chromium executable instead:
+
+```bash
+export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH="$(command -v chromium)"
+```
 
 ### Headed vs Headless
 

--- a/e2e-tests/kubernetes-headlamp-ci.yaml
+++ b/e2e-tests/kubernetes-headlamp-ci.yaml
@@ -60,6 +60,87 @@ data:
       user:
     current-context: test
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp-cluster-inventory
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: headlamp-cluster-inventory
+  namespace: kube-system
+rules:
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - clusterprofiles
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: headlamp-cluster-inventory
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: headlamp-cluster-inventory
+subjects:
+- kind: ServiceAccount
+  name: headlamp-cluster-inventory
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: headlamp-cluster-inventory-provider
+  namespace: kube-system
+data:
+  config.json: |
+    {
+      "providers": [
+        {
+          "name": "headlamp-e2e-token",
+          "execConfig": {
+            "apiVersion": "client.authentication.k8s.io/v1",
+            "command": "/etc/cluster-inventory/credential-plugin.sh",
+            "provideClusterInfo": true,
+            "interactiveMode": "Never"
+          }
+        }
+      ]
+    }
+  credential-plugin.sh: |
+    #!/bin/sh
+    set -eu
+
+    token="$(cat /var/run/secrets/cluster-inventory-spoke/token)"
+    printf '{"apiVersion":"client.authentication.k8s.io/v1","kind":"ExecCredential","status":{"token":"%s"}}\n' "$token"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: headlamp-cluster-inventory-spoke
+  namespace: kube-system
+type: Opaque
+stringData:
+  token: "${INVENTORY_SPOKE_TOKEN}"
+---
+apiVersion: multicluster.x-k8s.io/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: inventory-test2
+  namespace: kube-system
+spec:
+  displayName: inventory-test2
+  clusterManager:
+    name: headlamp-e2e
+---
 # Source: headlamp/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -81,6 +162,7 @@ spec:
         app.kubernetes.io/name: headlamp
         app.kubernetes.io/instance: headlamp
     spec:
+      serviceAccountName: headlamp-cluster-inventory
       initContainers:
       - command:
         - /bin/sh
@@ -103,6 +185,13 @@ spec:
         imagePullPolicy: Never
         args:
         - "-enable-dynamic-clusters"
+        - "-in-cluster"
+        - "-in-cluster-context-name=main"
+        - "-enable-cluster-inventory"
+        - "-cluster-inventory-provider-file=/etc/cluster-inventory/config.json"
+        - "-cluster-inventory-label-selector=!headlamp.dev/ignore"
+        - "-cluster-inventory-root-reconcile-interval=2s"
+        - "-cluster-inventory-no-crd-cache-ttl=2s"
         - "-plugins-dir=/build/plugins"
         env:
         - name: KUBECONFIG
@@ -116,6 +205,12 @@ spec:
           name: headlamp-plugins
         - mountPath: "/home/headlamp/.config/Headlamp/kubeconfigs"
           name: kubeconfig
+        - mountPath: /etc/cluster-inventory
+          name: cluster-inventory-provider
+          readOnly: true
+        - mountPath: /var/run/secrets/cluster-inventory-spoke
+          name: cluster-inventory-spoke
+          readOnly: true
       nodeSelector:
         'kubernetes.io/os': linux
       volumes:
@@ -128,6 +223,23 @@ spec:
           items:
           - key: config
             path: config
+      - name: cluster-inventory-provider
+        configMap:
+          name: headlamp-cluster-inventory-provider
+          items:
+          - key: config.json
+            path: config.json
+            mode: 0444
+          - key: credential-plugin.sh
+            path: credential-plugin.sh
+            mode: 0555
+      - name: cluster-inventory-spoke
+        secret:
+          secretName: headlamp-cluster-inventory-spoke
+          items:
+          - key: token
+            path: token
+            mode: 0444
 ---
 kind: Secret
 apiVersion: v1

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -17,6 +17,8 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';
 
+const chromiumExecutablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH?.trim();
+
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
@@ -64,6 +66,9 @@ const config: PlaywrightTestConfig = {
       name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
+        ...(chromiumExecutablePath
+          ? { launchOptions: { executablePath: chromiumExecutablePath } }
+          : {}),
       },
     },
 

--- a/e2e-tests/scripts/setup-multicluster.sh
+++ b/e2e-tests/scripts/setup-multicluster.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubernetes Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+CLUSTER_INVENTORY_API_VERSION="v0.1.3"
+HUB_CLUSTER="test"
+SPOKE_CLUSTER="test2"
+HUB_CONTEXT="test"
+SPOKE_CONTEXT="test2"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CREATED_CLUSTERS=false
+SKIP_IMAGE_BUILD=false
+
+log() {
+  printf '\n==> %s\n' "$*"
+}
+
+usage() {
+  cat <<'EOF'
+Usage: ./e2e-tests/scripts/setup-multicluster.sh [--skip-image-build]
+
+Set up the test/test2 kind clusters, Headlamp, and the Cluster Inventory fixture.
+
+Options:
+  --skip-image-build  Use Headlamp images already loaded into the clusters.
+  -h, --help          Show this help.
+EOF
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'error: required command not found: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+has_kind_cluster() {
+  kind get clusters 2>/dev/null | grep -Fxq "$1"
+}
+
+has_kube_context() {
+  kubectl config get-contexts -o name | grep -Fxq "$1"
+}
+
+context_cluster() {
+  kubectl config view -o json |
+    jq -r --arg context "$1" '.contexts[] | select(.name == $context) | .context.cluster'
+}
+
+cluster_ca_data() {
+  kubectl --context="$1" config view --raw --minify \
+    -o jsonpath='{.clusters[0].cluster.certificate-authority-data}'
+}
+
+node_ip() {
+  kubectl --context="$1" get nodes \
+    -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'
+}
+
+# apply_generated renders a kubectl create command and applies it, so that reruns
+# of this script do not fail on resources that already exist.
+apply_generated() {
+  local context="$1"
+  shift
+
+  kubectl --context="${context}" "$@" --dry-run=client -o yaml |
+    kubectl --context="${context}" apply -f -
+}
+
+print_headlamp_logs() {
+  if has_kube_context "${HUB_CONTEXT}"; then
+    printf '\nHeadlamp pod status:\n' >&2
+    kubectl --context="${HUB_CONTEXT}" -n kube-system get pods \
+      -l app.kubernetes.io/name=headlamp -o wide >&2 || true
+    printf '\nHeadlamp logs:\n' >&2
+    kubectl --context="${HUB_CONTEXT}" -n kube-system logs \
+      deployment/headlamp --all-containers --tail=200 >&2 || true
+  fi
+}
+
+cleanup() {
+  local status="$1"
+
+  if [[ "${status}" -eq 0 ]]; then
+    return
+  fi
+
+  print_headlamp_logs
+
+  if [[ "${CREATED_CLUSTERS}" != true ]]; then
+    return
+  fi
+
+  kind delete cluster --name "${HUB_CLUSTER}" >/dev/null 2>&1 || true
+  kind delete cluster --name "${SPOKE_CLUSTER}" >/dev/null 2>&1 || true
+  kubectl config delete-context "${HUB_CONTEXT}" >/dev/null 2>&1 || true
+  kubectl config delete-context "${SPOKE_CONTEXT}" >/dev/null 2>&1 || true
+}
+
+trap 'status=$?; cleanup "${status}"; exit "${status}"' EXIT
+trap 'exit 130' INT TERM
+
+# wait_for_inventory blocks until discovery has converged. Which ClusterProfile is
+# expected is asserted by tests/clusterInventory.spec.ts, not here.
+wait_for_inventory() {
+  local service_url="$1"
+  local config=""
+  local attempt
+
+  for ((attempt = 0; attempt < 120; attempt++)); do
+    config="$(curl -fsS --connect-timeout 2 --max-time 5 "${service_url}/config" 2>/dev/null || true)"
+    if jq -e '
+      [.clusters[] | select(.meta_data.source == "cluster_inventory")] | length == 1
+    ' <<<"${config}" >/dev/null 2>&1; then
+      return
+    fi
+
+    sleep 1
+  done
+
+  printf 'error: timed out waiting for a discovered ClusterProfile\n' >&2
+  jq -c '[.clusters[] | select(.meta_data.source == "cluster_inventory")]' \
+    <<<"${config}" >&2 || printf '%s\n' "${config}" >&2
+  return 1
+}
+
+write_playwright_env() {
+  local service_url="$1"
+  local spoke_token="$2"
+  local env_file
+  local hub_token
+  local -a env_values
+
+  hub_token="$(
+    kubectl --context="${HUB_CONTEXT}" -n kube-system \
+      create token headlamp-admin --duration=24h
+  )"
+  env_values=(
+    "HEADLAMP_TEST_URL=${service_url}"
+    "HEADLAMP_TEST_TOKEN=${hub_token}"
+    "HEADLAMP_TEST2_TOKEN=${spoke_token}"
+    "HEADLAMP_TEST_BACKEND_TOKEN=headlamp"
+    "HEADLAMP_CLUSTER_INVENTORY_E2E=true"
+  )
+
+  if [[ -n "${GITHUB_ENV:-}" ]]; then
+    printf '::add-mask::%s\n' "${hub_token}" "${spoke_token}"
+    printf '%s\n' "${env_values[@]}" >>"${GITHUB_ENV}"
+    log "Playwright environment added to GITHUB_ENV"
+    return
+  fi
+
+  env_file="${REPO_ROOT}/e2e-tests/.env"
+  (
+    umask 077
+    printf '%s\n' "${env_values[@]}" >"${env_file}"
+  )
+  chmod 600 "${env_file}"
+  log "Playwright environment written to e2e-tests/.env"
+}
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --skip-image-build)
+      SKIP_IMAGE_BUILD=true
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'error: unknown option: %s\n' "$1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+for command in curl docker envsubst grep jq kind kubectl uname; do
+  require_command "${command}"
+done
+if [[ "${SKIP_IMAGE_BUILD}" != true ]]; then
+  require_command make
+fi
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  printf 'error: this E2E currently supports Linux only\n' >&2
+  exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  printf 'error: Docker is not running or is not accessible\n' >&2
+  exit 1
+fi
+
+cluster_count=0
+context_count=0
+for cluster in "${HUB_CLUSTER}" "${SPOKE_CLUSTER}"; do
+  if has_kind_cluster "${cluster}"; then
+    ((cluster_count += 1))
+  fi
+done
+for context in "${HUB_CONTEXT}" "${SPOKE_CONTEXT}"; do
+  if has_kube_context "${context}"; then
+    ((context_count += 1))
+  fi
+done
+
+if [[ "${cluster_count}" -eq 0 && "${context_count}" -eq 0 ]]; then
+  log "Create kind clusters ${HUB_CLUSTER} and ${SPOKE_CLUSTER}"
+  CREATED_CLUSTERS=true
+  kind create cluster --name "${HUB_CLUSTER}"
+  kubectl config rename-context "kind-${HUB_CLUSTER}" "${HUB_CONTEXT}"
+  kind create cluster --name "${SPOKE_CLUSTER}"
+  kubectl config rename-context "kind-${SPOKE_CLUSTER}" "${SPOKE_CONTEXT}"
+elif [[ "${cluster_count}" -eq 2 && "${context_count}" -eq 2 ]]; then
+  log "Reuse kind clusters ${HUB_CLUSTER} and ${SPOKE_CLUSTER}"
+else
+  printf '%s\n' \
+    "error: expected both kind clusters and contexts (${HUB_CLUSTER}, ${SPOKE_CLUSTER}), or none" \
+    "found ${cluster_count} clusters and ${context_count} contexts" >&2
+  exit 1
+fi
+
+if [[ "$(context_cluster "${HUB_CONTEXT}")" != "kind-${HUB_CLUSTER}" ||
+  "$(context_cluster "${SPOKE_CONTEXT}")" != "kind-${SPOKE_CLUSTER}" ]]; then
+  printf 'error: the test contexts do not refer to the matching kind clusters\n' >&2
+  exit 1
+fi
+
+for context in "${HUB_CONTEXT}" "${SPOKE_CONTEXT}"; do
+  kubectl --context="${context}" wait --for=condition=Ready node --all --timeout=180s
+done
+
+if [[ "${SKIP_IMAGE_BUILD}" != true ]]; then
+  log "Build and load the Headlamp images"
+  cd "${REPO_ROOT}"
+  export BUILDKIT_PROGRESS="${BUILDKIT_PROGRESS:-plain}"
+  DOCKER_IMAGE_VERSION=latest make image
+  DOCKER_IMAGE_VERSION=latest \
+    DOCKER_PLUGINS_IMAGE_NAME=headlamp-plugins-test \
+    make build-plugins-container
+
+  kind load docker-image \
+    ghcr.io/headlamp-k8s/headlamp-plugins-test:latest \
+    ghcr.io/headlamp-k8s/headlamp:latest --name "${HUB_CLUSTER}"
+  # The in-cluster API spec runs Headlamp on the spoke cluster too.
+  kind load docker-image \
+    ghcr.io/headlamp-k8s/headlamp:latest --name "${SPOKE_CLUSTER}"
+fi
+
+log "Configure access to both clusters"
+for context in "${HUB_CONTEXT}" "${SPOKE_CONTEXT}"; do
+  apply_generated "${context}" -n kube-system create serviceaccount headlamp-admin
+  apply_generated "${context}" create clusterrolebinding headlamp-admin \
+    --serviceaccount=kube-system:headlamp-admin \
+    --clusterrole=cluster-admin
+done
+
+log "Create a workload on ${SPOKE_CLUSTER}"
+apply_generated "${SPOKE_CONTEXT}" create namespace inventory-demo
+apply_generated "${SPOKE_CONTEXT}" -n inventory-demo create deployment inventory-demo \
+  --image=registry.k8s.io/pause:3.10.1
+kubectl --context="${SPOKE_CONTEXT}" -n inventory-demo \
+  rollout status deployment/inventory-demo --timeout=300s
+
+log "Install the Cluster Inventory API on ${HUB_CLUSTER}"
+kubectl --context="${HUB_CONTEXT}" apply -f \
+  "https://raw.githubusercontent.com/kubernetes-sigs/cluster-inventory-api/${CLUSTER_INVENTORY_API_VERSION}/config/crd/bases/multicluster.x-k8s.io_clusterprofiles.yaml"
+kubectl --context="${HUB_CONTEXT}" wait --for=condition=Established \
+  crd/clusterprofiles.multicluster.x-k8s.io --timeout=120s
+
+HUB_NODE_IP="$(node_ip "${HUB_CONTEXT}")"
+TEST_CA_DATA="$(cluster_ca_data "${HUB_CONTEXT}")"
+TEST_SERVER="https://${HUB_NODE_IP}:6443"
+TEST2_CA_DATA="$(cluster_ca_data "${SPOKE_CONTEXT}")"
+TEST2_SERVER="https://$(node_ip "${SPOKE_CONTEXT}"):6443"
+INVENTORY_SPOKE_TOKEN="$(
+  kubectl --context="${SPOKE_CONTEXT}" -n kube-system \
+    create token headlamp-admin --duration=24h
+)"
+export TEST_CA_DATA TEST_SERVER TEST2_CA_DATA TEST2_SERVER INVENTORY_SPOKE_TOKEN
+
+log "Deploy Headlamp and the inventory-test2 ClusterProfile on ${HUB_CLUSTER}"
+envsubst \
+  '${TEST_CA_DATA} ${TEST_SERVER} ${TEST2_CA_DATA} ${TEST2_SERVER} ${INVENTORY_SPOKE_TOKEN}' \
+  <"${REPO_ROOT}/e2e-tests/kubernetes-headlamp-ci.yaml" |
+  kubectl --context="${HUB_CONTEXT}" apply -f -
+
+SPOKE_VERSION="$(
+  kubectl --context="${SPOKE_CONTEXT}" version -o json |
+    jq -r '.serverVersion.gitVersion'
+)"
+STATUS_PATCH="$(
+  jq -cn \
+    --arg server "${TEST2_SERVER}" \
+    --arg ca "${TEST2_CA_DATA}" \
+    --arg version "${SPOKE_VERSION}" \
+    '{
+      status: {
+        version: {kubernetes: $version},
+        accessProviders: [{
+          name: "headlamp-e2e-token",
+          cluster: {
+            server: $server,
+            "certificate-authority-data": $ca
+          }
+        }]
+      }
+    }'
+)"
+kubectl --context="${HUB_CONTEXT}" -n kube-system \
+  patch clusterprofile inventory-test2 \
+  --subresource=status --type=merge -p "${STATUS_PATCH}"
+
+kubectl --context="${HUB_CONTEXT}" -n kube-system \
+  wait deployment/headlamp --for=condition=Available=True --timeout=180s
+
+SERVICE_PORT="$(
+  kubectl --context="${HUB_CONTEXT}" -n kube-system get service headlamp \
+    -o jsonpath='{.spec.ports[0].nodePort}'
+)"
+SERVICE_URL="http://${HUB_NODE_IP}:${SERVICE_PORT}"
+
+log "Wait for Cluster Inventory discovery at ${SERVICE_URL}"
+wait_for_inventory "${SERVICE_URL}"
+write_playwright_env "${SERVICE_URL}" "${INVENTORY_SPOKE_TOKEN}"
+
+log "Multi-cluster E2E environment is ready at ${SERVICE_URL}"

--- a/e2e-tests/scripts/setup-multicluster.sh
+++ b/e2e-tests/scripts/setup-multicluster.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubernetes Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+CLUSTER_INVENTORY_API_VERSION="v0.1.3"
+HUB_CLUSTER="test"
+SPOKE_CLUSTER="test2"
+HUB_CONTEXT="test"
+SPOKE_CONTEXT="test2"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CREATED_CLUSTERS=false
+REUSED_CLUSTERS=false
+SKIP_IMAGE_BUILD=false
+
+log() {
+  printf '\n==> %s\n' "$*"
+}
+
+usage() {
+  cat <<'EOF'
+Usage: ./e2e-tests/scripts/setup-multicluster.sh [--skip-image-build]
+
+Set up the test/test2 kind clusters, Headlamp, and the Cluster Inventory fixture.
+
+Options:
+  --skip-image-build  Use Headlamp images already loaded into the clusters.
+  -h, --help          Show this help.
+EOF
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'error: required command not found: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+has_kind_cluster() {
+  kind get clusters 2>/dev/null | grep -Fxq "$1"
+}
+
+has_kube_context() {
+  kubectl config get-contexts -o name | grep -Fxq "$1"
+}
+
+context_cluster() {
+  kubectl config view -o json |
+    jq -r --arg context "$1" '.contexts[] | select(.name == $context) | .context.cluster'
+}
+
+cluster_ca_data() {
+  kubectl --context="$1" config view --raw --minify \
+    -o jsonpath='{.clusters[0].cluster.certificate-authority-data}'
+}
+
+node_ip() {
+  kubectl --context="$1" get nodes \
+    -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'
+}
+
+# apply_generated renders a kubectl create command and applies it, so that reruns
+# of this script do not fail on resources that already exist.
+apply_generated() {
+  local context="$1"
+  shift
+
+  kubectl --context="${context}" "$@" --dry-run=client -o yaml |
+    kubectl --context="${context}" apply -f -
+}
+
+print_headlamp_logs() {
+  if has_kube_context "${HUB_CONTEXT}"; then
+    printf '\nHeadlamp pod status:\n' >&2
+    kubectl --context="${HUB_CONTEXT}" -n kube-system get pods \
+      -l app.kubernetes.io/name=headlamp -o wide >&2 || true
+    printf '\nHeadlamp logs:\n' >&2
+    kubectl --context="${HUB_CONTEXT}" -n kube-system logs \
+      deployment/headlamp --all-containers --tail=200 >&2 || true
+  fi
+}
+
+cleanup() {
+  local status="$1"
+
+  if [[ "${status}" -eq 0 ]]; then
+    return
+  fi
+
+  print_headlamp_logs
+
+  if [[ "${CREATED_CLUSTERS}" != true ]]; then
+    return
+  fi
+
+  kind delete cluster --name "${HUB_CLUSTER}" >/dev/null 2>&1 || true
+  kind delete cluster --name "${SPOKE_CLUSTER}" >/dev/null 2>&1 || true
+  kubectl config delete-context "${HUB_CONTEXT}" >/dev/null 2>&1 || true
+  kubectl config delete-context "${SPOKE_CONTEXT}" >/dev/null 2>&1 || true
+}
+
+trap 'status=$?; cleanup "${status}"; exit "${status}"' EXIT
+trap 'exit 130' INT TERM
+
+# wait_for_inventory blocks until discovery has converged. Which ClusterProfile is
+# expected is asserted by tests/clusterInventory.spec.ts, not here.
+wait_for_inventory() {
+  local service_url="$1"
+  local config=""
+  local attempt
+
+  for ((attempt = 0; attempt < 120; attempt++)); do
+    config="$(curl -fsS --connect-timeout 2 --max-time 5 "${service_url}/config" 2>/dev/null || true)"
+    if jq -e '
+      [.clusters[] | select(.meta_data.source == "cluster_inventory")] | length == 1
+    ' <<<"${config}" >/dev/null 2>&1; then
+      return
+    fi
+
+    sleep 1
+  done
+
+  printf 'error: timed out waiting for a discovered ClusterProfile\n' >&2
+  jq -c '[.clusters[] | select(.meta_data.source == "cluster_inventory")]' \
+    <<<"${config}" >&2 || printf '%s\n' "${config}" >&2
+  return 1
+}
+
+write_playwright_env() {
+  local service_url="$1"
+  local spoke_token="$2"
+  local env_file
+  local hub_token
+  local -a env_values
+
+  hub_token="$(
+    kubectl --context="${HUB_CONTEXT}" -n kube-system \
+      create token headlamp-admin --duration=24h
+  )"
+  env_values=(
+    "HEADLAMP_TEST_URL=${service_url}"
+    "HEADLAMP_TEST_TOKEN=${hub_token}"
+    "HEADLAMP_TEST2_TOKEN=${spoke_token}"
+    "HEADLAMP_TEST_BACKEND_TOKEN=headlamp"
+    "HEADLAMP_CLUSTER_INVENTORY_E2E=true"
+  )
+
+  if [[ -n "${GITHUB_ENV:-}" ]]; then
+    printf '::add-mask::%s\n' "${hub_token}" "${spoke_token}"
+    printf '%s\n' "${env_values[@]}" >>"${GITHUB_ENV}"
+    log "Playwright environment added to GITHUB_ENV"
+    return
+  fi
+
+  env_file="${REPO_ROOT}/e2e-tests/.env"
+  (
+    umask 077
+    printf '%s\n' "${env_values[@]}" >"${env_file}"
+  )
+  chmod 600 "${env_file}"
+  log "Playwright environment written to e2e-tests/.env"
+}
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --skip-image-build)
+      SKIP_IMAGE_BUILD=true
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'error: unknown option: %s\n' "$1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+for command in curl docker envsubst grep jq kind kubectl uname; do
+  require_command "${command}"
+done
+if [[ "${SKIP_IMAGE_BUILD}" != true ]]; then
+  require_command make
+fi
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  printf 'error: this E2E currently supports Linux only\n' >&2
+  exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  printf 'error: Docker is not running or is not accessible\n' >&2
+  exit 1
+fi
+
+cluster_count=0
+context_count=0
+for cluster in "${HUB_CLUSTER}" "${SPOKE_CLUSTER}"; do
+  if has_kind_cluster "${cluster}"; then
+    ((cluster_count += 1))
+  fi
+done
+for context in "${HUB_CONTEXT}" "${SPOKE_CONTEXT}"; do
+  if has_kube_context "${context}"; then
+    ((context_count += 1))
+  fi
+done
+
+if [[ "${cluster_count}" -eq 0 && "${context_count}" -eq 0 ]]; then
+  log "Create kind clusters ${HUB_CLUSTER} and ${SPOKE_CLUSTER}"
+  CREATED_CLUSTERS=true
+  kind create cluster --name "${HUB_CLUSTER}"
+  kubectl config rename-context "kind-${HUB_CLUSTER}" "${HUB_CONTEXT}"
+  kind create cluster --name "${SPOKE_CLUSTER}"
+  kubectl config rename-context "kind-${SPOKE_CLUSTER}" "${SPOKE_CONTEXT}"
+elif [[ "${cluster_count}" -eq 2 && "${context_count}" -eq 2 ]]; then
+  log "Reuse kind clusters ${HUB_CLUSTER} and ${SPOKE_CLUSTER}"
+  REUSED_CLUSTERS=true
+else
+  printf '%s\n' \
+    "error: expected both kind clusters and contexts (${HUB_CLUSTER}, ${SPOKE_CLUSTER}), or none" \
+    "found ${cluster_count} clusters and ${context_count} contexts" >&2
+  exit 1
+fi
+
+if [[ "$(context_cluster "${HUB_CONTEXT}")" != "kind-${HUB_CLUSTER}" ||
+  "$(context_cluster "${SPOKE_CONTEXT}")" != "kind-${SPOKE_CLUSTER}" ]]; then
+  printf 'error: the test contexts do not refer to the matching kind clusters\n' >&2
+  exit 1
+fi
+
+for context in "${HUB_CONTEXT}" "${SPOKE_CONTEXT}"; do
+  kubectl --context="${context}" wait --for=condition=Ready node --all --timeout=180s
+done
+
+if [[ "${SKIP_IMAGE_BUILD}" != true ]]; then
+  log "Build and load the Headlamp images"
+  cd "${REPO_ROOT}"
+  export BUILDKIT_PROGRESS="${BUILDKIT_PROGRESS:-plain}"
+  DOCKER_IMAGE_VERSION=latest make image
+  DOCKER_IMAGE_VERSION=latest \
+    DOCKER_PLUGINS_IMAGE_NAME=headlamp-plugins-test \
+    make build-plugins-container
+
+  kind load docker-image \
+    ghcr.io/headlamp-k8s/headlamp-plugins-test:latest \
+    ghcr.io/headlamp-k8s/headlamp:latest --name "${HUB_CLUSTER}"
+  # The in-cluster API spec runs Headlamp on the spoke cluster too.
+  kind load docker-image \
+    ghcr.io/headlamp-k8s/headlamp:latest --name "${SPOKE_CLUSTER}"
+fi
+
+log "Configure access to both clusters"
+for context in "${HUB_CONTEXT}" "${SPOKE_CONTEXT}"; do
+  apply_generated "${context}" -n kube-system create serviceaccount headlamp-admin
+  apply_generated "${context}" create clusterrolebinding headlamp-admin \
+    --serviceaccount=kube-system:headlamp-admin \
+    --clusterrole=cluster-admin
+done
+
+log "Create a workload on ${SPOKE_CLUSTER}"
+apply_generated "${SPOKE_CONTEXT}" create namespace inventory-demo
+apply_generated "${SPOKE_CONTEXT}" -n inventory-demo create deployment inventory-demo \
+  --image=registry.k8s.io/pause:3.10.1
+kubectl --context="${SPOKE_CONTEXT}" -n inventory-demo \
+  rollout status deployment/inventory-demo --timeout=300s
+
+log "Install the Cluster Inventory API on ${HUB_CLUSTER}"
+kubectl --context="${HUB_CONTEXT}" apply -f \
+  "https://raw.githubusercontent.com/kubernetes-sigs/cluster-inventory-api/${CLUSTER_INVENTORY_API_VERSION}/config/crd/bases/multicluster.x-k8s.io_clusterprofiles.yaml"
+kubectl --context="${HUB_CONTEXT}" wait --for=condition=Established \
+  crd/clusterprofiles.multicluster.x-k8s.io --timeout=120s
+
+HUB_NODE_IP="$(node_ip "${HUB_CONTEXT}")"
+TEST_CA_DATA="$(cluster_ca_data "${HUB_CONTEXT}")"
+TEST_SERVER="https://${HUB_NODE_IP}:6443"
+TEST2_CA_DATA="$(cluster_ca_data "${SPOKE_CONTEXT}")"
+TEST2_SERVER="https://$(node_ip "${SPOKE_CONTEXT}"):6443"
+INVENTORY_SPOKE_TOKEN="$(
+  kubectl --context="${SPOKE_CONTEXT}" -n kube-system \
+    create token headlamp-admin --duration=24h
+)"
+export TEST_CA_DATA TEST_SERVER TEST2_CA_DATA TEST2_SERVER INVENTORY_SPOKE_TOKEN
+
+log "Deploy Headlamp and the inventory-test2 ClusterProfile on ${HUB_CLUSTER}"
+envsubst \
+  '${TEST_CA_DATA} ${TEST_SERVER} ${TEST2_CA_DATA} ${TEST2_SERVER} ${INVENTORY_SPOKE_TOKEN}' \
+  <"${REPO_ROOT}/e2e-tests/kubernetes-headlamp-ci.yaml" |
+  kubectl --context="${HUB_CONTEXT}" apply -f -
+
+SPOKE_VERSION="$(
+  kubectl --context="${SPOKE_CONTEXT}" version -o json |
+    jq -r '.serverVersion.gitVersion'
+)"
+STATUS_PATCH="$(
+  jq -cn \
+    --arg server "${TEST2_SERVER}" \
+    --arg ca "${TEST2_CA_DATA}" \
+    --arg version "${SPOKE_VERSION}" \
+    '{
+      status: {
+        version: {kubernetes: $version},
+        accessProviders: [{
+          name: "headlamp-e2e-token",
+          cluster: {
+            server: $server,
+            "certificate-authority-data": $ca
+          }
+        }]
+      }
+    }'
+)"
+kubectl --context="${HUB_CONTEXT}" -n kube-system \
+  patch clusterprofile inventory-test2 \
+  --subresource=status --type=merge -p "${STATUS_PATCH}"
+
+if [[ "${REUSED_CLUSTERS}" == true ]]; then
+  log "Restart Headlamp to use the reloaded images"
+  kubectl --context="${HUB_CONTEXT}" -n kube-system \
+    rollout restart deployment/headlamp
+fi
+
+kubectl --context="${HUB_CONTEXT}" -n kube-system \
+  rollout status deployment/headlamp --timeout=180s
+
+SERVICE_PORT="$(
+  kubectl --context="${HUB_CONTEXT}" -n kube-system get service headlamp \
+    -o jsonpath='{.spec.ports[0].nodePort}'
+)"
+SERVICE_URL="http://${HUB_NODE_IP}:${SERVICE_PORT}"
+
+log "Wait for Cluster Inventory discovery at ${SERVICE_URL}"
+wait_for_inventory "${SERVICE_URL}"
+write_playwright_env "${SERVICE_URL}" "${INVENTORY_SPOKE_TOKEN}"
+
+log "Multi-cluster E2E environment is ready at ${SERVICE_URL}"

--- a/e2e-tests/tests/clusterInventory.spec.ts
+++ b/e2e-tests/tests/clusterInventory.spec.ts
@@ -16,42 +16,44 @@
 
 import { expect, test } from '@playwright/test';
 
-const baseURL = process.env.HEADLAMP_TEST_URL || 'http://localhost:3000';
 const backendToken = process.env.HEADLAMP_TEST_BACKEND_TOKEN || 'headlamp';
 const shouldRun = process.env.HEADLAMP_CLUSTER_INVENTORY_E2E === 'true';
+const requestOptions = {
+  headers: {
+    'X-HEADLAMP_BACKEND-TOKEN': backendToken,
+  },
+};
 
 test.describe('Cluster Inventory', () => {
   test.skip(!shouldRun, 'Set HEADLAMP_CLUSTER_INVENTORY_E2E=true to run Cluster Inventory E2E');
 
   test('discovers clusters and proxies to them', async ({ request }) => {
-    const configResponse = await request.get('/config', {
-      baseURL,
-      headers: {
-        'X-HEADLAMP_BACKEND-TOKEN': backendToken,
-      },
-    });
+    const configResponse = await request.get('/config', requestOptions);
     expect(configResponse.status()).toBe(200);
 
     const config = await configResponse.json();
     const inventoryClusters = config.clusters.filter(
       (cluster: any) => cluster.meta_data?.source === 'cluster_inventory'
     );
-    expect(inventoryClusters.length).toBeGreaterThanOrEqual(1);
+    expect(inventoryClusters).toHaveLength(1);
 
-    for (const cluster of inventoryClusters) {
-      const clusterName = encodeURIComponent(cluster.name);
-      const response = await request.get(`/clusters/${clusterName}/api/v1/namespaces`, {
-        baseURL,
-        headers: {
-          'X-HEADLAMP_BACKEND-TOKEN': backendToken,
-        },
-      });
+    const cluster = inventoryClusters[0];
+    expect(cluster.meta_data.clusterInventory.profile).toMatchObject({
+      namespace: 'kube-system',
+      name: 'inventory-test2',
+    });
 
-      expect(response.status(), `expected namespace proxy to work for ${cluster.name}`).toBe(200);
+    const clusterName = encodeURIComponent(cluster.name);
+    const response = await request.get(
+      `/clusters/${clusterName}/api/v1/namespaces/inventory-demo/pods`,
+      requestOptions
+    );
 
-      const body = await response.json();
-      expect(body).toHaveProperty('items');
-      expect(Array.isArray(body.items)).toBe(true);
-    }
+    expect(response.status(), `expected pod proxy to work for ${cluster.name}`).toBe(200);
+
+    const body = await response.json();
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0].metadata.name).toMatch(/^inventory-demo-/);
+    expect(body.items[0].status.phase).toBe('Running');
   });
 });

--- a/e2e-tests/tests/multiCluster.spec.ts
+++ b/e2e-tests/tests/multiCluster.spec.ts
@@ -29,34 +29,19 @@ test.describe('multi-cluster setup', () => {
     await expect(page.locator('h1:has-text("Home")')).toBeVisible();
   });
 
-  test("home page should display two cluster selection buttons labeled 'test' and 'test2'", async ({
-    page,
-  }) => {
-    const buttons = page.locator('td a');
-    await expect(buttons).toHaveCount(2);
-    await expect(page.locator('td a', { hasText: /^test$/ })).toBeVisible();
-    await expect(page.locator('td a', { hasText: /^test2$/ })).toBeVisible();
-  });
-
-  test('home page should display a table containing exactly two rows, each representing a cluster entry', async ({
-    page,
-  }) => {
-    const tableRows = page.locator('table tbody tr');
-    await expect(tableRows).toHaveCount(2);
-  });
-
   test("table should contain 'Name' and 'Status' column headers", async ({ page }) => {
     await expect(page.locator('th', { hasText: 'Name' })).toBeVisible();
     await expect(page.locator('th', { hasText: 'Status' })).toBeVisible();
   });
 
-  test("table should list 'test' cluster and 'test2' cluster with an 'Active' status and valid links", async ({
+  test("table should include the configured 'test' and 'test2' clusters with valid links", async ({
     page,
   }) => {
     for (const clusterName of ['test', 'test2']) {
       const clusterAnchor = page.locator('table tbody tr td a', {
         hasText: new RegExp(`^${clusterName}$`),
       });
+      await expect(clusterAnchor).toHaveCount(1);
       await expect(clusterAnchor).toBeVisible();
       await expect(clusterAnchor).toHaveAttribute('href', `/c/${clusterName}/`);
 


### PR DESCRIPTION
## Summary

Scope ClusterProfile discovery to the namespace used by each Headlamp consumer.
This makes the recommended one-inventory-per-consumer model the default while
still allowing shared inventories through an explicit namespace list or `*`.

## Related Issue

https://github.com/kubernetes/enhancements/pull/6237

## Changes

- Default ClusterProfile discovery to the Headlamp pod namespace in-cluster and
  each kubeconfig context namespace out-of-cluster.
- Add server and Helm configuration for named namespaces or all namespaces.
- Validate namespace names and require `*` to be used on its own.
- Update the Cluster Inventory API dependency and provider examples to v0.1.3.

## Steps to Test

Prerequisites: Linux with Docker running, plus Node/npm, `curl`, `envsubst`, `jq`, `kind`, `kubectl`, and `make`.

From the repository root, run in order:

```bash
cd e2e-tests
npm ci
npx playwright install --with-deps
cd ..

./e2e-tests/scripts/setup-multicluster.sh

set -a
source e2e-tests/.env
set +a
cd e2e-tests
npx playwright test tests/multiCluster.spec.ts tests/clusterInventory.spec.ts
```

The setup creates `test` and `test2` when both are absent, builds and loads the Headlamp images, deploys the shared Headlamp and Inventory fixture, and writes the Playwright URL and temporary credentials to `e2e-tests/.env`. A later run reuses the same environment. The clusters remain available until explicitly deleted with `kind delete cluster --name test` and `kind delete cluster --name test2`.

## Screenshots (if applicable)

this change has no UI changes.

<img width="800" height="415" alt="CleanShot 2026-08-02 at 12 39 16" src="https://github.com/user-attachments/assets/18f18a05-a45b-4617-aaa0-82d36a70aa46" />

## Notes for the Reviewer

- Existing deployments that rely on cluster-wide discovery must set `*` explicitly.
- An explicit namespace list starts one informer per namespace and waits for all caches to sync before pruning contexts.
