### PR TITLE
ci: push-release-assets: Fix release tag and name mismatch

### DIFF
--- a/.github/workflows/push-release-assets.yml
+++ b/.github/workflows/push-release-assets.yml
@@ -139,6 +139,36 @@ jobs:
           echo "Executing: $CMD"
           eval $CMD
 
+      - name: Resolve release tag
+        id: release_tag
+        shell: bash
+        run: |
+          # gh release download/upload identify releases by their git tag, but
+          # inputs.release_name is matched against the release *name* (see
+          # push-release-assets.js), which for this repo's releases differs from
+          # the tag (e.g. name "0.44.0" vs tag "v0.44.0"). Resolve the actual tag
+          # via the API so download/upload target the right release.
+          set -eo pipefail
+          tags=$(gh api --paginate "repos/${{ github.repository }}/releases" \
+            --jq '[.[] | select(.name == env.RELEASE_NAME) | .tag_name]')
+
+          count=$(echo "$tags" | jq 'length')
+          if [ "$count" -eq 0 ]; then
+            echo "::error::Could not find a release named '$RELEASE_NAME' to resolve its tag"
+            exit 1
+          fi
+          if [ "$count" -gt 1 ]; then
+            echo "::error::Found $count releases named '$RELEASE_NAME'; expected exactly one"
+            exit 1
+          fi
+
+          tag=$(echo "$tags" | jq -r '.[0]')
+          echo "Resolved release name '$RELEASE_NAME' to tag '$tag'"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_UPDATE_TOKEN }}
+          RELEASE_NAME: ${{ inputs.release_name }}
+
       - name: Create and sign checksums signature
         run: |
           # Wait a moment for the checksums.txt to be available
@@ -148,17 +178,18 @@ jobs:
           mkdir -p ./temp-checksums
 
           # Download the checksums.txt file that was just uploaded
-          gh release download ${{ inputs.release_name }} --pattern "checksums.txt" --dir ./temp-checksums --clobber
+          gh release download "$RELEASE_TAG" --pattern "checksums.txt" --dir ./temp-checksums --clobber
 
           # Create detached signature for checksums.txt
           gpg --batch --yes --passphrase-file "$CR_PASSPHRASE_FILE" --default-key "${{ secrets.GPG_SIGNING_KEY_NAME }}" --armor --detach-sign ./temp-checksums/checksums.txt
 
           # Upload the signature file
-          gh release upload ${{ inputs.release_name }} ./temp-checksums/checksums.txt.asc --clobber
+          gh release upload "$RELEASE_TAG" ./temp-checksums/checksums.txt.asc --clobber
 
           echo "Checksums signature created and uploaded successfully"
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_UPDATE_TOKEN }}
+          RELEASE_TAG: ${{ steps.release_tag.outputs.tag }}
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -169,10 +200,11 @@ jobs:
             --bundle ./temp-checksums/checksums.txt.sigstore.json \
             ./temp-checksums/checksums.txt
 
-          gh release upload ${{ inputs.release_name }} \
+          gh release upload "$RELEASE_TAG" \
             ./temp-checksums/checksums.txt.sigstore.json \
             --clobber
 
           echo "Cosign bundle uploaded successfully"
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_UPDATE_TOKEN }}
+          RELEASE_TAG: ${{ steps.release_tag.outputs.tag }}

--- a/.github/workflows/push-release-assets.yml
+++ b/.github/workflows/push-release-assets.yml
@@ -139,6 +139,36 @@ jobs:
           echo "Executing: $CMD"
           eval $CMD
 
+      - name: Resolve release tag
+        id: release_tag
+        shell: bash
+        run: |
+          # gh release download/upload identify releases by their git tag, but
+          # inputs.release_name is matched against the release *name* (see
+          # push-release-assets.js), which for this repo's releases differs from
+          # the tag (e.g. name "0.44.0" vs tag "v0.44.0"). Resolve the actual tag
+          # via the API so download/upload target the right release.
+          set -eo pipefail
+          tags=$(gh api --paginate "repos/${{ github.repository }}/releases" \
+            | jq --slurp '[.[][] | select(.name == env.RELEASE_NAME) | .tag_name]')
+
+          count=$(echo "$tags" | jq 'length')
+          if [ "$count" -eq 0 ]; then
+            echo "::error::Could not find a release named '$RELEASE_NAME' to resolve its tag"
+            exit 1
+          fi
+          if [ "$count" -gt 1 ]; then
+            echo "::error::Found $count releases named '$RELEASE_NAME'; expected exactly one"
+            exit 1
+          fi
+
+          tag=$(echo "$tags" | jq -r '.[0]')
+          echo "Resolved release name '$RELEASE_NAME' to tag '$tag'"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_UPDATE_TOKEN }}
+          RELEASE_NAME: ${{ inputs.release_name }}
+
       - name: Create and sign checksums signature
         run: |
           # Wait a moment for the checksums.txt to be available
@@ -148,17 +178,18 @@ jobs:
           mkdir -p ./temp-checksums
 
           # Download the checksums.txt file that was just uploaded
-          gh release download ${{ inputs.release_name }} --pattern "checksums.txt" --dir ./temp-checksums --clobber
+          gh release download "$RELEASE_TAG" --pattern "checksums.txt" --dir ./temp-checksums --clobber
 
           # Create detached signature for checksums.txt
           gpg --batch --yes --passphrase-file "$CR_PASSPHRASE_FILE" --default-key "${{ secrets.GPG_SIGNING_KEY_NAME }}" --armor --detach-sign ./temp-checksums/checksums.txt
 
           # Upload the signature file
-          gh release upload ${{ inputs.release_name }} ./temp-checksums/checksums.txt.asc --clobber
+          gh release upload "$RELEASE_TAG" ./temp-checksums/checksums.txt.asc --clobber
 
           echo "Checksums signature created and uploaded successfully"
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_UPDATE_TOKEN }}
+          RELEASE_TAG: ${{ steps.release_tag.outputs.tag }}
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -169,10 +200,11 @@ jobs:
             --bundle ./temp-checksums/checksums.txt.sigstore.json \
             ./temp-checksums/checksums.txt
 
-          gh release upload ${{ inputs.release_name }} \
+          gh release upload "$RELEASE_TAG" \
             ./temp-checksums/checksums.txt.sigstore.json \
             --clobber
 
           echo "Cosign bundle uploaded successfully"
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_UPDATE_TOKEN }}
+          RELEASE_TAG: ${{ steps.release_tag.outputs.tag }}


### PR DESCRIPTION
## Summary

This PR fixes the release-signing steps in the `Upload Release Assets` workflow by resolving the release's git tag before calling `gh release download`/`gh release upload`, instead of passing the release's display name straight to `gh`.

## Related Issue

No tracked issue — found while testing the `0.44.0` release candidate. The `Upload Release Assets` run ([30427993783](https://github.com/kubernetes-sigs/headlamp/actions/runs/30427993783)) failed at "Create and sign checksums signature" with `release not found`, which also caused the subsequent cosign keyless-signing step to be skipped entirely.

## What I did to find and fix this

1. Was asked to test the `0.44.0` RC artifacts (Windows/Mac/Linux app builds + nightly container image). While checking CI status for the release, I noticed the `Upload Release Assets` run ([30427993783](https://github.com/kubernetes-sigs/headlamp/actions/runs/30427993783)) had failed.
2. Ran `gh run view 30427993783 --log-failed` and saw the failure was in the **"Create and sign checksums signature"** step, with the error `release not found` coming from `gh release download 0.44.0 --pattern "checksums.txt" ...`. Because that step failed, the two steps after it ("Install Cosign" and "Sign checksums.txt with cosign (keyless)") never ran, which matches the report that "cosign didn't run".
3. The step just before it, **"Upload assets to release"**, had succeeded — so assets clearly *were* uploaded to a release matching `0.44.0`. That meant `gh release download 0.44.0` should have found the same release. I read `app/scripts/push-release-assets.js` (used by that earlier step) and found it looks up the release via the GitHub API by matching `release.name`, not `release.tag_name`.
4. Checked existing releases (`gh api repos/kubernetes-sigs/headlamp/releases`) and confirmed the pattern: e.g. release **name** `0.43.0` has git **tag** `v0.43.0`. So the workflow's `inputs.release_name` (`0.44.0`, no `v`) matches the release by *name* in the node script, but `gh release download`/`upload` in the later steps look up releases by **tag**, and no release has the literal tag `0.44.0` — hence "release not found".
5. Fix: added a "Resolve release tag" step that queries `gh api repos/{owner}/{repo}/releases` and picks out the `tag_name` of the release whose `name` matches `inputs.release_name`, then passed that resolved tag (`$RELEASE_TAG`) into the `gh release download`/`upload` calls in both the gpg-signing and cosign-signing steps, instead of hardcoding an assumed `v` prefix.
6. Validated the updated YAML parses (`ruby -ryaml -e "YAML.load_file(...)"`) since `actionlint` wasn't available locally.

## Changes

- Added a "Resolve release tag" step to `.github/workflows/push-release-assets.yml` that looks up the actual `tag_name` for the release matching `inputs.release_name` via `gh api`.
- Updated the `gh release download`/`gh release upload` calls in the gpg-signing and cosign-signing steps to use the resolved tag (`$RELEASE_TAG`) instead of `inputs.release_name` directly.

## Steps to Test

1. Validate the workflow YAML parses correctly (done locally).
2. Trigger `Upload Release Assets` (`workflow_dispatch`) against a draft release whose name and tag differ (the normal case for this repo, e.g. name `0.44.0` / tag `v0.44.0`).
3. Confirm the "Resolve release tag" step resolves the correct tag, and both "Create and sign checksums signature" and "Sign checksums.txt with cosign (keyless)" steps succeed and upload `checksums.txt.asc` and the cosign bundle to the release.

## Screenshots (if applicable)

N/A — CI workflow change only.

## Notes for the Reviewer

- No changes to the "Upload assets to release" step (Octokit-based, matches by name) — only the two later steps that shell out to `gh`.
- Ran into this while smoke-testing the `0.44.0` RC artifacts (Windows/Mac/Linux builds all succeeded; Mac build notarization verified).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release asset publishing by reliably resolving the correct release tag.
  * Prevented asset uploads and downloads when the configured release cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
