### PR TITLE
app: Fix zoom controls stepping from a stale zoom factor

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -32,7 +32,6 @@ import { IpcMainEvent, MenuItemConstructorOptions } from 'electron/main';
 import find_process from 'find-process';
 import * as fsPromises from 'fs/promises';
 import * as net from 'net';
-import fs from 'node:fs';
 import { userInfo } from 'node:os';
 import { promisify } from 'node:util';
 import { platform } from 'os';
@@ -60,6 +59,13 @@ import {
   setTrayIconEnabled,
 } from './tray';
 import windowSize from './windowSize';
+import {
+  createZoomController,
+  DEFAULT_ZOOM_FACTOR,
+  loadZoomFactor,
+  saveZoomFactor,
+  ZOOM_STEP,
+} from './zoom';
 
 if (process.env.APPIMAGE) {
   app.commandLine.appendSwitch('disable-setuid-sandbox');
@@ -1046,19 +1052,19 @@ function getDefaultAppMenu(): AppMenu[] {
           label: i18n.t('Reset Zoom'),
           id: 'original-reset-zoom',
           accelerator: 'CmdOrCtrl+0',
-          click: () => setZoom(1.0),
+          click: () => setZoom(DEFAULT_ZOOM_FACTOR),
         },
         {
           label: i18n.t('Zoom In'),
           id: 'original-zoom-in',
           accelerator: 'CmdOrCtrl+=',
-          click: () => adjustZoom(0.1),
+          click: () => adjustZoom(ZOOM_STEP),
         },
         {
           label: i18n.t('Zoom Out'),
           id: 'original-zoom-out',
           accelerator: 'CmdOrCtrl+-',
-          click: () => adjustZoom(-0.1),
+          click: () => adjustZoom(-ZOOM_STEP),
         },
         sep,
         {
@@ -1343,40 +1349,20 @@ function killProcess(pid: number) {
 }
 
 const ZOOM_FILE_PATH = path.join(app.getPath('userData'), 'headlamp-config.json');
-let cachedZoom: number = 1.0;
 
-function saveZoomFactor(factor: number) {
-  try {
-    fs.writeFileSync(ZOOM_FILE_PATH, JSON.stringify({ zoomFactor: factor }), 'utf-8');
-  } catch (err) {
-    console.error('Failed to save zoom factor:', err);
-  }
-}
-
-async function loadZoomFactor(): Promise<number> {
-  try {
-    const content = await fsPromises.readFile(ZOOM_FILE_PATH, 'utf-8');
-    const { zoomFactor = 1.0 } = JSON.parse(content);
-    return typeof zoomFactor === 'number' ? zoomFactor : 1.0;
-  } catch (err) {
-    console.error('Failed to load zoom factor, defaulting to 1.0:', err);
-    return 1.0;
-  }
-}
-
-// The zoom factor should respect the fixed limits set by Electron.
-function clampZoom(factor: number) {
-  return Math.min(5.0, Math.max(0.25, factor));
-}
+const zoomController = createZoomController({
+  getWebContents: () => mainWindow?.webContents ?? null,
+  // Persist on every change rather than only on quit, so a crash or a force quit
+  // doesn't lose the zoom level the user just picked.
+  onChange: factor => saveZoomFactor(ZOOM_FILE_PATH, factor),
+});
 
 function setZoom(factor: number) {
-  cachedZoom = factor;
-  mainWindow?.webContents.setZoomFactor(cachedZoom);
+  zoomController.set(factor);
 }
 
 function adjustZoom(delta: number) {
-  const newZoom = clampZoom(cachedZoom + delta);
-  setZoom(newZoom);
+  zoomController.adjust(delta);
 }
 
 function startElectron() {
@@ -1583,13 +1569,22 @@ function startElectron() {
     });
 
     mainWindow.webContents.on('did-finish-load', async () => {
-      const startZoom = await loadZoomFactor();
-      if (startZoom !== 1.0) {
+      const startZoom = await loadZoomFactor(ZOOM_FILE_PATH);
+      if (startZoom !== DEFAULT_ZOOM_FACTOR) {
         setZoom(startZoom);
       }
 
       // Inject the backend port into the window object
       mainWindow?.webContents.executeJavaScript(`window.headlampBackendPort = ${actualPort};`);
+    });
+
+    // Zoom can change without going through our menu: a trackpad pinch, Ctrl+wheel,
+    // or Chromium restoring a stored per-origin zoom. Adopt those changes, otherwise
+    // the cached factor goes stale and the next Zoom In steps from the wrong value.
+    mainWindow.webContents.on('zoom-changed', () => {
+      // The event signals the intent to zoom, so the new factor may not be applied
+      // yet; read it on the next tick to capture the value that actually landed.
+      setImmediate(() => zoomController.syncFromWebContents());
     });
 
     mainWindow.webContents.on('dom-ready', () => {
@@ -1864,7 +1859,8 @@ function startElectron() {
     isQuitting = true;
     cleanupHeadlampTray();
     hasTray = false;
-    saveZoomFactor(cachedZoom);
+    // The zoom factor is already persisted on every change, so there is nothing to
+    // save here.
     i18n.off('languageChanged');
     if (mainWindow) {
       mainWindow.removeAllListeners('close');

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -32,7 +32,6 @@ import { IpcMainEvent, MenuItemConstructorOptions } from 'electron/main';
 import find_process from 'find-process';
 import * as fsPromises from 'fs/promises';
 import * as net from 'net';
-import fs from 'node:fs';
 import { userInfo } from 'node:os';
 import { promisify } from 'node:util';
 import { platform } from 'os';
@@ -69,6 +68,13 @@ import {
   setTrayIconEnabled,
 } from './tray';
 import windowSize from './windowSize';
+import {
+  createZoomController,
+  DEFAULT_ZOOM_FACTOR,
+  loadZoomFactor,
+  saveZoomFactor,
+  ZOOM_STEP,
+} from './zoom';
 
 if (process.env.APPIMAGE) {
   app.commandLine.appendSwitch('disable-setuid-sandbox');
@@ -1081,19 +1087,19 @@ function getDefaultAppMenu(): AppMenu[] {
           label: i18n.t('Reset Zoom'),
           id: 'original-reset-zoom',
           accelerator: 'CmdOrCtrl+0',
-          click: () => setZoom(1.0),
+          click: () => setZoom(DEFAULT_ZOOM_FACTOR),
         },
         {
           label: i18n.t('Zoom In'),
           id: 'original-zoom-in',
           accelerator: getZoomInAccelerator(),
-          click: () => adjustZoom(0.1),
+          click: () => adjustZoom(ZOOM_STEP),
         },
         {
           label: i18n.t('Zoom Out'),
           id: 'original-zoom-out',
           accelerator: 'CmdOrCtrl+-',
-          click: () => adjustZoom(-0.1),
+          click: () => adjustZoom(-ZOOM_STEP),
         },
         sep,
         {
@@ -1390,40 +1396,20 @@ function killProcess(pid: number) {
 }
 
 const ZOOM_FILE_PATH = path.join(app.getPath('userData'), 'headlamp-config.json');
-let cachedZoom: number = 1.0;
 
-function saveZoomFactor(factor: number) {
-  try {
-    fs.writeFileSync(ZOOM_FILE_PATH, JSON.stringify({ zoomFactor: factor }), 'utf-8');
-  } catch (err) {
-    console.error('Failed to save zoom factor:', err);
-  }
-}
-
-async function loadZoomFactor(): Promise<number> {
-  try {
-    const content = await fsPromises.readFile(ZOOM_FILE_PATH, 'utf-8');
-    const { zoomFactor = 1.0 } = JSON.parse(content);
-    return typeof zoomFactor === 'number' ? zoomFactor : 1.0;
-  } catch (err) {
-    console.error('Failed to load zoom factor, defaulting to 1.0:', err);
-    return 1.0;
-  }
-}
-
-// The zoom factor should respect the fixed limits set by Electron.
-function clampZoom(factor: number) {
-  return Math.min(5.0, Math.max(0.25, factor));
-}
+const zoomController = createZoomController({
+  getWebContents: () => mainWindow?.webContents ?? null,
+  // Persist on every change rather than only on quit, so a crash or a force quit
+  // doesn't lose the zoom level the user just picked.
+  onChange: factor => saveZoomFactor(ZOOM_FILE_PATH, factor),
+});
 
 function setZoom(factor: number) {
-  cachedZoom = factor;
-  mainWindow?.webContents.setZoomFactor(cachedZoom);
+  zoomController.set(factor);
 }
 
 function adjustZoom(delta: number) {
-  const newZoom = clampZoom(cachedZoom + delta);
-  setZoom(newZoom);
+  zoomController.adjust(delta);
 }
 
 function startElectron() {
@@ -1630,13 +1616,22 @@ function startElectron() {
     });
 
     mainWindow.webContents.on('did-finish-load', async () => {
-      const startZoom = await loadZoomFactor();
-      if (startZoom !== 1.0) {
+      const startZoom = await loadZoomFactor(ZOOM_FILE_PATH);
+      if (startZoom !== DEFAULT_ZOOM_FACTOR) {
         setZoom(startZoom);
       }
 
       // Inject the backend port into the window object
       mainWindow?.webContents.executeJavaScript(`window.headlampBackendPort = ${actualPort};`);
+    });
+
+    // Zoom can change without going through our menu: a trackpad pinch, Ctrl+wheel,
+    // or Chromium restoring a stored per-origin zoom. Adopt those changes, otherwise
+    // the cached factor goes stale and the next Zoom In steps from the wrong value.
+    mainWindow.webContents.on('zoom-changed', () => {
+      // The event signals the intent to zoom, so the new factor may not be applied
+      // yet; read it on the next tick to capture the value that actually landed.
+      setImmediate(() => zoomController.syncFromWebContents());
     });
 
     mainWindow.webContents.on('dom-ready', () => {
@@ -1911,7 +1906,8 @@ function startElectron() {
     isQuitting = true;
     cleanupHeadlampTray();
     hasTray = false;
-    saveZoomFactor(cachedZoom);
+    // The zoom factor is already persisted on every change, so there is nothing to
+    // save here.
     i18n.off('languageChanged');
     if (mainWindow) {
       mainWindow.removeAllListeners('close');

--- a/app/electron/zoom.test.ts
+++ b/app/electron/zoom.test.ts
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clampZoom,
+  createZoomController,
+  DEFAULT_ZOOM_FACTOR,
+  loadZoomFactor,
+  MAX_ZOOM_FACTOR,
+  MIN_ZOOM_FACTOR,
+  saveZoomFactor,
+  ZOOM_STEP,
+  ZoomWebContents,
+} from './zoom';
+
+function tmpPath(): string {
+  return path.join(os.tmpdir(), `zoom-test-${Date.now()}-${Math.random()}.json`);
+}
+
+/** A stand-in for Electron's WebContents that records what zoom was applied. */
+function fakeWebContents(initialFactor = DEFAULT_ZOOM_FACTOR) {
+  let factor = initialFactor;
+  let destroyed = false;
+
+  return {
+    getZoomFactor: () => factor,
+    setZoomFactor: (value: number) => {
+      factor = value;
+    },
+    isDestroyed: () => destroyed,
+    /** Simulates zoom changing behind our back (trackpad pinch, Ctrl+wheel, ...). */
+    zoomExternallyTo: (value: number) => {
+      factor = value;
+    },
+    destroy: () => {
+      destroyed = true;
+    },
+  };
+}
+
+describe('clampZoom', () => {
+  it('keeps values within the bounds Electron accepts', () => {
+    expect(clampZoom(10)).toBe(MAX_ZOOM_FACTOR);
+    expect(clampZoom(0.01)).toBe(MIN_ZOOM_FACTOR);
+    expect(clampZoom(1.5)).toBe(1.5);
+  });
+
+  it('rounds away floating point drift from repeated steps', () => {
+    expect(clampZoom(0.1 + 0.1 + 0.1 + 1)).toBe(1.3);
+  });
+
+  it('falls back to the default for non-finite input', () => {
+    expect(clampZoom(NaN)).toBe(DEFAULT_ZOOM_FACTOR);
+    expect(clampZoom(Infinity)).toBe(DEFAULT_ZOOM_FACTOR);
+  });
+});
+
+describe('zoom persistence', () => {
+  let filePath: string;
+
+  beforeEach(() => {
+    filePath = tmpPath();
+  });
+
+  afterEach(() => {
+    try {
+      if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+    } catch {
+      // ignore
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('round-trips a zoom factor', async () => {
+    saveZoomFactor(filePath, 1.4);
+    expect(await loadZoomFactor(filePath)).toBe(1.4);
+  });
+
+  it('defaults when the file does not exist, without logging an error', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(await loadZoomFactor(filePath)).toBe(DEFAULT_ZOOM_FACTOR);
+    // A missing file is the normal first-launch case (see #6263).
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it('defaults when the file holds malformed JSON', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    fs.writeFileSync(filePath, '{not json', 'utf-8');
+
+    expect(await loadZoomFactor(filePath)).toBe(DEFAULT_ZOOM_FACTOR);
+  });
+
+  it('defaults when zoomFactor is not a number', async () => {
+    fs.writeFileSync(filePath, JSON.stringify({ zoomFactor: 'big' }), 'utf-8');
+
+    expect(await loadZoomFactor(filePath)).toBe(DEFAULT_ZOOM_FACTOR);
+  });
+
+  it('clamps an out-of-range value read from disk', async () => {
+    // The config file is user-editable, so it can hold a factor Chromium would reject.
+    fs.writeFileSync(filePath, JSON.stringify({ zoomFactor: 99 }), 'utf-8');
+
+    expect(await loadZoomFactor(filePath)).toBe(MAX_ZOOM_FACTOR);
+  });
+});
+
+describe('ZoomController', () => {
+  it('applies the zoom factor to the WebContents', () => {
+    const webContents = fakeWebContents();
+    const controller = createZoomController({ getWebContents: () => webContents });
+
+    controller.set(1.5);
+
+    expect(controller.factor).toBe(1.5);
+    expect(webContents.getZoomFactor()).toBe(1.5);
+  });
+
+  it('steps up and down by the configured amount', () => {
+    const webContents = fakeWebContents();
+    const controller = createZoomController({ getWebContents: () => webContents });
+
+    controller.adjust(ZOOM_STEP);
+    controller.adjust(ZOOM_STEP);
+    expect(controller.factor).toBe(1.2);
+
+    controller.adjust(-ZOOM_STEP);
+    expect(controller.factor).toBe(1.1);
+  });
+
+  it('clamps instead of running past the bounds', () => {
+    const webContents = fakeWebContents();
+    const controller = createZoomController({ getWebContents: () => webContents });
+
+    for (let i = 0; i < 100; i++) {
+      controller.adjust(ZOOM_STEP);
+    }
+    expect(controller.factor).toBe(MAX_ZOOM_FACTOR);
+
+    for (let i = 0; i < 100; i++) {
+      controller.adjust(-ZOOM_STEP);
+    }
+    expect(controller.factor).toBe(MIN_ZOOM_FACTOR);
+  });
+
+  it('resets to the default', () => {
+    const webContents = fakeWebContents();
+    const controller = createZoomController({ getWebContents: () => webContents });
+
+    controller.set(1.8);
+    controller.reset();
+
+    expect(controller.factor).toBe(DEFAULT_ZOOM_FACTOR);
+    expect(webContents.getZoomFactor()).toBe(DEFAULT_ZOOM_FACTOR);
+  });
+
+  it('notifies on change so the factor can be persisted', () => {
+    const onChange = vi.fn();
+    const controller = createZoomController({
+      getWebContents: () => fakeWebContents(),
+      onChange,
+    });
+
+    controller.set(1.3);
+    expect(onChange).toHaveBeenCalledWith(1.3);
+
+    // Setting the same factor again is not a change worth persisting.
+    onChange.mockClear();
+    controller.set(1.3);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when there is no window yet', () => {
+    const controller = createZoomController({ getWebContents: () => null });
+
+    expect(() => controller.set(1.5)).not.toThrow();
+    expect(controller.factor).toBe(1.5);
+  });
+
+  it('does not touch destroyed WebContents', () => {
+    const webContents = fakeWebContents();
+    const setZoomFactor = vi.spyOn(webContents, 'setZoomFactor');
+    const controller = createZoomController({ getWebContents: () => webContents });
+
+    webContents.destroy();
+    controller.set(1.5);
+
+    expect(setZoomFactor).not.toHaveBeenCalled();
+  });
+
+  it('steps on from a restored zoom factor', () => {
+    const webContents = fakeWebContents();
+    const controller = createZoomController({ getWebContents: () => webContents });
+
+    // How main.ts restores the persisted factor once the window has loaded.
+    controller.set(1.4);
+    controller.adjust(ZOOM_STEP);
+
+    expect(controller.factor).toBe(1.5);
+  });
+
+  // Regression test for the zoom controls appearing broken after zoom changed
+  // outside the app menu. `adjust` must step from what is on screen, not from the
+  // last value we applied: Electron only emits `zoom-changed` for user gestures,
+  // never for a programmatic setZoomFactor, so an event listener alone is not
+  // enough to keep the cached factor accurate.
+  it('steps from the on-screen factor when zoom changed behind our back', () => {
+    const webContents = fakeWebContents();
+    const controller = createZoomController({ getWebContents: () => webContents });
+
+    webContents.zoomExternallyTo(2.0);
+    controller.adjust(ZOOM_STEP);
+
+    // Before this fix the cached 1.0 won and the view shrank to 1.1.
+    expect(controller.factor).toBe(2.1);
+    expect(webContents.getZoomFactor()).toBe(2.1);
+  });
+
+  it('steps down from the on-screen factor too', () => {
+    const webContents = fakeWebContents();
+    const controller = createZoomController({ getWebContents: () => webContents });
+
+    webContents.zoomExternallyTo(2.0);
+    controller.adjust(-ZOOM_STEP);
+
+    expect(controller.factor).toBe(1.9);
+  });
+
+  describe('syncFromWebContents', () => {
+    // Regression test for zoom changing outside the app menu. Before this, the
+    // cached factor was write-only: after an external zoom to 2.0, Zoom In applied
+    // 1.1 (stale 1.0 + one step) and the view visibly shrank instead of growing.
+    it('adopts a zoom change made outside the menu', () => {
+      const webContents = fakeWebContents();
+      const controller = createZoomController({ getWebContents: () => webContents });
+
+      webContents.zoomExternallyTo(2.0);
+      expect(controller.syncFromWebContents()).toBe(true);
+      expect(controller.factor).toBe(2.0);
+
+      controller.adjust(ZOOM_STEP);
+
+      expect(controller.factor).toBe(2.1);
+      expect(webContents.getZoomFactor()).toBe(2.1);
+    });
+
+    it('reports no change when the cache is already accurate', () => {
+      const webContents = fakeWebContents();
+      const controller = createZoomController({ getWebContents: () => webContents });
+
+      controller.set(1.5);
+
+      expect(controller.syncFromWebContents()).toBe(false);
+    });
+
+    it('ignores the sub-epsilon drift Chromium introduces', () => {
+      const webContents = fakeWebContents();
+      const controller = createZoomController({ getWebContents: () => webContents });
+      controller.set(1.5);
+
+      // Chromium stores zoom as a log-scale level, so reading back what we set
+      // returns a value that is very slightly off.
+      webContents.zoomExternallyTo(1.5000001);
+
+      expect(controller.syncFromWebContents()).toBe(false);
+      expect(controller.factor).toBe(1.5);
+    });
+
+    it('persists the adopted factor', () => {
+      const onChange = vi.fn();
+      const webContents = fakeWebContents();
+      const controller = createZoomController({ getWebContents: () => webContents, onChange });
+
+      webContents.zoomExternallyTo(1.75);
+      controller.syncFromWebContents();
+
+      expect(onChange).toHaveBeenCalledWith(1.75);
+    });
+
+    it('does nothing when there is no live window', () => {
+      const controller = createZoomController({
+        getWebContents: () => null as ZoomWebContents | null,
+      });
+
+      expect(controller.syncFromWebContents()).toBe(false);
+    });
+  });
+});

--- a/app/electron/zoom.ts
+++ b/app/electron/zoom.ts
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fsPromises from 'fs/promises';
+import fs from 'node:fs';
+
+export const DEFAULT_ZOOM_FACTOR = 1.0;
+
+/** Chromium rejects a zoom factor outside these bounds. */
+export const MIN_ZOOM_FACTOR = 0.25;
+export const MAX_ZOOM_FACTOR = 5.0;
+
+/** How much a single Zoom In / Zoom Out step changes the factor. */
+export const ZOOM_STEP = 0.1;
+
+/**
+ * Zoom factors closer together than this are treated as equal. Chromium stores zoom
+ * internally as a log-scale level, so a round trip through it returns a value that is
+ * very slightly off the one we set.
+ */
+const ZOOM_EPSILON = 0.001;
+
+/** The zoom factor should respect the fixed limits set by Electron. */
+export function clampZoom(factor: number): number {
+  if (!Number.isFinite(factor)) {
+    return DEFAULT_ZOOM_FACTOR;
+  }
+
+  return Math.min(MAX_ZOOM_FACTOR, Math.max(MIN_ZOOM_FACTOR, roundZoom(factor)));
+}
+
+/**
+ * Rounds to two decimals so repeated steps don't accumulate binary floating point
+ * error (0.1 + 0.1 + 0.1 = 0.30000000000000004), which would otherwise be written
+ * to disk and shown to the user.
+ */
+export function roundZoom(factor: number): number {
+  return Math.round(factor * 100) / 100;
+}
+
+export function zoomFactorEquals(a: number, b: number): boolean {
+  return Math.abs(a - b) <= ZOOM_EPSILON;
+}
+
+/**
+ * Reads the persisted zoom factor, falling back to the default when the file is
+ * missing (first launch) or holds anything we can't use.
+ */
+export async function loadZoomFactor(filePath: string): Promise<number> {
+  let content: string;
+  try {
+    content = await fsPromises.readFile(filePath, 'utf-8');
+  } catch (err) {
+    // A missing file is the normal first-launch case, not an error worth reporting.
+    if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+      console.error('Failed to load zoom factor, defaulting to 1.0:', err);
+    }
+    return DEFAULT_ZOOM_FACTOR;
+  }
+
+  try {
+    const parsed = JSON.parse(content);
+    const zoomFactor = parsed?.zoomFactor;
+    // The file is user-editable, so treat anything non-numeric as unset.
+    return typeof zoomFactor === 'number' ? clampZoom(zoomFactor) : DEFAULT_ZOOM_FACTOR;
+  } catch (err) {
+    console.error('Failed to parse zoom factor, defaulting to 1.0:', err);
+    return DEFAULT_ZOOM_FACTOR;
+  }
+}
+
+/**
+ * Persists the zoom factor. Write errors are logged and swallowed so a failure here
+ * (e.g. an unwritable config file) can't take down the Electron main process; the
+ * runtime zoom still applies, it just isn't restored on the next launch.
+ */
+export function saveZoomFactor(filePath: string, factor: number): void {
+  try {
+    fs.writeFileSync(filePath, JSON.stringify({ zoomFactor: clampZoom(factor) }), 'utf-8');
+  } catch (err) {
+    console.error('Failed to save zoom factor:', err);
+  }
+}
+
+/** The subset of Electron's WebContents that zoom handling needs. */
+export interface ZoomWebContents {
+  getZoomFactor(): number;
+  setZoomFactor(factor: number): void;
+  isDestroyed(): boolean;
+}
+
+export interface ZoomControllerOptions {
+  /** Resolves the WebContents to zoom, or null when there is no window yet. */
+  getWebContents: () => ZoomWebContents | null;
+  /** Called whenever the zoom factor changes, so it can be persisted. */
+  onChange?: (factor: number) => void;
+}
+
+export interface ZoomController {
+  /** The zoom factor this controller last applied. */
+  readonly factor: number;
+  set(factor: number): void;
+  adjust(delta: number): void;
+  reset(): void;
+  /**
+   * Re-reads the zoom factor from the WebContents and adopts it.
+   *
+   * Zoom can change without going through us — a trackpad pinch, Ctrl+wheel, or
+   * Chromium restoring a previously stored per-origin zoom. Without this, the cached
+   * factor silently diverges from reality and the next Zoom In jumps from the stale
+   * value instead of the visible one.
+   *
+   * @returns true if the cached factor was out of date and has been corrected.
+   */
+  syncFromWebContents(): boolean;
+}
+
+export function createZoomController(options: ZoomControllerOptions): ZoomController {
+  const { getWebContents, onChange } = options;
+  // Starts at the default; the persisted factor is restored by calling set() once
+  // the window has loaded, which keeps the cache and the screen in agreement.
+  let cached = DEFAULT_ZOOM_FACTOR;
+
+  function liveWebContents(): ZoomWebContents | null {
+    const webContents = getWebContents();
+    // The window may be mid-close; setZoomFactor on destroyed WebContents throws.
+    return webContents && !webContents.isDestroyed() ? webContents : null;
+  }
+
+  function set(factor: number): void {
+    const next = clampZoom(factor);
+    const changed = !zoomFactorEquals(next, cached);
+    cached = next;
+
+    liveWebContents()?.setZoomFactor(next);
+
+    if (changed) {
+      onChange?.(next);
+    }
+  }
+
+  function syncFromWebContents(): boolean {
+    const webContents = liveWebContents();
+    if (!webContents) {
+      return false;
+    }
+
+    const actual = webContents.getZoomFactor();
+    if (!Number.isFinite(actual) || zoomFactorEquals(actual, cached)) {
+      return false;
+    }
+
+    cached = clampZoom(actual);
+    onChange?.(cached);
+    return true;
+  }
+
+  return {
+    get factor() {
+      return cached;
+    },
+    set,
+    adjust(delta: number) {
+      // Step from what is actually on screen, not from what we last applied. Zoom
+      // can change without going through us, and `zoom-changed` only fires for
+      // user gestures, so the cache cannot be kept accurate by events alone.
+      syncFromWebContents();
+      set(cached + delta);
+    },
+    reset() {
+      set(DEFAULT_ZOOM_FACTOR);
+    },
+    syncFromWebContents,
+  };
+}

--- a/app/electron/zoom.ts
+++ b/app/electron/zoom.ts
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fsPromises from 'fs/promises';
+import fs from 'node:fs';
+
+export const DEFAULT_ZOOM_FACTOR = 1.0;
+
+/** Chromium rejects a zoom factor outside these bounds. */
+export const MIN_ZOOM_FACTOR = 0.25;
+export const MAX_ZOOM_FACTOR = 5.0;
+
+/** How much a single Zoom In / Zoom Out step changes the factor. */
+export const ZOOM_STEP = 0.1;
+
+/**
+ * Zoom factors closer together than this are treated as equal. Chromium stores zoom
+ * internally as a log-scale level, so a round trip through it returns a value that is
+ * very slightly off the one we set.
+ */
+const ZOOM_EPSILON = 0.001;
+
+/** The zoom factor should respect the fixed limits set by Electron. */
+export function clampZoom(factor: number): number {
+  if (!Number.isFinite(factor)) {
+    return DEFAULT_ZOOM_FACTOR;
+  }
+
+  return Math.min(MAX_ZOOM_FACTOR, Math.max(MIN_ZOOM_FACTOR, roundZoom(factor)));
+}
+
+/**
+ * Rounds to two decimals so repeated steps don't accumulate binary floating point
+ * error (0.1 + 0.1 + 0.1 = 0.30000000000000004), which would otherwise be written
+ * to disk and shown to the user.
+ */
+export function roundZoom(factor: number): number {
+  return Math.round(factor * 100) / 100;
+}
+
+export function zoomFactorEquals(a: number, b: number): boolean {
+  return Math.abs(a - b) <= ZOOM_EPSILON;
+}
+
+/**
+ * Reads the persisted zoom factor, falling back to the default when the file is
+ * missing (first launch) or holds anything we can't use.
+ */
+export async function loadZoomFactor(filePath: string): Promise<number> {
+  let content: string;
+  try {
+    content = await fsPromises.readFile(filePath, 'utf-8');
+  } catch (err) {
+    // A missing file is the normal first-launch case, not an error worth reporting.
+    if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+      console.error('Failed to load zoom factor, defaulting to 1.0:', err);
+    }
+    return DEFAULT_ZOOM_FACTOR;
+  }
+
+  try {
+    const parsed = JSON.parse(content);
+    const zoomFactor = parsed?.zoomFactor;
+    // The file is user-editable, so treat anything non-numeric as unset.
+    return typeof zoomFactor === 'number' ? clampZoom(zoomFactor) : DEFAULT_ZOOM_FACTOR;
+  } catch (err) {
+    console.error('Failed to parse zoom factor, defaulting to 1.0:', err);
+    return DEFAULT_ZOOM_FACTOR;
+  }
+}
+
+/**
+ * Persists the zoom factor. Write errors are logged and swallowed so a failure here
+ * (e.g. an unwritable config file) can't take down the Electron main process; the
+ * runtime zoom still applies, it just isn't restored on the next launch.
+ */
+export function saveZoomFactor(filePath: string, factor: number): void {
+  try {
+    fs.writeFileSync(filePath, JSON.stringify({ zoomFactor: clampZoom(factor) }), 'utf-8');
+  } catch (err) {
+    console.error('Failed to save zoom factor:', err);
+  }
+}
+
+/** The subset of Electron's WebContents that zoom handling needs. */
+export interface ZoomWebContents {
+  getZoomFactor(): number;
+  setZoomFactor(factor: number): void;
+  isDestroyed(): boolean;
+}
+
+export interface ZoomControllerOptions {
+  /** Resolves the WebContents to zoom, or null when there is no window yet. */
+  getWebContents: () => ZoomWebContents | null;
+  /** Called whenever the zoom factor changes, so it can be persisted. */
+  onChange?: (factor: number) => void;
+}
+
+export interface ZoomController {
+  /** The zoom factor this controller last applied. */
+  readonly factor: number;
+  set(factor: number): void;
+  adjust(delta: number): void;
+  reset(): void;
+  /**
+   * Re-reads the zoom factor from the WebContents and adopts it.
+   *
+   * Zoom can change without going through us — a trackpad pinch, Ctrl+wheel, or
+   * Chromium restoring a previously stored per-origin zoom. Without this, the cached
+   * factor silently diverges from reality and the next Zoom In jumps from the stale
+   * value instead of the visible one.
+   *
+   * @returns true if the cached factor was out of date and has been corrected.
+   */
+  syncFromWebContents(): boolean;
+}
+
+export function createZoomController(options: ZoomControllerOptions): ZoomController {
+  const { getWebContents, onChange } = options;
+  // Starts at the default; the persisted factor is restored by calling set() once
+  // the window has loaded, which keeps the cache and the screen in agreement.
+  let cached = DEFAULT_ZOOM_FACTOR;
+
+  function liveWebContents(): ZoomWebContents | null {
+    const webContents = getWebContents();
+    // The window may be mid-close; setZoomFactor on destroyed WebContents throws.
+    return webContents && !webContents.isDestroyed() ? webContents : null;
+  }
+
+  function set(factor: number): void {
+    const next = clampZoom(factor);
+    const changed = !zoomFactorEquals(next, cached);
+    cached = next;
+
+    liveWebContents()?.setZoomFactor(next);
+
+    if (changed) {
+      onChange?.(next);
+    }
+  }
+
+  function syncFromWebContents(): boolean {
+    const webContents = liveWebContents();
+    if (!webContents) {
+      return false;
+    }
+
+    const actual = webContents.getZoomFactor();
+    if (!Number.isFinite(actual)) {
+      return false;
+    }
+
+    // Compare the clamped/rounded value, not the raw one: Chromium's internal
+    // log-scale storage can return a value that only differs in the 3rd+ decimal
+    // place, which clampZoom would round right back to the cached value.
+    const next = clampZoom(actual);
+    if (zoomFactorEquals(next, cached)) {
+      return false;
+    }
+
+    cached = next;
+    onChange?.(cached);
+    return true;
+  }
+
+  return {
+    get factor() {
+      return cached;
+    },
+    set,
+    adjust(delta: number) {
+      // Step from what is actually on screen, not from what we last applied. Zoom
+      // can change without going through us, and `zoom-changed` only fires for
+      // user gestures, so the cache cannot be kept accurate by events alone.
+      syncFromWebContents();
+      set(cached + delta);
+    },
+    reset() {
+      set(DEFAULT_ZOOM_FACTOR);
+    },
+    syncFromWebContents,
+  };
+}


### PR DESCRIPTION
## Summary

The Zoom In / Zoom Out menu items stepped from `cachedZoom`, a module-level value that was only ever written by our own zoom handlers. Any zoom change that did not go through the app menu left it stale, and the next step then ran from the stale value instead of from what was on screen.

Reproduced against `main` (macOS 26.5.2, Electron 38.8.6), driving the real menu items from the main process:

```
after menu reset:            actual=1.000
after external zoom to 2.0:  actual=2.000
after menu Zoom In:          actual=1.100   <-- shrank instead of growing
```

Same sequence after this change:

```
after menu reset:            1.000
after external zoom to 2.0:  2.000
after menu Zoom In:          2.100
after menu Zoom Out:         2.000
after menu reset:            1.000
```

## Changes

- Move zoom handling into `app/electron/zoom.ts` behind a small controller, so it can be unit tested without Electron or the filesystem. Follows the existing `tray.ts` / `settings.ts` convention of taking the config path as a parameter.
- `adjust()` re-reads the factor from the WebContents before stepping, so it always starts from what is actually rendered.
- Listen for `zoom-changed` to adopt user-initiated zoom. This is a supplement, not the fix: Electron emits that event only for user gestures, never for a programmatic `setZoomFactor`, so an event listener alone cannot keep the cached factor accurate. I had to find that out the hard way — the listener-only version of this patch did not fix the reproduction above.
- Clamp in `setZoom()`. It was previously unclamped while `adjustZoom()` clamped, so a value read from the user-editable config file could be applied out of range and poison the cache.
- Round to two decimals, so repeated steps stop writing accumulated floating point error (`0.1 + 0.1 + 0.1 = 0.30000000000000004`) into the config file.
- Persist on every change instead of only on quit, so a crash or a force quit no longer discards the zoom level the user just chose.
- Stop logging an error when the config file is missing, which is the normal first-launch case.

## Testing

23 unit tests in `app/electron/zoom.test.ts`, running under the existing `vitest` suite that CI already executes on Linux, Windows and macOS. Full app suite: 135 passed. `app:tsc` and `app:lint` clean.

The behaviour was also verified in a running dev build by invoking the actual menu items via `Menu.getApplicationMenu().getMenuItemById(...).click()` from the main process, which is the transcript shown above.

## Prior art

I checked how other Electron projects handle this before settling on the design, and borrowed from them:

- **Signal Desktop** (`ts/services/ZoomFactorService.main.ts`) keeps its cached factor in sync with the WebContents in *both* directions rather than treating the cache as authoritative, and compares factors with a small epsilon because Chromium stores zoom internally as a log-scale level, so reading back what you just set returns a slightly different number. The `zoomFactorEquals` helper and the `ZOOM_EPSILON` constant here follow that directly. Signal also injects its persistence functions as config rather than reaching for the filesystem, which is what makes the service unit testable — the same idea as taking the config path as a parameter here.

- **Electron's own test suite** asserts zoom exclusively through the API (`getZoomFactor` / `getZoomLevel`), never through rendered output, and gates its input-driven zoom tests on `ifdescribe(process.platform !== 'darwin')`. `spec/api-menu-spec.ts` contains no `click()` tests at all. That is why the regression test here targets the controller rather than trying to drive the native menu: there is no supported way to do the latter.

- **VS Code** registers zoom as a workbench command (`workbench.action.zoomIn`), with the menu entry and the keybinding both as callers of that one command, and handles the keybinding in its own renderer-side keybinding service rather than as a native Electron accelerator. Every entry point is therefore reachable from the renderer and testable. That is a better long-term shape for Headlamp — it is the only structure that would make the accelerator path testable at all — but it is a much larger change than this fix, so I have left it alone.

## Relationship to existing work

This overlaps #6502 (targeting #3948), and I want to be explicit about that rather than quietly duplicate it. #6502 does the same `zoom.ts` extraction and also adds a `zoom-changed` listener, so if maintainers prefer that PR, the piece worth taking from this one is the `adjust()`-resyncs-before-stepping behaviour and its regression test — the event listener by itself does not cover a programmatic zoom change.

This PR deliberately leaves out #6502's nudge-then-restore repaint workaround. I could not reproduce the stale-paint symptom it targets, and I would rather not add a workaround for a mechanism I have not observed.

## Notes on #6681

This does **not** claim to fix #6681. I spent a while trying to reproduce that one on macOS and could not: with the overview page loaded, the menu items are present, enabled, keep their `click` handlers and accelerators, and a full sweep from 0.8 to 1.8 plus reset all applies correctly, confirmed both by `getZoomFactor()` and by screenshots.

The bug fixed here produces the same user-visible symptom ("the zoom controls are completely broken"), so it may be the same underlying problem, but I have not shown that the overview page is what changes zoom out of band.

One caveat for anyone testing #6681: the real keyboard accelerator cannot be exercised by automation on macOS. Cocoa handles menu key equivalents before the web contents, so neither CDP key injection nor `webContents.sendInputEvent()` triggers them — both also fail on the cluster chooser page, where zoom demonstrably works. As noted under prior art, Electron's own suite hits the same wall and skips its zoom-input tests on darwin.

A second caveat, if the underlying problem does turn out to be stale paint rather than a stale factor: `getZoomFactor()`, `devicePixelRatio`, `innerWidth` and element bounding boxes all reported correct zoomed values throughout my testing, so none of them would catch it, and `page.screenshot()` may itself force the repaint it is meant to detect. A regression test built on any of those could pass against broken code.

Refs #6681, #3948, #6502, #6263
