### PR TITLE
frontend: websocket: fan out shared watch listeners

### DIFF
--- a/e2e-tests/tests/podsPage.spec.ts
+++ b/e2e-tests/tests/podsPage.spec.ts
@@ -15,6 +15,9 @@
  */
 
 import { execFile } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { expect, test } from '@playwright/test';
 import { HeadlampPage } from './headlampPage';
@@ -22,8 +25,8 @@ import { podsPage } from './podsPage';
 
 const execFileAsync = promisify(execFile);
 
-async function kubectl(...args: string[]) {
-  await execFileAsync('kubectl', ['--context=test', ...args]);
+async function kubectl(kubeconfig: string, ...args: string[]) {
+  await execFileAsync('kubectl', ['--kubeconfig', kubeconfig, '--context=kind-test', ...args]);
 }
 
 function makePod(name: string, resourceVersion: string) {
@@ -148,16 +151,21 @@ test('multi tab create delete pod', async ({ browser }) => {
 test('removes a pod from the list when it is deleted with kubectl', async ({ page }) => {
   test.setTimeout(90000);
   const name = `headlamp-watch-${Date.now()}`;
-
-  await kubectl(
-    '--namespace=default',
-    'run',
-    name,
-    '--image=registry.k8s.io/pause:3.10',
-    '--restart=Never'
-  );
+  const tempDirectory = await mkdtemp(join(tmpdir(), 'headlamp-e2e-'));
+  const kubeconfig = join(tempDirectory, 'kubeconfig');
 
   try {
+    const { stdout } = await execFileAsync('kind', ['get', 'kubeconfig', '--name', 'test']);
+    await writeFile(kubeconfig, stdout);
+    await kubectl(
+      kubeconfig,
+      '--namespace=default',
+      'run',
+      name,
+      '--image=registry.k8s.io/pause:3.10',
+      '--restart=Never'
+    );
+
     const headlampPage = new HeadlampPage(page);
     await headlampPage.navigateToCluster('test', process.env.HEADLAMP_TEST_TOKEN);
     await headlampPage.navigateTopage('/c/test/pods', /Pods/);
@@ -165,18 +173,20 @@ test('removes a pod from the list when it is deleted with kubectl', async ({ pag
     const podLink = page.getByRole('link', { name, exact: true });
     await expect(podLink).toBeVisible({ timeout: 15000 });
 
-    await kubectl('--namespace=default', 'delete', 'pod', name, '--wait=false');
+    await kubectl(kubeconfig, '--namespace=default', 'delete', 'pod', name, '--wait=false');
 
     await expect(podLink).toHaveCount(0, { timeout: 45000 });
   } finally {
     await kubectl(
+      kubeconfig,
       '--namespace=default',
       'delete',
       'pod',
       name,
-      '--ignore-not-found=true',
-      '--wait=false'
-    );
+      '--ignore-not-found=true'
+    )
+      .catch(() => undefined)
+      .finally(() => rm(tempDirectory, { recursive: true, force: true }));
   }
 });
 

--- a/e2e-tests/tests/podsPage.spec.ts
+++ b/e2e-tests/tests/podsPage.spec.ts
@@ -14,9 +14,17 @@
  * limitations under the License.
  */
 
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { expect, test } from '@playwright/test';
 import { HeadlampPage } from './headlampPage';
 import { podsPage } from './podsPage';
+
+const execFileAsync = promisify(execFile);
+
+async function kubectl(...args: string[]) {
+  await execFileAsync('kubectl', ['--context=test', ...args]);
+}
 
 function makePod(name: string, resourceVersion: string) {
   return {
@@ -135,6 +143,41 @@ test('multi tab create delete pod', async ({ browser }) => {
 
   await realtimeUpdate1.createPod(name);
   await realtimeUpdate2.confirmPodCreation(name);
+});
+
+test('removes a pod from the list when it is deleted with kubectl', async ({ page }) => {
+  test.setTimeout(90000);
+  const name = `headlamp-watch-${Date.now()}`;
+
+  await kubectl(
+    '--namespace=default',
+    'run',
+    name,
+    '--image=registry.k8s.io/pause:3.10',
+    '--restart=Never'
+  );
+
+  try {
+    const headlampPage = new HeadlampPage(page);
+    await headlampPage.navigateToCluster('test', process.env.HEADLAMP_TEST_TOKEN);
+    await headlampPage.navigateTopage('/c/test/pods', /Pods/);
+
+    const podLink = page.getByRole('link', { name, exact: true });
+    await expect(podLink).toBeVisible({ timeout: 15000 });
+
+    await kubectl('--namespace=default', 'delete', 'pod', name, '--wait=false');
+
+    await expect(podLink).toHaveCount(0, { timeout: 45000 });
+  } finally {
+    await kubectl(
+      '--namespace=default',
+      'delete',
+      'pod',
+      name,
+      '--ignore-not-found=true',
+      '--wait=false'
+    );
+  }
 });
 
 test('react-hotkey for logs search', async ({ page }) => {

--- a/frontend/src/lib/k8s/api/v2/webSocket.test.ts
+++ b/frontend/src/lib/k8s/api/v2/webSocket.test.ts
@@ -38,6 +38,7 @@ describe('useWebSockets', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     WS.clean();
   });
 
@@ -65,8 +66,37 @@ describe('useWebSockets', () => {
     });
   });
 
-  it('keeps a shared websocket alive until the last listener unsubscribes', async () => {
+  it('delivers messages to remaining listeners when one listener throws', async () => {
     const url = 'api/v1/pods?watch=1&resourceVersion=2';
+    const server = new WS(`${BASE_WS_URL}${url}`);
+    const listenerError = new Error('listener failed');
+    const onMessageA = vi.fn(() => {
+      throw listenerError;
+    });
+    const onMessageB = vi.fn();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    renderHook(() =>
+      useWebSockets({
+        connections: [
+          { cluster: '', url, onMessage: onMessageA },
+          { cluster: '', url, onMessage: onMessageB },
+        ],
+      })
+    );
+
+    await server.connected;
+    await server.send(JSON.stringify({ type: 'DELETED', object: { metadata: { uid: 'pod-b' } } }));
+
+    await waitFor(() => {
+      expect(onMessageA).toHaveBeenCalledTimes(1);
+      expect(onMessageB).toHaveBeenCalledTimes(1);
+      expect(consoleError).toHaveBeenCalledWith('WebSocket listener error:', listenerError);
+    });
+  });
+
+  it('keeps a shared websocket alive until the last listener unsubscribes', async () => {
+    const url = 'api/v1/pods?watch=1&resourceVersion=3';
     const server = new WS(`${BASE_WS_URL}${url}`);
     const onMessageA = vi.fn();
     const onMessageB = vi.fn();
@@ -88,6 +118,34 @@ describe('useWebSockets', () => {
     hookA.unmount();
 
     await server.send(JSON.stringify({ type: 'DELETED', object: { metadata: { uid: 'pod-b' } } }));
+
+    await waitFor(() => {
+      expect(onMessageA).not.toHaveBeenCalled();
+      expect(onMessageB).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('keeps a pending shared websocket alive when its first listener unsubscribes', async () => {
+    const url = 'api/v1/pods?watch=1&resourceVersion=4';
+    const server = new WS(`${BASE_WS_URL}${url}`);
+    const onMessageA = vi.fn();
+    const onMessageB = vi.fn();
+
+    const hookA = renderHook(() =>
+      useWebSockets({
+        connections: [{ cluster: '', url, onMessage: onMessageA }],
+      })
+    );
+
+    renderHook(() =>
+      useWebSockets({
+        connections: [{ cluster: '', url, onMessage: onMessageB }],
+      })
+    );
+    hookA.unmount();
+
+    await server.connected;
+    await server.send(JSON.stringify({ type: 'DELETED', object: { metadata: { uid: 'pod-d' } } }));
 
     await waitFor(() => {
       expect(onMessageA).not.toHaveBeenCalled();

--- a/frontend/src/lib/k8s/api/v2/webSocket.test.ts
+++ b/frontend/src/lib/k8s/api/v2/webSocket.test.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import WS from 'vitest-websocket-mock';
+import { useWebSockets } from './webSocket';
+import { BASE_WS_URL } from './webSocket';
+
+vi.mock('../../../cluster', () => ({
+  getCluster: vi.fn(() => ''),
+}));
+
+vi.mock('../../../../stateless/findKubeconfigByClusterName', () => ({
+  findKubeconfigByClusterName: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../../../../stateless/getUserIdFromLocalStorage', () => ({
+  getUserIdFromLocalStorage: vi.fn(() => ''),
+}));
+
+describe('useWebSockets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    WS.clean();
+  });
+
+  it('delivers messages to all listeners that share the same websocket connection', async () => {
+    const url = 'api/v1/pods?watch=1&resourceVersion=1';
+    const server = new WS(`${BASE_WS_URL}${url}`);
+    const onMessageA = vi.fn();
+    const onMessageB = vi.fn();
+
+    renderHook(() =>
+      useWebSockets({
+        connections: [
+          { cluster: '', url, onMessage: onMessageA },
+          { cluster: '', url, onMessage: onMessageB },
+        ],
+      })
+    );
+
+    await server.connected;
+    await server.send(JSON.stringify({ type: 'DELETED', object: { metadata: { uid: 'pod-a' } } }));
+
+    await waitFor(() => {
+      expect(onMessageA).toHaveBeenCalledTimes(1);
+      expect(onMessageB).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('keeps a shared websocket alive until the last listener unsubscribes', async () => {
+    const url = 'api/v1/pods?watch=1&resourceVersion=2';
+    const server = new WS(`${BASE_WS_URL}${url}`);
+    const onMessageA = vi.fn();
+    const onMessageB = vi.fn();
+
+    const hookA = renderHook(() =>
+      useWebSockets({
+        connections: [{ cluster: '', url, onMessage: onMessageA }],
+      })
+    );
+
+    await server.connected;
+
+    renderHook(() =>
+      useWebSockets({
+        connections: [{ cluster: '', url, onMessage: onMessageB }],
+      })
+    );
+
+    hookA.unmount();
+
+    await server.send(JSON.stringify({ type: 'DELETED', object: { metadata: { uid: 'pod-b' } } }));
+
+    await waitFor(() => {
+      expect(onMessageA).not.toHaveBeenCalled();
+      expect(onMessageB).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/lib/k8s/api/v2/webSocket.ts
+++ b/frontend/src/lib/k8s/api/v2/webSocket.ts
@@ -100,6 +100,7 @@ export async function openWebSocket<T>(
     onMessage: (data: T) => void;
   }
 ) {
+  const connectionKey = cluster + url;
   const path = [url];
   const protocols = ['base64.binary.k8s.io', ...(moreProtocols ?? [])];
 
@@ -122,7 +123,8 @@ export async function openWebSocket<T>(
   socket.binaryType = 'arraybuffer';
   socket.addEventListener('message', (body: MessageEvent) => {
     const data = type === 'json' ? JSON.parse(body.data) : body.data;
-    onMessage(data);
+    const callbacks = listeners.get(connectionKey) ?? [onMessage];
+    callbacks.forEach(callback => callback(data));
   });
   socket.addEventListener('error', error => {
     console.error('WebSocket error:', error);
@@ -165,10 +167,10 @@ export function useWebSockets<T>({
     function connect({ cluster, url, onMessage }: WebSocketConnectionRequest<T>) {
       const connectionKey = cluster + url;
 
-      if (!sockets.has(connectionKey)) {
-        // Add new listener for this URL
-        listeners.set(connectionKey, [...(listeners.get(connectionKey) ?? []), onMessage]);
+      // Always register the current listener, even when reusing an existing socket.
+      listeners.set(connectionKey, [...(listeners.get(connectionKey) ?? []), onMessage]);
 
+      if (!sockets.has(connectionKey)) {
         // Mark socket as pending, so we don't open more than one
         sockets.set(connectionKey, 'pending');
 

--- a/frontend/src/lib/k8s/api/v2/webSocket.ts
+++ b/frontend/src/lib/k8s/api/v2/webSocket.ts
@@ -63,7 +63,7 @@ export type WebSocketConnectionRequest<T> = {
 /**
  * Keeps track of open WebSocket connections and active listeners
  */
-const sockets = new Map<string, WebSocket | 'pending'>();
+const sockets = new Map<string, WebSocket | symbol>();
 const listeners = new Map<string, Array<(update: any) => void>>();
 
 /**
@@ -124,7 +124,13 @@ export async function openWebSocket<T>(
   socket.addEventListener('message', (body: MessageEvent) => {
     const data = type === 'json' ? JSON.parse(body.data) : body.data;
     const callbacks = listeners.get(connectionKey) ?? [onMessage];
-    callbacks.forEach(callback => callback(data));
+    callbacks.forEach(callback => {
+      try {
+        callback(data);
+      } catch (error) {
+        console.error('WebSocket listener error:', error);
+      }
+    });
   });
   socket.addEventListener('error', error => {
     console.error('WebSocket error:', error);
@@ -161,8 +167,6 @@ export function useWebSockets<T>({
   useEffect(() => {
     if (!enabled) return;
 
-    let isCurrent = true;
-
     /** Open a connection to websocket */
     function connect({ cluster, url, onMessage }: WebSocketConnectionRequest<T>) {
       const connectionKey = cluster + url;
@@ -172,24 +176,30 @@ export function useWebSockets<T>({
 
       if (!sockets.has(connectionKey)) {
         // Mark socket as pending, so we don't open more than one
-        sockets.set(connectionKey, 'pending');
+        const pendingSocket = Symbol('pendingWebSocket');
+        sockets.set(connectionKey, pendingSocket);
 
-        let ws: WebSocket | undefined;
         openWebSocket(url, { protocols, type, cluster, onMessage })
           .then(socket => {
-            ws = socket;
+            // A newer connection replaced this pending one while it was opening.
+            if (sockets.get(connectionKey) !== pendingSocket) {
+              socket.close();
+              return;
+            }
 
-            // Hook was unmounted while it was connecting to WebSocket
-            // so we close the socket and clean up
-            if (!isCurrent) {
-              ws.close();
+            // All listeners unsubscribed while the socket was opening.
+            if ((listeners.get(connectionKey)?.length ?? 0) === 0) {
+              socket.close();
               sockets.delete(connectionKey);
               return;
             }
 
-            sockets.set(connectionKey, ws);
+            sockets.set(connectionKey, socket);
           })
           .catch(err => {
+            if (sockets.get(connectionKey) === pendingSocket) {
+              sockets.delete(connectionKey);
+            }
             console.error(err);
           });
       }
@@ -206,7 +216,7 @@ export function useWebSockets<T>({
         if (newListeners.length === 0) {
           const maybeExisting = sockets.get(connectionKey);
           if (maybeExisting) {
-            if (maybeExisting !== 'pending') {
+            if (typeof maybeExisting !== 'symbol') {
               maybeExisting.close();
             }
             sockets.delete(connectionKey);
@@ -218,7 +228,6 @@ export function useWebSockets<T>({
     const disconnectCallbacks = connections.map(endpoint => connect(endpoint));
 
     return () => {
-      isCurrent = false;
       disconnectCallbacks.forEach(fn => fn());
     };
   }, [enabled, type, connections, protocols]);


### PR DESCRIPTION
## Summary

This PR fixes the default frontend WebSocket watch path used when the multiplexer feature flag is off. The root cause was that the legacy shared WebSocket helper only delivered messages to the callback that originally opened the socket, so later subscribers on the same watch URL could miss updates and a cleanup from one subscriber could tear down a socket that another subscriber still depended on.

## Related Issue

No issue number was provided.

## Changes

- Updated the legacy shared WebSocket helper to register every subscriber for a reused socket in [`frontend/src/lib/k8s/api/v2/webSocket.ts`](/Users/rootp1/Documents/repos/hl/frontend/src/lib/k8s/api/v2/webSocket.ts:77).
- Updated incoming message handling to fan each watch event out to all listeners currently attached to that shared socket in [`frontend/src/lib/k8s/api/v2/webSocket.ts`](/Users/rootp1/Documents/repos/hl/frontend/src/lib/k8s/api/v2/webSocket.ts:123).
- Added regression coverage for shared-listener delivery and unsubscribe behavior in [`frontend/src/lib/k8s/api/v2/webSocket.test.ts`](/Users/rootp1/Documents/repos/hl/frontend/src/lib/k8s/api/v2/webSocket.test.ts:1).

## Steps to Test

1. Start the backend locally with `npm run backend:start` as documented in [`docs/development/backend.md`](/Users/rootp1/Documents/repos/hl/docs/development/backend.md:24).
2. Open Headlamp on macOS, navigate to the pod list for a cluster, and confirm the list is populated.
3. Delete a pod from the CLI with `kubectl delete pod <pod-name> -n <namespace>`.
4. Verify the deleted pod disappears from the list view without requiring a manual refresh.
5. Run the frontend regression tests:
   `cd frontend && npm test -- --run src/lib/k8s/api/v2/webSocket.test.ts src/lib/k8s/api/v2/useKubeObjectList.test.tsx`

## Screenshots (if applicable)

Not applicable for this frontend behavior fix.

## Notes for the Reviewer

- This touches the legacy non-multiplexer watch path, which is the default runtime path unless `REACT_APP_ENABLE_WEBSOCKET_MULTIPLEXER` is explicitly set to `true`.
- The fix is intentionally small: it does not change watch URL generation or backend routing, only listener registration and dispatch for reused direct sockets.
- Suggested commit title: `frontend: websocket: fan out shared watch listeners`

## Validation

- `cd frontend && npm test -- --run src/lib/k8s/api/v2/webSocket.test.ts` ✅
- `cd frontend && npm test -- --run src/lib/k8s/api/v2/useKubeObjectList.test.tsx` ✅
- `cd frontend && npm test -- --run src/lib/k8s/api/v2/multiplexer.test.ts src/lib/k8s/api/v2/webSocket.test.ts src/lib/k8s/api/v2/useKubeObjectList.test.tsx` ✅
- `cd frontend && npm run lint -- src/lib/k8s/api/v2/webSocket.ts src/lib/k8s/api/v2/webSocket.test.ts` ✅

## Sources Consulted

- [`backend/pkg/k8cache/cacheInvalidation.go`](/Users/rootp1/Documents/repos/hl/backend/pkg/k8cache/cacheInvalidation.go)
- [`backend/pkg/kubeconfig/contextStore.go`](/Users/rootp1/Documents/repos/hl/backend/pkg/kubeconfig/contextStore.go)
- [`README.md`](/Users/rootp1/Documents/repos/hl/README.md:1)
- [`docs/development/backend.md`](/Users/rootp1/Documents/repos/hl/docs/development/backend.md:16)
- [`docs/development/app.md`](/Users/rootp1/Documents/repos/hl/docs/development/app.md:10)
- [`.github/pull_request_template.md`](/Users/rootp1/Documents/repos/hl/.github/pull_request_template.md:1)
- [`docs/contributing.md`](/Users/rootp1/Documents/repos/hl/docs/contributing.md:40)
