### PR TITLE
fix: use mrt-row-actions id to hide actions column when all others hidden

### DIFF
--- a/frontend/src/components/common/Table/Table.stories.tsx
+++ b/frontend/src/components/common/Table/Table.stories.tsx
@@ -471,3 +471,20 @@ WithFilterMultiSelect.args = {
     },
   ],
 };
+
+// Row actions column should hide (and drop its grid track) when all data columns are hidden.
+export const RowActionsAllColumnsHidden = Template.bind({});
+RowActionsAllColumnsHidden.args = {
+  ...fixtureData,
+  enableRowActions: true,
+  renderRowActions: () => <Typography>action</Typography>,
+  initialState: {
+    columnVisibility: {
+      '0': false,
+      '1': false,
+      '2': false,
+      '3': false,
+      '4': false,
+    },
+  },
+};

--- a/frontend/src/components/common/Table/Table.test.tsx
+++ b/frontend/src/components/common/Table/Table.test.tsx
@@ -429,19 +429,45 @@ describe('Table states and options', () => {
     clientWidth.mockRestore();
   });
 
-  it('hides and restores the actions column with data-column visibility', () => {
-    tableMocks.columnVisibility = { '0': false };
-    const hiddenResult = renderTable({
+  it('hides and restores the actions column when all data columns are hidden', () => {
+    const result = renderTable({
       columns: [{ accessorKey: 'selected', header: 'Selection' }],
+      enableRowActions: true,
+      state: { columnVisibility: { '0': false } },
     });
 
     expect(tableMocks.setColumnVisibility).toHaveBeenCalledOnce();
-    hiddenResult.unmount();
+    expect(tableMocks.setColumnVisibility.mock.calls[0][0]({})).toEqual({
+      'mrt-row-actions': false,
+    });
 
-    tableMocks.setColumnVisibility.mockClear();
-    tableMocks.columnVisibility = { '0': true, actions: false };
-    renderTable({ columns: [{ accessorKey: 'selected', header: 'Selection' }] });
+    result.rerender(
+      <ThemeProvider theme={theme}>
+        <Table
+          columns={[{ accessorKey: 'selected', header: 'Selection' }]}
+          data={[{ selected: false }]}
+          enableRowActions
+          state={{ columnVisibility: { '0': true } }}
+        />
+      </ThemeProvider>
+    );
 
-    expect(tableMocks.setColumnVisibility).toHaveBeenCalledOnce();
+    expect(tableMocks.setColumnVisibility).toHaveBeenCalledTimes(2);
+    // The restore drops the effect's own override instead of forcing `true`,
+    // so any caller visibility state wins again.
+    expect(
+      tableMocks.setColumnVisibility.mock.calls[1][0]({ 'mrt-row-actions': false, '0': false })
+    ).toEqual({ '0': false });
+  });
+
+  it('keeps a caller-hidden actions column hidden while data columns are visible', () => {
+    renderTable({
+      columns: [{ accessorKey: 'selected', header: 'Selection' }],
+      enableRowActions: true,
+      state: { columnVisibility: { 'mrt-row-actions': false } },
+    });
+
+    expect(tableMocks.setColumnVisibility).not.toHaveBeenCalled();
+    expect(tableMocks.options.state.columnVisibility).toEqual({ 'mrt-row-actions': false });
   });
 });

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -516,21 +516,37 @@ export default function Table<RowItem extends Record<string, any>>({
     [table]
   );
 
+  // Whether this effect hid the actions column itself. Only then may it restore
+  // the column, so an actions column hidden by a caller (state.columnVisibility)
+  // or initialState keeps staying hidden.
+  const actionsHiddenByEffect = useRef(false);
+
   // Hide actions column when others are hidden
   useEffect(() => {
-    const visibility = table.getState().columnVisibility || {};
+    if (!tableProps.enableRowActions) {
+      return;
+    }
+    const visibility = mergedColumnVisibility;
 
     const shouldHideActions = tableColumns
-      .filter(col => (col.id ?? '') !== 'actions')
+      .filter(col => (col.id ?? '') !== 'mrt-row-actions')
       .every(col => visibility[col.id ?? ''] === false);
 
-    if (shouldHideActions && visibility['actions'] !== false) {
-      table.setColumnVisibility(prev => ({ ...prev, actions: false }));
-    } else if (!shouldHideActions && visibility['actions'] === false) {
-      table.setColumnVisibility(prev => ({ ...prev, actions: true }));
+    if (shouldHideActions && visibility['mrt-row-actions'] !== false) {
+      actionsHiddenByEffect.current = true;
+      table.setColumnVisibility(prev => ({ ...prev, 'mrt-row-actions': false }));
+    } else if (!shouldHideActions && actionsHiddenByEffect.current) {
+      // Drop this effect's own override instead of forcing `true`, so caller
+      // visibility state wins again after the data columns come back.
+      actionsHiddenByEffect.current = false;
+      table.setColumnVisibility(prev => {
+        const next = { ...prev };
+        delete next['mrt-row-actions'];
+        return next;
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [table.getState().columnVisibility, tableColumns, table]);
+  }, [mergedColumnVisibility, tableColumns, tableProps.enableRowActions]);
 
   const gridTemplateColumns = useMemo(() => {
     let preGridTemplateColumns = tableProps.columns
@@ -546,7 +562,9 @@ export default function Table<RowItem extends Record<string, any>>({
         return it.gridTemplate ?? '1fr';
       })
       .join(' ');
-    if (tableProps.enableRowActions) {
+    const actionsHidden =
+      tableProps.enableRowActions && mergedColumnVisibility?.['mrt-row-actions'] === false;
+    if (tableProps.enableRowActions && !actionsHidden) {
       preGridTemplateColumns = `${preGridTemplateColumns} 0.05fr`;
     }
     if (tableProps.enableRowSelection) {

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -520,13 +520,13 @@ export default function Table<RowItem extends Record<string, any>>({
     const visibility = table.getState().columnVisibility || {};
 
     const shouldHideActions = tableColumns
-      .filter(col => (col.id ?? '') !== 'actions')
+      .filter(col => (col.id ?? '') !== 'mrt-row-actions')
       .every(col => visibility[col.id ?? ''] === false);
 
-    if (shouldHideActions && visibility['actions'] !== false) {
-      table.setColumnVisibility(prev => ({ ...prev, actions: false }));
-    } else if (!shouldHideActions && visibility['actions'] === false) {
-      table.setColumnVisibility(prev => ({ ...prev, actions: true }));
+    if (shouldHideActions && visibility['mrt-row-actions'] !== false) {
+      table.setColumnVisibility(prev => ({ ...prev, 'mrt-row-actions': false }));
+    } else if (!shouldHideActions && visibility['mrt-row-actions'] === false) {
+      table.setColumnVisibility(prev => ({ ...prev, 'mrt-row-actions': true }));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [table.getState().columnVisibility, tableColumns, table]);

--- a/frontend/src/components/common/Table/__snapshots__/Table.RowActionsAllColumnsHidden.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.RowActionsAllColumnsHidden.stories.storyshot
@@ -1,0 +1,178 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-8atqhb"
+    >
+      <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="MuiBox-root css-ty8jgw"
+        role="status"
+      />
+      <div
+        class="MuiBox-root css-1ipmh7v"
+      >
+        <div
+          class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
+          style="min-height: 0px;"
+        >
+          <div
+            class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
+          >
+            <div
+              class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                role="alert"
+              >
+                <div
+                  class="MuiAlert-message css-1pxa9xg-MuiAlert-message"
+                >
+                  <div
+                    class="MuiStack-root css-5kul5x-MuiStack-root"
+                  >
+                    <div
+                      class="MuiBox-root css-k008qs"
+                    >
+                       
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+          style="opacity: 0; visibility: hidden;"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-18b7jph-MuiTypography-root"
+          >
+            Drop to group by 
+          </p>
+        </div>
+        <div
+          class="MuiBox-root css-zrlv9q"
+        >
+          <span />
+          <div
+            class="MuiBox-root css-1p0wbhh"
+          >
+            <div
+              class="MuiBox-root css-di3982"
+            >
+              <button
+                aria-label="Show/Hide search"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  data-testid="SearchIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                  />
+                </svg>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-label="Show/Hide filters"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  data-testid="FilterListIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
+                  />
+                </svg>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-haspopup="menu"
+                aria-label="Show/Hide columns"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  data-testid="ViewColumnIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M14.67 5v14H9.33V5zm1 14H21V5h-5.33zm-7.34 0V5H3v14z"
+                  />
+                </svg>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <table
+        class="MuiTable-root css-1wjj2v9-MuiTable-root"
+      >
+        <thead
+          class="MuiTableHead-root css-1tmrira-MuiTableHead-root"
+        >
+          <tr
+            class="css-1lqh5un"
+          />
+        </thead>
+        <tbody
+          class="css-1obf64m"
+        >
+          <tr
+            class="css-1ospngb"
+            data-selected="false"
+          />
+          <tr
+            class="css-1ospngb"
+            data-selected="false"
+          />
+          <tr
+            class="css-1ospngb"
+            data-selected="false"
+          />
+        </tbody>
+      </table>
+      <div
+        class="MuiBox-root css-1bxknjp"
+      >
+        <div
+          class="MuiBox-root css-1llu0od"
+        >
+          <span />
+          <div
+            class="MuiBox-root css-qpxlqp"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
## Summary

Fixes #6701

The `useEffect` in `Table.tsx` that collapses the actions column when all data columns are responsively hidden was toggling `visibility['actions']`. However, MRT registers the actions column under the id `'mrt-row-actions'` (pushed onto `columnOrder` at line 314). The mismatch meant the feature never fired — the actions column and its 0.05fr grid track stayed visible as an empty strip whenever all data columns were hidden.

## Changes

Replaced `'actions'` with `'mrt-row-actions'` in 4 spots inside the `useEffect`:
- The `filter` exclusion guard
- Both `visibility[...]` checks
- Both `setColumnVisibility` calls

## Steps to Test

1. Open any resource list table (e.g. Deployments).
2. Narrow the window until all data columns are responsively hidden.
3. Verify the actions column now collapses instead of rendering as an empty strip.