### PR TITLE
frontend: Project: Add Storybook stories for ResourceCategoriesList

### DIFF
--- a/frontend/src/components/project/ResourceCategoriesList.stories.tsx
+++ b/frontend/src/components/project/ResourceCategoriesList.stories.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import { KubeObject } from '../../lib/k8s/KubeObject';
+import { categoriesConfig } from '../../lib/k8s/ResourceCategory';
+import { KubeObjectStatus } from '../resourceMap/nodes/KubeObjectStatus';
+import { ResourceCategoriesList } from './ResourceCategoriesList';
+
+export default {
+  title: 'project/ResourceCategoriesList',
+  component: ResourceCategoriesList,
+} as Meta;
+
+const [workloads, storage, network] = categoriesConfig;
+
+/** The list only reads items.length, so the items themselves can be empty. */
+function makeItems(count: number) {
+  return Array.from({ length: count }, () => ({} as KubeObject));
+}
+
+function makeHealth(health: Partial<Record<KubeObjectStatus, number>>) {
+  return { success: 0, warning: 0, error: 0, ...health };
+}
+
+function makeCategory(
+  category: (typeof categoriesConfig)[number],
+  health: Partial<Record<KubeObjectStatus, number>>
+) {
+  const counts = makeHealth(health);
+  return {
+    category,
+    items: makeItems(counts.success + counts.warning + counts.error),
+    health: counts,
+  };
+}
+
+const Template: StoryFn<typeof ResourceCategoriesList> = args => (
+  <ResourceCategoriesList {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  categoryList: [
+    makeCategory(workloads, { success: 8 }),
+    makeCategory(storage, { success: 3 }),
+    makeCategory(network, { success: 2 }),
+  ],
+  onCategoryClick: () => {},
+};
+
+export const WithWarnings = Template.bind({});
+WithWarnings.args = {
+  categoryList: [
+    makeCategory(workloads, { success: 5, warning: 2 }),
+    makeCategory(storage, { success: 3 }),
+  ],
+  onCategoryClick: () => {},
+};
+
+export const WithErrors = Template.bind({});
+WithErrors.args = {
+  categoryList: [
+    makeCategory(workloads, { success: 4, warning: 1, error: 2 }),
+    makeCategory(storage, { success: 3 }),
+  ],
+  onCategoryClick: () => {},
+};
+
+export const EmptyCategory = Template.bind({});
+EmptyCategory.args = {
+  categoryList: [makeCategory(workloads, { success: 4 }), makeCategory(storage, {})],
+  onCategoryClick: () => {},
+};
+
+export const SelectedCategory = Template.bind({});
+SelectedCategory.args = {
+  categoryList: [
+    makeCategory(workloads, { success: 8 }),
+    makeCategory(storage, { success: 3 }),
+    makeCategory(network, { success: 2 }),
+  ],
+  selectedCategoryName: storage.label,
+  onCategoryClick: () => {},
+};
+
+export const Empty = Template.bind({});
+Empty.args = {
+  categoryList: [],
+  onCategoryClick: () => {},
+};

--- a/frontend/src/components/project/__snapshots__/ResourceCategoriesList.Default.stories.storyshot
+++ b/frontend/src/components/project/__snapshots__/ResourceCategoriesList.Default.stories.storyshot
@@ -1,0 +1,141 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-6su6fj"
+    >
+      <ul
+        class="MuiList-root MuiList-padding MuiList-dense css-h4y409-MuiList-root"
+      >
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters css-g2go0r-MuiListItem-root"
+        >
+          <div
+            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters css-12sacnv-MuiButtonBase-root-MuiListItemButton-root"
+            role="button"
+            tabindex="0"
+          >
+            <div
+              class="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
+            />
+            <div
+              class="MuiListItemText-root MuiListItemText-dense MuiListItemText-multiline css-konndc-MuiListItemText-root"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              >
+                Workloads
+              </span>
+              <p
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+              >
+                Applications and compute resources
+              </p>
+            </div>
+            <div
+              class="MuiListItemIcon-root css-1fqgk7o-MuiListItemIcon-root"
+            >
+              <div
+                class="MuiBox-root css-171onha"
+              >
+                <h6
+                  class="MuiTypography-root MuiTypography-h6 css-ay2tpq-MuiTypography-root"
+                >
+                  8
+                </h6>
+              </div>
+            </div>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </div>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters css-g2go0r-MuiListItem-root"
+        >
+          <div
+            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters css-12sacnv-MuiButtonBase-root-MuiListItemButton-root"
+            role="button"
+            tabindex="0"
+          >
+            <div
+              class="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
+            />
+            <div
+              class="MuiListItemText-root MuiListItemText-dense MuiListItemText-multiline css-konndc-MuiListItemText-root"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              >
+                Storage
+              </span>
+              <p
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+              >
+                Persistent data storage
+              </p>
+            </div>
+            <div
+              class="MuiListItemIcon-root css-1fqgk7o-MuiListItemIcon-root"
+            >
+              <div
+                class="MuiBox-root css-171onha"
+              >
+                <h6
+                  class="MuiTypography-root MuiTypography-h6 css-ay2tpq-MuiTypography-root"
+                >
+                  3
+                </h6>
+              </div>
+            </div>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </div>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters css-g2go0r-MuiListItem-root"
+        >
+          <div
+            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters css-12sacnv-MuiButtonBase-root-MuiListItemButton-root"
+            role="button"
+            tabindex="0"
+          >
+            <div
+              class="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
+            />
+            <div
+              class="MuiListItemText-root MuiListItemText-dense MuiListItemText-multiline css-konndc-MuiListItemText-root"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              >
+                Network
+              </span>
+              <p
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+              >
+                Network connectivity and exposure
+              </p>
+            </div>
+            <div
+              class="MuiListItemIcon-root css-1fqgk7o-MuiListItemIcon-root"
+            >
+              <div
+                class="MuiBox-root css-171onha"
+              >
+                <h6
+                  class="MuiTypography-root MuiTypography-h6 css-ay2tpq-MuiTypography-root"
+                >
+                  2
+                </h6>
+              </div>
+            </div>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/project/__snapshots__/ResourceCategoriesList.Empty.stories.storyshot
+++ b/frontend/src/components/project/__snapshots__/ResourceCategoriesList.Empty.stories.storyshot
@@ -1,0 +1,11 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-6su6fj"
+    >
+      <ul
+        class="MuiList-root MuiList-padding MuiList-dense css-h4y409-MuiList-root"
+      />
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/project/__snapshots__/ResourceCategoriesList.EmptyCategory.stories.storyshot
+++ b/frontend/src/components/project/__snapshots__/ResourceCategoriesList.EmptyCategory.stories.storyshot
@@ -1,0 +1,98 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-6su6fj"
+    >
+      <ul
+        class="MuiList-root MuiList-padding MuiList-dense css-h4y409-MuiList-root"
+      >
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters css-g2go0r-MuiListItem-root"
+        >
+          <div
+            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters css-12sacnv-MuiButtonBase-root-MuiListItemButton-root"
+            role="button"
+            tabindex="0"
+          >
+            <div
+              class="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
+            />
+            <div
+              class="MuiListItemText-root MuiListItemText-dense MuiListItemText-multiline css-konndc-MuiListItemText-root"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              >
+                Workloads
+              </span>
+              <p
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+              >
+                Applications and compute resources
+              </p>
+            </div>
+            <div
+              class="MuiListItemIcon-root css-1fqgk7o-MuiListItemIcon-root"
+            >
+              <div
+                class="MuiBox-root css-171onha"
+              >
+                <h6
+                  class="MuiTypography-root MuiTypography-h6 css-ay2tpq-MuiTypography-root"
+                >
+                  4
+                </h6>
+              </div>
+            </div>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </div>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters css-g2go0r-MuiListItem-root"
+        >
+          <div
+            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters css-12sacnv-MuiButtonBase-root-MuiListItemButton-root"
+            role="button"
+            tabindex="0"
+          >
+            <div
+              class="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
+            />
+            <div
+              class="MuiListItemText-root MuiListItemText-dense MuiListItemText-multiline css-konndc-MuiListItemText-root"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              >
+                Storage
+              </span>
+              <p
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+              >
+                Persistent data storage
+              </p>
+            </div>
+            <div
+              class="MuiListItemIcon-root css-1fqgk7o-MuiListItemIcon-root"
+            >
+              <div
+                class="MuiBox-root css-171onha"
+              >
+                <h6
+                  class="MuiTypography-root MuiTypography-h6 css-1r13x7i-MuiTypography-root"
+                >
+                  0
+                </h6>
+              </div>
+            </div>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/project/__snapshots__/ResourceCategoriesList.SelectedCategory.stories.storyshot
+++ b/frontend/src/components/project/__snapshots__/ResourceCategoriesList.SelectedCategory.stories.storyshot
@@ -1,0 +1,141 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-6su6fj"
+    >
+      <ul
+        class="MuiList-root MuiList-padding MuiList-dense css-h4y409-MuiList-root"
+      >
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters css-g2go0r-MuiListItem-root"
+        >
+          <div
+            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters css-12sacnv-MuiButtonBase-root-MuiListItemButton-root"
+            role="button"
+            tabindex="0"
+          >
+            <div
+              class="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
+            />
+            <div
+              class="MuiListItemText-root MuiListItemText-dense MuiListItemText-multiline css-konndc-MuiListItemText-root"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              >
+                Workloads
+              </span>
+              <p
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+              >
+                Applications and compute resources
+              </p>
+            </div>
+            <div
+              class="MuiListItemIcon-root css-1fqgk7o-MuiListItemIcon-root"
+            >
+              <div
+                class="MuiBox-root css-171onha"
+              >
+                <h6
+                  class="MuiTypography-root MuiTypography-h6 css-ay2tpq-MuiTypography-root"
+                >
+                  8
+                </h6>
+              </div>
+            </div>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </div>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters css-g2go0r-MuiListItem-root"
+        >
+          <div
+            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters Mui-selected css-12sacnv-MuiButtonBase-root-MuiListItemButton-root"
+            role="button"
+            tabindex="0"
+          >
+            <div
+              class="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
+            />
+            <div
+              class="MuiListItemText-root MuiListItemText-dense MuiListItemText-multiline css-konndc-MuiListItemText-root"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              >
+                Storage
+              </span>
+              <p
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+              >
+                Persistent data storage
+              </p>
+            </div>
+            <div
+              class="MuiListItemIcon-root css-1fqgk7o-MuiListItemIcon-root"
+            >
+              <div
+                class="MuiBox-root css-171onha"
+              >
+                <h6
+                  class="MuiTypography-root MuiTypography-h6 css-ay2tpq-MuiTypography-root"
+                >
+                  3
+                </h6>
+              </div>
+            </div>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </div>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters css-g2go0r-MuiListItem-root"
+        >
+          <div
+            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters css-12sacnv-MuiButtonBase-root-MuiListItemButton-root"
+            role="button"
+            tabindex="0"
+          >
+            <div
+              class="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
+            />
+            <div
+              class="MuiListItemText-root MuiListItemText-dense MuiListItemText-multiline css-konndc-MuiListItemText-root"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              >
+                Network
+              </span>
+              <p
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+              >
+                Network connectivity and exposure
+              </p>
+            </div>
+            <div
+              class="MuiListItemIcon-root css-1fqgk7o-MuiListItemIcon-root"
+            >
+              <div
+                class="MuiBox-root css-171onha"
+              >
+                <h6
+                  class="MuiTypography-root MuiTypography-h6 css-ay2tpq-MuiTypography-root"
+                >
+                  2
+                </h6>
+              </div>
+            </div>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/project/__snapshots__/ResourceCategoriesList.WithErrors.stories.storyshot
+++ b/frontend/src/components/project/__snapshots__/ResourceCategoriesList.WithErrors.stories.storyshot
@@ -1,0 +1,98 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-6su6fj"
+    >
+      <ul
+        class="MuiList-root MuiList-padding MuiList-dense css-h4y409-MuiList-root"
+      >
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters css-g2go0r-MuiListItem-root"
+        >
+          <div
+            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters css-12sacnv-MuiButtonBase-root-MuiListItemButton-root"
+            role="button"
+            tabindex="0"
+          >
+            <div
+              class="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
+            />
+            <div
+              class="MuiListItemText-root MuiListItemText-dense MuiListItemText-multiline css-konndc-MuiListItemText-root"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              >
+                Workloads
+              </span>
+              <p
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+              >
+                Applications and compute resources
+              </p>
+            </div>
+            <div
+              class="MuiListItemIcon-root css-1fqgk7o-MuiListItemIcon-root"
+            >
+              <div
+                class="MuiBox-root css-171onha"
+              >
+                <h6
+                  class="MuiTypography-root MuiTypography-h6 css-1xkn1z3-MuiTypography-root"
+                >
+                  7
+                </h6>
+              </div>
+            </div>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </div>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters css-g2go0r-MuiListItem-root"
+        >
+          <div
+            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters css-12sacnv-MuiButtonBase-root-MuiListItemButton-root"
+            role="button"
+            tabindex="0"
+          >
+            <div
+              class="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
+            />
+            <div
+              class="MuiListItemText-root MuiListItemText-dense MuiListItemText-multiline css-konndc-MuiListItemText-root"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              >
+                Storage
+              </span>
+              <p
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+              >
+                Persistent data storage
+              </p>
+            </div>
+            <div
+              class="MuiListItemIcon-root css-1fqgk7o-MuiListItemIcon-root"
+            >
+              <div
+                class="MuiBox-root css-171onha"
+              >
+                <h6
+                  class="MuiTypography-root MuiTypography-h6 css-ay2tpq-MuiTypography-root"
+                >
+                  3
+                </h6>
+              </div>
+            </div>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/project/__snapshots__/ResourceCategoriesList.WithWarnings.stories.storyshot
+++ b/frontend/src/components/project/__snapshots__/ResourceCategoriesList.WithWarnings.stories.storyshot
@@ -1,0 +1,98 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-6su6fj"
+    >
+      <ul
+        class="MuiList-root MuiList-padding MuiList-dense css-h4y409-MuiList-root"
+      >
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters css-g2go0r-MuiListItem-root"
+        >
+          <div
+            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters css-12sacnv-MuiButtonBase-root-MuiListItemButton-root"
+            role="button"
+            tabindex="0"
+          >
+            <div
+              class="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
+            />
+            <div
+              class="MuiListItemText-root MuiListItemText-dense MuiListItemText-multiline css-konndc-MuiListItemText-root"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              >
+                Workloads
+              </span>
+              <p
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+              >
+                Applications and compute resources
+              </p>
+            </div>
+            <div
+              class="MuiListItemIcon-root css-1fqgk7o-MuiListItemIcon-root"
+            >
+              <div
+                class="MuiBox-root css-171onha"
+              >
+                <h6
+                  class="MuiTypography-root MuiTypography-h6 css-mw8x6p-MuiTypography-root"
+                >
+                  7
+                </h6>
+              </div>
+            </div>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </div>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters css-g2go0r-MuiListItem-root"
+        >
+          <div
+            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-dense MuiListItemButton-gutters css-12sacnv-MuiButtonBase-root-MuiListItemButton-root"
+            role="button"
+            tabindex="0"
+          >
+            <div
+              class="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
+            />
+            <div
+              class="MuiListItemText-root MuiListItemText-dense MuiListItemText-multiline css-konndc-MuiListItemText-root"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              >
+                Storage
+              </span>
+              <p
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+              >
+                Persistent data storage
+              </p>
+            </div>
+            <div
+              class="MuiListItemIcon-root css-1fqgk7o-MuiListItemIcon-root"
+            >
+              <div
+                class="MuiBox-root css-171onha"
+              >
+                <h6
+                  class="MuiTypography-root MuiTypography-h6 css-ay2tpq-MuiTypography-root"
+                >
+                  3
+                </h6>
+              </div>
+            </div>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
## Summary

Adds Storybook stories (which double as snapshot tests via `frontend/src/storybook.test.tsx`) for `project/ResourceCategoriesList.tsx`, which had neither a story nor a unit test. It is rendered by both `ProjectDetails.tsx` and `ProjectResourcesTab.tsx`, so its render branches were previously uncovered by the snapshot suite. Every other component in `project/` already has a story.

Closes #6753

## Changes

Added `ResourceCategoriesList.stories.tsx` with 6 stories covering the render branches:

- `Default`: categories with items, all healthy (`mdi:check-circle`, `success.main`).
- `WithWarnings`: a category with `warning > 0` (`mdi:alert`, `warning.main`).
- `WithErrors`: a category with `error > 0`, which takes precedence over warnings (`mdi:alert-circle`, `error.main`).
- `EmptyCategory`: a category with zero items, so the count renders in `text.primary` and the health icon is suppressed.
- `SelectedCategory`: `selectedCategoryName` matching one row, exercising the `ListItemButton selected` styling.
- `Empty`: `categoryList: []`, renders an empty list.

Plus the generated storyshot snapshots. The hand written change is ~104 lines, the remaining ~587 lines are generated snapshots.

## Notes for the reviewer

- The component is purely props driven, so the stories need no MSW handlers, no Redux store and no router wrapper.
- Stories use the real `categoriesConfig` entries from `lib/k8s/ResourceCategory`. A small `makeCategory(category, health)` helper derives `items` from the health counts so the count and the color always agree. The list only reads `items.length`, so the items themselves are empty.
- The health color and icon mapping mirrors `getHealthIcon` in `projectUtils.ts`, so these stories double as coverage for it.
- Snapshots are deterministic: no timestamps, so nothing time or locale dependent. Iconify `<Icon>` renders as an empty element under jsdom, which is the norm across this repo's snapshots.

## Steps to test

1. `cd frontend && npm run storybook`, then open `project/ResourceCategoriesList` and check the six variants.
2. `npx vitest run src/storybook.test.tsx` passes with no snapshot drift (657 tests pass locally).
