### PR TITLE
telemetry: Add OpenTelemetry cache observability metrics

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -53,6 +53,7 @@ import (
 	cfg "github.com/kubernetes-sigs/headlamp/backend/pkg/config"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/helm"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/plugins"
@@ -1394,6 +1395,17 @@ func StartHeadlampServer(config *HeadlampConfig) {
 			logger.Log(logger.LevelError, nil, err, "Failed to properly shutdown telemetry")
 		}
 	}()
+
+	// Wire cache observability metrics hooks.
+	if config.TelemetryHandler != nil {
+		k8cache.OnCacheInvalidation = func() {
+			config.TelemetryHandler.RecordCacheInvalidation(context.Background())
+		}
+
+		k8sResponseCache.SetOnEvicted(func(_ string, _ string) {
+			config.TelemetryHandler.RecordCacheEviction(context.Background())
+		})
+	}
 
 	router := mux.NewRouter()
 

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -328,6 +328,8 @@ func cacheMiddlewareHandler(c *HeadlampConfig, next http.Handler, w http.Respons
 	if err := k8cache.StoreK8sResponseInCache(k8sResponseCache, r.URL, rcw, key); err != nil {
 		// Response was already written to client via rcw; just log the cache storage error
 		logger.Log(logger.LevelError, nil, err, "failed to store response in cache")
+	} else {
+		c.TelemetryHandler.RecordCacheStore(r.Context())
 	}
 }
 
@@ -371,8 +373,12 @@ func handleCacheAuthorization(
 
 	if served {
 		c.TelemetryHandler.RecordEvent(span, "Served from cache")
+		c.TelemetryHandler.RecordCacheHit(r.Context())
+
 		return true
 	}
+
+	c.TelemetryHandler.RecordCacheMiss(r.Context())
 
 	return false
 }

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -328,7 +328,7 @@ func cacheMiddlewareHandler(c *HeadlampConfig, next http.Handler, w http.Respons
 	if err := k8cache.StoreK8sResponseInCache(k8sResponseCache, r.URL, rcw, key); err != nil {
 		// Response was already written to client via rcw; just log the cache storage error
 		logger.Log(logger.LevelError, nil, err, "failed to store response in cache")
-	} else {
+	} else if k8cache.WasResponseStored(rcw, r.URL) {
 		c.TelemetryHandler.RecordCacheStore(r.Context())
 	}
 }
@@ -351,7 +351,12 @@ func handleCacheAuthorization(
 
 	isAllowed, authErr := k8cache.IsAllowed(contextKey, kContext, r)
 	if authErr != nil {
-		k8cache.ServeFromCacheOrForwardToK8s(k8sResponseCache, isAllowed, next, key, w, r, rcw)
+		served := k8cache.ServeFromCacheOrForwardToK8s(k8sResponseCache, isAllowed, next, key, w, r, rcw)
+		if served {
+			c.TelemetryHandler.RecordCacheHit(r.Context())
+		} else {
+			c.TelemetryHandler.RecordCacheMiss(r.Context())
+		}
 
 		return true
 	}

--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -567,12 +567,13 @@ func IsAllowed(
 // ServeFromCacheOrForwardToK8s attempts to serve a Kubernetes resource from cache.
 // If no cached value is found (or `isAllowed` is false), it forwards the request
 // to the next handler and stores the response in the cache for future requests.
+// It returns true when the response was served from cache.
 func ServeFromCacheOrForwardToK8s(k8scache cache.Cache[string], isAllowed bool, next http.Handler, key string,
 	w http.ResponseWriter, r *http.Request, rcw *ResponseCapture,
-) {
+) bool {
 	served, _ := LoadFromCache(k8scache, isAllowed, key, w, r)
 	if served {
-		return
+		return true
 	}
 
 	next.ServeHTTP(rcw, r)
@@ -580,6 +581,7 @@ func ServeFromCacheOrForwardToK8s(k8scache cache.Cache[string], isAllowed bool, 
 	err := StoreK8sResponseInCache(k8scache, r.URL, rcw, key)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "error while storing in the cache")
-		return
 	}
+
+	return false
 }

--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -183,6 +183,11 @@ func filterImportantResources(gvrList []schema.GroupVersionResource) []schema.Gr
 var (
 	watcherRegistry sync.Map
 	contextCancel   sync.Map
+
+	// OnCacheInvalidation is an optional callback invoked each time a watcher
+	// event triggers cache key deletion. It is set by the server at startup
+	// to record telemetry without coupling this package to the telemetry layer.
+	OnCacheInvalidation func()
 )
 
 // CheckForChanges lets 1 go routine to run for a contextKey which prevents
@@ -384,12 +389,14 @@ func invalidateCacheKeysForResourceEvent(
 
 	DeleteKeys(listKey, k8scache)
 
-	if name == "" {
-		return
+	if name != "" {
+		namedKey := buildCacheKey(gvr.Group, name, namespace, contextKey)
+		if err := k8scache.Delete(context.Background(), namedKey); err != nil {
+			logger.Log(logger.LevelError, nil, err, "error while deleting key")
+		}
 	}
 
-	namedKey := buildCacheKey(gvr.Group, name, namespace, contextKey)
-	if err := k8scache.Delete(context.Background(), namedKey); err != nil {
-		logger.Log(logger.LevelError, nil, err, "error while deleting key")
+	if OnCacheInvalidation != nil {
+		OnCacheInvalidation()
 	}
 }

--- a/backend/pkg/k8cache/cacheInvalidation_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_test.go
@@ -882,3 +882,82 @@ func TestSyncWatchers(t *testing.T) {
 	assert.True(t, canceled["ctx2"], "ctx2 should be canceled")
 	assert.False(t, canceled["ctx3"], "ctx3 should not be canceled")
 }
+
+func setupInvalidationHookInformer(
+	t *testing.T,
+	mockCache *MockCache,
+) (*dynamicfake.FakeDynamicClient, []schema.GroupVersionResource) {
+	t.Helper()
+
+	gvrList := []schema.GroupVersionResource{
+		{Group: "", Version: "v1", Resource: "pods"},
+	}
+
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: "", Version: "v1", Kind: "PodList"},
+		&unstructured.UnstructuredList{},
+	)
+
+	fakeClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{
+			{Group: "", Version: "v1", Resource: "pods"}: "PodList",
+		},
+	)
+
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(fakeClient, 0, "", nil)
+	k8cache.RunInformerToWatch(gvrList, factory, "test-hook-ctx", mockCache)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	factory.Start(ctx.Done())
+	factory.WaitForCacheSync(ctx.Done())
+
+	// Wait briefly for the initial sync to complete.
+	time.Sleep(200 * time.Millisecond)
+
+	return fakeClient, gvrList
+}
+
+func TestOnCacheInvalidationHook(t *testing.T) {
+	var (
+		callCount int32
+		mu        sync.Mutex
+	)
+
+	originalHook := k8cache.OnCacheInvalidation
+	k8cache.OnCacheInvalidation = func() {
+		mu.Lock()
+		callCount++
+		mu.Unlock()
+	}
+
+	t.Cleanup(func() { k8cache.OnCacheInvalidation = originalHook })
+
+	mockCache := &MockCache{store: map[string]string{"+pods+default+test-hook-ctx": "pod-data"}}
+	fakeClient, gvrList := setupInvalidationHookInformer(t, mockCache)
+
+	newPod := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata":   map[string]interface{}{"name": "hook-test-pod", "namespace": "default"},
+		},
+	}
+
+	_, err := fakeClient.Resource(gvrList[0]).Namespace("default").Create(
+		context.Background(), newPod, metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	count := callCount
+	mu.Unlock()
+
+	assert.GreaterOrEqual(t, count, int32(1),
+		"OnCacheInvalidation hook should have been called at least once")
+}

--- a/backend/pkg/k8cache/cacheInvalidation_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_test.go
@@ -952,12 +952,10 @@ func TestOnCacheInvalidationHook(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	time.Sleep(500 * time.Millisecond)
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
 
-	mu.Lock()
-	count := callCount
-	mu.Unlock()
-
-	assert.GreaterOrEqual(t, count, int32(1),
-		"OnCacheInvalidation hook should have been called at least once")
+		return callCount >= 1
+	}, 2*time.Second, 50*time.Millisecond, "OnCacheInvalidation hook should have been called at least once")
 }

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -344,9 +344,16 @@ func WasResponseStored(rcw *ResponseCapture, url *url.URL) bool {
 		return false
 	}
 
-	body := rcw.Body.String()
+	capturedHeaders := rcw.Header()
+	encoding := capturedHeaders.Get("Content-Encoding")
+	bodyBytes := rcw.Body.Bytes()
 
-	return !strings.Contains(body, "Failure")
+	dcmpBody, err := GetResponseBody(bodyBytes, encoding)
+	if err != nil {
+		return false
+	}
+
+	return !strings.Contains(dcmpBody, "Failure")
 }
 
 // redactContextKey returns a redacted version of the context key to avoid leaking PII/sensitive info in logs.

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -330,6 +330,25 @@ func StoreK8sResponseInCache(k8scache cache.Cache[string],
 	return nil
 }
 
+// WasResponseStored reports whether StoreK8sResponseInCache would have
+// actually written the response to the cache (as opposed to silently
+// skipping it). It mirrors the skip conditions: status >= 500, body
+// contains "Failure", or selfsubjectrulesreviews path. Callers use
+// this to record store_count only on actual cache writes.
+func WasResponseStored(rcw *ResponseCapture, url *url.URL) bool {
+	if rcw.StatusCode >= 500 {
+		return false
+	}
+
+	if strings.Contains(url.Path, "selfsubjectrulesreviews") {
+		return false
+	}
+
+	body := rcw.Body.String()
+
+	return !strings.Contains(body, "Failure")
+}
+
 // redactContextKey returns a redacted version of the context key to avoid leaking PII/sensitive info in logs.
 func redactContextKey(key string) string {
 	if key == "" {

--- a/backend/pkg/telemetry/export_test.go
+++ b/backend/pkg/telemetry/export_test.go
@@ -9,3 +9,7 @@ func InitRequestMetricsForTest(meter metric.Meter, metrics *Metrics) error {
 func InitApplicationMetricsForTest(meter metric.Meter, metrics *Metrics) error {
 	return initApplicationMetrics(meter, metrics)
 }
+
+func InitCacheMetricsForTest(meter metric.Meter, metrics *Metrics) error {
+	return initCacheMetrics(meter, metrics)
+}

--- a/backend/pkg/telemetry/metrics.go
+++ b/backend/pkg/telemetry/metrics.go
@@ -31,6 +31,16 @@ type Metrics struct {
 	ErrorCounter metric.Int64Counter
 	// KubeconfigRefreshCounter tracks the number of kubeconfig refresh operations
 	KubeconfigRefreshCounter metric.Int64Counter
+	// CacheHitCount tracks the number of cache hits
+	CacheHitCount metric.Int64Counter
+	// CacheMissCount tracks the number of cache misses
+	CacheMissCount metric.Int64Counter
+	// CacheStoreCount tracks the number of responses stored in cache
+	CacheStoreCount metric.Int64Counter
+	// CacheEvictionCount tracks the number of TTL-based cache evictions
+	CacheEvictionCount metric.Int64Counter
+	// CacheInvalidationCount tracks the number of watcher-triggered cache invalidations
+	CacheInvalidationCount metric.Int64Counter
 }
 
 // NewMetrics creates and registers a set of common application metrics.
@@ -47,6 +57,10 @@ func NewMetrics() (*Metrics, error) {
 	}
 
 	if err := initApplicationMetrics(meter, metrics); err != nil {
+		return nil, err
+	}
+
+	if err := initCacheMetrics(meter, metrics); err != nil {
 		return nil, err
 	}
 
@@ -116,6 +130,53 @@ func initApplicationMetrics(meter metric.Meter, metrics *Metrics) error {
 	metrics.ErrorCounter, err = meter.Int64Counter(
 		"headlamp.errors",
 		metric.WithDescription("Count of errors"),
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// initCacheMetrics initializes cache-related metrics.
+func initCacheMetrics(meter metric.Meter, metrics *Metrics) error {
+	var err error
+
+	metrics.CacheHitCount, err = meter.Int64Counter(
+		"headlamp.cache.hit_count",
+		metric.WithDescription("Number of cache hits"),
+	)
+	if err != nil {
+		return err
+	}
+
+	metrics.CacheMissCount, err = meter.Int64Counter(
+		"headlamp.cache.miss_count",
+		metric.WithDescription("Number of cache misses"),
+	)
+	if err != nil {
+		return err
+	}
+
+	metrics.CacheStoreCount, err = meter.Int64Counter(
+		"headlamp.cache.store_count",
+		metric.WithDescription("Number of responses stored in cache"),
+	)
+	if err != nil {
+		return err
+	}
+
+	metrics.CacheEvictionCount, err = meter.Int64Counter(
+		"headlamp.cache.eviction_count",
+		metric.WithDescription("Number of TTL-based cache evictions"),
+	)
+	if err != nil {
+		return err
+	}
+
+	metrics.CacheInvalidationCount, err = meter.Int64Counter(
+		"headlamp.cache.invalidation_count",
+		metric.WithDescription("Number of watcher-triggered cache invalidations"),
 	)
 	if err != nil {
 		return err

--- a/backend/pkg/telemetry/metrics_test.go
+++ b/backend/pkg/telemetry/metrics_test.go
@@ -94,6 +94,11 @@ func TestNewMetrics(t *testing.T) {
 	assert.NotNil(t, metrics.ClusterProxyRequests)
 	assert.NotNil(t, metrics.PluginLoadCount)
 	assert.NotNil(t, metrics.ErrorCounter)
+	assert.NotNil(t, metrics.CacheHitCount)
+	assert.NotNil(t, metrics.CacheMissCount)
+	assert.NotNil(t, metrics.CacheStoreCount)
+	assert.NotNil(t, metrics.CacheEvictionCount)
+	assert.NotNil(t, metrics.CacheInvalidationCount)
 
 	ctx := context.Background()
 	metrics.RequestCounter.Add(ctx, 1, metric.WithAttributes(attribute.String("test", "value")))
@@ -430,4 +435,23 @@ func TestInitApplicationMetrics(t *testing.T) {
 	require.NotNil(t, metrics.PluginLoadCount, "PluginLoadCount should be initialized")
 	require.NotNil(t, metrics.PluginDeleteCount, "PluginDeleteCount should be initialized")
 	require.NotNil(t, metrics.ErrorCounter, "ErrorCounter should be initialized")
+}
+
+func TestInitCacheMetrics(t *testing.T) {
+	provider, _ := setupTestMeter(t)
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+	})
+
+	meter := otel.Meter("headlamp-test")
+	metrics := &tel.Metrics{}
+
+	err := tel.InitCacheMetricsForTest(meter, metrics)
+	require.NoError(t, err)
+
+	require.NotNil(t, metrics.CacheHitCount, "CacheHitCount should be initialized")
+	require.NotNil(t, metrics.CacheMissCount, "CacheMissCount should be initialized")
+	require.NotNil(t, metrics.CacheStoreCount, "CacheStoreCount should be initialized")
+	require.NotNil(t, metrics.CacheEvictionCount, "CacheEvictionCount should be initialized")
+	require.NotNil(t, metrics.CacheInvalidationCount, "CacheInvalidationCount should be initialized")
 }

--- a/backend/pkg/telemetry/requesthandler.go
+++ b/backend/pkg/telemetry/requesthandler.go
@@ -101,3 +101,48 @@ func (h *RequestHandler) RecordRequestCount(ctx context.Context, r *http.Request
 		)...))
 	}
 }
+
+// RecordCacheHit increments the cache hit counter.
+func (h *RequestHandler) RecordCacheHit(ctx context.Context) {
+	if h == nil || h.metrics == nil {
+		return
+	}
+
+	h.metrics.CacheHitCount.Add(ctx, 1)
+}
+
+// RecordCacheMiss increments the cache miss counter.
+func (h *RequestHandler) RecordCacheMiss(ctx context.Context) {
+	if h == nil || h.metrics == nil {
+		return
+	}
+
+	h.metrics.CacheMissCount.Add(ctx, 1)
+}
+
+// RecordCacheStore increments the cache store counter.
+func (h *RequestHandler) RecordCacheStore(ctx context.Context) {
+	if h == nil || h.metrics == nil {
+		return
+	}
+
+	h.metrics.CacheStoreCount.Add(ctx, 1)
+}
+
+// RecordCacheEviction increments the cache eviction counter.
+func (h *RequestHandler) RecordCacheEviction(ctx context.Context) {
+	if h == nil || h.metrics == nil {
+		return
+	}
+
+	h.metrics.CacheEvictionCount.Add(ctx, 1)
+}
+
+// RecordCacheInvalidation increments the cache invalidation counter.
+func (h *RequestHandler) RecordCacheInvalidation(ctx context.Context) {
+	if h == nil || h.metrics == nil {
+		return
+	}
+
+	h.metrics.CacheInvalidationCount.Add(ctx, 1)
+}

--- a/backend/pkg/telemetry/requesthandler_test.go
+++ b/backend/pkg/telemetry/requesthandler_test.go
@@ -344,3 +344,138 @@ func TestRecordRequestCount(t *testing.T) {
 		})
 	})
 }
+
+func TestRecordCacheHit(t *testing.T) {
+	t.Run("increments cache hit counter", func(t *testing.T) {
+		metrics := setupMetrics(t)
+		handler := tel.NewRequestHandler(nil, metrics)
+
+		assert.NotPanics(t, func() {
+			handler.RecordCacheHit(context.Background())
+		})
+	})
+
+	t.Run("handles nil handler", func(t *testing.T) {
+		var handler *tel.RequestHandler
+
+		assert.NotPanics(t, func() {
+			handler.RecordCacheHit(context.Background())
+		})
+	})
+
+	t.Run("handles nil metrics", func(t *testing.T) {
+		handler := tel.NewRequestHandler(nil, nil)
+
+		assert.NotPanics(t, func() {
+			handler.RecordCacheHit(context.Background())
+		})
+	})
+}
+
+func TestRecordCacheMiss(t *testing.T) {
+	t.Run("increments cache miss counter", func(t *testing.T) {
+		metrics := setupMetrics(t)
+		handler := tel.NewRequestHandler(nil, metrics)
+
+		assert.NotPanics(t, func() {
+			handler.RecordCacheMiss(context.Background())
+		})
+	})
+
+	t.Run("handles nil handler", func(t *testing.T) {
+		var handler *tel.RequestHandler
+
+		assert.NotPanics(t, func() {
+			handler.RecordCacheMiss(context.Background())
+		})
+	})
+
+	t.Run("handles nil metrics", func(t *testing.T) {
+		handler := tel.NewRequestHandler(nil, nil)
+
+		assert.NotPanics(t, func() {
+			handler.RecordCacheMiss(context.Background())
+		})
+	})
+}
+
+func TestRecordCacheStore(t *testing.T) {
+	t.Run("increments cache store counter", func(t *testing.T) {
+		metrics := setupMetrics(t)
+		handler := tel.NewRequestHandler(nil, metrics)
+
+		assert.NotPanics(t, func() {
+			handler.RecordCacheStore(context.Background())
+		})
+	})
+
+	t.Run("handles nil handler", func(t *testing.T) {
+		var handler *tel.RequestHandler
+
+		assert.NotPanics(t, func() {
+			handler.RecordCacheStore(context.Background())
+		})
+	})
+
+	t.Run("handles nil metrics", func(t *testing.T) {
+		handler := tel.NewRequestHandler(nil, nil)
+
+		assert.NotPanics(t, func() {
+			handler.RecordCacheStore(context.Background())
+		})
+	})
+}
+
+func TestRecordCacheEviction(t *testing.T) {
+	t.Run("increments cache eviction counter", func(t *testing.T) {
+		metrics := setupMetrics(t)
+		handler := tel.NewRequestHandler(nil, metrics)
+
+		assert.NotPanics(t, func() {
+			handler.RecordCacheEviction(context.Background())
+		})
+	})
+
+	t.Run("handles nil handler", func(t *testing.T) {
+		var handler *tel.RequestHandler
+
+		assert.NotPanics(t, func() {
+			handler.RecordCacheEviction(context.Background())
+		})
+	})
+
+	t.Run("handles nil metrics", func(t *testing.T) {
+		handler := tel.NewRequestHandler(nil, nil)
+
+		assert.NotPanics(t, func() {
+			handler.RecordCacheEviction(context.Background())
+		})
+	})
+}
+
+func TestRecordCacheInvalidation(t *testing.T) {
+	t.Run("increments cache invalidation counter", func(t *testing.T) {
+		metrics := setupMetrics(t)
+		handler := tel.NewRequestHandler(nil, metrics)
+
+		assert.NotPanics(t, func() {
+			handler.RecordCacheInvalidation(context.Background())
+		})
+	})
+
+	t.Run("handles nil handler", func(t *testing.T) {
+		var handler *tel.RequestHandler
+
+		assert.NotPanics(t, func() {
+			handler.RecordCacheInvalidation(context.Background())
+		})
+	})
+
+	t.Run("handles nil metrics", func(t *testing.T) {
+		handler := tel.NewRequestHandler(nil, nil)
+
+		assert.NotPanics(t, func() {
+			handler.RecordCacheInvalidation(context.Background())
+		})
+	})
+}


### PR DESCRIPTION
## Summary

This PR adds 5 new OpenTelemetry Prometheus metrics to the Kubernetes API response cache subsystem.The backend cache has zero observability today , operators cannot tell if the cache is healthy ,what the hit/miss ratio is, or how often entries are evicted. These metrics make the cache debuggable in production via standard `/metrics` endpoints.

## Related Issue

Fixes #6709 

## Changes

- Added 5 new `Int64Counter` metric instruments to the `Metrics` struct in `telemetry/metrics.go`: `headlamp.cache.hit_count`, `headlamp.cache.miss_count`, `headlamp.cache.store_count`, `headlamp.cache.eviction_count`, `headlamp.cache.invalidation_count`
- Added `initCacheMetrics` function following the existing `initRequestMetrics`/`initApplicationMetrics` pattern
- Added nil-safe `RecordCacheHit/Miss/Store/Eviction/Invalidation` methods to `RequestHandler`
- Added a decoupled `OnCacheInvalidation` callback hook in `k8cache/cacheInvalidation.go` to avoid coupling k8cache to the telemetry package
- Wired hit/miss recording in `handleCacheAuthorization` (server.go)
- Wired store recording in `cacheMiddlewareHandler` (server.go)
- Wired invalidation and eviction hooks at server startup (headlamp.go)
- Added `InitCacheMetricsForTest` export for external test packages
- Added comprehensive tests: `TestInitCacheMetrics`, 15 sub-tests for `RecordCacheXxx` nil-safety, and `TestOnCacheInvalidationHook` verifying the watcher event triggers the callback
## Steps to Test

1. Start the backend with metrics enabled (`--enable-metrics`)
2. Make several requests to any Kubernetes resource list endpoint
3. Query `GET /metrics` and search for `headlamp_cache_`
4. Verify `hit_count` increases on repeated requests for the same resource
5. Verify `miss_count` increases on first-time or invalidated requests
6. Verify `store_count` increments when new responses are cached
7. Verify `invalidation_count` increments when a watched resource changes
 
## Notes for the Reviewer

- The k8cache package is intentionally kept decoupled from telemetry via a package-level `OnCacheInvalidation` callback rather than a direct import.
- Hit/miss/store metrics are recorded at the call site in `server.go` rather than inside the cache library itself, keeping the generic cache package free of telemetry concerns.
- All 5 `RecordCacheXxx` methods follow the existing nil-safe pattern (safe to call on nil handler or with nil metrics).
- This is the third PR improving the cache subsystem, after configurable resync period and configurable watch resources.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cache performance telemetry for hits, misses, stores, evictions, and invalidations.
  * Added visibility into cache activity during request handling and Kubernetes resource updates.
* **Bug Fixes**
  * Improved cache response handling so failed or unsuitable responses are not stored.
  * Cache forwarding now continues gracefully when caching fails, improving request reliability.
* **Tests**
  * Expanded coverage for cache behavior and telemetry recording, including safe handling when telemetry is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->