### PR TITLE
frontend: align section header actions

### DIFF
--- a/frontend/src/components/common/SectionHeader.test.tsx
+++ b/frontend/src/components/common/SectionHeader.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { createMuiTheme } from '../../lib/themes';
+import { TestContext } from '../../test';
+import SectionHeader from './SectionHeader';
+
+const theme = createMuiTheme({ name: 'test' });
+
+describe('SectionHeader', () => {
+  it('aligns title side actions in a centered row', () => {
+    render(
+      <TestContext>
+        <ThemeProvider theme={theme}>
+          <SectionHeader
+            title="Pods"
+            titleSideActions={[
+              <button key="create">Create</button>,
+              <button key="load">Load more</button>,
+            ]}
+          />
+        </ThemeProvider>
+      </TestContext>
+    );
+
+    const actions = screen.getByRole('button', { name: 'Create' }).parentElement;
+    expect(actions).toHaveStyle({
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: '8px',
+    });
+    expect(actions).toContainElement(screen.getByRole('button', { name: 'Load more' }));
+  });
+});

--- a/frontend/src/components/common/SectionHeader.tsx
+++ b/frontend/src/components/common/SectionHeader.tsx
@@ -68,7 +68,7 @@ export default function SectionHeader(props: SectionHeaderProps) {
               </Typography>
             )}
             {!!titleSideActions && (
-              <Box ml={1} justifyContent="center">
+              <Box ml={1} display="flex" alignItems="center" justifyContent="center" gap={1}>
                 {titleSideActions.map((action, i) => (
                   <React.Fragment key={i}>{action}</React.Fragment>
                 ))}


### PR DESCRIPTION
## Summary

Fixes the pod list header alignment when pagination adds the loaded count and **Load more** button alongside the create action.

## Changes

- Lay out `titleSideActions` as a centered flex row with consistent spacing.
- Add regression coverage for multiple title-side actions.

## Steps to Test

1. Open a cluster with more pods than the list page limit.
2. Navigate to **Workloads > Pods**.
3. Verify the create action, loaded count, and **Load more** button are aligned in one row.
4. Run `npm test -- --run src/components/common/SectionHeader.test.tsx src/components/pod/List.test.tsx`.

## Screenshots

| Before | After |
| --- | --- |
| ![Pod list header before alignment fix](https://raw.githubusercontent.com/illume/headlamp/pr-assets-pod-load-more-alignment/before.png) | ![Pod list header after alignment fix](https://raw.githubusercontent.com/illume/headlamp/pr-assets-pod-load-more-alignment/after.png) |

The screenshots use live local-cluster pod data. The browser added Kubernetes pagination metadata to the initial response so Headlamp rendered the existing loaded-count and **Load more** controls; no cluster data or production source was changed for capture.

## Notes for the Reviewer

- The layout fix is in the shared `SectionHeader` title-action container, avoiding pod-specific positioning.
- Validation: focused Vitest tests, ESLint, Prettier, and frontend TypeScript checks all pass.
