### PR TITLE
backend: multiplexer: Fix data loss and connection leak on reconnect

### DIFF
--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -606,6 +606,12 @@ func (m *Multiplexer) reconnect(conn *Connection) (*Connection, error) {
 	m.connections[m.createConnectionKey(conn.ClusterID, conn.Path, conn.UserID)] = newConn
 	m.mutex.Unlock()
 
+	// Start reading from the new connection. establishClusterConnection only
+	// starts the heartbeat, so without this the reconnected socket stays alive
+	// but nothing forwards its messages and the client silently stops receiving
+	// updates.
+	go m.handleClusterMessages(newConn, newConn.Client)
+
 	return newConn, nil
 }
 
@@ -1060,7 +1066,12 @@ func (m *Multiplexer) cleanupConnection(conn *Connection) {
 
 	m.mutex.Lock()
 	connKey := m.createConnectionKey(conn.ClusterID, conn.Path, conn.UserID)
-	delete(m.connections, connKey)
+	// Only drop the entry if it still points at this connection. After a
+	// reconnect the key holds the new connection, so cleaning up the old one
+	// must not evict the live entry.
+	if m.connections[connKey] == conn {
+		delete(m.connections, connKey)
+	}
 	m.mutex.Unlock()
 }
 

--- a/backend/cmd/multiplexer_test.go
+++ b/backend/cmd/multiplexer_test.go
@@ -467,6 +467,98 @@ func TestCleanupConnections(t *testing.T) {
 	assert.Equal(t, StateClosed, conn.Status.State)
 }
 
+func TestCleanupConnectionKeepsReconnectedConnection(t *testing.T) {
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+
+	clientConn, clientServer := createTestWebSocketConnection()
+	defer clientServer.Close()
+
+	// oldConn is torn down after a reconnect; newConn is the live connection
+	// that now lives under the same key.
+	oldConn := createTestConnection("test-cluster", "test-user", "/api/v1/pods", "", clientConn)
+	newConn := createTestConnection("test-cluster", "test-user", "/api/v1/pods", "", clientConn)
+
+	connKey := m.createConnectionKey("test-cluster", "/api/v1/pods", "test-user")
+	m.connections[connKey] = newConn
+
+	m.cleanupConnection(oldConn)
+
+	stored, ok := m.connections[connKey]
+	assert.True(t, ok, "reconnected connection should still be in the map")
+	assert.Same(t, newConn, stored, "map should still hold the live reconnected connection")
+}
+
+func TestCleanupConnectionRemovesOwnEntry(t *testing.T) {
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+
+	clientConn, clientServer := createTestWebSocketConnection()
+	defer clientServer.Close()
+
+	conn := createTestConnection("test-cluster", "test-user", "/api/v1/pods", "", clientConn)
+
+	connKey := m.createConnectionKey("test-cluster", "/api/v1/pods", "test-user")
+	m.connections[connKey] = conn
+
+	m.cleanupConnection(conn)
+
+	_, ok := m.connections[connKey]
+	assert.False(t, ok, "connection should be removed from the map")
+	assert.True(t, conn.closed, "connection should be closed")
+}
+
+func TestReconnectStartsReader(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+	m := NewMultiplexer(store, false)
+
+	mockServer := createMockKubeAPIServer()
+	defer mockServer.Close()
+
+	err := store.AddContext(&kubeconfig.Context{
+		Name: "test-cluster",
+		Cluster: &api.Cluster{
+			Server:                mockServer.URL,
+			InsecureSkipTLSVerify: true,
+		},
+	})
+	require.NoError(t, err)
+
+	clientConn, clientServer := createTestWebSocketConnection()
+	defer clientServer.Close()
+
+	conn := m.createConnection("test-cluster", "test-user", "/api/v1/pods", "watch=true", clientConn, nil)
+	wsConn, wsServer := createTestWebSocketConnection()
+
+	defer wsServer.Close()
+
+	conn.WSConn = wsConn.conn
+	conn.Status.State = StateError
+
+	newConn, err := m.reconnect(conn)
+	require.NoError(t, err)
+	require.NotNil(t, newConn)
+
+	connKey := m.createConnectionKey("test-cluster", "/api/v1/pods", "test-user")
+
+	m.mutex.RLock()
+	_, ok := m.connections[connKey]
+	m.mutex.RUnlock()
+	require.True(t, ok, "reconnected connection should be in the map")
+
+	// reconnect must start a reader for the new connection. Closing the upstream
+	// socket makes that reader exit and clean up the map entry. Without a reader
+	// the entry would linger.
+	_ = newConn.WSConn.Close()
+
+	assert.Eventually(t, func() bool {
+		m.mutex.RLock()
+		defer m.mutex.RUnlock()
+
+		_, present := m.connections[connKey]
+
+		return !present
+	}, 2*time.Second, 10*time.Millisecond, "reader started by reconnect should clean up after the upstream closes")
+}
+
 func TestCloseConnection(t *testing.T) {
 	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
 	clientConn, clientServer := createTestWebSocketConnection()
@@ -1473,23 +1565,24 @@ func TestReconnect_WithToken(t *testing.T) {
 	assert.NotNil(t, newConn)
 	assert.Equal(t, &originalToken, newConn.Token, "Token should be preserved during reconnection")
 
-	// Now update the token and verify it's used in reconnection
+	// Now verify an updated token is used on a subsequent reconnection. Use a
+	// fresh connection: reconnect attaches a reader to newConn, so closing its
+	// socket and reconnecting the same object would race that reader.
 	newToken := "new-refreshed-token"
-	newConn.Token = &newToken // Update the token on the new connection
+	conn2 := m.createConnection("test-cluster", "test-user", "/api/v1/services", "watch=true", clientConn, &newToken)
+	wsConn2, wsServer2 := createTestWebSocketConnection()
 
-	// Close the connection to force another reconnection
-	if newConn.WSConn != nil {
-		_ = newConn.WSConn.Close()
-	}
+	defer wsServer2.Close()
 
-	newConn.Status.State = StateError
+	conn2.WSConn = wsConn2.conn
+	conn2.Status.State = StateError
 
-	// Update the connection in the multiplexer's map
-	connKey = m.createConnectionKey(newConn.ClusterID, newConn.Path, newConn.UserID)
-	m.connections[connKey] = newConn
+	m.mutex.Lock()
+	m.connections[m.createConnectionKey(conn2.ClusterID, conn2.Path, conn2.UserID)] = conn2
+	m.mutex.Unlock()
 
 	// Reconnect with the new token
-	reconnConn, err := m.reconnect(newConn)
+	reconnConn, err := m.reconnect(conn2)
 	assert.NoError(t, err)
 	assert.NotNil(t, reconnConn)
 	assert.Equal(t, &newToken, reconnConn.Token, "Updated token should be used during reconnection")


### PR DESCRIPTION
## Summary

When a cluster WebSocket heartbeat fails, reconnect builds a fresh connection and stores it, but two things went wrong afterwards. establishClusterConnection only starts the heartbeat goroutine, not the reader (handleClusterMessages) that forwards cluster messages to the client. handleClusterMessages was started only when a connection was first created, so after a reconnect the new socket had a heartbeat but nothing read from it, and the client silently stopped receiving updates.

cleanupConnection also deleted the map entry purely by key. After a reconnect the key holds the new connection, so when the old reader returned and ran its deferred cleanup it evicted the live connection, leaking its goroutine and socket and letting the next subscribe open a duplicate.

This starts the reader for the reconnected connection, and only deletes the map entry when it still points at the connection being cleaned up.

## Related Issue

Fixes #6704

## Changes

- reconnect now starts handleClusterMessages for the new connection so its messages reach the client
- cleanupConnection only deletes the connections map entry when it still points at the connection being cleaned up
- added tests for the cleanup identity check and for reconnect starting a reader, and reworked TestReconnect_WithToken to reconnect a fresh connection with the updated token since reconnect now attaches a reader

## Steps to Test

1. `cd backend && go test ./cmd/ -race` passes (whole package)
2. With the multiplexer enabled (`REACT_APP_ENABLE_WEBSOCKET_MULTIPLEXER=true`), open a watch on a resource that updates
3. Force a heartbeat reconnect (briefly block the API server port, or drop the socket after the handshake) then restore connectivity
4. Change the watched resource and confirm updates still arrive, and that the connection stays in the map instead of leaking

## Screenshots (if applicable)


## Notes for the Reviewer

- This is separate from #6154 (duplicate monitor goroutine on reconnect); that fix doesn't start a reader for the new connection or stop cleanupConnection from evicting a live entry.
- I had to touch TestReconnect_WithToken: it closed a connection's socket and reconnected the same object, which now races the reader that reconnect attaches (it only failed under -race, which CI uses). The rewrite reconnects a fresh connection with the updated token, testing the same thing without the race.
