### PR TITLE
backend: serve plugins with no-cache when watching for changes

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -351,9 +351,12 @@ func addPluginRoutes(config *HeadlampConfig, r *mux.Router) {
 	// Serve development plugins
 	pluginHandler := http.StripPrefix(config.BaseURL+"/plugins/",
 		spa.BrotliSidecars(config.PluginDir, http.FileServer(http.Dir(config.PluginDir))))
-	// If we're running locally, then do not cache the plugins. This ensures that reloading them (development,
-	// update) will actually get the new content.
-	if !config.UseInCluster {
+	// Disable caching so that reloading plugins (development, or an update) actually serves the
+	// new content. This applies when running locally, and also in-cluster when plugin watching is
+	// enabled (--watch-plugins-changes): the server picks up the swapped bundle on disk, but
+	// without this header the browser keeps serving the stale main.js it cached earlier. Gate on the
+	// same condition as the plugin watcher below so the two stay in lockstep.
+	if !config.UseInCluster || config.WatchPluginsChanges {
 		pluginHandler = serveWithNoCacheHeader(pluginHandler)
 	}
 
@@ -363,7 +366,7 @@ func addPluginRoutes(config *HeadlampConfig, r *mux.Router) {
 	if config.UserPluginDir != "" {
 		userPluginsHandler := http.StripPrefix(config.BaseURL+"/user-plugins/",
 			spa.BrotliSidecars(config.UserPluginDir, http.FileServer(http.Dir(config.UserPluginDir))))
-		if !config.UseInCluster {
+		if !config.UseInCluster || config.WatchPluginsChanges {
 			userPluginsHandler = serveWithNoCacheHeader(userPluginsHandler)
 		}
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -1187,6 +1187,63 @@ func TestDrainNodeCancelledContextDoesNotWriteCache(t *testing.T) {
 	}, 100*time.Millisecond, 10*time.Millisecond, "cache should not be written when context is already cancelled")
 }
 
+// TestPluginStaticCacheControl verifies that plugin bundles are served with a
+// "Cache-Control: no-cache" header whenever the server is configured to pick up
+// plugin changes: always when running locally, and in-cluster when
+// --watch-plugins-changes is enabled. Without the header the server picks up a
+// swapped bundle on disk but browsers keep serving the stale main.js they cached
+// earlier. In the default in-cluster case (no watching) the header is omitted,
+// preserving the existing caching behavior.
+func TestPluginStaticCacheControl(t *testing.T) {
+	tests := []struct {
+		name                string
+		useInCluster        bool
+		watchPluginsChanges bool
+		wantNoCache         bool
+	}{
+		{name: "local dev serves no-cache", useInCluster: false, watchPluginsChanges: false, wantNoCache: true},
+		{name: "in-cluster without watching caches", useInCluster: true, watchPluginsChanges: false, wantNoCache: false},
+		{name: "in-cluster with watching serves no-cache", useInCluster: true, watchPluginsChanges: true, wantNoCache: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Plugin dir containing a single plugin bundle (test-plugin/main.js).
+			pluginDir := t.TempDir()
+			bundleDir := filepath.Join(pluginDir, "test-plugin")
+			require.NoError(t, os.Mkdir(bundleDir, 0o750))
+			require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "main.js"), []byte("export default {};"), 0o600))
+
+			c := HeadlampConfig{
+				HeadlampConfig: &headlampconfig.HeadlampConfig{
+					HeadlampCFG: &headlampconfig.HeadlampCFG{
+						UseInCluster:        tc.useInCluster,
+						WatchPluginsChanges: tc.watchPluginsChanges,
+						KubeConfigPath:      filepath.Join("headlamp_testdata", "kubeconfig"),
+						PluginDir:           pluginDir,
+						KubeConfigStore:     kubeconfig.NewContextStore(),
+					},
+					Cache:            cache.New[interface{}](),
+					TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+					TelemetryHandler: &telemetry.RequestHandler{},
+				},
+			}
+
+			handler := createHeadlampHandler(context.Background(), &c)
+
+			rr, err := getResponse(handler, http.MethodGet, "/plugins/test-plugin/main.js", nil)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, rr.Code)
+
+			if tc.wantNoCache {
+				assert.Equal(t, "no-cache", rr.Header().Get("Cache-Control"))
+			} else {
+				assert.Empty(t, rr.Header().Get("Cache-Control"))
+			}
+		})
+	}
+}
+
 func TestDeletePlugin(t *testing.T) {
 	// create temp dir for plugins
 	tempDir, err := os.MkdirTemp("", "plugins")

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -1243,6 +1243,80 @@ func TestDrainNodeSkipsDaemonSetPods(t *testing.T) {
 	assert.False(t, deleted.Load(), "DaemonSet pod should not be deleted during drain")
 }
 
+// TestPluginStaticCacheControl verifies that plugin bundles are served with a
+// "Cache-Control: no-cache" header whenever the server is configured to pick up
+// plugin changes: always when running locally, and in-cluster when
+// --watch-plugins-changes is enabled. Without the header the server picks up a
+// swapped bundle on disk but browsers keep serving the stale main.js they cached
+// earlier. In the default in-cluster case (no watching) the header is omitted,
+// preserving the existing caching behavior.
+//
+// Both watched static handlers are covered: the development plugins served at
+// /plugins/ and the user-installed plugins served at /user-plugins/.
+func TestPluginStaticCacheControl(t *testing.T) {
+	tests := []struct {
+		name                string
+		useInCluster        bool
+		watchPluginsChanges bool
+		wantNoCache         bool
+	}{
+		{name: "local dev serves no-cache", useInCluster: false, watchPluginsChanges: false, wantNoCache: true},
+		{name: "in-cluster without watching caches", useInCluster: true, watchPluginsChanges: false, wantNoCache: false},
+		{name: "in-cluster with watching serves no-cache", useInCluster: true, watchPluginsChanges: true, wantNoCache: true},
+	}
+
+	// writeBundle creates <root>/test-plugin/main.js and returns the root.
+	writeBundle := func(t *testing.T, root string) string {
+		t.Helper()
+
+		bundleDir := filepath.Join(root, "test-plugin")
+		require.NoError(t, os.Mkdir(bundleDir, 0o750))
+		require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "main.js"), []byte("export default {};"), 0o600))
+
+		return root
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pluginDir := writeBundle(t, t.TempDir())
+			userPluginDir := writeBundle(t, t.TempDir())
+
+			c := HeadlampConfig{
+				HeadlampConfig: &headlampconfig.HeadlampConfig{
+					HeadlampCFG: &headlampconfig.HeadlampCFG{
+						UseInCluster:        tc.useInCluster,
+						WatchPluginsChanges: tc.watchPluginsChanges,
+						KubeConfigPath:      filepath.Join("headlamp_testdata", "kubeconfig"),
+						PluginDir:           pluginDir,
+						UserPluginDir:       userPluginDir,
+						KubeConfigStore:     kubeconfig.NewContextStore(),
+					},
+					Cache:            cache.New[interface{}](),
+					TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+					TelemetryHandler: &telemetry.RequestHandler{},
+				},
+			}
+
+			handler := createHeadlampHandler(context.Background(), &c)
+
+			for _, path := range []string{
+				"/plugins/test-plugin/main.js",
+				"/user-plugins/test-plugin/main.js",
+			} {
+				rr, err := getResponse(handler, http.MethodGet, path, nil)
+				require.NoError(t, err)
+				require.Equal(t, http.StatusOK, rr.Code, path)
+
+				if tc.wantNoCache {
+					assert.Equal(t, "no-cache", rr.Header().Get("Cache-Control"), path)
+				} else {
+					assert.Empty(t, rr.Header().Get("Cache-Control"), path)
+				}
+			}
+		})
+	}
+}
+
 func TestDeletePlugin(t *testing.T) {
 	// create temp dir for plugins
 	tempDir, err := os.MkdirTemp("", "plugins")


### PR DESCRIPTION
## What this does

Serves plugin bundles with `Cache-Control: no-cache` when running in-cluster **and** `--watch-plugins-changes` is enabled, so an updated plugin actually reaches the browser instead of only being refreshed server-side.

## Problem

When Headlamp runs in-cluster, plugin static files under `/plugins/` (and `/user-plugins/`) are served with no `Cache-Control`/`ETag` — only `Last-Modified`. Browsers then apply heuristic freshness to `main.js` and keep serving a stale bundle for a long time after an update. Enabling `--watch-plugins-changes` makes the *server* pick up the swapped file on disk, but the browser still hands back the copy it cached earlier, and a hard reload is unreliable because the frontend fetches the plugin dynamically after page load (plain `fetch(.../main.js)`, no cache-busting).

The existing no-cache handling was gated on `!config.UseInCluster`, so in-cluster deployments never got it.

## Fix

Extend the no-cache gate on the `/plugins/` and `/user-plugins/` handlers to also apply in-cluster when `WatchPluginsChanges` is set — the same condition already used to start the plugin file watcher a few lines below, keeping the two in lockstep. It's opt-in: operators who turn on `--watch-plugins-changes` to get live plugin updates now get them all the way through to the browser. Default in-cluster behavior (no watching) is unchanged, and shipped `static-plugins/` (never watched) and the dynamic `GET /plugins` list route are intentionally left as-is.

## Testing

- New table-driven `TestPluginStaticCacheControl` covering the `/plugins/` static handler: local (no-cache), in-cluster default (no header, unchanged), and in-cluster + watch (no-cache).
- Verified with the real `headlamp-server` binary over HTTP: `-in-cluster -watch-plugins-changes` returns `Cache-Control: no-cache`; `-in-cluster` alone returns none.
- Full `backend/cmd` package tests, `go vet`, and `golangci-lint` all pass.
