### PR TITLE
app: plugin-management: Guard artifacthub.title access in list

### DIFF
--- a/app/electron/plugin-management.test.ts
+++ b/app/electron/plugin-management.test.ts
@@ -50,6 +50,43 @@ function getUniqueTestDir(basePath: string, testName: string): string {
 }
 
 describe('PluginManager', () => {
+  it('should list plugins even when a package.json has no artifacthub', () => {
+    // Regression test: a plugin without an artifacthub key used to throw
+    // TypeError inside list(), hiding all other plugins as well.
+    const pluginsDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'list-no-artifacthub');
+
+    const makePlugin = (name: string, packageJson: object) => {
+      const dir = path.join(pluginsDir, name);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'main.js'), '');
+      fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(packageJson));
+    };
+
+    try {
+      makePlugin('no-artifacthub-plugin', {
+        name: 'no-artifacthub-plugin',
+        version: '1.0.0',
+        isManagedByHeadlampPlugin: true,
+      });
+      makePlugin('with-artifacthub-plugin', {
+        name: 'with-artifacthub-plugin',
+        version: '1.0.0',
+        isManagedByHeadlampPlugin: true,
+        artifacthub: { title: 'With ArtifactHub' },
+      });
+      const plugins = PluginManager.list(pluginsDir)!;
+      expect(plugins).toBeDefined();
+
+      const noArtifactHub = plugins.find(p => p.pluginName === 'no-artifacthub-plugin');
+      expect(noArtifactHub).toBeDefined();
+      expect(noArtifactHub!.pluginTitle).toBeNull();
+      // The sibling plugin must still be listed alongside it.
+      expect(plugins.some(p => p.pluginName === 'with-artifacthub-plugin')).toBe(true);
+    } finally {
+      fs.rmSync(pluginsDir, { recursive: true, force: true });
+    }
+  });
+
   it('should install plugin with platform-specific binaries', async () => {
     // Create unique directories for this test
     const testDataDir = getUniqueTestDir(TEST_DATA_BASE_DIR, 'platform-specific-data');
@@ -671,4 +708,32 @@ describe('TLS error detection', () => {
       }
     }
   }, 30000);
+
+  it('should throw when plugin has artifacthub url but no version', async () => {
+    // Regression test: a plugin with artifacthub.url but no artifacthub.version
+    // used to reach semver.lte with undefined, causing a crash.
+    const pluginsDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'partial-artifacthub');
+    const pluginDir = path.join(pluginsDir, 'partial-plugin');
+
+    try {
+      fs.mkdirSync(pluginDir, { recursive: true });
+      fs.writeFileSync(path.join(pluginDir, 'main.js'), '');
+      fs.writeFileSync(
+        path.join(pluginDir, 'package.json'),
+        JSON.stringify({
+          name: 'partial-plugin',
+          version: '1.0.0',
+          isManagedByHeadlampPlugin: true,
+          // url present but version is intentionally missing
+          artifacthub: { url: 'https://artifacthub.io/packages/headlamp/test-repo/partial-plugin' },
+        })
+      );
+
+      await expect(
+        PluginManager.update('partial-plugin', pluginsDir, HEADLAMP_VERSION, null, null)
+      ).rejects.toThrow('No artifacthub version found for plugin');
+    } finally {
+      fs.rmSync(pluginsDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/app/electron/plugin-management.test.ts
+++ b/app/electron/plugin-management.test.ts
@@ -418,6 +418,109 @@ function getUniqueTestDir(basePath: string, testName: string): string {
 }
 
 describe('PluginManager', () => {
+  it('should list plugins even when a package.json has no artifacthub', () => {
+    // Regression test: a plugin without an artifacthub key used to throw
+    // TypeError inside list(), hiding all other plugins as well.
+    const pluginsDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'list-no-artifacthub');
+
+    const makePlugin = (name: string, packageJson: object) => {
+      const dir = path.join(pluginsDir, name);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'main.js'), '');
+      fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(packageJson));
+    };
+
+    try {
+      makePlugin('no-artifacthub-plugin', {
+        name: 'no-artifacthub-plugin',
+        version: '1.0.0',
+        isManagedByHeadlampPlugin: true,
+      });
+      makePlugin('with-artifacthub-plugin', {
+        name: 'with-artifacthub-plugin',
+        version: '1.0.0',
+        isManagedByHeadlampPlugin: true,
+        artifacthub: { title: 'With ArtifactHub' },
+      });
+      // artifacthub present but empty: subfields must normalize to null, not undefined.
+      makePlugin('empty-artifacthub-plugin', {
+        name: 'empty-artifacthub-plugin',
+        version: '1.0.0',
+        isManagedByHeadlampPlugin: true,
+        artifacthub: {},
+      });
+      const plugins = PluginManager.list(pluginsDir)!;
+      expect(plugins).toBeDefined();
+
+      const noArtifactHub = plugins.find(p => p.pluginName === 'no-artifacthub-plugin');
+      expect(noArtifactHub).toBeDefined();
+      expect(noArtifactHub!.pluginTitle).toBeNull();
+      // The sibling plugin must still be listed alongside it.
+      expect(plugins.some(p => p.pluginName === 'with-artifacthub-plugin')).toBe(true);
+
+      const emptyArtifactHub = plugins.find(p => p.pluginName === 'empty-artifacthub-plugin');
+      expect(emptyArtifactHub).toBeDefined();
+      expect(emptyArtifactHub!.pluginTitle).toBeNull();
+      expect(emptyArtifactHub!.author).toBeNull();
+    } finally {
+      fs.rmSync(pluginsDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should throw when updating a plugin with no artifacthub metadata', async () => {
+    // list() now returns such plugins, so update() must reject explicitly
+    // instead of dereferencing the missing artifacthub object.
+    const pluginsDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'update-no-artifacthub');
+    const pluginDir = path.join(pluginsDir, 'no-artifacthub-plugin');
+
+    try {
+      fs.mkdirSync(pluginDir, { recursive: true });
+      fs.writeFileSync(path.join(pluginDir, 'main.js'), '');
+      fs.writeFileSync(
+        path.join(pluginDir, 'package.json'),
+        JSON.stringify({
+          name: 'no-artifacthub-plugin',
+          version: '1.0.0',
+          isManagedByHeadlampPlugin: true,
+        })
+      );
+
+      await expect(
+        PluginManager.update('no-artifacthub-plugin', pluginsDir, HEADLAMP_VERSION, null, null)
+      ).rejects.toThrow('No artifacthub URL found for plugin');
+    } finally {
+      fs.rmSync(pluginsDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should throw when plugin has an artifacthub url but no version', async () => {
+    // Regression test: a plugin with artifacthub.url but no artifacthub.version
+    // used to reach semver.lte with undefined.
+    const pluginsDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'partial-artifacthub');
+    const pluginDir = path.join(pluginsDir, 'partial-plugin');
+
+    try {
+      fs.mkdirSync(pluginDir, { recursive: true });
+      fs.writeFileSync(path.join(pluginDir, 'main.js'), '');
+      fs.writeFileSync(
+        path.join(pluginDir, 'package.json'),
+        JSON.stringify({
+          name: 'partial-plugin',
+          version: '1.0.0',
+          isManagedByHeadlampPlugin: true,
+          // url present but version is intentionally missing
+          artifacthub: { url: 'https://artifacthub.io/packages/headlamp/test-repo/partial-plugin' },
+        })
+      );
+
+      await expect(
+        PluginManager.update('partial-plugin', pluginsDir, HEADLAMP_VERSION, null, null)
+      ).rejects.toThrow('No artifacthub version found for plugin');
+    } finally {
+      fs.rmSync(pluginsDir, { recursive: true, force: true });
+    }
+  });
+
   it('should install plugin with platform-specific binaries', async () => {
     // Create unique directories for this test
     const testDataDir = getUniqueTestDir(TEST_DATA_BASE_DIR, 'platform-specific-data');

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -88,13 +88,13 @@ type ProgressCallback = (progress: ProgressResp) => void;
 
 interface PluginData {
   pluginName: string;
-  pluginTitle: string;
-  pluginVersion: string;
+  pluginTitle: string | null;
+  pluginVersion: string | null;
   folderName: string;
-  artifacthubURL: string;
-  repoName: string;
-  author: string;
-  artifacthubVersion: string;
+  artifacthubURL: string | null;
+  repoName: string | null;
+  author: string | null;
+  artifacthubVersion: string | null;
 }
 
 /**
@@ -284,14 +284,17 @@ export class PluginManager {
       }
 
       const pluginDir = path.join(destinationFolder, plugin.folderName);
-      // read the package.json of the plugin
-      const packageJsonPath = path.join(pluginDir, 'package.json');
-      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 
+      if (!plugin.artifacthubURL) {
+        throw new Error('No artifacthub URL found for plugin');
+      }
+      if (!plugin.artifacthubVersion) {
+        throw new Error('No artifacthub version found for plugin');
+      }
       const pluginData = await fetchPluginInfo(plugin.artifacthubURL, progressCallback, signal);
 
       const latestVersion = pluginData.version;
-      const currentVersion = packageJson.artifacthub.version;
+      const currentVersion = plugin.artifacthubVersion;
 
       if (semver.lte(latestVersion, currentVersion)) {
         throw new Error('No updates available');
@@ -402,7 +405,7 @@ export class PluginManager {
           const packageJsonPath = path.join(pluginDir, 'package.json');
           const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
           const pluginName = packageJson.name || pluginFolder.name;
-          const pluginTitle = packageJson.artifacthub.title;
+          const pluginTitle = packageJson.artifacthub ? packageJson.artifacthub.title : null;
           const pluginVersion = packageJson.version || null;
           const artifacthubURL = packageJson.artifacthub ? packageJson.artifacthub.url : null;
           const repoName = packageJson.artifacthub ? packageJson.artifacthub.repoName : null;

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -108,13 +108,13 @@ type ProgressCallback = (progress: ProgressResp) => void;
 
 interface PluginData {
   pluginName: string;
-  pluginTitle: string;
-  pluginVersion: string;
+  pluginTitle: string | null;
+  pluginVersion: string | null;
   folderName: string;
-  artifacthubURL: string;
-  repoName: string;
-  author: string;
-  artifacthubVersion: string;
+  artifacthubURL: string | null;
+  repoName: string | null;
+  author: string | null;
+  artifacthubVersion: string | null;
 }
 
 /**
@@ -893,14 +893,17 @@ export class PluginManager {
       }
 
       const pluginDir = path.join(destinationFolder, plugin.folderName);
-      // read the package.json of the plugin
-      const packageJsonPath = path.join(pluginDir, 'package.json');
-      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 
+      if (!plugin.artifacthubURL) {
+        throw new Error(`No artifacthub URL found for plugin "${pluginName}"`);
+      }
+      if (!plugin.artifacthubVersion) {
+        throw new Error(`No artifacthub version found for plugin "${pluginName}"`);
+      }
       const pluginData = await fetchPluginInfo(plugin.artifacthubURL, progressCallback, signal);
 
       const latestVersion = pluginData.version;
-      const currentVersion = packageJson.artifacthub.version;
+      const currentVersion = plugin.artifacthubVersion;
       // Keep semver out of the main-process heap until a plugin update is requested.
       const { default: semver } = await import('semver');
 
@@ -1032,14 +1035,12 @@ export class PluginManager {
           const packageJsonPath = path.join(pluginDir, 'package.json');
           const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
           const pluginName = packageJson.name || pluginFolder.name;
-          const pluginTitle = packageJson.artifacthub.title;
+          const pluginTitle = packageJson.artifacthub?.title ?? null;
           const pluginVersion = packageJson.version || null;
-          const artifacthubURL = packageJson.artifacthub ? packageJson.artifacthub.url : null;
-          const repoName = packageJson.artifacthub ? packageJson.artifacthub.repoName : null;
-          const author = packageJson.artifacthub ? packageJson.artifacthub.author : null;
-          const artifacthubVersion = packageJson.artifacthub
-            ? packageJson.artifacthub.version
-            : null;
+          const artifacthubURL = packageJson.artifacthub?.url ?? null;
+          const repoName = packageJson.artifacthub?.repoName ?? null;
+          const author = packageJson.artifacthub?.author ?? null;
+          const artifacthubVersion = packageJson.artifacthub?.version ?? null;
           // Store plugin data (folder name and plugin name)
           pluginsData.push({
             pluginName,

--- a/plugins/pluginctl/src/plugin-management.js
+++ b/plugins/pluginctl/src/plugin-management.js
@@ -249,7 +249,7 @@ class PluginManager {
           const packageJsonPath = path.join(pluginDir, 'package.json');
           const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
           const pluginName = packageJson.name || pluginFolder.name;
-          const pluginTitle = packageJson.artifacthub.title;
+          const pluginTitle = packageJson.artifacthub ? packageJson.artifacthub.title : null;
           const pluginVersion = packageJson.version || null;
           const artifacthubURL = packageJson.artifacthub ? packageJson.artifacthub.url : null;
           const repoName = packageJson.artifacthub ? packageJson.artifacthub.repoName : null;

--- a/plugins/pluginctl/src/plugin-management.js
+++ b/plugins/pluginctl/src/plugin-management.js
@@ -130,14 +130,18 @@ class PluginManager {
       }
 
       const pluginDir = path.join(destinationFolder, plugin.folderName);
-      // read the package.json of the plugin
-      const packageJsonPath = path.join(pluginDir, 'package.json');
-      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+      if (!plugin.artifacthubURL) {
+        throw new Error(`No artifacthub URL found for plugin "${pluginName}"`);
+      }
+      if (!plugin.artifacthubVersion) {
+        throw new Error(`No artifacthub version found for plugin "${pluginName}"`);
+      }
 
       const pluginData = await fetchPluginInfo(plugin.artifacthubURL, progressCallback, signal);
 
       const latestVersion = pluginData.version;
-      const currentVersion = packageJson.artifacthub.version;
+      const currentVersion = plugin.artifacthubVersion;
 
       if (semver.lte(latestVersion, currentVersion)) {
         throw new Error('No updates available');
@@ -249,14 +253,12 @@ class PluginManager {
           const packageJsonPath = path.join(pluginDir, 'package.json');
           const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
           const pluginName = packageJson.name || pluginFolder.name;
-          const pluginTitle = packageJson.artifacthub.title;
+          const pluginTitle = packageJson.artifacthub?.title ?? null;
           const pluginVersion = packageJson.version || null;
-          const artifacthubURL = packageJson.artifacthub ? packageJson.artifacthub.url : null;
-          const repoName = packageJson.artifacthub ? packageJson.artifacthub.repoName : null;
-          const author = packageJson.artifacthub ? packageJson.artifacthub.author : null;
-          const artifacthubVersion = packageJson.artifacthub
-            ? packageJson.artifacthub.version
-            : null;
+          const artifacthubURL = packageJson.artifacthub?.url ?? null;
+          const repoName = packageJson.artifacthub?.repoName ?? null;
+          const author = packageJson.artifacthub?.author ?? null;
+          const artifacthubVersion = packageJson.artifacthub?.version ?? null;
           // Store plugin data (folder name and plugin name)
           pluginsData.push({
             pluginName,

--- a/plugins/pluginctl/src/plugin-management.test.js
+++ b/plugins/pluginctl/src/plugin-management.test.js
@@ -89,6 +89,36 @@ describe('PluginManager Test Cases', () => {
       });
     });
 
+    test('List Plugins when package.json has no artifacthub', () => {
+      // Regression test: a plugin without an artifacthub key used to throw
+      // TypeError inside list(), hiding all other plugins as well.
+      const noArtifactHubDir = path.join(workDir, 'no-artifacthub-plugin');
+      fs.mkdirSync(noArtifactHubDir);
+      fs.writeFileSync(path.join(noArtifactHubDir, 'main.js'), '');
+      fs.writeFileSync(
+        path.join(noArtifactHubDir, 'package.json'),
+        JSON.stringify({
+          name: 'no-artifacthub-plugin',
+          version: '1.0.0',
+          isManagedByHeadlampPlugin: true,
+        })
+      );
+
+      PluginManager.list(workDir, mockProgressCallback);
+      expect(mockProgressCallback).toHaveBeenCalledWith({
+        type: 'success',
+        message: 'Plugins Listed',
+        data: expect.any(Array),
+      });
+
+      const plugins = mockProgressCallback.mock.calls[0][0].data;
+      const noArtifactHub = plugins.find(p => p.pluginName === 'no-artifacthub-plugin');
+      expect(noArtifactHub).toBeDefined();
+      expect(noArtifactHub.pluginTitle).toBeNull();
+      // The pre-installed flux plugin must still be listed alongside it.
+      expect(plugins.some(p => p.pluginName === '@headlamp-k8s/flux')).toBe(true);
+    });
+
     test('No Update available for Plugin', async () => {
       const packageJSONPath = `${workDir}/headlamp_flux/package.json`;
       const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath));

--- a/plugins/pluginctl/src/plugin-management.test.js
+++ b/plugins/pluginctl/src/plugin-management.test.js
@@ -89,6 +89,98 @@ describe('PluginManager Test Cases', () => {
       });
     });
 
+    test('List Plugins when package.json has no artifacthub', () => {
+      // Regression test: a plugin without an artifacthub key used to throw
+      // TypeError inside list(), hiding all other plugins as well.
+      const noArtifactHubDir = path.join(workDir, 'no-artifacthub-plugin');
+      fs.mkdirSync(noArtifactHubDir);
+      fs.writeFileSync(path.join(noArtifactHubDir, 'main.js'), '');
+      fs.writeFileSync(
+        path.join(noArtifactHubDir, 'package.json'),
+        JSON.stringify({
+          name: 'no-artifacthub-plugin',
+          version: '1.0.0',
+          isManagedByHeadlampPlugin: true,
+        })
+      );
+
+      PluginManager.list(workDir, mockProgressCallback);
+      expect(mockProgressCallback).toHaveBeenCalledWith({
+        type: 'success',
+        message: 'Plugins Listed',
+        data: expect.any(Array),
+      });
+
+      const plugins = mockProgressCallback.mock.calls[0][0].data;
+      const noArtifactHub = plugins.find(p => p.pluginName === 'no-artifacthub-plugin');
+      expect(noArtifactHub).toBeDefined();
+      expect(noArtifactHub.pluginTitle).toBeNull();
+      // The pre-installed flux plugin must still be listed alongside it.
+      expect(plugins.some(p => p.pluginName === '@headlamp-k8s/flux')).toBe(true);
+    });
+
+    test('List Plugins normalizes missing artifacthub subfields to null', () => {
+      // artifacthub present but empty: subfields must be null, not undefined.
+      const emptyDir = path.join(workDir, 'empty-artifacthub-plugin');
+      fs.mkdirSync(emptyDir);
+      fs.writeFileSync(path.join(emptyDir, 'main.js'), '');
+      fs.writeFileSync(
+        path.join(emptyDir, 'package.json'),
+        JSON.stringify({
+          name: 'empty-artifacthub-plugin',
+          version: '1.0.0',
+          isManagedByHeadlampPlugin: true,
+          artifacthub: {},
+        })
+      );
+
+      PluginManager.list(workDir, mockProgressCallback);
+
+      const plugins = mockProgressCallback.mock.calls[0][0].data;
+      const emptyArtifactHub = plugins.find(p => p.pluginName === 'empty-artifacthub-plugin');
+      expect(emptyArtifactHub).toBeDefined();
+      expect(emptyArtifactHub.pluginTitle).toBeNull();
+      expect(emptyArtifactHub.author).toBeNull();
+    });
+
+    test('Update Plugin throws when artifacthub URL is missing', async () => {
+      const noArtifactHubDir = path.join(workDir, 'no-artifacthub-plugin');
+      fs.mkdirSync(noArtifactHubDir);
+      fs.writeFileSync(path.join(noArtifactHubDir, 'main.js'), '');
+      fs.writeFileSync(
+        path.join(noArtifactHubDir, 'package.json'),
+        JSON.stringify({
+          name: 'no-artifacthub-plugin',
+          version: '1.0.0',
+          isManagedByHeadlampPlugin: true,
+        })
+      );
+
+      await expect(
+        PluginManager.update('no-artifacthub-plugin', workDir, '', null, null)
+      ).rejects.toThrow('No artifacthub URL found for plugin');
+    });
+
+    test('Update Plugin throws when artifacthub version is missing', async () => {
+      // url present but version absent: semver.lte must never see undefined.
+      const partialDir = path.join(workDir, 'partial-artifacthub-plugin');
+      fs.mkdirSync(partialDir);
+      fs.writeFileSync(path.join(partialDir, 'main.js'), '');
+      fs.writeFileSync(
+        path.join(partialDir, 'package.json'),
+        JSON.stringify({
+          name: 'partial-artifacthub-plugin',
+          version: '1.0.0',
+          isManagedByHeadlampPlugin: true,
+          artifacthub: { url: FLUX_URL },
+        })
+      );
+
+      await expect(
+        PluginManager.update('partial-artifacthub-plugin', workDir, '', null, null)
+      ).rejects.toThrow('No artifacthub version found for plugin');
+    });
+
     test('No Update available for Plugin', async () => {
       const packageJSONPath = `${workDir}/headlamp_flux/package.json`;
       const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath));


### PR DESCRIPTION
## Summary

This PR fixes a crash in `PluginManager.list()` when a plugin's `package.json` has no `artifacthub` object. The title field was read without a null check, while every sibling field (`url`, `repoName`, `author`, `version`) was already guarded. One such plugin caused a `TypeError` that aborted the entire loop, hiding all other plugins from the manager UI.

## Related Issue

Fixes #6690

## Changes

- `app/electron/plugin-management.ts`: guard `pluginTitle` with the same conditional used by sibling fields.
- `plugins/pluginctl/src/plugin-management.js`: same fix in the JS copy of the same function.

## Steps to Test

1. Create a plugin folder in the user plugins directory with a valid `main.js` and `package.json` that has no `artifacthub` key (but passes `checkValidPluginFolder`).
2. Open the Plugins page in the desktop app (or run `pluginctl list`).
3. Verify the plugin without `artifacthub` metadata is listed (title is null/empty) and all other plugins still appear.
4. Before this fix, the whole list would be empty due to the TypeError.

## Notes for the Reviewer

- Two-file change; both files share the same logic. The fix aligns `pluginTitle` with the defensive pattern already used for `artifacthubURL`, `repoName`, `author`, and `artifacthubVersion` on the lines immediately below.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed plugin listing when an installed plugin lacks optional metadata.
  * Plugins without a title now appear with a blank title instead of preventing the plugin list from loading.
  * Existing plugins continue to display correctly alongside incomplete metadata.
  * Plugin updates now show a clear error when no Artifact Hub URL is available.

* **Tests**
  * Added regression coverage for missing plugin metadata and mixed plugin listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->