### PR TITLE
backend: Guard the drain status cache value type assertion

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -2967,7 +2967,7 @@ func (c *HeadlampConfig) drainNodePods(
 Since node drain is an async operation, we need to poll for the status of the drain operation
 This endpoint returns the status of the drain operation.
 */
-func (c *HeadlampConfig) handleNodeDrainStatus(w http.ResponseWriter, r *http.Request) {
+func (c *HeadlampConfig) handleNodeDrainStatus(w http.ResponseWriter, r *http.Request) { //nolint:funlen
 	start := time.Now()
 	ctx := r.Context()
 
@@ -3008,12 +3008,22 @@ func (c *HeadlampConfig) handleNodeDrainStatus(w http.ResponseWriter, r *http.Re
 
 		return
 	}
+	// The cache is shared and typed as interface{}, so guard the assertion
+	// instead of letting a non-string value panic the handler.
+	id, ok := cacheItem.(string)
+	if !ok {
+		c.handleError(w, ctx, span, fmt.Errorf("unexpected cache value type %T", cacheItem),
+			"invalid drain status", http.StatusInternalServerError)
+
+		return
+	}
+
 	// Prepare successful response
 	responsePayload := struct {
 		ID      string `json:"id"`
 		Cluster string `json:"cluster"`
 	}{
-		ID:      cacheItem.(string),
+		ID:      id,
 		Cluster: drainPayload.Cluster,
 	}
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -912,6 +912,44 @@ func TestDrainAndCordonNode(t *testing.T) { //nolint:funlen
 	}
 }
 
+func TestDrainNodeStatusNonStringCacheValue(t *testing.T) {
+	cache := cache.New[interface{}]()
+	kubeConfigStore := kubeconfig.NewContextStore()
+	kubeConfigPath := filepath.Join("headlamp_testdata", "kubeconfig")
+
+	handler := createHeadlampHandler(context.Background(), &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:    false,
+				KubeConfigPath:  kubeConfigPath,
+				KubeConfigStore: kubeConfigStore,
+			},
+			Cache:            cache,
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	})
+
+	cacheKey := uuid.NewSHA1(uuid.Nil, []byte(minikubeName+"\x00"+minikubeName)).String()
+
+	// A non-string value under the drain status key must not panic the handler.
+	if err := cache.SetWithTTL(context.Background(), cacheKey, true, DrainNodeCacheTTL*time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	url := fmt.Sprintf("/drain-node-status?cluster=%s&nodeName=%s", minikubeName, minikubeName)
+
+	rr, err := getResponse(handler, "GET", url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if status := rr.Code; status != http.StatusInternalServerError {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusInternalServerError)
+	}
+}
+
 func TestDrainNodePodDeletionFailure(t *testing.T) { //nolint:funlen
 	podOk := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary

handleNodeDrainStatus reads a value from the shared cache and asserts it to a string with a bare cacheItem.(string). The cache is typed interface{}, so a non-string value under that key would panic the handler. The panic is recovered per request, but a handler shouldn't be able to panic on a cache read, and the cache is shared with other values.

This uses a comma-ok assertion and returns a 500 with a clear message when the value isn't a string instead of asserting blindly.

## Related Issue

Fixes #6750

## Changes

- Updated handleNodeDrainStatus in backend/cmd/headlamp.go to guard the cache value assertion with a comma-ok check and return a 500 via c.handleError when it isn't a string
- Added TestDrainNodeStatusNonStringCacheValue in backend/cmd/headlamp_test.go

## Steps to Test

1. Run `go test ./cmd/ -run TestDrainNodeStatusNonStringCacheValue` from backend/ and confirm it passes
2. To see it catch the bug, revert just the headlamp.go change and rerun, the test panics with "interface conversion: interface {} is bool, not string", then passes again with the fix
3. The rest of the cmd suite stays green and golangci-lint reports no issues

## Screenshots (if applicable)


## Notes for the Reviewer

- Not triggerable today: the drain path only stores strings ("success", "error: ...") under this key and the key is a UUID from the node name and cluster so it can't collide with the other values in the shared cache. This is defensive hardening, matching how the adjacent handlers guard their inputs
- Added //nolint:funlen to the handler to match the neighbouring handleNodeDrain, since the guard pushed it a few lines over the limit
