### PR TITLE
frontend: node: Clean up debug pod on terminal close

### DIFF
--- a/frontend/src/components/node/NodeShellTerminal.test.tsx
+++ b/frontend/src/components/node/NodeShellTerminal.test.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'vitest-canvas-mock';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { TestContext } from '../../test';
+import { NodeShellTerminal } from './NodeShellTerminal';
+
+const { mockApply, mockDelete, podConstructorCalls } = vi.hoisted(() => ({
+  mockApply: vi.fn(),
+  mockDelete: vi.fn().mockResolvedValue(undefined),
+  podConstructorCalls: [] as any[],
+}));
+
+vi.mock('../../lib/cluster', () => ({
+  getCluster: () => 'cluster-a',
+}));
+
+vi.mock('../../lib/k8s/api/v1/apply', () => ({
+  apply: (...args: any[]) => mockApply(...args),
+}));
+
+vi.mock('../../lib/k8s/api/v1/streamingApi', () => ({
+  stream: () => ({
+    cancel: vi.fn(),
+    getSocket: () => null,
+  }),
+}));
+
+vi.mock('../../helpers/clusterSettings', () => ({
+  loadClusterSettings: () => ({}),
+  DEFAULT_NODE_SHELL_LINUX_IMAGE: 'busybox',
+  DEFAULT_NODE_SHELL_NAMESPACE: 'default',
+}));
+
+vi.mock('../../lib/k8s/pod', () => ({
+  default: class MockPod {
+    kubePod: any;
+    cluster: any;
+    delete = mockDelete;
+    constructor(kubePod: any, cluster: any) {
+      this.kubePod = kubePod;
+      this.cluster = cluster;
+      podConstructorCalls.push({ kubePod, cluster });
+    }
+  },
+}));
+
+const mockNode = {
+  getName: () => 'test-node',
+  metadata: { uid: 'node-1' },
+} as any;
+
+describe('NodeShellTerminal', () => {
+  beforeEach(() => {
+    mockDelete.mockClear();
+    podConstructorCalls.length = 0;
+  });
+
+  it('deletes the debug pod when the terminal unmounts after the shell connects', async () => {
+    mockApply.mockResolvedValue({});
+
+    const { unmount } = render(
+      <TestContext>
+        <NodeShellTerminal item={mockNode} onClose={() => {}} />
+      </TestContext>
+    );
+
+    await vi.waitFor(() => expect(podConstructorCalls.length).toBe(1));
+
+    unmount();
+
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('still deletes the debug pod if the terminal is closed before creation finishes (race regression)', async () => {
+    let resolveApply: (value: unknown) => void;
+    mockApply.mockReturnValue(
+      new Promise(res => {
+        resolveApply = res;
+      })
+    );
+
+    const { unmount } = render(
+      <TestContext>
+        <NodeShellTerminal item={mockNode} onClose={() => {}} />
+      </TestContext>
+    );
+
+    // Close before apply() (and therefore shell()) has resolved.
+    unmount();
+    expect(podConstructorCalls.length).toBe(0);
+    expect(mockDelete).not.toHaveBeenCalled();
+
+    // Pod creation completes after the component is already gone.
+    resolveApply!({});
+    await vi.waitFor(() => expect(podConstructorCalls.length).toBe(1));
+
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/node/NodeShellTerminal.tsx
+++ b/frontend/src/components/node/NodeShellTerminal.tsx
@@ -29,7 +29,7 @@ import { getCluster } from '../../lib/cluster';
 import { apply } from '../../lib/k8s/api/v1/apply';
 import { stream, StreamResultsCb } from '../../lib/k8s/api/v1/streamingApi';
 import Node from '../../lib/k8s/node';
-import { KubePod } from '../../lib/k8s/pod';
+import Pod, { KubePod } from '../../lib/k8s/pod';
 import { Channel, useTerminalStream, XTerminalConnected } from '../../lib/k8s/useTerminalStream';
 import store from '../../redux/stores/store';
 
@@ -107,7 +107,7 @@ function uniqueString() {
 }
 
 /**
- * Creates the node debugger pod and opens an attach stream to it.
+ * Creates a privileged debug pod on the given node and attaches to its shell.
  *
  * @param item - Node to open a shell on
  * @param cluster - Cluster the node belongs to, already resolved by the caller
@@ -115,7 +115,8 @@ function uniqueString() {
  * @param onError - Error handler callback, called with the pod creation failure message when the
  *                  thrown value carries one, and with undefined otherwise so the caller can supply a
  *                  translated fallback
- * @returns Object with the stream if successful, empty object on error
+ * @returns The attach stream and the created Pod (for later cleanup), or an
+ * empty object if pod creation fails.
  */
 async function shell(
   item: Node,
@@ -153,14 +154,18 @@ async function shell(
   ];
   return {
     stream: stream(url, onExec, { cluster, additionalProtocols, isJson: false }),
+    pod: new Pod(kubePod, cluster),
   };
 }
 
+/** Terminal for a node debug shell — creates the debug pod, streams the session, and deletes the pod when the terminal closes. */
 export function NodeShellTerminal(props: NodeShellTerminalProps) {
   const { item, onClose } = props;
   const [terminalContainerRef, setTerminalContainerRef] = useState<HTMLElement | null>(null);
   const exitSentRef = useRef(false);
   const pendingExitRef = useRef(false);
+  const podRef = useRef<Pod | null>(null);
+  const isUnmountedRef = useRef(false);
   const { t } = useTranslation(['translation']);
   const { enqueueSnackbar } = useSnackbar();
 
@@ -178,13 +183,27 @@ export function NodeShellTerminal(props: NodeShellTerminalProps) {
       }
 
       xtermRef.current?.xterm.writeln('Trying to open a shell');
-      const { stream } = await shell(item, cluster, onDataCallback, (errorMessage?: string) => {
-        const message = errorMessage || t('translation|Failed to create node shell pod');
-        enqueueSnackbar(t('translation|Failed to open node shell: {{message}}', { message }), {
-          variant: 'error',
-        });
-        xtermRef.current?.xterm.writeln(`\r\n${t('translation|Error')}: ${message}\r\n`);
-      });
+      const { stream, pod } = await shell(
+        item,
+        cluster,
+        onDataCallback,
+        (errorMessage?: string) => {
+          const message = errorMessage || t('translation|Failed to create node shell pod');
+          enqueueSnackbar(t('translation|Failed to open node shell: {{message}}', { message }), {
+            variant: 'error',
+          });
+          xtermRef.current?.xterm.writeln(`\r\n${t('translation|Error')}: ${message}\r\n`);
+        }
+      );
+      if (pod) {
+        if (isUnmountedRef.current) {
+          pod.delete().catch(e => {
+            console.error('Error:DebugNode: deleting pod', e);
+          });
+        } else {
+          podRef.current = pod;
+        }
+      }
       return {
         stream,
       };
@@ -299,6 +318,17 @@ export function NodeShellTerminal(props: NodeShellTerminalProps) {
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      isUnmountedRef.current = true;
+      if (podRef.current) {
+        podRef.current.delete().catch(e => {
+          console.error('Error:DebugNode: deleting pod', e);
+        });
+      }
+    };
   }, []);
 
   return (


### PR DESCRIPTION
## Summary

"Debug Node" creates a privileged pod (hostPID, hostIPC, hostNetwork, host filesystem mounted at `/host`) for the debug shell. Closing the terminal never deleted that pod, so it stayed in the cluster in `Succeeded` state indefinitely. This adds pod cleanup on terminal close.

## Related Issue

Fixes #6746

## Changes

- `NodeShellTerminal.tsx`: capture the pod created by `shell()` in a ref
- Import the `Pod` class alongside the existing `KubePod` type
- Add an unmount-cleanup effect that deletes the pod when the terminal closes, regardless of how it was closed (X button, taskbar close, or typing `exit` in the shell)

## Steps to Test

1. Open a Node's detail page, click "Debug Node", wait for the shell to connect.
2. Close the terminal using the panel's X button.
3. Check `kubectl get pods -n <debug namespace>` — the `node-debugger-*` pod should be gone or `Terminating`.
4. Repeat, closing via the taskbar close button, and by typing `exit` inside the shell instead — same result each time.

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- The cleanup is in an unmount effect, not `wrappedOnClose`. The panel's X button and taskbar close both call `Activity.close(id)` directly and never invoke `wrappedOnClose`, so that was the only place a fix would actually cover every close path.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of temporary terminal resources when leaving the node terminal.
  * Ensured resources are also removed if the terminal closes before setup finishes.
  * Added handling and logging for cleanup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->