### PR TITLE
fix: add underscore folder name variants for ai-assistant plugin

### DIFF
--- a/app/electron/runCmd.test.ts
+++ b/app/electron/runCmd.test.ts
@@ -51,6 +51,7 @@ vi.mock('./main', () => ({
 }));
 
 import {
+  addRunCmdConsent,
   checkPermissionSecret,
   environmentOverrides,
   handleRunCommand,
@@ -423,5 +424,41 @@ describe('runScript', () => {
 
     expect(consoleErrorMock).toHaveBeenCalledTimes(1);
     expect(exitMock).toHaveBeenCalledWith(1);
+  });
+});
+
+describe('addRunCmdConsent', () => {
+  const AI_ASSISTANT_COMMANDS = ['gh auth', 'az account', 'az cognitiveservices'];
+
+  it.each([
+    ['headlamp_ai-assistant'],
+    ['headlamp_ai_assistant'],
+    ['headlamp_ai-assistantprerelease'],
+    ['headlamp_ai_assistantprerelease'],
+  ])('pre-populates AI assistant commands for plugin name "%s"', async pluginName => {
+    const { loadSettings, saveSettings } = await import('./settings');
+    vi.mocked(loadSettings).mockReturnValueOnce({ confirmedCommands: {} });
+    vi.mocked(saveSettings).mockClear();
+
+    addRunCmdConsent({ name: pluginName });
+
+    expect(saveSettings).toHaveBeenCalledTimes(1);
+    const savedSettings = vi.mocked(saveSettings).mock.calls[0][1] as any;
+    for (const cmd of AI_ASSISTANT_COMMANDS) {
+      expect(savedSettings.confirmedCommands[cmd]).toBe(true);
+    }
+  });
+
+  it('does not pre-populate AI assistant commands for an unrecognised plugin name', async () => {
+    const { loadSettings, saveSettings } = await import('./settings');
+    vi.mocked(loadSettings).mockReturnValueOnce({ confirmedCommands: {} });
+    vi.mocked(saveSettings).mockClear();
+
+    addRunCmdConsent({ name: 'some-other-plugin' });
+
+    const savedSettings = vi.mocked(saveSettings).mock.calls[0]?.[1] as any;
+    for (const cmd of AI_ASSISTANT_COMMANDS) {
+      expect(savedSettings?.confirmedCommands?.[cmd]).toBeUndefined();
+    }
   });
 });

--- a/app/electron/runCmd.ts
+++ b/app/electron/runCmd.ts
@@ -153,9 +153,14 @@ export function addRunCmdConsent(pluginInfo: { name: string }): void {
     commands = COMMANDS_WITH_CONSENT.headlamp_minikube;
   }
 
+  // Match both hyphen and underscore variants: the ArtifactHub installer may create
+  // the folder as 'headlamp_ai-assistant' or 'headlamp_ai_assistant' depending on
+  // the version of Headlamp and the plugin manager being used.
   const pluginIsAiAssistant =
     pluginInfo.name === 'headlamp_ai-assistant' ||
+    pluginInfo.name === 'headlamp_ai_assistant' ||
     pluginInfo.name === 'headlamp_ai-assistantprerelease' ||
+    pluginInfo.name === 'headlamp_ai_assistantprerelease' ||
     (process.env.NODE_ENV === 'development' && pluginInfo.name === 'ai-assistant');
   if (pluginIsAiAssistant) {
     commands = COMMANDS_WITH_CONSENT.headlamp_ai_assistant;

--- a/frontend/src/plugin/runPlugin.test.ts
+++ b/frontend/src/plugin/runPlugin.test.ts
@@ -542,4 +542,86 @@ describe('identifyPackages', () => {
     );
     expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
   });
+
+  // Tests for underscore variants (ArtifactHub installer uses underscores)
+  test('should identify ai-assistant package by underscore plugins path', () => {
+    const result = identifyPackages(
+      'plugins/headlamp_ai_assistant',
+      '@headlamp-k8s/ai-assistant',
+      false
+    );
+    expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+  });
+
+  test('should identify ai-assistant package by underscore user-plugins path', () => {
+    const result = identifyPackages(
+      'user-plugins/headlamp_ai_assistant',
+      '@headlamp-k8s/ai-assistant',
+      false
+    );
+    expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+  });
+
+  test('should identify ai-assistant package by underscore static-plugins path', () => {
+    const result = identifyPackages(
+      'static-plugins/headlamp_ai_assistant',
+      '@headlamp-k8s/ai-assistant',
+      false
+    );
+    expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+  });
+
+  test('should identify ai-assistant package by underscore prerelease plugins path', () => {
+    const result = identifyPackages(
+      'plugins/headlamp_ai_assistantprerelease',
+      '@headlamp-k8s/ai-assistantprerelease',
+      false
+    );
+    expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+  });
+
+  test('should identify ai-assistant package by underscore prerelease user-plugins path', () => {
+    const result = identifyPackages(
+      'user-plugins/headlamp_ai_assistantprerelease',
+      '@headlamp-k8s/ai-assistantprerelease',
+      false
+    );
+    expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+  });
+
+  test('should identify ai-assistant package by underscore prerelease static-plugins path', () => {
+    const result = identifyPackages(
+      'static-plugins/headlamp_ai_assistantprerelease',
+      '@headlamp-k8s/ai-assistantprerelease',
+      false
+    );
+    expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+  });
+
+  test('should handle windows paths for ai-assistant underscore variant', () => {
+    const result = identifyPackages(
+      'plugins\\headlamp_ai_assistant',
+      '@headlamp-k8s/ai-assistant',
+      false
+    );
+    expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+  });
+
+  test('should handle windows static paths for ai-assistant underscore variant', () => {
+    const result = identifyPackages(
+      'static-plugins\\headlamp_ai_assistant',
+      '@headlamp-k8s/ai-assistant',
+      false
+    );
+    expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+  });
+
+  test('should handle windows paths for ai-assistant underscore prerelease variant', () => {
+    const result = identifyPackages(
+      'plugins\\headlamp_ai_assistantprerelease',
+      '@headlamp-k8s/ai-assistantprerelease',
+      false
+    );
+    expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+  });
 });

--- a/frontend/src/plugin/runPlugin.ts
+++ b/frontend/src/plugin/runPlugin.ts
@@ -191,6 +191,9 @@ export function identifyPackages(
     .replace(/user-plugins[\\/]/, 'user-plugins/');
 
   // For artifacthub installed packages, the package name is the folder name.
+  // The ArtifactHub installer converts hyphens to underscores in folder names,
+  // so 'headlamp_ai-assistant' (hyphen) and 'headlamp_ai_assistant' (underscore)
+  // must both be recognised.
   const pluginPaths: Record<string, string[]> = {
     '@headlamp-k8s/minikube': [
       'plugins/headlamp_minikube',
@@ -207,6 +210,13 @@ export function identifyPackages(
       'plugins/headlamp_ai-assistantprerelease',
       'user-plugins/headlamp_ai-assistantprerelease',
       'static-plugins/headlamp_ai-assistantprerelease',
+      // Underscore variants: ArtifactHub installer converts hyphens to underscores
+      'plugins/headlamp_ai_assistant',
+      'user-plugins/headlamp_ai_assistant',
+      'static-plugins/headlamp_ai_assistant',
+      'plugins/headlamp_ai_assistantprerelease',
+      'user-plugins/headlamp_ai_assistantprerelease',
+      'static-plugins/headlamp_ai_assistantprerelease',
     ],
   };
 


### PR DESCRIPTION
## What

Fixes #6736.

The ArtifactHub installer creates the plugin folder as `headlamp_ai_assistant` (all underscores), but `identifyPackages()` and `addRunCmdConsent()` only recognised `headlamp_ai-assistant` (hyphen between `ai` and `assistant`). This caused two bugs for all marketplace-installed users:

1. **`pluginRunCommand` never injected** — `identifyPackages()` path check always returned `false`, so `commandRunner` stayed `null`, `cliDetectionEnabled` was `false`, and the **Auto Detect button never rendered** in Settings.
2. **Command consent never pre-approved** — `addRunCmdConsent()` name check never matched, so `gh auth` / `az account` consent was never written to `settings.json` on install. Calls to `pluginRunCommand('gh', ...)` then either showed a blocking consent dialog users missed, or timed out silently after 15 s.

## How

Add the underscore folder name variants alongside the existing hyphen variants in both files so both naming conventions are recognised:

### `frontend/src/plugin/runPlugin.ts`
```diff
 '@headlamp-k8s/ai-assistant': [
   'plugins/headlamp_ai-assistant',
   'user-plugins/headlamp_ai-assistant',
   'static-plugins/headlamp_ai-assistant',
   'plugins/headlamp_ai-assistantprerelease',
   'user-plugins/headlamp_ai-assistantprerelease',
   'static-plugins/headlamp_ai-assistantprerelease',
+  // Underscore variants: ArtifactHub installer converts hyphens to underscores
+  'plugins/headlamp_ai_assistant',
+  'user-plugins/headlamp_ai_assistant',
+  'static-plugins/headlamp_ai_assistant',
+  'plugins/headlamp_ai_assistantprerelease',
+  'user-plugins/headlamp_ai_assistantprerelease',
+  'static-plugins/headlamp_ai_assistantprerelease',
 ],
```

### `app/electron/runCmd.ts`
```diff
 const pluginIsAiAssistant =
   pluginInfo.name === 'headlamp_ai-assistant' ||
+  pluginInfo.name === 'headlamp_ai_assistant' ||
   pluginInfo.name === 'headlamp_ai-assistantprerelease' ||
+  pluginInfo.name === 'headlamp_ai_assistantprerelease' ||
   (process.env.NODE_ENV === 'development' && pluginInfo.name === 'ai-assistant');
```

## Testing

- Install `@headlamp-k8s/ai-assistant` from the marketplace (folder will be `headlamp_ai_assistant`).
- Restart Headlamp desktop.
- In DevTools console: `typeof pluginRunCommand` should return `"function"`.
- Settings → AI Assistant should show the **Auto Detect** button next to **Add Provider**.
- `settings.json` → `confirmedCommands` should be populated with `gh auth`, `az account`, `az cognitiveservices`.
