### PR TITLE
frontend: streamingApi: compare resourceVersion as an opaque string

### DIFF
--- a/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
+++ b/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
@@ -173,6 +173,67 @@ describe('apiProxy', () => {
         server.send(JSON.stringify({ type: 'MODIFIED', object: modifiedConfigMap }));
         expect(cb).toHaveBeenNthCalledWith(3, [{ actionType: 'MODIFIED', ...modifiedConfigMap }]);
       });
+
+      it('applies a MODIFIED event whose resourceVersion is distinct but collapses under parseInt', async () => {
+        const server = new WS(
+          `${wsUrl}clusters/${clusterName}/apis/${mockSingleResource[0]}/${mockSingleResource[1]}/${mockSingleResource[2]}`
+        );
+
+        const client = apiProxy.apiFactory(...mockSingleResource);
+        client.list(cb, errCb, {}, clusterName);
+
+        await server.connected;
+
+        // Two distinct resourceVersions above Number.MAX_SAFE_INTEGER that both
+        // parseInt() to the same number. resourceVersion is opaque, so the newer
+        // MODIFIED event must still be applied.
+        const addedObject = {
+          ...mockConfigMap,
+          metadata: { ...mockConfigMap.metadata, resourceVersion: '18014398509481984' },
+        };
+        const modifiedObject = {
+          ...mockConfigMap,
+          metadata: { ...mockConfigMap.metadata, resourceVersion: '18014398509481985' },
+          data: { ...mockConfigMap.data, volumeName: 'pvc-updated' },
+        };
+
+        server.send(JSON.stringify({ type: 'ADDED', object: addedObject }));
+        server.send(JSON.stringify({ type: 'MODIFIED', object: modifiedObject }));
+
+        expect(cb).toHaveBeenLastCalledWith([{ actionType: 'MODIFIED', ...modifiedObject }]);
+      });
+
+      it('applies a MODIFIED event even when the object has no resourceVersion', async () => {
+        const server = new WS(
+          `${wsUrl}clusters/${clusterName}/apis/${mockSingleResource[0]}/${mockSingleResource[1]}/${mockSingleResource[2]}`
+        );
+
+        const client = apiProxy.apiFactory(...mockSingleResource);
+        client.list(cb, errCb, {}, clusterName);
+
+        await server.connected;
+
+        const addedObject = {
+          ...mockConfigMap,
+          metadata: { ...mockConfigMap.metadata, resourceVersion: '1' },
+        };
+        // A MODIFIED event with no resourceVersion must still be applied, not dropped.
+        const modifiedObject = {
+          ...mockConfigMap,
+          metadata: { ...mockConfigMap.metadata, resourceVersion: undefined },
+          data: { ...mockConfigMap.data, volumeName: 'pvc-no-rv' },
+        };
+
+        server.send(JSON.stringify({ type: 'ADDED', object: addedObject }));
+        server.send(JSON.stringify({ type: 'MODIFIED', object: modifiedObject }));
+
+        expect(cb).toHaveBeenLastCalledWith([
+          expect.objectContaining({
+            actionType: 'MODIFIED',
+            data: expect.objectContaining({ volumeName: 'pvc-no-rv' }),
+          }),
+        ]);
+      });
     });
 
     describe('multipleApiFactory', () => {

--- a/frontend/src/lib/k8s/api/v1/streamingApi.ts
+++ b/frontend/src/lib/k8s/api/v1/streamingApi.ts
@@ -224,13 +224,16 @@ export function streamResultsForCluster(
         const existing = results[object.metadata.uid];
 
         if (existing) {
-          if (!existing.metadata.resourceVersion || !object.metadata.resourceVersion) {
-            console.error('Missing resourceVersion in object', object);
-            break;
-          }
-          const currentVersion = parseInt(existing.metadata.resourceVersion, 10);
-          const newVersion = parseInt(object.metadata.resourceVersion, 10);
-          if (currentVersion < newVersion) {
+          // resourceVersion is an opaque string, so only skip the update when
+          // both versions are present and equal. Parsing it to a number is
+          // wrong: clients must not assume it is numeric or ordered, and large
+          // values exceed JS safe-integer precision, so two distinct versions
+          // can collapse to the same number and silently drop a genuinely newer
+          // event. When either version is missing we apply the update rather
+          // than drop it.
+          const existingRV = existing.metadata.resourceVersion;
+          const newRV = object.metadata.resourceVersion;
+          if (!existingRV || !newRV || existingRV !== newRV) {
             Object.assign(existing, object);
           }
         } else {


### PR DESCRIPTION
## Summary

streamResultsForCluster applied a MODIFIED watch event only when the new resourceVersion parsed to a larger integer than the stored one. Kubernetes treats resourceVersion as an opaque string that clients must not assume is numeric or ordered, and parseInt also loses precision above Number.MAX_SAFE_INTEGER, so two distinct versions can collapse to the same number. When that happens the newer event is silently dropped and the list keeps showing stale data until a manual refresh.

This compares the resourceVersion strings for inequality instead of parsing them to numbers, and drops the separate branch that discarded a MODIFIED event when either resourceVersion was missing. Mirrors the v2 fix in KubeList.applyUpdate (#6550).

## Related Issue

Fixes #6745

## Changes

- Updated streamResultsForCluster in frontend/src/lib/k8s/api/v1/streamingApi.ts to compare resourceVersion as an opaque string instead of parsing it to an int
- Removed the branch that dropped a MODIFIED event when either resourceVersion was missing
- Added a regression test in frontend/src/lib/k8s/api/v1/apiProxy.test.ts

## Steps to Test

1. Run `npm test -- apiProxy` from frontend/ and confirm the new "applies a MODIFIED event whose resourceVersion is distinct but collapses under parseInt" test passes
2. To see it catch the bug, revert just streamingApi.ts to main and rerun — the new test fails, then passes again with the fix
3. The rest of the apiProxy suite stays green (68 tests)

## Screenshots (if applicable)


## Notes for the Reviewer

- Same class of bug as #6548, fixed the same way as its v2 counterpart #6550, just in the older v1 streaming path that's still reachable through apiFactory().list() and the exported plugin API
- The precision collapse needs resourceVersions past the JS safe-integer range so it's rare in practice, but the numeric comparison also breaks the opaque-string contract regardless
