### PR TITLE
fix(frontend): isolate AuthVisible authorization cache by cluster

### DIFF
--- a/frontend/src/components/common/Resource/AuthVisible.test.tsx
+++ b/frontend/src/components/common/Resource/AuthVisible.test.tsx
@@ -28,6 +28,10 @@ describe('AuthVisible', () => {
       defaultOptions: {
         queries: {
           retry: false,
+          // Keep cached data fresh so a newly mounted observer serves it from the
+          // cache instead of refetching. This lets the cluster-isolation test prove
+          // real cache reuse rather than in-flight request deduplication.
+          staleTime: Infinity,
         },
       },
     });
@@ -101,6 +105,83 @@ describe('AuthVisible', () => {
     });
 
     expect(screen.queryByText('Authorized Content')).toBeNull();
+  });
+
+  it('isolates authorization results by cluster while sharing them within a cluster', async () => {
+    const createMockItem = (cluster: string, allowed: boolean) => ({
+      _class: () => ({
+        apiName: 'pods',
+        apiVersion: 'v1',
+      }),
+      cluster,
+      getName: () => 'test-pod',
+      getAuthorization: vi.fn().mockResolvedValue({
+        status: {
+          allowed,
+        },
+      }),
+    });
+
+    const clusterAItem = createMockItem('cluster-a', true);
+    const sameClusterItem = createMockItem('cluster-a', false);
+    const clusterBItem = createMockItem('cluster-b', false);
+
+    // Render first cluster-a item and wait for authorization to complete
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <AuthVisible item={clusterAItem as any} authVerb="get">
+          <div>Cluster A content</div>
+        </AuthVisible>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Cluster A content')).toBeInTheDocument();
+    });
+
+    expect(clusterAItem.getAuthorization).toHaveBeenCalledTimes(1);
+
+    // Render equivalent cluster-a item - should reuse cached result
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <AuthVisible item={clusterAItem as any} authVerb="get">
+          <div>Cluster A content</div>
+        </AuthVisible>
+        <AuthVisible item={sameClusterItem as any} authVerb="get">
+          <div>Same cluster content</div>
+        </AuthVisible>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Same cluster content')).toBeInTheDocument();
+    });
+
+    expect(clusterAItem.getAuthorization).toHaveBeenCalledTimes(1);
+    expect(sameClusterItem.getAuthorization).not.toHaveBeenCalled();
+
+    // Render cluster-b item - should make new authorization request
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <AuthVisible item={clusterAItem as any} authVerb="get">
+          <div>Cluster A content</div>
+        </AuthVisible>
+        <AuthVisible item={sameClusterItem as any} authVerb="get">
+          <div>Same cluster content</div>
+        </AuthVisible>
+        <AuthVisible item={clusterBItem as any} authVerb="get">
+          <div>Cluster B content</div>
+        </AuthVisible>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Cluster B content')).toBeNull();
+    });
+
+    expect(clusterAItem.getAuthorization).toHaveBeenCalledTimes(1);
+    expect(sameClusterItem.getAuthorization).not.toHaveBeenCalled();
+    expect(clusterBItem.getAuthorization).toHaveBeenCalledTimes(1);
   });
 
   it('warns and returns null if authVerb is invalid', () => {

--- a/frontend/src/components/common/Resource/AuthVisible.tsx
+++ b/frontend/src/components/common/Resource/AuthVisible.tsx
@@ -16,6 +16,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import React, { useEffect } from 'react';
+import { getCluster } from '../../../lib/cluster';
 import { KubeObject } from '../../../lib/k8s/KubeObject';
 import { KubeObjectClass } from '../../../lib/k8s/KubeObject';
 
@@ -66,6 +67,7 @@ export default function AuthVisible(props: AuthVisibleProps) {
 
   const itemClass: KubeObjectClass | null = (item as KubeObject)?._class?.() ?? item;
   const itemName = (item as KubeObject)?.getName?.();
+  const cluster = (item as KubeObject)?.cluster ?? getCluster();
 
   const { data } = useQuery<any>({
     enabled: !!item && isAuthVerbValid,
@@ -77,13 +79,14 @@ export default function AuthVisible(props: AuthVisibleProps) {
       authVerb,
       subresource,
       namespace,
+      cluster,
     ],
     queryFn: async () => {
       try {
         const res = await item!.getAuthorization(
           authVerb,
           { subresource, namespace },
-          (item as any).cluster
+          cluster ?? undefined
         );
         return res;
       } catch (e: any) {


### PR DESCRIPTION
## Summary

Fixes the authorization cache used by `AuthVisible` so authorization results are isolated by cluster.

Previously, equivalent resources rendered from different clusters could reuse the same cached authorization result in multi-cluster views, resulting in incorrect action visibility.

## Changes

- Include the effective cluster in the React Query cache key.
- Use the same cluster value when performing authorization requests.
- Add a regression test verifying:
  - authorization results are isolated across clusters;
  - cache entries are reused within the same cluster.

Fixes #6731
