### PR TITLE
app: restore macOS zoom-in shortcut

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -936,6 +936,10 @@ function getAcceleratorForPlatform(navigation: 'left' | 'right') {
   }
 }
 
+function getZoomInAccelerator() {
+  return platform() === 'darwin' ? 'CmdOrCtrl+Plus' : 'CmdOrCtrl+=';
+}
+
 function getDefaultAppMenu(): AppMenu[] {
   const isMac = process.platform === 'darwin';
 
@@ -1082,7 +1086,7 @@ function getDefaultAppMenu(): AppMenu[] {
         {
           label: i18n.t('Zoom In'),
           id: 'original-zoom-in',
-          accelerator: 'CmdOrCtrl+=',
+          accelerator: getZoomInAccelerator(),
           click: () => adjustZoom(0.1),
         },
         {


### PR DESCRIPTION
## Summary

This PR fixes the macOS desktop zoom-in shortcut regression by restoring Electron's `CmdOrCtrl+Plus` accelerator for the `Zoom In` menu item.

## Related Issue

N/A

## Changes

- Fixed the desktop app `Zoom In` menu accelerator in `app/electron/main.ts`

## Steps to Test

1. Run the Headlamp backend and frontend from this repository.
2. Launch the desktop app on macOS.
3. Use the `View -> Zoom In` action or press `Cmd` `+`.
4. Verify the app zooms in.
5. Verify `View -> Zoom Out` and `View -> Reset Zoom` still work.

## Screenshots (if applicable)

Default zoom:

![Headlamp default zoom](https://raw.githubusercontent.com/rootp1/headlamp/app-macos-zoom-shortcut-fix/headlamp-default.png)

Zoomed in:

![Headlamp zoomed in](https://raw.githubusercontent.com/rootp1/headlamp/app-macos-zoom-shortcut-fix/headlamp-zoomed-in.png)

## Notes for the Reviewer

- The regression was isolated to the `Zoom In` accelerator string; the zoom handler itself still works on macOS.
- Validation run locally: `npm run app:test:unit`
