### PR TITLE
frontend: streamingApi: Keep the newest resources when limiting

### DIFF
--- a/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
+++ b/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
@@ -85,6 +85,33 @@ const modifiedConfigMap = {
   metadata: { ...mockConfigMap.metadata, resourceVersion: '5678' },
   data: { ...mockConfigMap.data, volumeName: 'pvc-xyz-5678' },
 };
+const oldestConfigMap = {
+  ...mockConfigMap,
+  metadata: {
+    ...mockConfigMap.metadata,
+    creationTimestamp: '2023-04-25T20:31:27Z',
+    name: 'oldest',
+    uid: 'abc-oldest',
+  },
+};
+const middleConfigMap = {
+  ...mockConfigMap,
+  metadata: {
+    ...mockConfigMap.metadata,
+    creationTimestamp: '2023-04-26T20:31:27Z',
+    name: 'middle',
+    uid: 'abc-middle',
+  },
+};
+const newestConfigMap = {
+  ...mockConfigMap,
+  metadata: {
+    ...mockConfigMap.metadata,
+    creationTimestamp: '2023-04-27T20:31:27Z',
+    name: 'newest',
+    uid: 'abc-newest',
+  },
+};
 
 describe('apiProxy', () => {
   describe('clusterRequest', () => {
@@ -583,6 +610,31 @@ describe('apiProxy', () => {
               });
             })
             .catch(err => done(err));
+        }));
+
+      it('Keeps the most recent resources when over the limit', () =>
+        new Promise<void>(done => {
+          expect.assertions(1);
+
+          apiProxy.streamResultsForCluster(
+            streamResultsUrl,
+            { cb, errCb, cluster: clusterName },
+            { watch: '1', limit: 2 }
+          );
+
+          mockServer.on('connection', async (socket: any) => {
+            for (const configMap of [oldestConfigMap, middleConfigMap, newestConfigMap]) {
+              socket.send(JSON.stringify({ type: 'ADDED', object: configMap }));
+            }
+
+            const lastCall = cb.mock.calls[cb.mock.calls.length - 1][0];
+            expect(lastCall.map((item: any) => item.metadata.name)).toEqual([
+              newestConfigMap.metadata.name,
+              middleConfigMap.metadata.name,
+            ]);
+
+            done();
+          });
         }));
     });
   });

--- a/frontend/src/lib/k8s/api/v1/streamingApi.ts
+++ b/frontend/src/lib/k8s/api/v1/streamingApi.ts
@@ -264,7 +264,7 @@ export function streamResultsForCluster(
         // Reverse sort, so we have the most recent resources at the beginning of the array.
         return 0 - (aTime - bTime);
       });
-      values.splice(0, values.length - maxResources);
+      values.splice(maxResources);
     }
 
     if (isDebugVerbose('k8s/apiProxy@push cb(values)')) {


### PR DESCRIPTION
## Summary

`streamResultsForCluster` limits the result set by sorting the values so the most recent are first, then calling `values.splice(0, values.length - maxResources)`. `splice(0, n)` removes from the front of the array, which after that sort is the newest items, so the function discarded exactly the resources it had just sorted to the top and kept the oldest ones.

With `limit: 2` and three resources, the callback received `[middle, oldest]` where `[newest, middle]` was intended.

The fix drops everything after the first `maxResources` entries instead, which is what the existing sort and its comment already describe. The sort itself is unchanged.

## Related Issue

Fixes #6674

## Changes

- `streamingApi.ts`: `values.splice(0, values.length - maxResources)` becomes `values.splice(maxResources)`.
- `apiProxy.test.ts`: a regression test in the existing `streamResultsForCluster` block, plus three fixtures differing only in `creationTimestamp`, `name` and `uid`.

## Steps to Test

```
cd frontend

npx vitest run src/lib/k8s/api/v1/apiProxy.test.ts   # 68 passed
npx vitest run src/lib/k8s                           # 462 passed

npm run frontend:lint
npm run frontend:tsc
```

To confirm the new test is load-bearing, restore the old `splice` call and re-run `apiProxy.test.ts`. It fails with `expected [ 'middle', 'oldest' ] to deeply equal [ 'newest', 'middle' ]`, which is the bug itself. I verified this rather than assuming it.

## Notes for the Reviewer

The affected path is the v1 list code, still reachable through `KubeObject.useApiList`/`useConnectApi` and through `apiFactory`, `apiFactoryWithNamespace` and `streamResultsForCluster` as exported from `lib/k8s/apiProxy` for plugin authors. `KubeObject.useList` now goes through the v2 `useKubeObjectList`, so the in-app resource list views do not hit this. I mention it so the impact is not overstated: this is the v1 and plugin-facing path, not the main list views.

The sort keys off `lastTimestamp`, which suggests events were the intended consumer, and returning the oldest events rather than the most recent is the least useful outcome for that case.

Unrelated to this change, `src/storybook.test.tsx` has one failing snapshot on my machine, `Version Dialog > VersionDialog`. It fails identically on a clean `main` with my changes stashed, so I have left it alone.
