### PR TITLE
releaser: add security-check command for backend and Dockerfile scanning

### DIFF
--- a/tools/releaser/README.md
+++ b/tools/releaser/README.md
@@ -169,13 +169,23 @@ releaser ci app --list
 releaser ci app --list --platform mac --latest 3 --output json
 ```
 
+### `security-check` — Scan the backend and Dockerfiles for security issues
+
+Runs [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) against the Go backend module to catch known vulnerabilities, and [`hadolint`](https://github.com/hadolint/hadolint) against `Dockerfile`, `Dockerfile.plugins`, and `docker-extension/Dockerfile` to catch Dockerfile security issues (e.g. unpinned packages, missing pipefail on piped `RUN` commands). Exits non-zero if any check reports a real problem.
+
+Requires the Go toolchain (for `govulncheck`) and Docker (used to run `hadolint` without a local install) to be available on `PATH`; a check is skipped with a warning if its tool isn't found.
+
+```bash
+releaser security-check
+```
+
 ## Development
 
 Source code is in `src/` and is organized as follows:
 
 - `src/index.ts` — CLI entry point and command definitions
-- `src/commands/` — Individual command implementations (`check`, `start`, `tag`, `publish`, `build`, `get-app-runs`)
-- `src/utils/` — Shared utilities (`git`, `github`, `version`)
+- `src/commands/` — Individual command implementations (`check`, `start`, `tag`, `publish`, `build`, `get-app-runs`, `security-check`)
+- `src/utils/` — Shared utilities (`git`, `github`, `version`, `security`)
 
 To rebuild after making changes:
 

--- a/tools/releaser/README.md
+++ b/tools/releaser/README.md
@@ -170,13 +170,23 @@ releaser ci app --list
 releaser ci app --list --platform mac --latest 3 --output json
 ```
 
+### `security-check` — Scan the backend and Dockerfiles for security issues
+
+Runs [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) against the Go backend module to catch known vulnerabilities, and [`hadolint`](https://github.com/hadolint/hadolint) against `Dockerfile`, `Dockerfile.plugins`, and `docker-extension/Dockerfile` to catch Dockerfile security issues (e.g. unpinned packages, missing pipefail on piped `RUN` commands). Exits non-zero if any check reports a real problem.
+
+Requires the Go toolchain (for `govulncheck`) and Docker (used to run `hadolint` without a local install) to be available on `PATH`; a check is skipped with a warning if its tool isn't found.
+
+```bash
+releaser security-check
+```
+
 ## Development
 
 Source code is in `src/` and is organized as follows:
 
 - `src/index.ts` — CLI entry point and command definitions
-- `src/commands/` — Individual command implementations (`check`, `start`, `tag`, `publish`, `build`, `get-app-runs`)
-- `src/utils/` — Shared utilities (`git`, `github`, `version`)
+- `src/commands/` — Individual command implementations (`check`, `start`, `tag`, `publish`, `build`, `get-app-runs`, `security-check`)
+- `src/utils/` — Shared utilities (`git`, `github`, `version`, `security`)
 
 To rebuild after making changes:
 

--- a/tools/releaser/src/commands/security-check.ts
+++ b/tools/releaser/src/commands/security-check.ts
@@ -1,0 +1,56 @@
+import chalk from 'chalk';
+import {
+  checkBackendVulnerabilities,
+  checkDockerfileSecurity,
+  SecurityCheckResult,
+} from '../utils/security.js';
+
+const DOCKERFILES = ['Dockerfile', 'Dockerfile.plugins', 'docker-extension/Dockerfile'];
+
+function reportResult(result: SecurityCheckResult): void {
+  if (result.skipped) {
+    console.log(chalk.yellow(`⚠️  ${result.name}: ${result.message}`));
+  } else if (result.passed) {
+    console.log(chalk.green(`✅ ${result.name}: ${result.message}`));
+  } else {
+    console.error(chalk.red(`❌ ${result.name}: ${result.message}`));
+  }
+
+  if (result.output && result.output.trim()) {
+    console.log(result.output.trim());
+  }
+}
+
+export async function securityCheck(): Promise<void> {
+  console.log(chalk.blue('Running backend and Dockerfile security checks...\n'));
+
+  const results: SecurityCheckResult[] = [
+    checkBackendVulnerabilities(),
+    ...DOCKERFILES.map(dockerfile => checkDockerfileSecurity(dockerfile)),
+  ];
+
+  results.forEach(reportResult);
+
+  const failed = results.filter(result => !result.skipped && !result.passed);
+  const skipped = results.filter(result => result.skipped);
+
+  console.log('');
+
+  if (skipped.length > 0) {
+    console.log(
+      chalk.yellow(`ℹ️  ${skipped.length} check(s) skipped (see warnings above)`)
+    );
+  }
+
+  if (failed.length > 0) {
+    console.error(chalk.red(`❌ ${failed.length} security check(s) failed`));
+    process.exit(1);
+  }
+
+  if (skipped.length === results.length) {
+    console.log(chalk.yellow('⚠️  All security checks were skipped; nothing was actually verified'));
+    return;
+  }
+
+  console.log(chalk.green('✅ No security issues found'));
+}

--- a/tools/releaser/src/commands/security-check.ts
+++ b/tools/releaser/src/commands/security-check.ts
@@ -1,0 +1,51 @@
+import chalk from 'chalk';
+import {
+  checkBackendVulnerabilities,
+  checkDockerfileSecurity,
+  SecurityCheckResult,
+} from '../utils/security.js';
+
+const DOCKERFILES = ['Dockerfile', 'Dockerfile.plugins', 'docker-extension/Dockerfile'];
+
+function reportResult(result: SecurityCheckResult): void {
+  if (result.skipped) {
+    console.log(chalk.yellow(`⚠️  ${result.name}: ${result.message}`));
+  } else if (result.passed) {
+    console.log(chalk.green(`✅ ${result.name}: ${result.message}`));
+  } else {
+    console.error(chalk.red(`❌ ${result.name}: ${result.message}`));
+  }
+
+  if (result.output && result.output.trim()) {
+    console.log(result.output.trim());
+  }
+}
+
+export async function securityCheck(): Promise<void> {
+  console.log(chalk.blue('Running backend and Dockerfile security checks...\n'));
+
+  const results: SecurityCheckResult[] = [
+    checkBackendVulnerabilities(),
+    ...DOCKERFILES.map(dockerfile => checkDockerfileSecurity(dockerfile)),
+  ];
+
+  results.forEach(reportResult);
+
+  const failed = results.filter(result => !result.skipped && !result.passed);
+  const skipped = results.filter(result => result.skipped);
+
+  console.log('');
+
+  if (skipped.length > 0) {
+    console.log(
+      chalk.yellow(`ℹ️  ${skipped.length} check(s) skipped (see warnings above)`)
+    );
+  }
+
+  if (failed.length > 0) {
+    console.error(chalk.red(`❌ ${failed.length} security check(s) failed`));
+    process.exit(1);
+  }
+
+  console.log(chalk.green('✅ No security issues found'));
+}

--- a/tools/releaser/src/index.ts
+++ b/tools/releaser/src/index.ts
@@ -10,6 +10,7 @@ import { tagRelease } from './commands/tag.js';
 import { publishRelease } from './commands/publish.js';
 import { buildArtifacts } from './commands/build.js';
 import { getAppRuns } from './commands/get-app-runs.js';
+import { securityCheck } from './commands/security-check.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -29,6 +30,10 @@ program.command('check')
   .description('Check if a release exists and verify all artifacts are present')
   .argument('<release-version>', 'Version to check (e.g., 0.30.0)')
   .action(checkRelease);
+
+program.command('security-check')
+  .description('Scan the backend for known vulnerabilities (govulncheck) and Dockerfiles for security issues (hadolint)')
+  .action(securityCheck);
 
 program.command('start')
   .description('Update package.json with new version and commit changes')

--- a/tools/releaser/src/utils/security.ts
+++ b/tools/releaser/src/utils/security.ts
@@ -1,0 +1,162 @@
+import { spawnSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import path from 'path';
+import { getRepoRoot } from './git.js';
+
+export interface SecurityCheckResult {
+  name: string;
+  passed: boolean;
+  skipped: boolean;
+  message: string;
+  output?: string;
+}
+
+function isCommandAvailable(command: string, versionArgs: string[] = ['--version']): boolean {
+  const result = spawnSync(command, versionArgs, { encoding: 'utf-8' });
+  return !result.error && result.status === 0;
+}
+
+/**
+ * Runs govulncheck against the Go backend module to catch known vulnerabilities
+ * in the backend and its dependencies before a release.
+ */
+export function checkBackendVulnerabilities(): SecurityCheckResult {
+  const name = 'Backend vulnerabilities (govulncheck)';
+  const repoRoot = getRepoRoot();
+  const backendDir = path.join(repoRoot, 'backend');
+
+  if (!existsSync(path.join(backendDir, 'go.mod'))) {
+    return {
+      name,
+      passed: false,
+      skipped: true,
+      message: 'Skipped: backend/go.mod not found',
+    };
+  }
+
+  if (!isCommandAvailable('go', ['version'])) {
+    return {
+      name,
+      passed: false,
+      skipped: true,
+      message: 'Skipped: Go toolchain not found on PATH',
+    };
+  }
+
+  const govulncheckModule = process.env.GOVULNCHECK_MODULE || 'golang.org/x/vuln/cmd/govulncheck@latest';
+
+  const result = spawnSync('go', ['run', govulncheckModule, './...'], {
+    cwd: backendDir,
+    encoding: 'utf-8',
+  });
+
+  if (result.error) {
+    return {
+      name,
+      passed: false,
+      skipped: true,
+      message: `Skipped: failed to run govulncheck (${result.error.message})`,
+    };
+  }
+
+  const output = `${result.stdout || ''}${result.stderr || ''}`;
+
+  // govulncheck exits 0 when clean and 3 when vulnerabilities are found. Any
+  // other non-zero status indicates the scan itself failed (e.g. network or
+  // module resolution issues) rather than an actual vulnerability finding.
+  if (result.status !== 0 && result.status !== 3) {
+    return {
+      name,
+      passed: false,
+      skipped: true,
+      message: `Skipped: govulncheck failed to complete (exit code ${result.status})`,
+      output,
+    };
+  }
+
+  return {
+    name,
+    passed: result.status === 0,
+    skipped: false,
+    message:
+      result.status === 0
+        ? 'No known vulnerabilities found in the backend module'
+        : 'govulncheck reported known vulnerabilities in the backend module',
+    output,
+  };
+}
+
+/**
+ * Runs hadolint against a Dockerfile to catch common security misconfigurations
+ * (running as root, unpinned base images, use of ADD over COPY, etc).
+ */
+export function checkDockerfileSecurity(
+  dockerfileRelativePath = 'Dockerfile'
+): SecurityCheckResult {
+  const name = `Dockerfile security (hadolint: ${dockerfileRelativePath})`;
+  const repoRoot = getRepoRoot();
+  const dockerfilePath = path.join(repoRoot, dockerfileRelativePath);
+
+  if (!existsSync(dockerfilePath)) {
+    return {
+      name,
+      passed: false,
+      skipped: true,
+      message: `Skipped: ${dockerfileRelativePath} not found`,
+    };
+  }
+
+  if (!isCommandAvailable('docker')) {
+    return {
+      name,
+      passed: false,
+      skipped: true,
+      message: 'Skipped: Docker not found on PATH (required to run hadolint)',
+    };
+  }
+
+  const dockerfileContents = readFileSync(dockerfilePath, 'utf-8');
+  const hadolintImage = process.env.HADOLINT_IMAGE || 'hadolint/hadolint';
+
+  const result = spawnSync(
+    'docker',
+    ['run', '--rm', '-i', hadolintImage, 'hadolint', '--failure-threshold', 'error', '-'],
+    { input: dockerfileContents, encoding: 'utf-8' }
+  );
+
+  if (result.error) {
+    return {
+      name,
+      passed: false,
+      skipped: true,
+      message: `Skipped: failed to run hadolint (${result.error.message})`,
+    };
+  }
+
+  const output = `${result.stdout || ''}${result.stderr || ''}`;
+
+  // Docker itself can fail (e.g. daemon not running, image pull failure,
+  // invalid CLI usage) using exit codes such as 125, 126 or 127. Those are
+  // not Dockerfile findings from hadolint and shouldn't be reported as such.
+  const dockerExecutionFailureCodes = [125, 126, 127];
+  if (result.status === null || dockerExecutionFailureCodes.includes(result.status)) {
+    return {
+      name,
+      passed: false,
+      skipped: true,
+      message: `Skipped: docker failed to run hadolint (exit code ${result.status})`,
+      output,
+    };
+  }
+
+  return {
+    name,
+    passed: result.status === 0,
+    skipped: false,
+    message:
+      result.status === 0
+        ? `No issues found in ${dockerfileRelativePath}`
+        : `hadolint reported issues in ${dockerfileRelativePath}`,
+    output,
+  };
+}

--- a/tools/releaser/src/utils/security.ts
+++ b/tools/releaser/src/utils/security.ts
@@ -1,0 +1,162 @@
+import { spawnSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import path from 'path';
+import { getRepoRoot } from './git.js';
+
+export interface SecurityCheckResult {
+  name: string;
+  passed: boolean;
+  skipped: boolean;
+  message: string;
+  output?: string;
+}
+
+function isCommandAvailable(command: string): boolean {
+  const result = spawnSync(command, ['--version'], { encoding: 'utf-8' });
+  return !result.error && result.status === 0;
+}
+
+/**
+ * Runs govulncheck against the Go backend module to catch known vulnerabilities
+ * in the backend and its dependencies before a release.
+ */
+export function checkBackendVulnerabilities(): SecurityCheckResult {
+  const name = 'Backend vulnerabilities (govulncheck)';
+  const repoRoot = getRepoRoot();
+  const backendDir = path.join(repoRoot, 'backend');
+
+  if (!existsSync(path.join(backendDir, 'go.mod'))) {
+    return {
+      name,
+      passed: false,
+      skipped: true,
+      message: 'Skipped: backend/go.mod not found',
+    };
+  }
+
+  if (!isCommandAvailable('go')) {
+    return {
+      name,
+      passed: false,
+      skipped: true,
+      message: 'Skipped: Go toolchain not found on PATH',
+    };
+  }
+
+  const govulncheckModule = process.env.GOVULNCHECK_MODULE || 'golang.org/x/vuln/cmd/govulncheck@latest';
+
+  const result = spawnSync('go', ['run', govulncheckModule, './...'], {
+    cwd: backendDir,
+    encoding: 'utf-8',
+  });
+
+  if (result.error) {
+    return {
+      name,
+      passed: false,
+      skipped: true,
+      message: `Skipped: failed to run govulncheck (${result.error.message})`,
+    };
+  }
+
+  const output = `${result.stdout || ''}${result.stderr || ''}`;
+
+  // govulncheck exits 0 when clean and 3 when vulnerabilities are found. Any
+  // other non-zero status indicates the scan itself failed (e.g. network or
+  // module resolution issues) rather than an actual vulnerability finding.
+  if (result.status !== 0 && result.status !== 3) {
+    return {
+      name,
+      passed: false,
+      skipped: true,
+      message: `Skipped: govulncheck failed to complete (exit code ${result.status})`,
+      output,
+    };
+  }
+
+  return {
+    name,
+    passed: result.status === 0,
+    skipped: false,
+    message:
+      result.status === 0
+        ? 'No known vulnerabilities found in the backend module'
+        : 'govulncheck reported known vulnerabilities in the backend module',
+    output,
+  };
+}
+
+/**
+ * Runs hadolint against a Dockerfile to catch common security misconfigurations
+ * (running as root, unpinned base images, use of ADD over COPY, etc).
+ */
+export function checkDockerfileSecurity(
+  dockerfileRelativePath = 'Dockerfile'
+): SecurityCheckResult {
+  const name = `Dockerfile security (hadolint: ${dockerfileRelativePath})`;
+  const repoRoot = getRepoRoot();
+  const dockerfilePath = path.join(repoRoot, dockerfileRelativePath);
+
+  if (!existsSync(dockerfilePath)) {
+    return {
+      name,
+      passed: false,
+      skipped: true,
+      message: `Skipped: ${dockerfileRelativePath} not found`,
+    };
+  }
+
+  if (!isCommandAvailable('docker')) {
+    return {
+      name,
+      passed: false,
+      skipped: true,
+      message: 'Skipped: Docker not found on PATH (required to run hadolint)',
+    };
+  }
+
+  const dockerfileContents = readFileSync(dockerfilePath, 'utf-8');
+  const hadolintImage = process.env.HADOLINT_IMAGE || 'hadolint/hadolint';
+
+  const result = spawnSync(
+    'docker',
+    ['run', '--rm', '-i', hadolintImage, 'hadolint', '--failure-threshold', 'error', '-'],
+    { input: dockerfileContents, encoding: 'utf-8' }
+  );
+
+  if (result.error) {
+    return {
+      name,
+      passed: false,
+      skipped: true,
+      message: `Skipped: failed to run hadolint (${result.error.message})`,
+    };
+  }
+
+  const output = `${result.stdout || ''}${result.stderr || ''}`;
+
+  // Docker itself can fail (e.g. daemon not running, image pull failure,
+  // invalid CLI usage) using exit codes such as 125, 126 or 127. Those are
+  // not Dockerfile findings from hadolint and shouldn't be reported as such.
+  const dockerExecutionFailureCodes = [125, 126, 127];
+  if (result.status === null || dockerExecutionFailureCodes.includes(result.status)) {
+    return {
+      name,
+      passed: false,
+      skipped: true,
+      message: `Skipped: docker failed to run hadolint (exit code ${result.status})`,
+      output,
+    };
+  }
+
+  return {
+    name,
+    passed: result.status === 0,
+    skipped: false,
+    message:
+      result.status === 0
+        ? `No issues found in ${dockerfileRelativePath}`
+        : `hadolint reported issues in ${dockerfileRelativePath}`,
+    output,
+  };
+}


### PR DESCRIPTION
## Summary

This PR adds a `releaser security-check` command that scans the Go backend and the project's Dockerfiles for security issues before a release.

- Runs `govulncheck` against `backend/` to catch known vulnerabilities in the backend module and its dependencies.
- Runs `hadolint` (via Docker, no local install required) against `Dockerfile`, `Dockerfile.plugins`, and `docker-extension/Dockerfile` to catch Dockerfile security issues (unpinned package installs, missing `pipefail` on piped `RUN` commands, etc.), scoped to `--failure-threshold error` so existing style/best-practice warnings don't fail the check.
- Each check is skipped with a warning (not a hard failure) if its required tool (Go or Docker) isn't available on `PATH`, and the command exits non-zero only if a real issue is found.

## Related Issue

N/A

## Changes

- Added `tools/releaser/src/utils/security.ts` with `checkBackendVulnerabilities` and `checkDockerfileSecurity`.
- Added `tools/releaser/src/commands/security-check.ts` and wired it up as `releaser security-check` in `tools/releaser/src/index.ts`.
- Documented the new command in `tools/releaser/README.md`.

## Steps to Test

1. `cd tools/releaser && npm install && npm run build`
2. `node dist/index.js security-check`
3. Confirm it reports the backend module's govulncheck results and hadolint results for each Dockerfile, and exits non-zero only when a real error is found.

## Notes for the Reviewer

- Currently `govulncheck` reports real known vulnerabilities in the backend's containerd/helm dependency chain (e.g. GO-2026-5932, GO-2026-5622), which is the intended behavior of this check — surfacing them for a maintainer to triage/upgrade rather than silently passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `security-check` command for release validation.
  * Scans backend dependencies for known vulnerabilities and Dockerfiles for security issues.
  * Displays passed, skipped, and failed checks with detailed results.
  * Returns a failure status when security checks detect issues.

* **Documentation**
  * Added setup requirements, usage instructions, warning behavior, and command references for security checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
