### PR TITLE
Backend: Don't log errors when no kubeconfig is set

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -603,6 +603,10 @@ func loadKubeConfigClusters(config *HeadlampConfig, path string, skipFunc func(k
 // loadDynamicClusters loads clusters that Headlamp itself persists when clusters are added at
 // runtime. That file will only exist once such a cluster has been added, so a missing file is normal.
 func loadDynamicClusters(config *HeadlampConfig, path string, skipFunc func(kubeconfig.Context) bool) {
+	if path == "" {
+		return
+	}
+
 	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
 		logger.Log(logger.LevelInfo, map[string]string{"kubeconfig": path}, nil,
 			"No kubeconfig for dynamically added clusters")
@@ -712,9 +716,9 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 	kubeConfigPersistenceFile, err := defaultHeadlampKubeConfigFile()
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "getting default kubeconfig persistence file")
+	} else {
+		loadDynamicClusters(config, kubeConfigPersistenceFile, skipFunc)
 	}
-
-	loadDynamicClusters(config, kubeConfigPersistenceFile, skipFunc)
 
 	addPluginRoutes(config, r)
 

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -568,6 +568,55 @@ func setupInClusterContext(config *HeadlampConfig) {
 	}
 }
 
+// loadKubeConfigClusters loads clusters from the user-configured kubeconfig file.
+// In-cluster Headlamp builds its context from the pod, so having no kubeconfig
+// is expected behavior, not an error.
+func loadKubeConfigClusters(config *HeadlampConfig, path string, skipFunc func(kubeconfig.Context) bool) {
+	if path == "" {
+		msg := "No kubeconfig set"
+		if config.UseInCluster {
+			msg = "No kubeconfig set, using only the in-cluster context"
+		}
+
+		logger.Log(logger.LevelInfo, nil, nil, msg)
+
+		return
+	}
+
+	err := kubeconfig.LoadAndStoreKubeConfigs(config.KubeConfigStore, path, kubeconfig.KubeConfig, skipFunc)
+	if err == nil {
+		return
+	}
+
+	msg := "loading kubeconfig"
+
+	if errors.Is(err, os.ErrNotExist) {
+		msg = "kubeconfig not found, set -kubeconfig or the KUBECONFIG env var"
+		if config.UseInCluster {
+			msg = "kubeconfig not found, set -kubeconfig or HEADLAMP_CONFIG_KUBECONFIG and mount the file into the pod"
+		}
+	}
+
+	logger.Log(logger.LevelError, map[string]string{"kubeconfig": path}, err, msg)
+}
+
+// loadDynamicClusters loads clusters that Headlamp itself persists when clusters are added at
+// runtime. That file will only exist once such a cluster has been added, so a missing file is normal.
+func loadDynamicClusters(config *HeadlampConfig, path string, skipFunc func(kubeconfig.Context) bool) {
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		logger.Log(logger.LevelInfo, map[string]string{"kubeconfig": path}, nil,
+			"No kubeconfig for dynamically added clusters")
+
+		return
+	}
+
+	err := kubeconfig.LoadAndStoreKubeConfigs(config.KubeConfigStore, path, kubeconfig.DynamicCluster, skipFunc)
+	if err != nil {
+		logger.Log(logger.LevelError, map[string]string{"kubeconfig": path}, err,
+			"loading the kubeconfig of dynamically added clusters")
+	}
+}
+
 //nolint:gocognit,funlen,gocyclo
 func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Handler {
 	kubeConfigPath := config.KubeConfigPath
@@ -649,10 +698,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 	logger.Log(logger.LevelInfo, nil, nil, "  API Routers:")
 
 	// load kubeConfig clusters
-	err := kubeconfig.LoadAndStoreKubeConfigs(config.KubeConfigStore, kubeConfigPath, kubeconfig.KubeConfig, skipFunc)
-	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "loading kubeconfig")
-	}
+	loadKubeConfigClusters(config, kubeConfigPath, skipFunc)
 
 	// Prometheus metrics endpoint
 	// to enable this endpoint, run command run-backend-with-metrics
@@ -668,11 +714,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		logger.Log(logger.LevelError, nil, err, "getting default kubeconfig persistence file")
 	}
 
-	err = kubeconfig.LoadAndStoreKubeConfigs(config.KubeConfigStore, kubeConfigPersistenceFile,
-		kubeconfig.DynamicCluster, skipFunc)
-	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "loading dynamic kubeconfig")
-	}
+	loadDynamicClusters(config, kubeConfigPersistenceFile, skipFunc)
 
 	addPluginRoutes(config, r)
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -123,6 +123,137 @@ func TestCreateHeadlampHandlerSkipsInClusterContextWhenConfigUnavailable(t *test
 	require.Error(t, err)
 }
 
+//nolint:funlen
+func TestLoadKubeConfigClustersLogging(t *testing.T) {
+	tests := []struct {
+		name          string
+		useInCluster  bool
+		path          string
+		expectedMsg   string
+		expectedLevel uint
+	}{
+		{
+			name:          "no kubeconfig",
+			expectedMsg:   "No kubeconfig set",
+			expectedLevel: logger.LevelInfo,
+		},
+		{
+			name:          "no in-cluster kubeconfig",
+			useInCluster:  true,
+			expectedMsg:   "No kubeconfig set, using only the in-cluster context",
+			expectedLevel: logger.LevelInfo,
+		},
+		{
+			name:          "missing kubeconfig",
+			path:          filepath.Join(t.TempDir(), "missing-kubeconfig"),
+			expectedMsg:   "kubeconfig not found, set -kubeconfig or the KUBECONFIG env var",
+			expectedLevel: logger.LevelError,
+		},
+		{
+			name:          "missing in-cluster kubeconfig",
+			useInCluster:  true,
+			path:          filepath.Join(t.TempDir(), "missing-in-cluster-kubeconfig"),
+			expectedMsg:   "kubeconfig not found, set -kubeconfig or HEADLAMP_CONFIG_KUBECONFIG and mount the file into the pod",
+			expectedLevel: logger.LevelError,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var logs []struct {
+				level uint
+				msg   string
+			}
+
+			originalLogFunc := logger.SetLogFunc(func(level uint, _ map[string]string, _ interface{}, msg string) {
+				logs = append(logs, struct {
+					level uint
+					msg   string
+				}{level: level, msg: msg})
+			})
+			defer logger.SetLogFunc(originalLogFunc)
+
+			config := &HeadlampConfig{
+				HeadlampConfig: &headlampconfig.HeadlampConfig{
+					HeadlampCFG: &headlampconfig.HeadlampCFG{
+						UseInCluster:    test.useInCluster,
+						KubeConfigStore: kubeconfig.NewContextStore(),
+					},
+				},
+			}
+
+			loadKubeConfigClusters(config, test.path, nil)
+
+			require.Len(t, logs, 1)
+			assert.Equal(t, test.expectedLevel, logs[0].level)
+			assert.Equal(t, test.expectedMsg, logs[0].msg)
+		})
+	}
+}
+
+func TestLoadDynamicClustersLogging(t *testing.T) {
+	invalidKubeconfig := filepath.Join(t.TempDir(), "invalid-kubeconfig")
+	require.NoError(t, os.WriteFile(invalidKubeconfig, []byte("contexts: ["), 0o600))
+
+	tests := []struct {
+		name          string
+		path          string
+		expectedLevel uint
+		expectedMsg   string
+	}{
+		{name: "empty path"},
+		{
+			name:          "missing kubeconfig",
+			path:          filepath.Join(t.TempDir(), "missing-dynamic-kubeconfig"),
+			expectedLevel: logger.LevelInfo,
+			expectedMsg:   "No kubeconfig for dynamically added clusters",
+		},
+		{
+			name:          "invalid kubeconfig",
+			path:          invalidKubeconfig,
+			expectedLevel: logger.LevelError,
+			expectedMsg:   "loading the kubeconfig of dynamically added clusters",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var logs []struct {
+				level uint
+				msg   string
+			}
+
+			originalLogFunc := logger.SetLogFunc(func(level uint, _ map[string]string, _ interface{}, msg string) {
+				logs = append(logs, struct {
+					level uint
+					msg   string
+				}{level: level, msg: msg})
+			})
+			defer logger.SetLogFunc(originalLogFunc)
+
+			config := &HeadlampConfig{
+				HeadlampConfig: &headlampconfig.HeadlampConfig{
+					HeadlampCFG: &headlampconfig.HeadlampCFG{
+						KubeConfigStore: kubeconfig.NewContextStore(),
+					},
+				},
+			}
+
+			loadDynamicClusters(config, test.path, nil)
+
+			if test.expectedMsg == "" {
+				assert.Empty(t, logs)
+
+				return
+			}
+
+			require.Len(t, logs, 1)
+			assert.Equal(t, test.expectedLevel, logs[0].level)
+			assert.Equal(t, test.expectedMsg, logs[0].msg)
+		})
+	}
+}
+
 func getResponse(handler http.Handler, method, url string, body interface{}) (*httptest.ResponseRecorder, error) {
 	req, err := makeJSONReq(method, url, body)
 	if err != nil {


### PR DESCRIPTION
## Summary

Currently, all in-cluster Headlamp deployments log two errors on every startup about a missing kubeconfig, which is neither required nor expected (for most users) in that mode. See issue #1826

This PR takes our two `LoadAndStoreKubeConfigs` call locations (for dynamic & regular clusters) & replaces them with `loadKubeConfigClusters` and `loadDynamicClusters` helpers to additionally handle & surface appropriate logs scoped to the user's setup. The previously unconditional error logs are now scoped down to basic info startup messages & errors are now only surfaced when a user-provided kubeconfig has issues, as expected. 

## Related Issue

- Part of  https://github.com/kubernetes-sigs/headlamp/issues/1826
- Fixes #6530
- Fixes #6531


## Changes

Moved two `LoadAndStoreKubeConfigs` call locations into `loadKubeConfigClusters` and `loadDynamicClusters` helpers to handle different kubeconfig configuration possibilites & surface appropriate logs. 

The new cases : 
- Empty kubeconfig path: Now yields info, not error. `setKubeConfigPath` intentionally leaves it empty in-cluster.
- Missing dynamic-cluster file: Also yields info, not error. It's only written when dynamic clusters are enabled, which is off by default.
- Missing configured kubeconfig: Yields an error, this time now naming the setting to use based on the setup. In-cluster points at   `-kubeconfig` flag or  `HEADLAMP_CONFIG_KUBECONFIG` env var, since plain `KUBECONFIG` is ignored there & then non in-cluster points at `-kubeconfig` flag / `KUBECONFIG` env var.


## Steps to Test

Logic is mostly conditional & calling other functions- so a good E2E test here would be manually invoking & observing the new behavior.

No config:
1. Deploy Headlamp in-cluster with no kubeconfig set
2. Observe `No kubeconfig set, using only the in-cluster context` & `No kubeconfig for dynamically added clusters` info logs.

Present Config:
1. Deploy Headlamp in-cluster with kubeconfig set either via `-kubeconfig` or `HEADLAMP_CONFIG_KUBECONFIG`
2. For a valid kubeconfig, ensure errors do not appear.
3. For a bad kubeconfig path, ensure that `kubeconfig not found, set -kubeconfig or HEADLAMP_CONFIG_KUBECONFIG and mount the file into the pod` errors appear.