### PR TITLE
frontend: resourceMap: Fix fit to screen, and resize issues

### DIFF
--- a/e2e-tests/tests/resourceMap.spec.ts
+++ b/e2e-tests/tests/resourceMap.spec.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, Page, test } from '@playwright/test';
+import { HeadlampPage } from './headlampPage';
+
+const namespace = {
+  apiVersion: 'v1',
+  kind: 'Namespace',
+  metadata: {
+    name: 'resize-test',
+    uid: 'resize-test-namespace',
+    resourceVersion: '1',
+  },
+  status: { phase: 'Active' },
+};
+
+const pods = Array.from({ length: 1001 }, (_, index) => ({
+  apiVersion: 'v1',
+  kind: 'Pod',
+  metadata: {
+    name: `resize-test-pod-${index}`,
+    namespace: namespace.metadata.name,
+    uid: `resize-test-pod-${index}`,
+    resourceVersion: String(index + 1),
+  },
+  status: {
+    phase: 'Running',
+    conditions: [{ type: 'Ready', status: 'True' }],
+  },
+}));
+
+const emptyCollections: Record<string, string> = {
+  cronjobs: 'CronJob',
+  daemonsets: 'DaemonSet',
+  deployments: 'Deployment',
+  endpoints: 'Endpoints',
+  endpointslices: 'EndpointSlice',
+  ingresses: 'Ingress',
+  ingressclasses: 'IngressClass',
+  jobs: 'Job',
+  jobsets: 'JobSet',
+  networkpolicies: 'NetworkPolicy',
+  persistentvolumeclaims: 'PersistentVolumeClaim',
+  replicasets: 'ReplicaSet',
+  services: 'Service',
+  statefulsets: 'StatefulSet',
+};
+
+function list(kind: string, items: unknown[]) {
+  return {
+    apiVersion: 'v1',
+    kind: `${kind}List`,
+    metadata: { resourceVersion: '1' },
+    items,
+  };
+}
+
+async function mockResourceMapCollections(page: Page, cluster: string) {
+  const mockedResources = new Set<string>();
+  await page.route(new RegExp(`/clusters/${cluster}/apis?/`), async route => {
+    const request = route.request();
+    const url = new URL(request.url());
+
+    if (request.method() !== 'GET' || url.searchParams.get('watch') === '1') {
+      await route.continue();
+      return;
+    }
+
+    const resource = url.pathname.split('/').at(-1);
+    if (resource === 'namespaces') {
+      mockedResources.add(resource);
+      await route.fulfill({ json: list('Namespace', [namespace]) });
+      return;
+    }
+    if (resource === 'pods') {
+      mockedResources.add(resource);
+      await route.fulfill({ json: list('Pod', pods) });
+      return;
+    }
+    if (resource === 'customresourcedefinitions') {
+      await route.fulfill({ json: list('CustomResourceDefinition', []) });
+      return;
+    }
+    const kind = resource && emptyCollections[resource];
+    if (kind) {
+      await route.fulfill({ json: list(kind, []) });
+      return;
+    }
+
+    await route.continue();
+  });
+
+  return mockedResources;
+}
+
+test('keeps a simplified namespace expanded while resizing', async ({ page }) => {
+  test.setTimeout(60_000);
+  const cluster = process.env.HEADLAMP_TEST_CLUSTER || 'test';
+  const headlampPage = new HeadlampPage(page);
+  const mockedResources = await mockResourceMapCollections(page, cluster);
+  await headlampPage.navigateToCluster(cluster, process.env.HEADLAMP_TEST_TOKEN);
+
+  await headlampPage.navigateTopage(`/c/${cluster}/map`);
+
+  await expect.poll(() => [...mockedResources].sort()).toEqual(['namespaces', 'pods']);
+
+  const namespaceNode = page.locator(`[data-id="${namespace.metadata.uid}"]`);
+  await expect(namespaceNode).toBeVisible({ timeout: 30_000 });
+  await namespaceNode.getByRole('button').click();
+
+  const assertExpandedTopology = async () => {
+    const parent = page.locator(`.react-flow__node.parent[data-id="${namespace.metadata.uid}"]`);
+    const children = page.locator(`.react-flow__node[data-id^="resize-test-pod-"]:not(.parent)`);
+
+    await expect(parent).toHaveCount(1);
+    await expect(children).toHaveCount(500);
+  };
+
+  await assertExpandedTopology();
+
+  for (const viewport of [
+    { width: 390, height: 844 },
+    { width: 1200, height: 800 },
+    { width: 600, height: 500 },
+    { width: 1200, height: 800 },
+  ]) {
+    await page.setViewportSize(viewport);
+    await assertExpandedTopology();
+  }
+});

--- a/frontend/src/components/resourceMap/GraphRenderer.test.tsx
+++ b/frontend/src/components/resourceMap/GraphRenderer.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, render } from '@testing-library/react';
+import { GraphRenderer } from './GraphRenderer';
+
+const mocks = vi.hoisted(() => ({
+  reactFlowProps: undefined as Record<string, any> | undefined,
+}));
+
+vi.mock('@xyflow/react', () => ({
+  Background: () => null,
+  BackgroundVariant: { Dots: 'dots' },
+  ConnectionMode: { Loose: 'loose' },
+  Controls: ({ children }: { children: React.ReactNode }) => children,
+  ReactFlow: (props: Record<string, any>) => {
+    mocks.reactFlowProps = props;
+    return <div>{props.children}</div>;
+  },
+}));
+
+vi.mock('./GraphControls', () => ({
+  GraphControls: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('./edges/GraphEdgeComponent', () => ({
+  GraphEdgeComponent: () => null,
+}));
+
+vi.mock('./nodes/KubeObjectNode', () => ({
+  KubeObjectNodeComponent: () => null,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('GraphRenderer', () => {
+  beforeEach(() => {
+    mocks.reactFlowProps = undefined;
+  });
+
+  it('forwards continuous viewport movement through onMove', () => {
+    const onMove = vi.fn();
+    render(<GraphRenderer nodes={[]} edges={[]} onMove={onMove} />);
+
+    expect(mocks.reactFlowProps?.onMove).toBe(onMove);
+    expect(mocks.reactFlowProps?.onMoveStart).toBeUndefined();
+
+    const viewport = { x: 10, y: 20, zoom: 1 };
+    act(() => mocks.reactFlowProps?.onMove(null, viewport));
+    expect(onMove).toHaveBeenCalledWith(null, viewport);
+  });
+});

--- a/frontend/src/components/resourceMap/GraphRenderer.tsx
+++ b/frontend/src/components/resourceMap/GraphRenderer.tsx
@@ -26,7 +26,7 @@ import {
   EdgeMouseHandler,
   Node,
   NodeMouseHandler,
-  OnMoveStart,
+  OnMove,
   ReactFlow,
 } from '@xyflow/react';
 import React from 'react';
@@ -54,8 +54,8 @@ export interface GraphRendererProps {
   onNodeClick?: NodeMouseHandler<Node>;
   /** Callback when an edge is clicked */
   onEdgeClick?: EdgeMouseHandler<Edge>;
-  /** Callback when the graph is started to be moved */
-  onMoveStart?: OnMoveStart;
+  /** Callback while the graph viewport is moving */
+  onMove?: OnMove;
   /** Callback when the background is clicked */
   onBackgroundClick?: () => void;
   /** Additional components to render */
@@ -72,7 +72,7 @@ export function GraphRenderer({
   edges,
   onNodeClick,
   onEdgeClick,
-  onMoveStart,
+  onMove,
   onBackgroundClick,
   children,
   controlActions,
@@ -125,7 +125,7 @@ export function GraphRenderer({
       elementsSelectable
       onNodeClick={onNodeClick}
       onEdgeClick={onEdgeClick}
-      onMove={onMoveStart}
+      onMove={onMove}
       onClick={e => {
         if ((e.target as HTMLElement)?.className?.includes?.('react-flow__pane')) {
           onBackgroundClick?.();

--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -114,6 +114,9 @@ interface GraphViewContentProps {
   defaultFilters?: GraphFilter[];
 }
 
+export const MAP_PERFORMANCE_FEATURES_ENABLED =
+  import.meta.env.REACT_APP_HEADLAMP_ENABLE_MAP_PERFORMANCE_FEATURES === 'true';
+
 const defaultFiltersValue: GraphFilter[] = [];
 
 interface GraphViewInternalProps extends Omit<GraphViewContentProps, 'defaultSources'> {
@@ -543,11 +546,13 @@ function GraphViewContent({
                   />
                 )}
 
-                <ChipToggleButton
-                  label={t('Incremental Updates')}
-                  isActive={useIncrementalUpdates}
-                  onClick={() => setUseIncrementalUpdates(!useIncrementalUpdates)}
-                />
+                {MAP_PERFORMANCE_FEATURES_ENABLED && (
+                  <ChipToggleButton
+                    label={t('Incremental Updates')}
+                    isActive={useIncrementalUpdates}
+                    onClick={() => setUseIncrementalUpdates(!useIncrementalUpdates)}
+                  />
+                )}
 
                 {graphSize < 50 && (
                   <ChipToggleButton
@@ -557,11 +562,13 @@ function GraphViewContent({
                   />
                 )}
 
-                <ChipToggleButton
-                  label={t('Performance Stats')}
-                  isActive={showPerformanceStats}
-                  onClick={() => setShowPerformanceStats(!showPerformanceStats)}
-                />
+                {MAP_PERFORMANCE_FEATURES_ENABLED && (
+                  <ChipToggleButton
+                    label={t('Performance Stats')}
+                    isActive={showPerformanceStats}
+                    onClick={() => setShowPerformanceStats(!showPerformanceStats)}
+                  />
+                )}
               </Box>
 
               <div style={{ flexGrow: 1 }}>
@@ -604,7 +611,7 @@ function GraphViewContent({
             </Box>
           </CustomThemeProvider>
 
-          {showPerformanceStats && (
+          {MAP_PERFORMANCE_FEATURES_ENABLED && showPerformanceStats && (
             <PerformanceStats
               visible={showPerformanceStats}
               onToggle={() => setShowPerformanceStats(false)}

--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -43,6 +43,7 @@ import { setNamespaceFilter } from '../../redux/filterSlice';
 import { useTypedSelector } from '../../redux/hooks';
 import { NamespacesAutocomplete } from '../common/NamespacesAutocomplete';
 import { filterGraph, filterGraphIncremental, GraphFilter } from './graph/graphFiltering';
+import { getGraphForNamespaceSelection } from './graph/graphForNamespaceSelection';
 import {
   collapseGraph,
   findGroupContaining,
@@ -348,10 +349,20 @@ function GraphViewContent({
 
   const activeNamespaces = groupBy === 'namespace' ? allNamespaces : undefined;
   const activeNodes = groupBy === 'node' ? allNodes : undefined;
+  const graphForGrouping = useMemo(
+    () =>
+      getGraphForNamespaceSelection(
+        filteredGraph,
+        simplifiedGraph,
+        activeNamespaces ?? [],
+        selectedNodeId
+      ),
+    [filteredGraph, simplifiedGraph, activeNamespaces, selectedNodeId]
+  );
 
   const { visibleGraph, fullGraph } = useMemo(() => {
     const perfStart = performance.now();
-    const graph = groupGraph(simplifiedGraph.nodes, simplifiedGraph.edges, {
+    const graph = groupGraph(graphForGrouping.nodes, graphForGrouping.edges, {
       groupBy,
       namespaces: activeNamespaces ?? [],
       k8sNodes: activeNodes ?? [],
@@ -373,7 +384,7 @@ function GraphViewContent({
     }
 
     return { visibleGraph, fullGraph: graph };
-  }, [simplifiedGraph, groupBy, selectedNodeId, expandAll, activeNamespaces, activeNodes]);
+  }, [graphForGrouping, groupBy, selectedNodeId, expandAll, activeNamespaces, activeNodes]);
 
   const viewport = useGraphViewport();
 
@@ -576,7 +587,7 @@ function GraphViewContent({
                   nodes={layoutedGraph.nodes}
                   edges={layoutedGraph.edges}
                   isLoading={isLoading}
-                  onMoveStart={e => {
+                  onMove={e => {
                     if (e === null) return;
                     viewportMovedRef.current = true;
                   }}

--- a/frontend/src/components/resourceMap/__snapshots__/GraphView.BasicExample.stories.storyshot
+++ b/frontend/src/components/resourceMap/__snapshots__/GraphView.BasicExample.stories.storyshot
@@ -172,20 +172,6 @@
             />
           </div>
           <div
-            class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorPrimary MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-filledPrimary css-661vdt-MuiButtonBase-root-MuiChip-root"
-            role="button"
-            tabindex="0"
-          >
-            <span
-              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
-            >
-              Incremental Updates
-            </span>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
-          </div>
-          <div
             class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-1b73nf-MuiButtonBase-root-MuiChip-root"
             role="button"
             tabindex="0"
@@ -194,20 +180,6 @@
               class="MuiChip-label MuiChip-labelMedium css-1jzq0dw-MuiChip-label"
             >
               Expand All
-            </span>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
-          </div>
-          <div
-            class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-1b73nf-MuiButtonBase-root-MuiChip-root"
-            role="button"
-            tabindex="0"
-          >
-            <span
-              class="MuiChip-label MuiChip-labelMedium css-1jzq0dw-MuiChip-label"
-            >
-              Performance Stats
             </span>
             <span
               class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"

--- a/frontend/src/components/resourceMap/__snapshots__/GraphView.PerformanceTest100000Pods.stories.storyshot
+++ b/frontend/src/components/resourceMap/__snapshots__/GraphView.PerformanceTest100000Pods.stories.storyshot
@@ -339,34 +339,6 @@
                   Showing 300 of 105060 nodes
                 </span>
               </div>
-              <div
-                class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorPrimary MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-filledPrimary css-661vdt-MuiButtonBase-root-MuiChip-root"
-                role="button"
-                tabindex="0"
-              >
-                <span
-                  class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
-                >
-                  Incremental Updates
-                </span>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
-              </div>
-              <div
-                class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-1b73nf-MuiButtonBase-root-MuiChip-root"
-                role="button"
-                tabindex="0"
-              >
-                <span
-                  class="MuiChip-label MuiChip-labelMedium css-1jzq0dw-MuiChip-label"
-                >
-                  Performance Stats
-                </span>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
-              </div>
             </div>
             <div
               style="flex-grow: 1;"

--- a/frontend/src/components/resourceMap/__snapshots__/GraphView.PerformanceTest20000Pods.stories.storyshot
+++ b/frontend/src/components/resourceMap/__snapshots__/GraphView.PerformanceTest20000Pods.stories.storyshot
@@ -337,34 +337,6 @@
                   Showing 300 of 34350 nodes
                 </span>
               </div>
-              <div
-                class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorPrimary MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-filledPrimary css-661vdt-MuiButtonBase-root-MuiChip-root"
-                role="button"
-                tabindex="0"
-              >
-                <span
-                  class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
-                >
-                  Incremental Updates
-                </span>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
-              </div>
-              <div
-                class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-1b73nf-MuiButtonBase-root-MuiChip-root"
-                role="button"
-                tabindex="0"
-              >
-                <span
-                  class="MuiChip-label MuiChip-labelMedium css-1jzq0dw-MuiChip-label"
-                >
-                  Performance Stats
-                </span>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
-              </div>
             </div>
             <div
               style="flex-grow: 1;"

--- a/frontend/src/components/resourceMap/__snapshots__/GraphView.PerformanceTest2000Pods.stories.storyshot
+++ b/frontend/src/components/resourceMap/__snapshots__/GraphView.PerformanceTest2000Pods.stories.storyshot
@@ -337,34 +337,6 @@
                   Showing 500 of 2000 nodes
                 </span>
               </div>
-              <div
-                class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorPrimary MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-filledPrimary css-661vdt-MuiButtonBase-root-MuiChip-root"
-                role="button"
-                tabindex="0"
-              >
-                <span
-                  class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
-                >
-                  Incremental Updates
-                </span>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
-              </div>
-              <div
-                class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-1b73nf-MuiButtonBase-root-MuiChip-root"
-                role="button"
-                tabindex="0"
-              >
-                <span
-                  class="MuiChip-label MuiChip-labelMedium css-1jzq0dw-MuiChip-label"
-                >
-                  Performance Stats
-                </span>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
-              </div>
             </div>
             <div
               style="flex-grow: 1;"

--- a/frontend/src/components/resourceMap/__snapshots__/GraphView.PerformanceTest5000Pods.stories.storyshot
+++ b/frontend/src/components/resourceMap/__snapshots__/GraphView.PerformanceTest5000Pods.stories.storyshot
@@ -334,34 +334,6 @@
                   Showing 500 of 8850 nodes
                 </span>
               </div>
-              <div
-                class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorPrimary MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-filledPrimary css-661vdt-MuiButtonBase-root-MuiChip-root"
-                role="button"
-                tabindex="0"
-              >
-                <span
-                  class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
-                >
-                  Incremental Updates
-                </span>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
-              </div>
-              <div
-                class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-1b73nf-MuiButtonBase-root-MuiChip-root"
-                role="button"
-                tabindex="0"
-              >
-                <span
-                  class="MuiChip-label MuiChip-labelMedium css-1jzq0dw-MuiChip-label"
-                >
-                  Performance Stats
-                </span>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
-              </div>
             </div>
             <div
               style="flex-grow: 1;"

--- a/frontend/src/components/resourceMap/__snapshots__/GraphView.PerformanceTest500Pods.stories.storyshot
+++ b/frontend/src/components/resourceMap/__snapshots__/GraphView.PerformanceTest500Pods.stories.storyshot
@@ -251,34 +251,6 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </div>
-              <div
-                class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorPrimary MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-filledPrimary css-661vdt-MuiButtonBase-root-MuiChip-root"
-                role="button"
-                tabindex="0"
-              >
-                <span
-                  class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
-                >
-                  Incremental Updates
-                </span>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
-              </div>
-              <div
-                class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-1b73nf-MuiButtonBase-root-MuiChip-root"
-                role="button"
-                tabindex="0"
-              >
-                <span
-                  class="MuiChip-label MuiChip-labelMedium css-1jzq0dw-MuiChip-label"
-                >
-                  Performance Stats
-                </span>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
-              </div>
             </div>
             <div
               style="flex-grow: 1;"

--- a/frontend/src/components/resourceMap/graph/graphForNamespaceSelection.test.ts
+++ b/frontend/src/components/resourceMap/graph/graphForNamespaceSelection.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type Namespace from '../../../lib/k8s/namespace';
+import { getGraphForNamespaceSelection } from './graphForNamespaceSelection';
+import { getGraphForSelectedNamespace } from './graphSimplification';
+
+vi.mock('./graphSimplification', () => ({
+  getGraphForSelectedNamespace: vi.fn((_filtered, simplified) => simplified),
+}));
+
+describe('getGraphForNamespaceSelection', () => {
+  const namespace = {
+    metadata: { name: 'selected', uid: 'selected-namespace-uid' },
+  } as Namespace;
+
+  const filteredGraph = { nodes: [], edges: [] };
+  const simplifiedGraph = { nodes: [], edges: [], simplified: true };
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('passes the namespace name for a selected Namespace UID', () => {
+    getGraphForNamespaceSelection(
+      filteredGraph,
+      simplifiedGraph,
+      [namespace],
+      namespace.metadata.uid
+    );
+
+    expect(getGraphForSelectedNamespace).toHaveBeenCalledWith(
+      filteredGraph,
+      simplifiedGraph,
+      namespace.metadata.name
+    );
+  });
+
+  it('does not scope a non-namespace selection', () => {
+    getGraphForNamespaceSelection(filteredGraph, simplifiedGraph, [namespace], 'pod-uid');
+
+    expect(getGraphForSelectedNamespace).toHaveBeenCalledWith(
+      filteredGraph,
+      simplifiedGraph,
+      undefined
+    );
+  });
+});

--- a/frontend/src/components/resourceMap/graph/graphForNamespaceSelection.ts
+++ b/frontend/src/components/resourceMap/graph/graphForNamespaceSelection.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type Namespace from '../../../lib/k8s/namespace';
+import type { GraphEdge, GraphNode } from './graphModel';
+import { getGraphForSelectedNamespace } from './graphSimplification';
+
+type Graph = { nodes: GraphNode[]; edges: GraphEdge[] };
+type SimplifiedGraph = Graph & { simplified: boolean };
+
+export function getGraphForNamespaceSelection(
+  filteredGraph: Graph,
+  simplifiedGraph: SimplifiedGraph,
+  namespaces: Namespace[],
+  selectedNodeId?: string
+) {
+  const namespaceName = namespaces.find(namespace => namespace.metadata.uid === selectedNodeId)
+    ?.metadata.name;
+
+  return getGraphForSelectedNamespace(filteredGraph, simplifiedGraph, namespaceName);
+}

--- a/frontend/src/components/resourceMap/graph/graphLayout.test.ts
+++ b/frontend/src/components/resourceMap/graph/graphLayout.test.ts
@@ -231,6 +231,42 @@ describe('applyGraphLayout', () => {
     expect(result.edges).toEqual([]);
   });
 
+  it('does not reuse a collapsed group layout after the group expands', async () => {
+    type MockElkNode = Record<string, unknown> & { children?: MockElkNode[] };
+    const child = { id: 'pod' };
+    const collapsedGraph: GraphNode = {
+      id: 'root',
+      nodes: [{ id: 'namespace', collapsed: true, nodes: [child] }],
+    };
+    const expandedGraph: GraphNode = {
+      id: 'root',
+      nodes: [{ id: 'namespace', collapsed: false, nodes: [child] }],
+    };
+    mocks.layout.mockImplementation(async elkGraph => ({
+      ...elkGraph,
+      children: elkGraph.children.map((node: MockElkNode) => ({
+        ...node,
+        x: 0,
+        y: 0,
+        children: node.children?.map((childNode: MockElkNode) => ({
+          ...childNode,
+          x: 10,
+          y: 10,
+        })),
+      })),
+    }));
+    const { applyGraphLayout } = await import('./graphLayout');
+
+    const collapsedLayout = await applyGraphLayout(collapsedGraph, 1);
+    const expandedLayout = await applyGraphLayout(expandedGraph, 1);
+    const cachedExpandedLayout = await applyGraphLayout(expandedGraph, 1);
+
+    expect(collapsedLayout.nodes.map(node => node.id)).toEqual(['namespace']);
+    expect(expandedLayout.nodes.map(node => node.id)).toEqual(['namespace', 'pod']);
+    expect(cachedExpandedLayout.nodes.map(node => node.id)).toEqual(['namespace', 'pod']);
+    expect(mocks.layout).toHaveBeenCalledTimes(2);
+  });
+
   it('returns an empty graph when ELK construction fails', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const constructorError = new Error('worker unavailable');
@@ -310,6 +346,20 @@ describe('getGraphCacheKey', () => {
     const graph1 = makeGraph([{ id: 'a' }, { id: 'b' }]);
     const graph2 = makeGraph([{ id: 'a' }, { id: 'c' }]);
     expect(getGraphCacheKey(graph1, 1.5)).not.toBe(getGraphCacheKey(graph2, 1.5));
+  });
+
+  it('should produce different keys for collapsed and expanded groups', () => {
+    const child = { id: 'pod' };
+    const collapsedGraph: GraphNode = {
+      id: 'root',
+      nodes: [{ id: 'namespace', collapsed: true, nodes: [child] }],
+    };
+    const expandedGraph: GraphNode = {
+      id: 'root',
+      nodes: [{ id: 'namespace', collapsed: false, nodes: [child] }],
+    };
+
+    expect(getGraphCacheKey(collapsedGraph, 1.5)).not.toBe(getGraphCacheKey(expandedGraph, 1.5));
   });
 
   it('should frame node IDs to distinguish different ID sequences', () => {

--- a/frontend/src/components/resourceMap/graph/graphLayout.tsx
+++ b/frontend/src/components/resourceMap/graph/graphLayout.tsx
@@ -67,7 +67,7 @@ function hashFramedString(str: string, seed: number): number {
  * Generate a cache key for the graph
  *
  * Uses a running hash over ALL nodes/edges in a single O(n) pass.
- * - Hashes every node ID and every edge (source→target) during forEachNode traversal
+ * - Hashes every node ID, collapsed state, and edge (source→target) during traversal
  * - O(n) time proportional to total string length, O(1) extra memory
  * - No arrays, no sorting, no sampling — processes the full graph
  */
@@ -81,6 +81,7 @@ export function getGraphCacheKey(graph: GraphNode, aspectRatio: number): string 
   forEachNode(graph, node => {
     nodeCount++;
     nodeHash = hashFramedString(node.id, nodeHash);
+    nodeHash = hashFramedString(node.collapsed ? 'collapsed' : 'expanded', nodeHash);
 
     if (node.edges && node.edges.length > 0) {
       edgeCount += node.edges.length;

--- a/frontend/src/components/resourceMap/graph/graphSimplification.test.ts
+++ b/frontend/src/components/resourceMap/graph/graphSimplification.test.ts
@@ -20,6 +20,7 @@ import { GraphEdge, GraphNode } from './graphModel';
 import {
   EXTREME_SIMPLIFICATION_THRESHOLD,
   EXTREME_SIMPLIFIED_NODE_LIMIT,
+  getGraphForSelectedNamespace,
   selectTopN,
   SIMPLIFIED_NODE_LIMIT,
   simplifyGraph,
@@ -30,6 +31,57 @@ import {
 const _dont_delete_me = App;
 
 describe('graphSimplification', () => {
+  const makeNamespacePods = (count: number, namespace: string): GraphNode[] =>
+    Array.from({ length: count }, (_, i) => ({
+      id: `${namespace}-pod-${i}`,
+      kubeObject: new Pod({
+        kind: 'Pod',
+        metadata: {
+          name: `pod-${i}`,
+          namespace,
+          uid: `${namespace}-pod-${i}`,
+        },
+        status: { phase: 'Running', conditions: [{ type: 'Ready', status: 'True' }] },
+      } as any),
+    }));
+
+  describe('getGraphForSelectedNamespace', () => {
+    it('shows every resource in a small selected namespace', () => {
+      const namespaceNodes = makeNamespacePods(15, 'small');
+      const otherNodes = makeNamespacePods(1000, 'other');
+      const filteredGraph = { nodes: [...namespaceNodes, ...otherNodes], edges: [] };
+      const simplifiedGraph = simplifyGraph(filteredGraph.nodes, [], {
+        enabled: true,
+        maxNodes: SIMPLIFIED_NODE_LIMIT,
+      });
+
+      const result = getGraphForSelectedNamespace(filteredGraph, simplifiedGraph, 'small');
+
+      expect(result.simplified).toBe(false);
+      expect(result.nodes).toHaveLength(15);
+      expect(result.nodes.every(node => node.kubeObject?.metadata.namespace === 'small')).toBe(
+        true
+      );
+    });
+
+    it('simplifies a selected namespace with 10,000 resources', () => {
+      const namespaceNodes = makeNamespacePods(10000, 'large');
+      const filteredGraph = { nodes: namespaceNodes, edges: [] };
+      const simplifiedGraph = simplifyGraph(namespaceNodes, [], {
+        enabled: true,
+        maxNodes: SIMPLIFIED_NODE_LIMIT,
+      });
+
+      const result = getGraphForSelectedNamespace(filteredGraph, simplifiedGraph, 'large');
+
+      expect(result.simplified).toBe(true);
+      expect(result.nodes).toHaveLength(SIMPLIFIED_NODE_LIMIT);
+      expect(result.nodes.every(node => node.kubeObject?.metadata.namespace === 'large')).toBe(
+        true
+      );
+    });
+  });
+
   describe('simplifyGraph', () => {
     it('should not simplify when disabled', () => {
       const nodes: GraphNode[] = Array.from({ length: 2000 }, (_, i) => ({

--- a/frontend/src/components/resourceMap/graph/graphSimplification.ts
+++ b/frontend/src/components/resourceMap/graph/graphSimplification.ts
@@ -93,6 +93,42 @@ export const EXTREME_SIMPLIFICATION_THRESHOLD = 10000;
 export const EXTREME_SIMPLIFIED_NODE_LIMIT = 300;
 
 /**
+ * Build the graph shown after selecting a namespace from a simplified overview.
+ * The namespace is scoped from the unsimplified graph, then simplified using its
+ * own resource count so small namespaces remain complete and large ones stay
+ * safe to render.
+ *
+ * @param filteredGraph Unsimplified graph after applying active filters.
+ * @param simplifiedGraph Graph used for the overview.
+ * @param namespaceName Selected namespace name, if the selection is a namespace.
+ * @returns The selected namespace graph, or the overview graph when not applicable.
+ */
+export function getGraphForSelectedNamespace(
+  filteredGraph: { nodes: GraphNode[]; edges: GraphEdge[] },
+  simplifiedGraph: { nodes: GraphNode[]; edges: GraphEdge[]; simplified: boolean },
+  namespaceName?: string
+) {
+  if (!simplifiedGraph.simplified || !namespaceName) return simplifiedGraph;
+
+  const namespaceNodes = filteredGraph.nodes.filter(
+    node => node.kubeObject?.metadata?.namespace === namespaceName
+  );
+  const namespaceNodeIds = new Set(namespaceNodes.map(node => node.id));
+  const namespaceEdges = filteredGraph.edges.filter(
+    edge => namespaceNodeIds.has(edge.source) && namespaceNodeIds.has(edge.target)
+  );
+  const maxNodes =
+    namespaceNodes.length > EXTREME_SIMPLIFICATION_THRESHOLD
+      ? EXTREME_SIMPLIFIED_NODE_LIMIT
+      : SIMPLIFIED_NODE_LIMIT;
+
+  return simplifyGraph(namespaceNodes, namespaceEdges, {
+    enabled: namespaceNodes.length > SIMPLIFICATION_THRESHOLD,
+    maxNodes,
+  });
+}
+
+/**
  * Simplifies a large graph by keeping only the most important nodes.
  *
  * For graphs larger than the threshold, reduces the node count to keep

--- a/frontend/src/components/resourceMap/sources/definitions/relations.test.tsx
+++ b/frontend/src/components/resourceMap/sources/definitions/relations.test.tsx
@@ -69,6 +69,17 @@ const service = (
   cluster = 'cluster-a'
 ) => new Service({ metadata, spec: { selector, ports: [] }, status: {} } as any, cluster);
 
+describe('KubeObject class matching', () => {
+  it('does not match a generic plugin object to a typed resource class', () => {
+    const resource = new KubeObject({
+      kind: 'PluginResource',
+      metadata: { uid: 'plugin-resource' },
+    } as any);
+
+    expect(Pod.isClassOf(resource)).toBe(false);
+  });
+});
+
 describe('matchesLabels', () => {
   it('matches every requested label and rejects missing or different labels', () => {
     const item = pod({ uid: 'pod', labels: { app: 'web', tier: 'frontend' } });

--- a/frontend/src/components/resourceMap/useGraphViewport.test.ts
+++ b/frontend/src/components/resourceMap/useGraphViewport.test.ts
@@ -21,17 +21,19 @@ import { useGraphViewport } from './useGraphViewport';
 
 const mocks = vi.hoisted(() => ({
   getNodes: vi.fn(),
-  getNodesBounds: vi.fn(),
+  getLayoutNodesBounds: vi.fn(),
+  getFlowNodesBounds: vi.fn(),
   getViewportForBounds: vi.fn(),
   setViewport: vi.fn(),
   setZoomMode: vi.fn(),
 }));
 
 vi.mock('@xyflow/react', () => ({
+  getNodesBounds: mocks.getLayoutNodesBounds,
   getViewportForBounds: mocks.getViewportForBounds,
   useReactFlow: () => ({
     getNodes: mocks.getNodes,
-    getNodesBounds: mocks.getNodesBounds,
+    getNodesBounds: mocks.getFlowNodesBounds,
     setViewport: mocks.setViewport,
   }),
   useStore: (selector: (state: { width: number; height: number }) => unknown) =>
@@ -50,20 +52,21 @@ describe('useGraphViewport', () => {
   it('uses current nodes and the stored 100% mode by default', () => {
     const nodes = [{ id: 'current-node' }] as Node[];
     mocks.getNodes.mockReturnValue(nodes);
-    mocks.getNodesBounds.mockReturnValue({ x: 10, y: 20, width: 300, height: 100 });
+    mocks.getFlowNodesBounds.mockReturnValue({ x: 10, y: 20, width: 300, height: 100 });
 
     const { result } = renderHook(() => useGraphViewport());
 
     act(() => result.current.updateViewport({}));
 
     expect(result.current.aspectRatio).toBe(2);
-    expect(mocks.getNodesBounds).toHaveBeenCalledWith(nodes);
+    expect(mocks.getFlowNodesBounds).toHaveBeenCalledWith(nodes);
+    expect(mocks.getLayoutNodesBounds).not.toHaveBeenCalled();
     expect(mocks.setZoomMode).not.toHaveBeenCalled();
     expect(mocks.setViewport).toHaveBeenCalledWith({ x: 250, y: 150, zoom: 1 });
   });
 
   it('uses top-left padding independently for dimensions that do not fit at 100%', () => {
-    mocks.getNodesBounds.mockReturnValue({ x: 0, y: 0, width: 750, height: 200 });
+    mocks.getLayoutNodesBounds.mockReturnValue({ x: 0, y: 0, width: 750, height: 200 });
     const { result } = renderHook(() => useGraphViewport());
 
     act(() => result.current.updateViewport({ nodes: [], mode: '100%' }));
@@ -74,7 +77,7 @@ describe('useGraphViewport', () => {
       zoom: 1,
     });
 
-    mocks.getNodesBounds.mockReturnValue({ x: 0, y: 0, width: 200, height: 350 });
+    mocks.getLayoutNodesBounds.mockReturnValue({ x: 0, y: 0, width: 200, height: 350 });
     act(() => result.current.updateViewport({ nodes: [], mode: '100%' }));
 
     expect(mocks.setViewport).toHaveBeenLastCalledWith({
@@ -87,7 +90,7 @@ describe('useGraphViewport', () => {
   it('fits padded bounds and persists a changed fit mode', () => {
     const bounds = { x: 25, y: 40, width: 500, height: 250 };
     const fittedViewport = { x: 12, y: 18, zoom: 0.75 };
-    mocks.getNodesBounds.mockReturnValue(bounds);
+    mocks.getLayoutNodesBounds.mockReturnValue(bounds);
     mocks.getViewportForBounds.mockReturnValue(fittedViewport);
     const { result } = renderHook(() => useGraphViewport());
 
@@ -113,7 +116,7 @@ describe('useGraphViewport', () => {
 
   it('reports an unknown mode without changing the viewport', () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
-    mocks.getNodesBounds.mockReturnValue({ x: 0, y: 0, width: 1, height: 1 });
+    mocks.getLayoutNodesBounds.mockReturnValue({ x: 0, y: 0, width: 1, height: 1 });
     const { result } = renderHook(() => useGraphViewport());
 
     act(() => result.current.updateViewport({ nodes: [], mode: 'unsupported' as 'fit' | '100%' }));
@@ -121,5 +124,27 @@ describe('useGraphViewport', () => {
     expect(consoleError).toHaveBeenCalledWith('Unknown zoom mode', 'unsupported');
     expect(mocks.setViewport).not.toHaveBeenCalled();
     consoleError.mockRestore();
+  });
+
+  it('builds absolute lookup positions for nested layout nodes', () => {
+    const nodes = [
+      { id: 'group', position: { x: 100, y: 50 }, width: 400, height: 300, data: {} },
+      {
+        id: 'child',
+        parentId: 'group',
+        position: { x: 20, y: 30 },
+        width: 220,
+        height: 70,
+        data: {},
+      },
+    ] as Node[];
+    mocks.getLayoutNodesBounds.mockReturnValue({ x: 100, y: 50, width: 400, height: 300 });
+
+    const { result } = renderHook(() => useGraphViewport());
+    act(() => result.current.updateViewport({ nodes }));
+
+    const nodeLookup = mocks.getLayoutNodesBounds.mock.calls[0][1].nodeLookup;
+    expect(nodeLookup.get('group').internals.positionAbsolute).toEqual({ x: 100, y: 50 });
+    expect(nodeLookup.get('child').internals.positionAbsolute).toEqual({ x: 120, y: 80 });
   });
 });

--- a/frontend/src/components/resourceMap/useGraphViewport.ts
+++ b/frontend/src/components/resourceMap/useGraphViewport.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { getViewportForBounds, Node, useReactFlow, useStore } from '@xyflow/react';
+import { getNodesBounds, getViewportForBounds, Node, useReactFlow, useStore } from '@xyflow/react';
 import { useCallback, useMemo } from 'react';
 import { useLocalStorageState } from '../globalSearch/useLocalStorageState';
 import { maxZoom, minZoom, viewportPaddingPx } from './graphConstants';
@@ -31,6 +31,57 @@ import { maxZoom, minZoom, viewportPaddingPx } from './graphConstants';
  */
 type zoomMode = '100%' | 'fit';
 
+/**
+ * Calculate bounds for a newly generated layout before React Flow has added it
+ * to its internal node lookup.
+ *
+ * Layout node positions are relative to their parents. Build the lookup that
+ * `getNodesBounds` needs so nested nodes use absolute positions without falling
+ * back to stale nodes from the currently rendered graph.
+ *
+ * @param nodes Newly generated layout nodes, including parent relationships.
+ * @returns Bounds containing all layout nodes in absolute graph coordinates.
+ */
+export function getLayoutNodesBounds(nodes: Node[]) {
+  const nodesById = new Map(nodes.map(node => [node.id, node]));
+  const absolutePositions = new Map<string, { x: number; y: number }>();
+
+  const getAbsolutePosition = (node: Node): { x: number; y: number } => {
+    const cachedPosition = absolutePositions.get(node.id);
+    if (cachedPosition) return cachedPosition;
+
+    const parent = node.parentId ? nodesById.get(node.parentId) : undefined;
+    const parentPosition = parent ? getAbsolutePosition(parent) : { x: 0, y: 0 };
+    const position = {
+      x: parentPosition.x + node.position.x,
+      y: parentPosition.y + node.position.y,
+    };
+    absolutePositions.set(node.id, position);
+    return position;
+  };
+
+  const nodeLookup = new Map(
+    nodes.map(node => [
+      node.id,
+      {
+        ...node,
+        measured: {
+          width: node.measured?.width ?? node.width,
+          height: node.measured?.height ?? node.height,
+        },
+        internals: {
+          positionAbsolute: getAbsolutePosition(node),
+          // Bounds only use geometry; z is required by InternalNode but does not affect the box.
+          z: 0,
+          userNode: node,
+        },
+      },
+    ])
+  );
+
+  return getNodesBounds(nodes, { nodeLookup });
+}
+
 /** Helper hook to deal with viewport zooming */
 export const useGraphViewport = () => {
   const [zoomMode, setZoomMode] = useLocalStorageState<zoomMode>('map-zoom-mode', '100%');
@@ -41,7 +92,7 @@ export const useGraphViewport = () => {
 
   const updateViewport = useCallback(
     ({
-      nodes = flow.getNodes(),
+      nodes,
       mode = zoomMode,
     }: {
       /** List of nodes, if not provided will use current nodes in the graph */
@@ -53,7 +104,8 @@ export const useGraphViewport = () => {
         setZoomMode(() => mode);
       }
 
-      const bounds = flow.getNodesBounds(nodes);
+      const bounds =
+        nodes === undefined ? flow.getNodesBounds(flow.getNodes()) : getLayoutNodesBounds(nodes);
 
       if (mode === 'fit') {
         const viewport = getViewportForBounds(

--- a/frontend/src/lib/k8s/KubeObject.ts
+++ b/frontend/src/lib/k8s/KubeObject.ts
@@ -138,8 +138,9 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
    */
   static get apiGroupName(): string | undefined {
     // Get any of the versions, group will be the same
-    const apiVersion = typeof this.apiVersion === 'string' ? this.apiVersion : this.apiVersion[0];
+    const apiVersion = Array.isArray(this.apiVersion) ? this.apiVersion[0] : this.apiVersion;
 
+    if (!apiVersion) return;
     if (!apiVersion.includes('/')) return;
 
     return apiVersion.split('/')[0];


### PR DESCRIPTION
## Summary

Restore Resource Map viewport fitting after selecting a grouped node. The map now calculates bounds from the newly generated layout instead of consulting React Flow's stale lookup for the previously rendered topology.

The change also hides the map performance diagnostic controls by default. They remain available by setting `REACT_APP_HEADLAMP_ENABLE_MAP_PERFORMANCE_FEATURES=true`.

## Related Issue

Regression after #4991.

## Changes

- Build a parent-aware node lookup for newly laid-out nodes so nested resource bounds use absolute graph coordinates.
- Keep toolbar viewport actions on React Flow's live node lookup.
- Forward viewport movement through `onMoveStart`, matching the callback contract used to detect manual movement.
- Add direct coverage for the `GraphRenderer` move-start wiring and nested layout bounds.
- Hide **Incremental Updates** and **Performance Stats** unless the performance feature flag is enabled.
- Update the affected Resource Map story snapshots.
- Expand selected namespaces from filtered resources, then apply namespace-local simplification.
- Include collapsed state in layout cache keys so resizing cannot restore the wrong parent/child layout.


## Behavior Comparison

Compared against pre-performance commit `ea308a9bb` using the same BasicExample story and viewport sizes:

- Both revisions show the same three resources after selecting **Node with children**.
- In default `100%` mode, the fixed map recenters the selected layout and keeps every node in view.
- In mobile Fit mode, selection updates the transform with every selected node inside the viewport.
- Nested/sub-flow bounds no longer depend on the previous React Flow topology.

## Screenshots

### Fit to screen fixes
 
#### 0.43.0 (before before)

https://github.com/user-attachments/assets/84cac7d8-317c-483c-9855-7804aa3349db

#### Main branch (before, broken)

https://github.com/user-attachments/assets/79d5a6b7-af27-4230-b4e5-02b28b20902d

#### this PR (after, fixed)

https://github.com/user-attachments/assets/da0aea47-f275-4478-9f0a-63449c165660


### Simplification fixes

#### Nodes inside namespace not there issue

> map simplification seems glitchy, namespace node doesn't show any child elements when simplification is enabled (edited)

https://github.com/user-attachments/assets/e6801320-bfb7-4e3a-9996-876280dcdd5f


#### Simplification resizing issue

> there's also a visual bug when resizing window, parent node (namespace) becomes broken and children nodes appear or disappear

https://github.com/user-attachments/assets/837d5fe4-ef66-467f-9e97-0d73bd47a50e



## Steps to Test

0. See videos.
1. Open the Resource Map and choose **Fit to screen**.
2. Select a grouped node such as **Node with children**.
3. Verify the selected resources are fitted and centered in the viewport.
4. Verify **Incremental Updates** and **Performance Stats** are hidden by default.
5. Start the frontend with `REACT_APP_HEADLAMP_ENABLE_MAP_PERFORMANCE_FEATURES=true` and verify both controls are visible.
6. With simplification enabled, select a small namespace and verify all resources are shown.
7. Select a very large namespace and verify it remains simplified.
8. Resize repeatedly between desktop and mobile sizes; verify the namespace parent and children remain stable.
9. Also check mobile view. (As well as improving over main branch... things fit a bit better also compared to previous Headlamp release 0.43.0)

## Validation

- `npm test -- --run src/components/resourceMap` (296 tests)
- `npm run frontend:tsc`
- Focused ESLint for changed Resource Map files
- `cd e2e-tests && npx playwright test tests/resourceMap.spec.ts` (desktop/mobile resize loop)

Assisted by copilot.