### PR TITLE
frontend: filterSlice: guard uid and name in search filter

### DIFF
--- a/frontend/src/redux/filterSlice.test.ts
+++ b/frontend/src/redux/filterSlice.test.ts
@@ -16,6 +16,7 @@
 
 import { getSavedNamespaces } from '../lib/storage';
 import filterReducer, {
+  filterResource,
   FilterState,
   initialState,
   resetFilter,
@@ -86,6 +87,34 @@ describe('filterSlice', () => {
     it('should return empty array if no data exists for the cluster', () => {
       const restored = getSavedNamespaces('non-existent-cluster');
       expect(restored).toEqual([]);
+    });
+  });
+
+  describe('filterResource search', () => {
+    const filter: FilterState = { ...initialState, namespaces: new Set() };
+
+    const makeItem = (metadata: object) => ({ kind: 'Pod', apiVersion: 'v1', metadata } as any);
+
+    it('matches a normal item by name', () => {
+      const item = makeItem({ uid: 'abc', name: 'my-pod', namespace: 'default' });
+      expect(filterResource(item, filter, 'my-pod')).toBe(true);
+    });
+
+    it('does not crash when uid is missing', () => {
+      const item = makeItem({ name: 'my-pod', namespace: 'default' });
+      expect(() => filterResource(item, filter, 'nope')).not.toThrow();
+      expect(filterResource(item, filter, 'nope')).toBe(false);
+    });
+
+    it('does not crash when name is missing', () => {
+      const item = makeItem({ uid: 'abc', namespace: 'default' });
+      expect(() => filterResource(item, filter, 'nope')).not.toThrow();
+      expect(filterResource(item, filter, 'nope')).toBe(false);
+    });
+
+    it('still matches on available fields when uid and name are missing', () => {
+      const item = makeItem({ namespace: 'default', labels: { app: 'nginx' } });
+      expect(filterResource(item, filter, 'nginx')).toBe(true);
     });
   });
 });

--- a/frontend/src/redux/filterSlice.ts
+++ b/frontend/src/redux/filterSlice.ts
@@ -60,9 +60,9 @@ export function filterResource(
   if (search) {
     const filterString = search.toLowerCase();
     const usedMatchCriteria = [
-      item.metadata.uid.toLowerCase(),
+      item.metadata.uid?.toLowerCase() ?? '',
       item.metadata.namespace ? item.metadata.namespace.toLowerCase() : '',
-      item.metadata.name.toLowerCase(),
+      item.metadata.name?.toLowerCase() ?? '',
       ...Object.keys(item.metadata.labels || {}).map(item => item.toLowerCase()),
       ...Object.values(item.metadata.labels || {}).map(item => item.toLowerCase()),
     ];


### PR DESCRIPTION
## Summary

filterResource dereferences metadata.uid and metadata.name with .toLowerCase() when a search is active, but neither is guarded even though the namespace and labels right next to them are. A resource list that contains a row without a uid or name therefore throws "Cannot read properties of undefined" as soon as the user types in the search box, and because it happens during filtering the whole list drops to the error boundary instead of just skipping that row.

Guard uid and name the same way namespace and labels already are, so a row missing either field simply doesn't match on it rather than crashing the list.

## Related Issue

Fixes #6624

## Changes

- Updated `filterResource` in `frontend/src/redux/filterSlice.ts` to guard `metadata.uid` and `metadata.name` with `?.toLowerCase() ?? ''`
- Added `filterResource` search tests in `frontend/src/redux/filterSlice.test.ts` for a normal item and items missing uid or name

## Steps to Test

1. Open a resource list that has a row whose metadata is missing uid or name (some custom/aggregated objects, or anything run through useFilterFunc that isn't a standard API object).
2. Type anything into the list's search box.
3. Before the fix the list crashes to the error boundary; after it, search filters normally and the incomplete row is just skipped.

## Screenshots (if applicable)


## Notes for the Reviewer

- Standard API objects always get a server-assigned uid/name so most people won't hit this, but namespace and labels in the same array were already guarded, so this just brings uid and name in line with them. Doesn't look like a regression.
