### PR TITLE
frontend: CircularChart: Show loading state while metrics load

### DIFF
--- a/frontend/src/components/cluster/Charts/ResourceCharts.stories.tsx
+++ b/frontend/src/components/cluster/Charts/ResourceCharts.stories.tsx
@@ -196,6 +196,18 @@ MemoryChartPod.args = {
   resource: 'memory',
 };
 
+// Metrics not loaded yet (items present, metrics null, no error): should show a
+// loading state rather than a misleading 0%.
+export const MemoryChartLoading = Template1.bind({});
+MemoryChartLoading.args = {
+  chart_props: {
+    items: [mockNode],
+    itemsMetrics: null,
+    noMetrics: false,
+  },
+  resource: 'memory',
+};
+
 // CPU Chart Stories
 export const CpuChartWithMetrics = Template1.bind({});
 CpuChartWithMetrics.args = {
@@ -222,6 +234,18 @@ CpuChartPod.args = {
   chart_props: {
     items: [mockPod],
     itemsMetrics: [mockPodMetrics],
+    noMetrics: false,
+  },
+  resource: 'cpu',
+};
+
+// Metrics not loaded yet (items present, metrics null, no error): should show a
+// loading state rather than a misleading 0%.
+export const CpuChartLoading = Template1.bind({});
+CpuChartLoading.args = {
+  chart_props: {
+    items: [mockNode],
+    itemsMetrics: null,
     noMetrics: false,
   },
   resource: 'cpu',

--- a/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.CpuChartLoading.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.CpuChartLoading.stories.storyshot
@@ -1,0 +1,63 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
+    >
+      <div
+        class="MuiBox-root css-qrw4x1"
+      >
+        <div
+          class="MuiBox-root css-1sl8dhm"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
+            >
+              CPU Usage
+            </p>
+          </div>
+          <p
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
+          />
+        </div>
+        <div
+          class="MuiBox-root css-0"
+        >
+          <div
+            aria-busy="true"
+            aria-live="polite"
+            class="MuiBox-root css-2esbmj"
+          >
+            <div
+              class="MuiBox-root css-5cned0"
+            >
+              <span
+                aria-label="Loading data for "
+                class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary css-1g0vz9s-MuiCircularProgress-root"
+                role="progressbar"
+                style="width: 40px; height: 40px;"
+                title="Loading data for "
+              >
+                <svg
+                  class="MuiCircularProgress-svg css-1idz92c-MuiCircularProgress-svg"
+                  viewBox="22 22 44 44"
+                >
+                  <circle
+                    class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-176wh8e-MuiCircularProgress-circle"
+                    cx="44"
+                    cy="44"
+                    fill="none"
+                    r="20.2"
+                    stroke-width="3.6"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.MemoryChartLoading.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.MemoryChartLoading.stories.storyshot
@@ -1,0 +1,63 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
+    >
+      <div
+        class="MuiBox-root css-qrw4x1"
+      >
+        <div
+          class="MuiBox-root css-1sl8dhm"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
+            >
+              Memory Usage
+            </p>
+          </div>
+          <p
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
+          />
+        </div>
+        <div
+          class="MuiBox-root css-0"
+        >
+          <div
+            aria-busy="true"
+            aria-live="polite"
+            class="MuiBox-root css-2esbmj"
+          >
+            <div
+              class="MuiBox-root css-5cned0"
+            >
+              <span
+                aria-label="Loading data for "
+                class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary css-1g0vz9s-MuiCircularProgress-root"
+                role="progressbar"
+                style="width: 40px; height: 40px;"
+                title="Loading data for "
+              >
+                <svg
+                  class="MuiCircularProgress-svg css-1idz92c-MuiCircularProgress-svg"
+                  viewBox="22 22 44 44"
+                >
+                  <circle
+                    class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-176wh8e-MuiCircularProgress-circle"
+                    cx="44"
+                    cy="44"
+                    fill="none"
+                    r="20.2"
+                    stroke-width="3.6"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/CircularChart.tsx
+++ b/frontend/src/components/common/Resource/CircularChart.tsx
@@ -73,6 +73,11 @@ export function CircularChart(props: CircularChartProps) {
   function getResourceUsage() {
     if (!items) return [-1, -1];
 
+    // Metrics haven't arrived yet (no data and no error). Report this as a
+    // loading state (-1) instead of computing a usage of 0, so the tile shows
+    // '…' rather than a misleading 0% until the real values load.
+    if (!noMetrics && itemsMetrics === null) return [-1, -1];
+
     const nodeMetrics = filterMetrics(items, itemsMetrics);
     const usedValue = _.sumBy(nodeMetrics, resourceUsedGetter);
     const availableValue = _.sumBy(items as List<Node | Pod>, resourceAvailableGetter);


### PR DESCRIPTION
**What this PR does**

Fixes the CPU and Memory usage tiles briefly showing `0.0 %` while metrics are still loading.

`CircularChart` computed `used` as `0` whenever metrics had not arrived yet, which is indistinguishable from real zero usage. On first load (or on a slow connection) the CPU and Memory tiles flashed a misleading `0.0 %` before the real values came in.

Now, when metrics have not loaded yet (no data and no error, i.e. not the `noMetrics` state), the chart reports a loading state instead of `0`, so the tile shows a loading indicator until the real usage arrives. This matches how the Pods usage tile already behaves. The `noMetrics` path (metrics-server not installed) and a loaded-but-empty result are unaffected.

**Testing**

Added `MemoryChartLoading` and `CpuChartLoading` stories covering the "metrics not loaded yet" state, with snapshots confirming the tile renders a loading indicator rather than `0.0 %`.

Closes #6716