### PR TITLE
Fix/validate backstage postmessage origin

### DIFF
--- a/frontend/src/components/App/Home/index.test.tsx
+++ b/frontend/src/components/App/Home/index.test.tsx
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import { TestContext } from '../../../test';
+
+vi.mock('../../../lib/k8s', () => ({
+  useClustersConf: vi.fn(() => ({})),
+  useClustersVersion: vi.fn(() => [{}, {}]),
+}));
+
+vi.mock('../../../lib/k8s/event', () => ({
+  default: class Event {},
+  useEventWarningList: vi.fn(() => ({})),
+}));
+
+// Keep the test focused on the HEADLAMP_READY wiring by stubbing the heavy children.
+vi.mock('./ClusterTable', () => ({ default: () => null }));
+vi.mock('./RecentClusters', () => ({ default: () => null }));
+vi.mock('../../project/ProjectList', () => ({ default: () => null }));
+vi.mock('../../common/SectionBox', () => ({
+  default: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../../../helpers/isBackstage', () => ({
+  isBackstage: () => true,
+}));
+
+import { useClustersConf } from '../../../lib/k8s';
+import Home from './index';
+
+function renderHome() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TestContext>
+        <Home />
+      </TestContext>
+    </QueryClientProvider>
+  );
+}
+
+describe('Home Backstage readiness notification', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    vi.clearAllMocks();
+    (useClustersConf as Mock).mockReturnValue({
+      c1: { name: 'c1' },
+      c2: { name: 'c2' },
+    });
+    vi.spyOn(window.parent, 'postMessage').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('notifies the single configured origin once', () => {
+    vi.stubEnv('REACT_APP_BACKSTAGE_ORIGIN', 'https://backstage.example.com');
+
+    renderHome();
+
+    expect(window.parent.postMessage).toHaveBeenCalledTimes(1);
+    expect(window.parent.postMessage).toHaveBeenCalledWith(
+      { type: 'HEADLAMP_READY' },
+      'https://backstage.example.com'
+    );
+  });
+
+  it('notifies every configured origin once each', () => {
+    vi.stubEnv(
+      'REACT_APP_BACKSTAGE_ORIGIN',
+      'https://backstage.example.com,https://other-backstage.example.com'
+    );
+
+    renderHome();
+
+    expect(window.parent.postMessage).toHaveBeenCalledTimes(2);
+    expect(window.parent.postMessage).toHaveBeenCalledWith(
+      { type: 'HEADLAMP_READY' },
+      'https://backstage.example.com'
+    );
+    expect(window.parent.postMessage).toHaveBeenCalledWith(
+      { type: 'HEADLAMP_READY' },
+      'https://other-backstage.example.com'
+    );
+  });
+
+  it('sends nothing when no origin is configured', () => {
+    vi.stubEnv('REACT_APP_BACKSTAGE_ORIGIN', '');
+
+    renderHome();
+
+    expect(window.parent.postMessage).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/App/Home/index.tsx
+++ b/frontend/src/components/App/Home/index.tsx
@@ -20,7 +20,10 @@ import { isEqual } from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
-import { setupBackstageMessageReceiver } from '../../../helpers/backstageMessageReceiver';
+import {
+  getTrustedBackstageOrigins,
+  setupBackstageMessageReceiver,
+} from '../../../helpers/backstageMessageReceiver';
 import { useAutoConnectClusters } from '../../../helpers/clusterAutoConnect';
 import { isBackstage } from '../../../helpers/isBackstage';
 import { isElectron } from '../../../helpers/isElectron';
@@ -151,7 +154,11 @@ function HomeComponent(props: HomeComponentProps) {
 
   React.useEffect(() => {
     if (isBackstage()) {
-      window.parent.postMessage({ type: 'HEADLAMP_READY' }, '*');
+      // Only announce readiness to a configured, trusted Backstage origin.
+      const [trustedOrigin] = getTrustedBackstageOrigins();
+      if (trustedOrigin) {
+        window.parent.postMessage({ type: 'HEADLAMP_READY' }, trustedOrigin);
+      }
       return setupBackstageMessageReceiver();
     }
   }, []);

--- a/frontend/src/components/App/Home/index.tsx
+++ b/frontend/src/components/App/Home/index.tsx
@@ -154,11 +154,10 @@ function HomeComponent(props: HomeComponentProps) {
 
   React.useEffect(() => {
     if (isBackstage()) {
-      // Only announce readiness to a configured, trusted Backstage origin.
-      const [trustedOrigin] = getTrustedBackstageOrigins();
-      if (trustedOrigin) {
-        window.parent.postMessage({ type: 'HEADLAMP_READY' }, trustedOrigin);
-      }
+      // Only announce readiness to configured, trusted Backstage origins.
+      getTrustedBackstageOrigins().forEach(origin => {
+        window.parent.postMessage({ type: 'HEADLAMP_READY' }, origin);
+      });
       return setupBackstageMessageReceiver();
     }
   }, []);

--- a/frontend/src/helpers/backstageMessageReceiver.test.ts
+++ b/frontend/src/helpers/backstageMessageReceiver.test.ts
@@ -165,4 +165,78 @@ describe('setupBackstageMessageReceiver', () => {
     expect(findAndReplaceKubeconfig).not.toHaveBeenCalled();
     expect(window.parent.postMessage).not.toHaveBeenCalled();
   });
+
+  it('ignores a null event.data from the trusted origin', async () => {
+    dispatchMessage(null, TRUSTED_ORIGIN);
+    await vi.runAllTimersAsync();
+
+    expect(getBackstageToken()).toBeNull();
+    expect(window.parent.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('ignores a primitive event.data from the trusted origin', async () => {
+    dispatchMessage('not-an-object', TRUSTED_ORIGIN);
+    await vi.runAllTimersAsync();
+
+    expect(getBackstageToken()).toBeNull();
+    expect(window.parent.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('ignores a message with a null payload field', async () => {
+    dispatchMessage({ type: 'BACKSTAGE_AUTH_TOKEN', payload: null }, TRUSTED_ORIGIN);
+    await vi.runAllTimersAsync();
+
+    expect(getBackstageToken()).toBeNull();
+    expect(window.parent.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('ignores a message with a primitive payload field', async () => {
+    dispatchMessage({ type: 'BACKSTAGE_AUTH_TOKEN', payload: 'trusted-token' }, TRUSTED_ORIGIN);
+    await vi.runAllTimersAsync();
+
+    expect(getBackstageToken()).toBeNull();
+    expect(window.parent.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('ignores a message with an unknown type', async () => {
+    dispatchMessage(
+      { type: 'BACKSTAGE_UNKNOWN_TYPE', payload: { token: 'trusted-token' } },
+      TRUSTED_ORIGIN
+    );
+    await vi.runAllTimersAsync();
+
+    expect(getBackstageToken()).toBeNull();
+    expect(window.parent.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('ignores a BACKSTAGE_AUTH_TOKEN message with no token', async () => {
+    dispatchMessage({ type: 'BACKSTAGE_AUTH_TOKEN', payload: {} }, TRUSTED_ORIGIN);
+    await vi.runAllTimersAsync();
+
+    expect(getBackstageToken()).toBeNull();
+    expect(window.parent.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('ignores a BACKSTAGE_AUTH_TOKEN message with a non-string token', async () => {
+    dispatchMessage({ type: 'BACKSTAGE_AUTH_TOKEN', payload: { token: 12345 } }, TRUSTED_ORIGIN);
+    await vi.runAllTimersAsync();
+
+    expect(getBackstageToken()).toBeNull();
+    expect(window.parent.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('ignores a BACKSTAGE_KUBECONFIG message with a non-string kubeconfig', async () => {
+    const findAndReplaceKubeconfig = vi
+      .spyOn(statelessFunctions, 'findAndReplaceKubeconfig')
+      .mockResolvedValue(undefined as any);
+
+    dispatchMessage(
+      { type: 'BACKSTAGE_KUBECONFIG', payload: { kubeconfig: 12345 } },
+      TRUSTED_ORIGIN
+    );
+    await vi.runAllTimersAsync();
+
+    expect(findAndReplaceKubeconfig).not.toHaveBeenCalled();
+    expect(window.parent.postMessage).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/helpers/backstageMessageReceiver.test.ts
+++ b/frontend/src/helpers/backstageMessageReceiver.test.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import jsyaml from 'js-yaml';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as statelessFunctions from '../stateless';
+import {
+  getBackstageToken,
+  getTrustedBackstageOrigins,
+  isTrustedBackstageOrigin,
+  setupBackstageMessageReceiver,
+} from './backstageMessageReceiver';
+import { encodeBase64 } from './base64';
+
+vi.mock('./isBackstage', () => ({
+  isBackstage: () => true,
+}));
+
+const TRUSTED_ORIGIN = 'https://backstage.example.com';
+const UNTRUSTED_ORIGIN = 'https://evil.example.com';
+
+function dispatchMessage(data: unknown, origin: string) {
+  window.dispatchEvent(new MessageEvent('message', { data, origin }));
+}
+
+describe('getTrustedBackstageOrigins / isTrustedBackstageOrigin', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('trusts no origin when REACT_APP_BACKSTAGE_ORIGIN is unset', () => {
+    vi.stubEnv('REACT_APP_BACKSTAGE_ORIGIN', '');
+
+    expect(getTrustedBackstageOrigins()).toEqual([]);
+    expect(isTrustedBackstageOrigin(TRUSTED_ORIGIN)).toBe(false);
+  });
+
+  it('trusts a single configured origin', () => {
+    vi.stubEnv('REACT_APP_BACKSTAGE_ORIGIN', TRUSTED_ORIGIN);
+
+    expect(getTrustedBackstageOrigins()).toEqual([TRUSTED_ORIGIN]);
+    expect(isTrustedBackstageOrigin(TRUSTED_ORIGIN)).toBe(true);
+    expect(isTrustedBackstageOrigin(UNTRUSTED_ORIGIN)).toBe(false);
+  });
+
+  it('trusts a comma-separated list of origins, trimming whitespace', () => {
+    vi.stubEnv(
+      'REACT_APP_BACKSTAGE_ORIGIN',
+      ` ${TRUSTED_ORIGIN} , https://other-backstage.example.com `
+    );
+
+    expect(getTrustedBackstageOrigins()).toEqual([
+      TRUSTED_ORIGIN,
+      'https://other-backstage.example.com',
+    ]);
+    expect(isTrustedBackstageOrigin('https://other-backstage.example.com')).toBe(true);
+  });
+});
+
+describe('setupBackstageMessageReceiver', () => {
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    vi.stubEnv('REACT_APP_BACKSTAGE_ORIGIN', TRUSTED_ORIGIN);
+    vi.useFakeTimers();
+    vi.spyOn(window.parent, 'postMessage').mockImplementation(() => {});
+    cleanup = setupBackstageMessageReceiver();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    localStorage.clear();
+  });
+
+  it('accepts a BACKSTAGE_AUTH_TOKEN message from the trusted origin', async () => {
+    dispatchMessage(
+      { type: 'BACKSTAGE_AUTH_TOKEN', payload: { token: 'trusted-token' } },
+      TRUSTED_ORIGIN
+    );
+    await vi.runAllTimersAsync();
+
+    expect(getBackstageToken()).toBe('trusted-token');
+  });
+
+  it('ignores a message from an untrusted origin and does not store its token', async () => {
+    dispatchMessage(
+      { type: 'BACKSTAGE_AUTH_TOKEN', payload: { token: 'malicious-token' } },
+      UNTRUSTED_ORIGIN
+    );
+    await vi.runAllTimersAsync();
+
+    expect(getBackstageToken()).toBeNull();
+    expect(window.parent.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('sends the acknowledgement only to the validated trusted origin', async () => {
+    dispatchMessage(
+      { type: 'BACKSTAGE_AUTH_TOKEN', payload: { token: 'trusted-token' } },
+      TRUSTED_ORIGIN
+    );
+    await vi.runAllTimersAsync();
+
+    expect(window.parent.postMessage).toHaveBeenCalledTimes(1);
+    expect(window.parent.postMessage).toHaveBeenCalledWith(
+      { type: 'BACKSTAGE_AUTH_TOKEN_ACK' },
+      TRUSTED_ORIGIN
+    );
+  });
+
+  it('stores the kubeconfig and acknowledges a BACKSTAGE_KUBECONFIG message from the trusted origin', async () => {
+    const findAndReplaceKubeconfig = vi
+      .spyOn(statelessFunctions, 'findAndReplaceKubeconfig')
+      .mockResolvedValue(undefined as any);
+
+    const kubeconfig = {
+      apiVersion: 'v1',
+      kind: 'Config',
+      'current-context': 'test-context',
+      contexts: [{ name: 'test-context', context: { cluster: 'test-cluster', user: 'test-user' } }],
+      clusters: [{ name: 'test-cluster', cluster: {} }],
+      users: [{ name: 'test-user', user: {} }],
+    };
+    const kubeconfigBase64 = encodeBase64(jsyaml.dump(kubeconfig));
+
+    dispatchMessage(
+      { type: 'BACKSTAGE_KUBECONFIG', payload: { kubeconfig: kubeconfigBase64 } },
+      TRUSTED_ORIGIN
+    );
+    await vi.runAllTimersAsync();
+
+    expect(findAndReplaceKubeconfig).toHaveBeenCalledWith('test-context', expect.any(String), true);
+    expect(window.parent.postMessage).toHaveBeenCalledWith(
+      { type: 'BACKSTAGE_KUBECONFIG_ACK' },
+      TRUSTED_ORIGIN
+    );
+  });
+
+  it('ignores a BACKSTAGE_KUBECONFIG message from an untrusted origin', async () => {
+    const findAndReplaceKubeconfig = vi
+      .spyOn(statelessFunctions, 'findAndReplaceKubeconfig')
+      .mockResolvedValue(undefined as any);
+
+    dispatchMessage(
+      { type: 'BACKSTAGE_KUBECONFIG', payload: { kubeconfig: 'irrelevant' } },
+      UNTRUSTED_ORIGIN
+    );
+    await vi.runAllTimersAsync();
+
+    expect(findAndReplaceKubeconfig).not.toHaveBeenCalled();
+    expect(window.parent.postMessage).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/helpers/backstageMessageReceiver.ts
+++ b/frontend/src/helpers/backstageMessageReceiver.ts
@@ -143,6 +143,49 @@ interface BackstageMessage {
 
 const BACKSTAGE_ACK_TIMEOUT_MS = 1000;
 
+const BACKSTAGE_MESSAGE_TYPES: Array<BackstageMessage['type']> = [
+  'BACKSTAGE_AUTH_TOKEN',
+  'BACKSTAGE_KUBECONFIG',
+];
+
+/**
+ * isBackstageMessage is a runtime type guard for BackstageMessage.
+ *
+ * event.data comes from outside the application, so its shape cannot be
+ * relied upon to match the BackstageMessage type just because it is cast to
+ * it. This checks the shape at runtime before the message is processed,
+ * rejecting anything that doesn't match rather than letting mistyped fields
+ * (e.g. a non-string token) flow into token/kubeconfig storage.
+ *
+ * @param data - the raw `event.data` from a postMessage event
+ * @returns true if data is a well-formed BackstageMessage
+ */
+function isBackstageMessage(data: unknown): data is BackstageMessage {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+
+  const { type, payload } = data as Record<string, unknown>;
+
+  if (!BACKSTAGE_MESSAGE_TYPES.includes(type as BackstageMessage['type'])) {
+    return false;
+  }
+
+  if (payload === undefined) {
+    return true;
+  }
+
+  if (typeof payload !== 'object' || payload === null) {
+    return false;
+  }
+
+  const { token, kubeconfig } = payload as Record<string, unknown>;
+  return (
+    (token === undefined || typeof token === 'string') &&
+    (kubeconfig === undefined || typeof kubeconfig === 'string')
+  );
+}
+
 /**
  * Sets up a listener for messages from the Backstage app.
  * Handles Backstage auth token messages by storing the Backstage token,
@@ -158,8 +201,12 @@ export function setupBackstageMessageReceiver(): () => void {
         return;
       }
 
+      if (!isBackstageMessage(event.data)) {
+        return;
+      }
+
       try {
-        const { type, payload } = event.data as BackstageMessage;
+        const { type, payload } = event.data;
         if (type === 'BACKSTAGE_AUTH_TOKEN') {
           const { token } = payload || {};
           if (token) {

--- a/frontend/src/helpers/backstageMessageReceiver.ts
+++ b/frontend/src/helpers/backstageMessageReceiver.ts
@@ -24,6 +24,39 @@ import { isBackstage } from './isBackstage';
 const BACKSTAGE_TOKEN_STORAGE_KEY = 'backstage_token';
 
 /**
+ * getTrustedBackstageOrigins returns the origins that are allowed to exchange
+ * postMessage data with the embedded Headlamp instance.
+ *
+ * Configured via the REACT_APP_BACKSTAGE_ORIGIN environment variable, which
+ * may contain a single origin or a comma-separated list of origins (useful
+ * when the same Headlamp build is embedded by more than one Backstage
+ * deployment). If unset, no origin is trusted.
+ *
+ * @returns the list of trusted Backstage origins
+ */
+export function getTrustedBackstageOrigins(): string[] {
+  const configuredOrigins = import.meta.env.REACT_APP_BACKSTAGE_ORIGIN;
+  if (!configuredOrigins) {
+    return [];
+  }
+
+  return configuredOrigins
+    .split(',')
+    .map((origin: string) => origin.trim())
+    .filter(Boolean);
+}
+
+/**
+ * isTrustedBackstageOrigin checks whether the given origin is a configured, trusted Backstage origin.
+ *
+ * @param origin - the origin to check, e.g. from a MessageEvent
+ * @returns true if the origin is trusted
+ */
+export function isTrustedBackstageOrigin(origin: string): boolean {
+  return getTrustedBackstageOrigins().includes(origin);
+}
+
+/**
  * setBackstageToken sets the backstage token in the local storage
  *
  * @param token - the token to set
@@ -120,6 +153,11 @@ const BACKSTAGE_ACK_TIMEOUT_MS = 1000;
 export function setupBackstageMessageReceiver(): () => void {
   if (isBackstage()) {
     const handleMessage = async (event: MessageEvent) => {
+      // Reject messages from any origin that isn't an explicitly trusted Backstage origin.
+      if (!isTrustedBackstageOrigin(event.origin)) {
+        return;
+      }
+
       try {
         const { type, payload } = event.data as BackstageMessage;
         if (type === 'BACKSTAGE_AUTH_TOKEN') {
@@ -128,7 +166,7 @@ export function setupBackstageMessageReceiver(): () => void {
             setBackstageToken(token);
             // send acknowledgement message back to parent after a timeout to ensure the parent is ready to receive the acknowledgement.
             setTimeout(() => {
-              window.parent.postMessage({ type: 'BACKSTAGE_AUTH_TOKEN_ACK' }, '*');
+              window.parent.postMessage({ type: 'BACKSTAGE_AUTH_TOKEN_ACK' }, event.origin);
             }, BACKSTAGE_ACK_TIMEOUT_MS);
           }
         } else if (type === 'BACKSTAGE_KUBECONFIG') {
@@ -138,7 +176,7 @@ export function setupBackstageMessageReceiver(): () => void {
             await storeKubeconfigFromBackstage(kubeconfig);
             // send acknowledgement message back to parent after a timeout to ensure the parent is ready to receive the acknowledgement.
             setTimeout(() => {
-              window.parent.postMessage({ type: 'BACKSTAGE_KUBECONFIG_ACK' }, '*');
+              window.parent.postMessage({ type: 'BACKSTAGE_KUBECONFIG_ACK' }, event.origin);
             }, BACKSTAGE_ACK_TIMEOUT_MS);
           }
         }


### PR DESCRIPTION
## Summary

This PR fixes a security issue in the Backstage integration by validating the origin of incoming `window.postMessage` events before processing authentication messages. It also replaces wildcard (`"*"`) target origins with explicitly trusted origins when sending messages back to the parent window.

Additionally, the `HEADLAMP_READY` message sent from the Home page is now posted only to a configured trusted origin.

## Related Issue

Fixes #6754, #6757

## Changes

* Added trusted origin validation for incoming Backstage `postMessage` events.
* Introduced helper functions to determine trusted origins from `REACT_APP_BACKSTAGE_ORIGIN`.
* Ignored messages received from untrusted origins before processing authentication tokens or kubeconfig data.
* Replaced wildcard (`"*"` ) target origins with the validated `event.origin` when sending `BACKSTAGE_AUTH_TOKEN_ACK`.
* Updated the `HEADLAMP_READY` message to target only the configured trusted origin.
* Added comprehensive unit tests covering:

  * trusted origin acceptance,
  * untrusted origin rejection,
  * prevention of token storage from untrusted origins,
  * ACK messages sent only to validated origins,
  * preservation of existing behavior for valid messages, including kubeconfig storage.

## Steps to Test

1. Configure `REACT_APP_BACKSTAGE_ORIGIN` with a trusted Backstage origin.
2. Run the frontend and send a valid `BACKSTAGE_AUTH_TOKEN` message from the configured origin.
3. Verify that the authentication token and kubeconfig (when provided) are processed correctly.
4. Send the same message from an untrusted origin.
5. Verify that the message is ignored and no authentication token or kubeconfig is stored.
6. Confirm that `BACKSTAGE_AUTH_TOKEN_ACK` is sent only to the validated sender origin.
7. Verify that `HEADLAMP_READY` is sent only when a trusted origin is configured.

## Notes for the Reviewer

* This change is security-focused and preserves existing behavior for trusted Backstage integrations.
* The implementation affects only the Backstage `postMessage` communication flow and the `HEADLAMP_READY` message.
* Added unit tests to cover both trusted and untrusted origin scenarios and ensure existing functionality remains unchanged.
