### PR TITLE
Fix stale repo path in winget-create.js

### DIFF
--- a/app/windows/winget/winget-create.js
+++ b/app/windows/winget/winget-create.js
@@ -79,7 +79,7 @@ async function createYAMLFiles(version, downloadURL, date, notesURL, checksum) {
 async function fetchGithubReleaseInfo() {
   const tag = projectVersion;
   const res = await fetch(
-    `https://api.github.com/repos/headlamp-k8s/headlamp/releases/tags/v${tag}`
+    `https://api.github.com/repos/kubernetes-sigs/headlamp/releases/tags/v${tag}`
   );
 
   if (!res.ok) {

--- a/tools/releaser/src/utils/github.ts
+++ b/tools/releaser/src/utils/github.ts
@@ -100,8 +100,17 @@ export async function checkArtifactsForRelease(releaseDraft: GitHubRelease): Pro
     `Headlamp-${releaseVersion}-linux-armv7l.tar.gz`,
     `Headlamp-${releaseVersion}-linux-x64.tar.gz`,
     `Headlamp-${releaseVersion}-win-x64.exe`,
+    `Headlamp-${releaseVersion}-win-arm64.exe`,
     `headlamp_${releaseVersion}-1_amd64.deb`,
     `checksums.txt`
+  ];
+
+  // Optional assets: known/expected but not required for a release to be considered ready.
+  // Currently the MSI installer is built alongside the win-x64/arm64 .exe installers, but we
+  // don't yet require it for every release, so it's tracked here instead of requiredAssets.
+  const optionalAssets = [
+    `Headlamp-${releaseVersion}-win-x64.msi`,
+    `Headlamp-${releaseVersion}-win-arm64.msi`
   ];
 
   const assets = releaseDraft.assets || [];
@@ -109,11 +118,17 @@ export async function checkArtifactsForRelease(releaseDraft: GitHubRelease): Pro
   requiredAssets.forEach(asset => {
     foundAssets[asset] = false;
   });
+  const foundOptionalAssets: Record<string, boolean> = {};
+  optionalAssets.forEach(asset => {
+    foundOptionalAssets[asset] = false;
+  });
   const unknownAssets: string[] = [];
 
   assets.forEach((asset: ReleaseAsset) => {
     if (foundAssets.hasOwnProperty(asset.name)) {
       foundAssets[asset.name] = true;
+    } else if (foundOptionalAssets.hasOwnProperty(asset.name)) {
+      foundOptionalAssets[asset.name] = true;
     } else {
       unknownAssets.push(asset.name);
     }
@@ -126,6 +141,14 @@ export async function checkArtifactsForRelease(releaseDraft: GitHubRelease): Pro
     } else {
       console.error(chalk.red(`❌ Missing asset: ${assetName}`));
       allFound = false;
+    }
+  });
+
+  Object.entries(foundOptionalAssets).forEach(([assetName, found]) => {
+    if (found) {
+      console.log(chalk.green(`✅ Found optional asset: ${assetName}`));
+    } else {
+      console.log(chalk.gray(`ℹ️  Optional asset not present: ${assetName}`));
     }
   });
 


### PR DESCRIPTION
## Summary
- `releaser check 0.44.0` reports the winget package as "not found" because no manifest submission has happened yet in `microsoft/winget-pkgs` for that version — that part is a manual release step (running `winget-create.js` and opening a PR against `microsoft/winget-pkgs`), not a code bug.
- While investigating, found that `app/windows/winget/winget-create.js` still queries `repos/headlamp-k8s/headlamp` instead of `repos/kubernetes-sigs/headlamp`. It currently works only because GitHub 301-redirects the old path; this fixes the reference to point at the current org directly so it doesn't silently rely on that redirect.

## Test plan
- [ ] `node app/windows/winget/winget-create.js 0.44.0 <dir>` generates manifests successfully for v0.44.0