### PR TITLE
frontend: fix useClustersVersion polling when tab is in background

### DIFF
--- a/e2e-tests/tests/multiCluster.spec.ts
+++ b/e2e-tests/tests/multiCluster.spec.ts
@@ -68,6 +68,41 @@ test.describe('multi-cluster setup', () => {
     }
   });
 
+  test('cluster version polling pauses in the background and resumes immediately', async ({
+    page,
+  }) => {
+    await page.evaluate(() => localStorage.setItem('recent_clusters', JSON.stringify(['test'])));
+
+    let versionRequests = 0;
+    page.on('request', request => {
+      if (new URL(request.url()).pathname.endsWith('/clusters/test/version')) {
+        versionRequests++;
+      }
+    });
+
+    await page.reload();
+    await expect.poll(() => versionRequests).toBe(1);
+
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => 'hidden',
+      });
+      window.dispatchEvent(new Event('visibilitychange'));
+    });
+    await page.waitForTimeout(11_000);
+    expect(versionRequests).toBe(1);
+
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => 'visible',
+      });
+      window.dispatchEvent(new Event('visibilitychange'));
+    });
+    await expect.poll(() => versionRequests, { timeout: 2_000 }).toBe(2);
+  });
+
   test("user should be able to login to 'test' cluster, perform logout and return to cluster selection", async ({
     page,
   }) => {

--- a/frontend/src/lib/k8s/index.test.ts
+++ b/frontend/src/lib/k8s/index.test.ts
@@ -14,11 +14,23 @@
  * limitations under the License.
  */
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { afterEach, beforeEach, vi } from 'vitest';
 import { createRouteURL } from '../router/createRouteURL';
-import { labelSelectorToQuery, ResourceClasses } from '.';
-import { LabelSelector } from './cluster';
+import { labelSelectorToQuery, ResourceClasses, useClustersVersion } from '.';
+import { clusterRequest } from './api/v1/clusterRequests';
+import { Cluster, LabelSelector } from './cluster';
 import { KubeObjectClass } from './KubeObject';
 import Namespace from './namespace';
+
+vi.mock('./api/v1/clusterRequests', async () => {
+  const actual = await vi.importActual<typeof import('./api/v1/clusterRequests')>(
+    './api/v1/clusterRequests'
+  );
+  return { ...actual, clusterRequest: vi.fn() };
+});
 
 // Remove NetworkPolicy and ControllerRevision since we don't have list/details pages for them.
 const k8sClassesToTest = Object.values(ResourceClasses).filter(
@@ -219,6 +231,69 @@ describe('Label selector', () => {
       ],
     });
     expect(query).toBe('!label2');
+  });
+});
+
+describe('useClustersVersion', () => {
+  let queryClient: QueryClient;
+
+  function wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          refetchOnWindowFocus: false,
+          retry: false,
+          staleTime: 3 * 60_000,
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  test('returns versions and errors by cluster name', async () => {
+    const request = vi.mocked(clusterRequest);
+    request.mockImplementation((_path, params) => {
+      if (params?.cluster === 'unavailable') {
+        return Promise.reject(new Error('unavailable'));
+      }
+      return Promise.resolve({ gitVersion: 'v1.32.0' });
+    });
+
+    const clusters = [{ name: 'available' }, { name: 'unavailable' }] as Cluster[];
+    const { result } = renderHook(() => useClustersVersion(clusters), { wrapper });
+
+    await waitFor(() => expect(result.current[1].unavailable).toBeInstanceOf(Error));
+
+    expect(result.current[0]).toEqual({ available: { gitVersion: 'v1.32.0' } });
+    expect(result.current[1].available).toBeNull();
+  });
+
+  test('pauses polling while hidden and refetches immediately when visible', async () => {
+    const request = vi.mocked(clusterRequest).mockResolvedValue({ gitVersion: 'v1.32.0' });
+    const visibilityState = vi.spyOn(document, 'visibilityState', 'get');
+    visibilityState.mockReturnValue('visible');
+
+    renderHook(() => useClustersVersion([{ name: 'cluster' }] as Cluster[]), { wrapper });
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+
+    visibilityState.mockReturnValue('hidden');
+    act(() => window.dispatchEvent(new Event('visibilitychange')));
+    await act(() => vi.advanceTimersByTimeAsync(20_000));
+    expect(request).toHaveBeenCalledTimes(1);
+
+    visibilityState.mockReturnValue('visible');
+    act(() => window.dispatchEvent(new Event('visibilitychange')));
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
   });
 });
 

--- a/frontend/src/lib/k8s/index.ts
+++ b/frontend/src/lib/k8s/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useQueries } from '@tanstack/react-query';
 import _ from 'lodash';
 import React, { useMemo } from 'react';
 import { ConfigState } from '../../redux/configSlice';
@@ -272,6 +273,8 @@ export function matchExpressionSimplifier(
   return segments;
 }
 
+const versionFetchInterval = 10000; // ms
+
 /** Hook to get the version of the clusters given by the parameter.
  *
  * @param clusters
@@ -283,88 +286,33 @@ export function useClustersVersion(clusters: Cluster[]) {
     error: ApiError | null;
   };
 
-  const [clusterNames, setClusterNames] = React.useState<string[]>(
-    Object.values(clusters).map(c => c.name)
+  const [clusterNames, setClusterNames] = React.useState<string[]>(() =>
+    Object.values(clusters)
+      .map(c => c.name)
+      .sort()
   );
-  const [versions, setVersions] = React.useState<{ [cluster: string]: VersionInfo }>({});
-  const versionFetchInterval = 10000; // ms
-  const cancelledRef = React.useRef(false);
-  const lastUpdateRef = React.useRef(0);
 
+  // clusters gets a new array reference on every render; only update clusterNames when
+  // the actual set of names changes to avoid unnecessary query resets.
   React.useEffect(() => {
-    // We sort the lists so the order of clusters doesn't influence our comparison. We only
-    // care for presence, not for order.
-    const newClusterNames = Object.values(clusters)
+    const nextClusterNames = Object.values(clusters)
       .map(c => c.name)
       .sort();
-    const sortedClusterNames = [...clusterNames].sort();
-    if (_.isEqual(sortedClusterNames, newClusterNames)) {
-      return;
-    }
+    setClusterNames(prev => (_.isEqual(prev, nextClusterNames) ? prev : nextClusterNames));
+  }, [clusters]);
 
-    setClusterNames(newClusterNames);
-    lastUpdateRef.current = Date.now();
-  }, [clusters, clusterNames]);
+  const queries = React.useMemo(
+    () =>
+      clusterNames.map(clusterName => ({
+        queryKey: ['clusterVersion', clusterName],
+        queryFn: () => getVersion(clusterName),
+        refetchInterval: versionFetchInterval,
+        retry: false, // surface errors immediately rather than hammering unreachable clusters
+      })),
+    [clusterNames]
+  );
 
-  React.useEffect(() => {
-    const newVersions: typeof versions = {};
-
-    function updateValues() {
-      if (cancelledRef.current) {
-        return;
-      }
-
-      let needsUpdate = false;
-
-      setVersions(currentVersions => {
-        const newVersionsToSet = { ...currentVersions };
-        for (const clusterName in newVersions) {
-          if (!_.isEqual(newVersionsToSet[clusterName], newVersions[clusterName])) {
-            needsUpdate = true;
-            newVersionsToSet[clusterName] = newVersions[clusterName];
-          }
-        }
-
-        return needsUpdate ? newVersionsToSet : currentVersions;
-      });
-    }
-
-    clusterNames.forEach(clusterName => {
-      getVersion(clusterName)
-        .then(version => {
-          newVersions[clusterName] = { version, error: null };
-        })
-        .catch(err => {
-          newVersions[clusterName] = { version: null, error: err };
-        })
-        .finally(() => {
-          updateValues();
-        });
-    });
-  }, [clusterNames]);
-
-  React.useEffect(() => {
-    cancelledRef.current = false;
-    // Trigger periodically
-    const timeout = setInterval(() => {
-      if (cancelledRef.current) {
-        return;
-      }
-
-      if (Date.now() - lastUpdateRef.current > versionFetchInterval - 1) {
-        // Refreshes the list of clusters
-        // Creating a new array will trigger the useEffect above
-        // effectively refreshing the versions/errors/statuses
-        setClusterNames([...clusterNames]);
-      }
-    }, versionFetchInterval);
-
-    return function cleanup() {
-      cancelledRef.current = true;
-      clearInterval(timeout);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const results = useQueries({ queries });
 
   return React.useMemo<
     [{ [clusterName: string]: StringDict }, { [clusterName: string]: VersionInfo['error'] }]
@@ -372,15 +320,20 @@ export function useClustersVersion(clusters: Cluster[]) {
     const versionsInfo: { [clusterName: string]: StringDict } = {};
     const errorsInfo: { [clusterName: string]: VersionInfo['error'] } = {};
 
-    Object.entries(versions).forEach(([clusterName, versionInfo]) => {
-      if (!!versionInfo.version) {
-        versionsInfo[clusterName] = versionInfo.version;
+    clusterNames.forEach((clusterName, i) => {
+      const { data, error } = results[i];
+      if (data) {
+        versionsInfo[clusterName] = data;
       }
-      errorsInfo[clusterName] = versionInfo.error;
+      // Only set the error key once the query has resolved. An absent key (undefined)
+      // signals "still loading" to getClusterStatus; null means the cluster is active.
+      if (!results[i].isPending) {
+        errorsInfo[clusterName] = (error as ApiError | null) ?? null;
+      }
     });
 
     return [versionsInfo, errorsInfo];
-  }, [versions]);
+  }, [clusterNames, results]);
 }
 
 // Other exports that can be used by plugins:

--- a/frontend/src/lib/k8s/index.ts
+++ b/frontend/src/lib/k8s/index.ts
@@ -307,6 +307,8 @@ export function useClustersVersion(clusters: Cluster[]) {
         queryKey: ['clusterVersion', clusterName],
         queryFn: () => getVersion(clusterName),
         refetchInterval: versionFetchInterval,
+        refetchIntervalInBackground: false,
+        refetchOnWindowFocus: 'always' as const,
         retry: false, // surface errors immediately rather than hammering unreachable clusters
       })),
     [clusterNames]


### PR DESCRIPTION
## Problem

The `/version` endpoint was being polled every 10s via a raw `setInterval` in `useClustersVersion`, which kept firing even when the browser tab was hidden (e.g. user switched to another tab). This caused unnecessary network requests to every connected cluster while the user wasn't actively using Headlamp.

## Solution

Replace the manual `setInterval` with React Query's `useQueries` and `refetchInterval`. React Query automatically pauses polling when the tab is hidden, since `refetchIntervalInBackground` defaults to `false`.

A ref with `_.isEqual` is used to stabilise the `clusterNames` reference so that interval timers are not reset on every render when the `clusters` prop gets a new array reference (e.g. while a new cluster is connecting).

## Testing

- Opened Headlamp with multiple clusters connected and observed `/version` requests in browser network tab
- Switched to a different browser tab — requests stopped
- Switched back — requests resumed after 10s
- Connected a new cluster — requests continued at the correct 10s interval without continuous firing