### PR TITLE
frontend: Add missing Storybook stories for EventsLifetimeInfo

### DIFF
--- a/frontend/src/components/common/EventsLifetimeInfo.stories.tsx
+++ b/frontend/src/components/common/EventsLifetimeInfo.stories.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import React from 'react';
+import EventsLifetimeInfo from './EventsLifetimeInfo';
+
+export default {
+  title: 'common/EventsLifetimeInfo',
+  component: EventsLifetimeInfo,
+} as Meta;
+
+const Template: StoryFn = () => <EventsLifetimeInfo />;
+
+export const Default = Template.bind({});

--- a/frontend/src/components/common/__snapshots__/EventsLifetimeInfo.Default.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/EventsLifetimeInfo.Default.stories.storyshot
@@ -1,0 +1,15 @@
+<body>
+  <div>
+    <button
+      aria-label="Events lifetime information"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element="true"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</body>


### PR DESCRIPTION
## Summary

This PR adds missing Storybook coverage by adding a story for the presentational widget `EventsLifetimeInfo`.

## Related Issue

Fixes #6708

## Changes

- Added `frontend/src/components/common/EventsLifetimeInfo.stories.tsx` to cover the default state of the widget and its tooltip.
- Generated and updated the Storyshot snapshots for the new file.

## Steps to Test

1. From the `frontend` directory, run `npm run storybook`.
2. Navigate to the `common` component group in the Storybook sidebar.
3. Verify that the `EventsLifetimeInfo` widget renders correctly and its tooltip appears on hover.
4. Run `npm run test` and observe that all storyshot snapshot tests pass without any mismatches.


## Notes for the Reviewer

- This widget is purely presentational and requires no props or mock data, making it a very straightforward and stable candidate for snapshot testing.