### PR TITLE
dev: add contributor environment check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,8 @@ default_agent: "@dev-agent"
 > - `/docs/platforms.md` - Tested platforms list
 >
 > **Build/Config files:**
-> - `/package.json` - Root package with all npm scripts and Node.js version (>=20.11.1)
-> - `/backend/go.mod` - Go version (1.25.9)
+> - `/package.json` - Root package with all npm scripts and Node.js version (>=22.0.0)
+> - `/backend/go.mod` - Go version (1.26.5)
 > - `/CONTRIBUTING.md` - Contributing guidelines
 > - `/OWNERS` - Code reviewers and approvers
 
@@ -74,9 +74,9 @@ should NOT unless explicitly requested or strictly necessary for the change
 ### Tech stack and environment
 - **Languages:** TypeScript (frontend), Go (backend).
 - **Runtimes/tools:**
-  - Node.js >=20.11.1 (specified in `/package.json` engines field)
-  - npm >=10.0.0 (specified in `/package.json` engines field)
-  - Go 1.25.9 (specified in `/backend/go.mod`)
+  - Node.js >=22.0.0 (specified in `/package.json` engines field)
+  - npm >=11.0.0 (specified in `/package.json` engines field)
+  - Go 1.26.5 (specified in `/backend/go.mod`)
 - **Reproduce locally:** Use commands from `/package.json` scripts section and documentation files listed above.
 
 ---
@@ -377,9 +377,9 @@ Reference sources:
 4. ✅ **File is ready for commit** - consulted-files list is complete and all placeholders have been replaced with exact commands and paths from the repository
 
 **Version Information:**
-- Node.js: >=20.11.1 (from `/package.json`)
-- npm: >=10.0.0 (from `/package.json`)
-- Go: 1.25.9 (from `/backend/go.mod`)
+- Node.js: >=22.0.0 (from `/package.json`)
+- npm: >=11.0.0 (from `/package.json`)
+- Go: 1.26.5 (from `/backend/go.mod`)
 
 **Key Command Sources:**
 - Build/test commands: `/package.json`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,13 @@ Ready to run Headlamp locally? Here's the full setup from scratch.
 
 ### Prerequisites
 
-Make sure you have Node.js (>= 22.0.0 with npm >= 11.0.0) and Go installed before starting; see the development dependencies for the full list.
+Make sure you have Node.js (>= 22.0.0 with npm >= 11.0.0) and Go (>= 1.26.5) installed before starting; see the development dependencies for the full list.
+
+You can validate your local toolchain and contributor-facing version metadata with:
+
+```bash
+npm run env:check
+```
 
 ### Build and Run
 

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -16,8 +16,14 @@ These are the required dependencies to get started. Other dependencies are pulle
 
 - [Node.js](https://nodejs.org/en/download/) >= 22.0.0 (LTS recommended). Many of us use [nvm](https://github.com/nvm-sh/nvm) for installing multiple versions of Node.
 - [npm](https://www.npmjs.com/) (>= 11.0.0)
-- [Go](https://go.dev/doc/install) (>= 1.25.9)
+- [Go](https://go.dev/doc/install) (>= 1.26.5)
 - [Kubernetes](https://kubernetes.io/), we suggest [minikube](https://minikube.sigs.k8s.io/docs/) as one good K8s installation for testing locally. Other k8s installations are supported (see [platforms](../platforms.md)).
+
+To validate the local toolchain and detect version drift in contributor-facing metadata, run:
+
+```bash
+npm run env:check
+```
 
 You can install the required frontend, app, and backend dependencies by running:
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "install:frontend": "npm run frontend:install",
     "install:backend": "npm run backend:build",
     "install:app": "npm run app:install",
+    "env:check": "node ./tools/check-contributor-env.js",
     "build": "npm run backend:build && npm run frontend:build",
     "dev": "npm run start",
     "start": "concurrently \"npm run backend:start\" \"npm run frontend:start\" --names \"backend,frontend\" --prefix-colors \"blue,green\"",

--- a/tools/check-contributor-env.js
+++ b/tools/check-contributor-env.js
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+const {execFileSync} = require('node:child_process');
+
+function normalizeVersion(version) {
+  return version
+    .trim()
+    .replace(/^v/i, '')
+    .replace(/^go/i, '')
+    .split('-')[0];
+}
+
+function toVersionParts(version) {
+  return normalizeVersion(version)
+    .split('.')
+    .map(part => Number.parseInt(part, 10))
+    .concat([0, 0, 0])
+    .slice(0, 3);
+}
+
+function compareVersions(left, right) {
+  const leftParts = toVersionParts(left);
+  const rightParts = toVersionParts(right);
+
+  for (let index = 0; index < 3; index += 1) {
+    if (leftParts[index] > rightParts[index]) {
+      return 1;
+    }
+
+    if (leftParts[index] < rightParts[index]) {
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+function versionSatisfies(actual, requirement) {
+  const trimmedRequirement = requirement.trim();
+
+  if (trimmedRequirement.startsWith('>=')) {
+    return compareVersions(actual, trimmedRequirement.slice(2).trim()) >= 0;
+  }
+
+  return compareVersions(actual, trimmedRequirement) === 0;
+}
+
+function parseGoMod(goModContent) {
+  const languageMatch = goModContent.match(/^go\s+(\d+(?:\.\d+){1,2})$/m);
+  const toolchainMatch = goModContent.match(/^toolchain\s+go(\d+(?:\.\d+){1,2})$/m);
+
+  if (!languageMatch) {
+    throw new Error('Could not find the Go language version in backend/go.mod');
+  }
+
+  return {
+    languageVersion: normalizeVersion(languageMatch[1]),
+    toolchainVersion: toolchainMatch ? normalizeVersion(toolchainMatch[1]) : null,
+  };
+}
+
+function getRepoRequirements(repoRoot) {
+  const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+  const goMod = fs.readFileSync(path.join(repoRoot, 'backend/go.mod'), 'utf8');
+  const goRequirements = parseGoMod(goMod);
+
+  return {
+    nodeRange: packageJson.engines.node,
+    npmRange: packageJson.engines.npm,
+    goRange: `>=${goRequirements.toolchainVersion || goRequirements.languageVersion}`,
+    goLanguageVersion: goRequirements.languageVersion,
+    goToolchainVersion: goRequirements.toolchainVersion,
+  };
+}
+
+function getCommandVersion(command, args, pattern) {
+  try {
+    const output = execFileSync(command, args, {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const match = output.match(pattern);
+
+    if (!match) {
+      return {
+        ok: false,
+        actual: null,
+        message: `could not parse version from \`${command} ${args.join(' ')}\` output`,
+      };
+    }
+
+    return {
+      ok: true,
+      actual: normalizeVersion(match[1]),
+      message: null,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      actual: null,
+      message: error.code === 'ENOENT' ? `\`${command}\` is not installed` : error.message,
+    };
+  }
+}
+
+function buildDocChecks(requirements) {
+  return [
+    {
+      label: 'AGENTS.md consulted Node.js version',
+      file: 'AGENTS.md',
+      pattern: /Root package with all npm scripts and Node\.js version \(([^)]+)\)/,
+      expected: requirements.nodeRange,
+    },
+    {
+      label: 'AGENTS.md consulted Go version',
+      file: 'AGENTS.md',
+      pattern: /`\/backend\/go\.mod` - Go version \(([^)]+)\)/,
+      expected: requirements.goToolchainVersion || requirements.goLanguageVersion,
+    },
+    {
+      label: 'AGENTS.md runtime Node.js version',
+      file: 'AGENTS.md',
+      pattern: /Node\.js ([^ ]+) \(specified in `\/package\.json` engines field\)/,
+      expected: requirements.nodeRange,
+    },
+    {
+      label: 'AGENTS.md runtime npm version',
+      file: 'AGENTS.md',
+      pattern: /npm ([^ ]+) \(specified in `\/package\.json` engines field\)/,
+      expected: requirements.npmRange,
+    },
+    {
+      label: 'AGENTS.md runtime Go version',
+      file: 'AGENTS.md',
+      pattern: /Go ([^ ]+) \(specified in `\/backend\/go\.mod`\)/,
+      expected: requirements.goToolchainVersion || requirements.goLanguageVersion,
+    },
+    {
+      label: 'AGENTS.md version info Node.js version',
+      file: 'AGENTS.md',
+      pattern: /Node\.js: ([^ ]+) \(from `\/package\.json`\)/,
+      expected: requirements.nodeRange,
+    },
+    {
+      label: 'AGENTS.md version info npm version',
+      file: 'AGENTS.md',
+      pattern: /npm: ([^ ]+) \(from `\/package\.json`\)/,
+      expected: requirements.npmRange,
+    },
+    {
+      label: 'AGENTS.md version info Go version',
+      file: 'AGENTS.md',
+      pattern: /Go: ([^ ]+) \(from `\/backend\/go\.mod`\)/,
+      expected: requirements.goToolchainVersion || requirements.goLanguageVersion,
+    },
+    {
+      label: 'CONTRIBUTING.md prerequisite Node.js version',
+      file: 'CONTRIBUTING.md',
+      pattern: /Node\.js \((>=\s*\d+(?:\.\d+){1,2}) with npm/,
+      expected: requirements.nodeRange,
+      normalize: value => value.replace(/\s+/g, ''),
+    },
+    {
+      label: 'CONTRIBUTING.md prerequisite npm version',
+      file: 'CONTRIBUTING.md',
+      pattern: /npm (>=\s*\d+(?:\.\d+){1,2})\)/,
+      expected: requirements.npmRange,
+      normalize: value => value.replace(/\s+/g, ''),
+    },
+    {
+      label: 'CONTRIBUTING.md prerequisite Go version',
+      file: 'CONTRIBUTING.md',
+      pattern: /Go \((>=\s*\d+(?:\.\d+){1,2})\) installed/,
+      expected: requirements.goRange,
+      normalize: value => value.replace(/\s+/g, ''),
+    },
+    {
+      label: 'docs/development/index.md Node.js version',
+      file: 'docs/development/index.md',
+      pattern: /\[Node\.js\][^\n]*>=\s*(\d+(?:\.\d+){1,2})/,
+      expected: requirements.nodeRange,
+      actualPrefix: '>=',
+    },
+    {
+      label: 'docs/development/index.md npm version',
+      file: 'docs/development/index.md',
+      pattern: /\[npm\][^\n]*\(>=\s*(\d+(?:\.\d+){1,2})\)/,
+      expected: requirements.npmRange,
+      actualPrefix: '>=',
+    },
+    {
+      label: 'docs/development/index.md Go version',
+      file: 'docs/development/index.md',
+      pattern: /\[Go\][^\n]*>=\s*(\d+(?:\.\d+){1,2})/,
+      expected: requirements.goRange,
+      actualPrefix: '>=',
+    },
+  ];
+}
+
+function evaluateDocCheck(repoRoot, check) {
+  const content = fs.readFileSync(path.join(repoRoot, check.file), 'utf8');
+  const match = content.match(check.pattern);
+
+  if (!match) {
+    return {
+      ok: false,
+      label: check.label,
+      file: check.file,
+      actual: null,
+      expected: check.expected,
+      message: 'pattern not found',
+    };
+  }
+
+  const rawActual = `${check.actualPrefix || ''}${match[1].trim()}`;
+  const actual = check.normalize ? check.normalize(rawActual) : rawActual;
+  const expected = check.normalize ? check.normalize(check.expected) : check.expected;
+
+  return {
+    ok: actual === expected,
+    label: check.label,
+    file: check.file,
+    actual,
+    expected,
+    message: actual === expected ? null : `expected ${expected}, found ${actual}`,
+  };
+}
+
+function printLocalToolChecks(requirements) {
+  const checks = [
+    {
+      label: 'Node.js',
+      expected: requirements.nodeRange,
+      lookup: () => ({ok: true, actual: normalizeVersion(process.version), message: null}),
+    },
+    {
+      label: 'npm',
+      expected: requirements.npmRange,
+      lookup: () => getCommandVersion('npm', ['--version'], /([0-9]+(?:\.[0-9]+){1,2})/),
+    },
+    {
+      label: 'Go',
+      expected: requirements.goRange,
+      lookup: () => getCommandVersion('go', ['version'], /go([0-9]+(?:\.[0-9]+){1,2})/),
+    },
+  ];
+
+  const results = checks.map(check => {
+    const lookup = check.lookup();
+
+    if (!lookup.ok) {
+      return {
+        ok: false,
+        label: check.label,
+        message: lookup.message,
+      };
+    }
+
+    const satisfies = versionSatisfies(lookup.actual, check.expected);
+
+    return {
+      ok: satisfies,
+      label: check.label,
+      message: satisfies
+        ? `${lookup.actual} satisfies ${check.expected}`
+        : `${lookup.actual} does not satisfy ${check.expected}`,
+    };
+  });
+
+  console.log('Authoritative toolchain requirements:');
+  console.log(`- Node.js: ${requirements.nodeRange}`);
+  console.log(`- npm: ${requirements.npmRange}`);
+  console.log(
+    `- Go: ${requirements.goRange}` +
+      (requirements.goToolchainVersion
+        ? ` (toolchain ${requirements.goToolchainVersion}, language version ${requirements.goLanguageVersion})`
+        : '')
+  );
+  console.log('');
+  console.log('Local environment:');
+
+  for (const result of results) {
+    console.log(`- ${result.ok ? 'PASS' : 'FAIL'} ${result.label}: ${result.message}`);
+  }
+
+  return results;
+}
+
+function printDocChecks(repoRoot, requirements) {
+  const results = buildDocChecks(requirements).map(check => evaluateDocCheck(repoRoot, check));
+
+  console.log('');
+  console.log('Contributor metadata drift:');
+
+  for (const result of results) {
+    if (result.ok) {
+      console.log(`- PASS ${result.label}`);
+      continue;
+    }
+
+    console.log(
+      `- FAIL ${result.label}: ${result.message || 'mismatch'}${result.file ? ` (${result.file})` : ''}`
+    );
+  }
+
+  return results;
+}
+
+function parseArguments(argv) {
+  return {
+    skipDocs: argv.includes('--skip-docs'),
+    skipLocal: argv.includes('--skip-local'),
+  };
+}
+
+function main(argv = process.argv.slice(2), repoRoot = process.cwd()) {
+  const options = parseArguments(argv);
+  const requirements = getRepoRequirements(repoRoot);
+  const results = [];
+
+  if (!options.skipLocal) {
+    results.push(...printLocalToolChecks(requirements));
+  }
+
+  if (!options.skipDocs) {
+    results.push(...printDocChecks(repoRoot, requirements));
+  }
+
+  const failures = results.filter(result => !result.ok);
+
+  console.log('');
+  console.log(
+    failures.length === 0
+      ? 'Contributor environment check passed.'
+      : `Contributor environment check failed with ${failures.length} issue(s).`
+  );
+
+  return failures.length === 0 ? 0 : 1;
+}
+
+if (require.main === module) {
+  process.exitCode = main();
+}
+
+module.exports = {
+  buildDocChecks,
+  compareVersions,
+  evaluateDocCheck,
+  getRepoRequirements,
+  normalizeVersion,
+  parseGoMod,
+  versionSatisfies,
+};

--- a/tools/check-contributor-env.js
+++ b/tools/check-contributor-env.js
@@ -1,0 +1,372 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+const {execFileSync} = require('node:child_process');
+
+function normalizeVersion(version) {
+  return version
+    .trim()
+    .replace(/^v/i, '')
+    .replace(/^go/i, '')
+    .split('-')[0];
+}
+
+function toVersionParts(version) {
+  return normalizeVersion(version)
+    .split('.')
+    .map(part => Number.parseInt(part, 10))
+    .concat([0, 0, 0])
+    .slice(0, 3);
+}
+
+function isPrereleaseVersion(version) {
+  const stripped = version.trim().replace(/^v/i, '').replace(/^go/i, '');
+
+  return /-/.test(stripped) || /^\d+(?:\.\d+){0,2}[a-z]/i.test(stripped);
+}
+
+function compareVersions(left, right) {
+  const leftParts = toVersionParts(left);
+  const rightParts = toVersionParts(right);
+
+  for (let index = 0; index < 3; index += 1) {
+    if (leftParts[index] > rightParts[index]) {
+      return 1;
+    }
+
+    if (leftParts[index] < rightParts[index]) {
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+function versionSatisfies(actual, requirement) {
+  const trimmedRequirement = requirement.trim();
+
+  if (isPrereleaseVersion(actual)) {
+    return false;
+  }
+
+  if (trimmedRequirement.startsWith('>=')) {
+    return compareVersions(actual, trimmedRequirement.slice(2).trim()) >= 0;
+  }
+
+  return compareVersions(actual, trimmedRequirement) === 0;
+}
+
+function parseGoMod(goModContent) {
+  const normalizedContent = goModContent.replace(/\r\n?/g, '\n');
+  const languageMatch = normalizedContent.match(/^go\s+(\d+(?:\.\d+){1,2})$/m);
+  const toolchainMatch = normalizedContent.match(/^toolchain\s+go(\d+(?:\.\d+){1,2})$/m);
+
+  if (!languageMatch) {
+    throw new Error('Could not find the Go language version in backend/go.mod');
+  }
+
+  return {
+    languageVersion: normalizeVersion(languageMatch[1]),
+    toolchainVersion: toolchainMatch ? normalizeVersion(toolchainMatch[1]) : null,
+  };
+}
+
+function getRepoRequirements(repoRoot) {
+  const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+  const goMod = fs.readFileSync(path.join(repoRoot, 'backend/go.mod'), 'utf8');
+  const goRequirements = parseGoMod(goMod);
+
+  return {
+    nodeRange: packageJson.engines.node,
+    npmRange: packageJson.engines.npm,
+    goRange: `>=${goRequirements.toolchainVersion || goRequirements.languageVersion}`,
+    goLanguageVersion: goRequirements.languageVersion,
+    goToolchainVersion: goRequirements.toolchainVersion,
+  };
+}
+
+function getCommandVersion(command, args, pattern, options = {}) {
+  try {
+    const output = execFileSync(command, args, {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: options.useShellOnWindows && process.platform === 'win32',
+    });
+    const match = output.match(pattern);
+
+    if (!match) {
+      return {
+        ok: false,
+        actual: null,
+        message: `could not parse version from \`${command} ${args.join(' ')}\` output`,
+      };
+    }
+
+    return {
+      ok: true,
+      actual: normalizeVersion(match[1]),
+      message: null,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      actual: null,
+      message: error.code === 'ENOENT' ? `\`${command}\` is not installed` : error.message,
+    };
+  }
+}
+
+function buildDocChecks(requirements) {
+  return [
+    {
+      label: 'AGENTS.md consulted Node.js version',
+      file: 'AGENTS.md',
+      pattern: /Root package with all npm scripts and Node\.js version \(([^)]+)\)/,
+      expected: requirements.nodeRange,
+    },
+    {
+      label: 'AGENTS.md consulted Go version',
+      file: 'AGENTS.md',
+      pattern: /`\/backend\/go\.mod` - Go version \(([^)]+)\)/,
+      expected: requirements.goToolchainVersion || requirements.goLanguageVersion,
+    },
+    {
+      label: 'AGENTS.md runtime Node.js version',
+      file: 'AGENTS.md',
+      pattern: /Node\.js ([^ ]+) \(specified in `\/package\.json` engines field\)/,
+      expected: requirements.nodeRange,
+    },
+    {
+      label: 'AGENTS.md runtime npm version',
+      file: 'AGENTS.md',
+      pattern: /npm ([^ ]+) \(specified in `\/package\.json` engines field\)/,
+      expected: requirements.npmRange,
+    },
+    {
+      label: 'AGENTS.md runtime Go version',
+      file: 'AGENTS.md',
+      pattern: /Go ([^ ]+) \(specified in `\/backend\/go\.mod`\)/,
+      expected: requirements.goToolchainVersion || requirements.goLanguageVersion,
+    },
+    {
+      label: 'AGENTS.md version info Node.js version',
+      file: 'AGENTS.md',
+      pattern: /Node\.js: ([^ ]+) \(from `\/package\.json`\)/,
+      expected: requirements.nodeRange,
+    },
+    {
+      label: 'AGENTS.md version info npm version',
+      file: 'AGENTS.md',
+      pattern: /npm: ([^ ]+) \(from `\/package\.json`\)/,
+      expected: requirements.npmRange,
+    },
+    {
+      label: 'AGENTS.md version info Go version',
+      file: 'AGENTS.md',
+      pattern: /Go: ([^ ]+) \(from `\/backend\/go\.mod`\)/,
+      expected: requirements.goToolchainVersion || requirements.goLanguageVersion,
+    },
+    {
+      label: 'CONTRIBUTING.md prerequisite Node.js version',
+      file: 'CONTRIBUTING.md',
+      pattern: /Node\.js \((>=\s*\d+(?:\.\d+){1,2}) with npm/,
+      expected: requirements.nodeRange,
+      normalize: value => value.replace(/\s+/g, ''),
+    },
+    {
+      label: 'CONTRIBUTING.md prerequisite npm version',
+      file: 'CONTRIBUTING.md',
+      pattern: /npm (>=\s*\d+(?:\.\d+){1,2})\)/,
+      expected: requirements.npmRange,
+      normalize: value => value.replace(/\s+/g, ''),
+    },
+    {
+      label: 'CONTRIBUTING.md prerequisite Go version',
+      file: 'CONTRIBUTING.md',
+      pattern: /Go \((>=\s*\d+(?:\.\d+){1,2})\) installed/,
+      expected: requirements.goRange,
+      normalize: value => value.replace(/\s+/g, ''),
+    },
+    {
+      label: 'docs/development/index.md Node.js version',
+      file: 'docs/development/index.md',
+      pattern: /\[Node\.js\][^\n]*>=\s*(\d+(?:\.\d+){1,2})/,
+      expected: requirements.nodeRange,
+      actualPrefix: '>=',
+    },
+    {
+      label: 'docs/development/index.md npm version',
+      file: 'docs/development/index.md',
+      pattern: /\[npm\][^\n]*\(>=\s*(\d+(?:\.\d+){1,2})\)/,
+      expected: requirements.npmRange,
+      actualPrefix: '>=',
+    },
+    {
+      label: 'docs/development/index.md Go version',
+      file: 'docs/development/index.md',
+      pattern: /\[Go\][^\n]*>=\s*(\d+(?:\.\d+){1,2})/,
+      expected: requirements.goRange,
+      actualPrefix: '>=',
+    },
+  ];
+}
+
+function evaluateDocCheck(repoRoot, check) {
+  const content = fs.readFileSync(path.join(repoRoot, check.file), 'utf8');
+  const match = content.match(check.pattern);
+
+  if (!match) {
+    return {
+      ok: false,
+      label: check.label,
+      file: check.file,
+      actual: null,
+      expected: check.expected,
+      message: 'pattern not found',
+    };
+  }
+
+  const rawActual = `${check.actualPrefix || ''}${match[1].trim()}`;
+  const actual = check.normalize ? check.normalize(rawActual) : rawActual;
+  const expected = check.normalize ? check.normalize(check.expected) : check.expected;
+
+  return {
+    ok: actual === expected,
+    label: check.label,
+    file: check.file,
+    actual,
+    expected,
+    message: actual === expected ? null : `expected ${expected}, found ${actual}`,
+  };
+}
+
+function printLocalToolChecks(requirements) {
+  const checks = [
+    {
+      label: 'Node.js',
+      expected: requirements.nodeRange,
+      lookup: () => ({ok: true, actual: normalizeVersion(process.version), message: null}),
+    },
+    {
+      label: 'npm',
+      expected: requirements.npmRange,
+      lookup: () =>
+        getCommandVersion('npm', ['--version'], /([0-9]+(?:\.[0-9]+){1,2})/, {
+          useShellOnWindows: true,
+        }),
+    },
+    {
+      label: 'Go',
+      expected: requirements.goRange,
+      lookup: () => getCommandVersion('go', ['version'], /go([0-9]+(?:\.[0-9]+){1,2})/),
+    },
+  ];
+
+  const results = checks.map(check => {
+    const lookup = check.lookup();
+
+    if (!lookup.ok) {
+      return {
+        ok: false,
+        label: check.label,
+        message: lookup.message,
+      };
+    }
+
+    const satisfies = versionSatisfies(lookup.actual, check.expected);
+
+    return {
+      ok: satisfies,
+      label: check.label,
+      message: satisfies
+        ? `${lookup.actual} satisfies ${check.expected}`
+        : `${lookup.actual} does not satisfy ${check.expected}`,
+    };
+  });
+
+  console.log('Authoritative toolchain requirements:');
+  console.log(`- Node.js: ${requirements.nodeRange}`);
+  console.log(`- npm: ${requirements.npmRange}`);
+  console.log(
+    `- Go: ${requirements.goRange}` +
+      (requirements.goToolchainVersion
+        ? ` (toolchain ${requirements.goToolchainVersion}, language version ${requirements.goLanguageVersion})`
+        : '')
+  );
+  console.log('');
+  console.log('Local environment:');
+
+  for (const result of results) {
+    console.log(`- ${result.ok ? 'PASS' : 'FAIL'} ${result.label}: ${result.message}`);
+  }
+
+  return results;
+}
+
+function printDocChecks(repoRoot, requirements) {
+  const results = buildDocChecks(requirements).map(check => evaluateDocCheck(repoRoot, check));
+
+  console.log('');
+  console.log('Contributor metadata drift:');
+
+  for (const result of results) {
+    if (result.ok) {
+      console.log(`- PASS ${result.label}`);
+      continue;
+    }
+
+    console.log(
+      `- FAIL ${result.label}: ${result.message || 'mismatch'}${result.file ? ` (${result.file})` : ''}`
+    );
+  }
+
+  return results;
+}
+
+function parseArguments(argv) {
+  return {
+    skipDocs: argv.includes('--skip-docs'),
+    skipLocal: argv.includes('--skip-local'),
+  };
+}
+
+function main(argv = process.argv.slice(2), repoRoot = process.cwd()) {
+  const options = parseArguments(argv);
+  const requirements = getRepoRequirements(repoRoot);
+  const results = [];
+
+  if (!options.skipLocal) {
+    results.push(...printLocalToolChecks(requirements));
+  }
+
+  if (!options.skipDocs) {
+    results.push(...printDocChecks(repoRoot, requirements));
+  }
+
+  const failures = results.filter(result => !result.ok);
+
+  console.log('');
+  console.log(
+    failures.length === 0
+      ? 'Contributor environment check passed.'
+      : `Contributor environment check failed with ${failures.length} issue(s).`
+  );
+
+  return failures.length === 0 ? 0 : 1;
+}
+
+if (require.main === module) {
+  process.exitCode = main();
+}
+
+module.exports = {
+  buildDocChecks,
+  compareVersions,
+  evaluateDocCheck,
+  getRepoRequirements,
+  normalizeVersion,
+  parseGoMod,
+  versionSatisfies,
+};

--- a/tools/check-contributor-env.test.js
+++ b/tools/check-contributor-env.test.js
@@ -1,0 +1,53 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  compareVersions,
+  evaluateDocCheck,
+  parseGoMod,
+  versionSatisfies,
+} = require('./check-contributor-env');
+
+test('parseGoMod returns both language and toolchain versions', () => {
+  const parsed = parseGoMod('module example.com/test\n\ngo 1.26.0\n\ntoolchain go1.26.5\n');
+
+  assert.deepEqual(parsed, {
+    languageVersion: '1.26.0',
+    toolchainVersion: '1.26.5',
+  });
+});
+
+test('compareVersions normalizes prefixes and missing patch numbers', () => {
+  assert.equal(compareVersions('v26.4.0', '26.4'), 0);
+  assert.equal(compareVersions('go1.26.5', '1.26.4'), 1);
+  assert.equal(compareVersions('1.25.9', '1.26.0'), -1);
+});
+
+test('versionSatisfies supports minimum and exact requirements', () => {
+  assert.equal(versionSatisfies('11.18.0', '>=11.0.0'), true);
+  assert.equal(versionSatisfies('1.26.5', '>=1.26.5'), true);
+  assert.equal(versionSatisfies('1.26.4', '>=1.26.5'), false);
+  assert.equal(versionSatisfies('22.0.0', '22.0.0'), true);
+  assert.equal(versionSatisfies('23.0.0', '22.0.0'), false);
+});
+
+test('evaluateDocCheck reports drift clearly', () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-env-check-'));
+  const docPath = path.join(repoRoot, 'AGENTS.md');
+
+  fs.writeFileSync(docPath, 'Node.js >=20.11.1 (specified in `/package.json` engines field)\n');
+
+  const result = evaluateDocCheck(repoRoot, {
+    label: 'AGENTS runtime Node.js version',
+    file: 'AGENTS.md',
+    pattern: /Node\.js ([^ ]+) \(specified in `\/package\.json` engines field\)/,
+    expected: '>=22.0.0',
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.actual, '>=20.11.1');
+  assert.equal(result.expected, '>=22.0.0');
+});

--- a/tools/check-contributor-env.test.js
+++ b/tools/check-contributor-env.test.js
@@ -1,0 +1,69 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  compareVersions,
+  evaluateDocCheck,
+  parseGoMod,
+  versionSatisfies,
+} = require('./check-contributor-env');
+
+test('parseGoMod returns both language and toolchain versions', () => {
+  const parsed = parseGoMod('module example.com/test\n\ngo 1.26.0\n\ntoolchain go1.26.5\n');
+
+  assert.deepEqual(parsed, {
+    languageVersion: '1.26.0',
+    toolchainVersion: '1.26.5',
+  });
+});
+
+test('parseGoMod handles CRLF line endings', () => {
+  const parsed = parseGoMod(
+    'module example.com/test\r\n\r\ngo 1.26.0\r\n\r\ntoolchain go1.26.5\r\n'
+  );
+
+  assert.deepEqual(parsed, {
+    languageVersion: '1.26.0',
+    toolchainVersion: '1.26.5',
+  });
+});
+
+test('compareVersions normalizes prefixes and missing patch numbers', () => {
+  assert.equal(compareVersions('v26.4.0', '26.4'), 0);
+  assert.equal(compareVersions('go1.26.5', '1.26.4'), 1);
+  assert.equal(compareVersions('1.25.9', '1.26.0'), -1);
+});
+
+test('versionSatisfies supports minimum and exact requirements', () => {
+  assert.equal(versionSatisfies('11.18.0', '>=11.0.0'), true);
+  assert.equal(versionSatisfies('1.26.5', '>=1.26.5'), true);
+  assert.equal(versionSatisfies('1.26.4', '>=1.26.5'), false);
+  assert.equal(versionSatisfies('22.0.0', '22.0.0'), true);
+  assert.equal(versionSatisfies('23.0.0', '22.0.0'), false);
+});
+
+test('versionSatisfies rejects prerelease versions against final-release requirements', () => {
+  assert.equal(versionSatisfies('v22.0.0-rc.1', '>=22.0.0'), false);
+  assert.equal(versionSatisfies('go1.26rc1', '>=1.26.0'), false);
+});
+
+test('evaluateDocCheck reports drift clearly', () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-env-check-'));
+  const docPath = path.join(repoRoot, 'AGENTS.md');
+
+  fs.writeFileSync(docPath, 'Node.js >=20.11.1 (specified in `/package.json` engines field)\n');
+
+  const result = evaluateDocCheck(repoRoot, {
+    label: 'AGENTS runtime Node.js version',
+    file: 'AGENTS.md',
+    pattern: /Node\.js ([^ ]+) \(specified in `\/package\.json` engines field\)/,
+    expected: '>=22.0.0',
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.actual, '>=20.11.1');
+  assert.equal(result.expected, '>=22.0.0');
+});


### PR DESCRIPTION
## Summary
- add a contributor-facing `npm run env:check` command
- derive required Node.js, npm, and Go versions from `package.json` and `backend/go.mod`
- detect drift in contributor-facing metadata and docs that duplicate toolchain requirements

## Linked Issue
Fixes #6741

## What Changed
- added `tools/check-contributor-env.js` to validate local Node.js, npm, and Go versions
- added `tools/check-contributor-env.test.js` with focused coverage for version parsing and drift detection
- exposed the check through `package.json` as `npm run env:check`
- updated contributor-facing version references in `AGENTS.md`, `CONTRIBUTING.md`, and `docs/development/index.md`

## Verification
- `npm run env:check` — passed
- `node --test tools/check-contributor-env.test.js` — passed
- `npm run lint` — passed
- `npm test` — passed
- `npm run backend:test` — passed
- `npm run frontend:test` — passed

## Steps to Test
1. Run `npm run env:check` from the repository root.
2. Confirm it reports the required Node.js, npm, and Go versions from `package.json` and `backend/go.mod`.
3. Confirm the command exits successfully when the local environment and contributor-facing metadata match those authoritative sources.

## Scope
- unrelated files were not changed

## Notes for the Reviewer
- this adds a reusable contributor and release-preparation check rather than another one-off documentation-only fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `npm run env:check` command to validate local Node.js, npm, and Go versions against project requirements.
  * The check also identifies inconsistencies in contributor documentation and reports actionable failures.

* **Documentation**
  * Updated prerequisites to require Node.js 22+, npm 11+, and Go 1.26.5+.
  * Added guidance for validating the local development environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
