### PR TITLE
releaser: recognize win-arm64 exe and msi installer assets

### DIFF
--- a/tools/releaser/src/utils/github.ts
+++ b/tools/releaser/src/utils/github.ts
@@ -100,8 +100,17 @@ export async function checkArtifactsForRelease(releaseDraft: GitHubRelease): Pro
     `Headlamp-${releaseVersion}-linux-armv7l.tar.gz`,
     `Headlamp-${releaseVersion}-linux-x64.tar.gz`,
     `Headlamp-${releaseVersion}-win-x64.exe`,
+    `Headlamp-${releaseVersion}-win-arm64.exe`,
     `headlamp_${releaseVersion}-1_amd64.deb`,
     `checksums.txt`
+  ];
+
+  // Optional assets: known/expected but not required for a release to be considered ready.
+  // Currently the MSI installer is built alongside the win-x64/arm64 .exe installers, but we
+  // don't yet require it for every release, so it's tracked here instead of requiredAssets.
+  const optionalAssets = [
+    `Headlamp-${releaseVersion}-win-x64.msi`,
+    `Headlamp-${releaseVersion}-win-arm64.msi`
   ];
 
   const assets = releaseDraft.assets || [];
@@ -109,11 +118,17 @@ export async function checkArtifactsForRelease(releaseDraft: GitHubRelease): Pro
   requiredAssets.forEach(asset => {
     foundAssets[asset] = false;
   });
+  const foundOptionalAssets: Record<string, boolean> = {};
+  optionalAssets.forEach(asset => {
+    foundOptionalAssets[asset] = false;
+  });
   const unknownAssets: string[] = [];
 
   assets.forEach((asset: ReleaseAsset) => {
-    if (foundAssets.hasOwnProperty(asset.name)) {
+    if (Object.prototype.hasOwnProperty.call(foundAssets, asset.name)) {
       foundAssets[asset.name] = true;
+    } else if (Object.prototype.hasOwnProperty.call(foundOptionalAssets, asset.name)) {
+      foundOptionalAssets[asset.name] = true;
     } else {
       unknownAssets.push(asset.name);
     }
@@ -126,6 +141,14 @@ export async function checkArtifactsForRelease(releaseDraft: GitHubRelease): Pro
     } else {
       console.error(chalk.red(`❌ Missing asset: ${assetName}`));
       allFound = false;
+    }
+  });
+
+  Object.entries(foundOptionalAssets).forEach(([assetName, found]) => {
+    if (found) {
+      console.log(chalk.green(`✅ Found optional asset: ${assetName}`));
+    } else {
+      console.log(chalk.gray(`ℹ️  Optional asset not present: ${assetName}`));
     }
   });
 


### PR DESCRIPTION
## Summary

This PR fixes a gap in the `releaser` tool by adding the win-arm64 installer and MSI packages to its known-assets list.

## Related Issue

Fixes #N/A

## Changes

- Added `Headlamp-<version>-win-arm64.exe` to the required asset list in `checkArtifactsForRelease`, matching the existing `win-x64.exe` requirement.
- Added a new "optional assets" category for `win-x64.msi` / `win-arm64.msi`, so they're reported as found/not-found without failing the check when absent, since MSI isn't produced for every release yet.

## Steps to Test

1. `cd tools/releaser && npm install && npx tsc --noEmit` — confirm it compiles cleanly.
2. Run `releaser check <version>` against a release draft that includes `win-arm64.exe` and/or the `.msi` assets (e.g. v0.44.0) and confirm they no longer appear under "Unknown assets".

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- This only touches `tools/releaser`, the internal release-checking CLI — no user-facing app changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Windows MSI files are now treated as optional release assets.
  * Release readiness is no longer blocked when optional MSI files are unavailable.
  * Release asset checks now safely distinguish required and optional files.
  * Release checks clearly report whether optional MSI files are available or absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
