### PR TITLE
docker-ext: bump headlamp base image to v0.44.0

### DIFF
--- a/docker-extension/Dockerfile
+++ b/docker-extension/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/headlamp-k8s/headlamp:v0.33.0@sha256:99823f32b085e31d6344055b9c866cf24d0beb1ae3df1b879c4cfcb1f9c26311 as headlamp
+FROM ghcr.io/headlamp-k8s/headlamp:v0.44.0@sha256:b491653c1a0d380b70b67a4024f1204591f9c84a68ee567778d53d28b1856168 AS headlamp
 
 FROM scratch
 

--- a/docker-extension/docker-compose.yml
+++ b/docker-extension/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   headlamp:
-    image: ghcr.io/headlamp-k8s/headlamp:v0.33.0
+    image: ghcr.io/headlamp-k8s/headlamp:v0.44.0@sha256:b491653c1a0d380b70b67a4024f1204591f9c84a68ee567778d53d28b1856168
     command: ["--kubeconfig","/headlamp/config/config", "--port","64446", "--enable-dynamic-clusters"]
     restart: unless-stopped
     volumes:


### PR DESCRIPTION

## Summary

This PR updates the Headlamp Docker Desktop extension to use the `v0.44.0` base image instead of `v0.33.0`, bringing it in line with the current `main` branch. It also fixes a small Dockerfile lint warning caused by the `FROM`/`AS` casing.

---

## Changes

- Updated `docker-extension/Dockerfile` to use `ghcr.io/headlamp-k8s/headlamp:v0.44.0` with the corresponding image digest.
- Updated the image tag in `docker-extension/docker-compose.yml` from `v0.33.0` to `v0.44.0`.
- Changed `as` to `AS` in the Dockerfile to resolve the `FromAsCasing` lint warning.

---

## Steps to Test

1. Run `docker build -t headlamp ./docker-extension` and verify the image builds successfully with no Dockerfile casing warning.
2. Run `docker extension install headlamp`.
3. Open **Docker Desktop → Extensions**, launch Headlamp, and confirm it loads successfully and connects to a local `minikube` cluster.

---

## Notes for the Reviewer

- This is limited to a base image version bump and a small Dockerfile cleanup. No application logic or UI code was changed.
- Verified locally by building the image, installing the extension in Docker Desktop, launching it, and connecting to a local `minikube` cluster.