### PR TITLE
frontend: gate Gateway API sidebar entry on cluster API discovery

### DIFF
--- a/frontend/src/components/Sidebar/Sidebar.stories.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.stories.tsx
@@ -19,6 +19,7 @@ import { Meta, StoryFn } from '@storybook/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { http, HttpResponse } from 'msw';
 import { SnackbarProvider } from 'notistack';
+import { useEffect, useRef } from 'react';
 import { initialState as THEME_INITIAL_STATE } from '../../components/App/themeSlice';
 import { initialState as CONFIG_INITIAL_STATE } from '../../redux/configSlice';
 import { initialState as FILTER_INITIAL_STATE } from '../../redux/filterSlice';
@@ -111,6 +112,143 @@ InClusterSidebarOpen.args = {
     sidebar: DefaultSidebars.IN_CLUSTER,
   },
 };
+const TemplateWithCluster: StoryFn<StoryProps> = args => {
+  // getCluster()/useCluster() read window.location directly rather than the
+  // MemoryRouter context, so TestContext's routerMap alone doesn't give
+  // components a real selected cluster in stories/tests. Set it explicitly
+  // before the tree below mounts (its initial state is captured synchronously
+  // on first render), and restore the original path on unmount so this
+  // doesn't leak into other stories/tests sharing the same jsdom window.
+  const originalPathnameRef = useRef<string>();
+  if (originalPathnameRef.current === undefined) {
+    originalPathnameRef.current = window.location.pathname;
+    window.history.replaceState(null, '', '/c/test-cluster');
+  }
+  useEffect(() => {
+    return () => {
+      window.history.replaceState(null, '', originalPathnameRef.current);
+    };
+  }, []);
+
+  const sidebarStore = configureStore({
+    reducer: (
+      state = {
+        ui: { ...uiSlice.getInitialState() },
+      }
+    ) => state,
+    preloadedState: {
+      plugins: { loaded: true },
+      theme: { ...THEME_INITIAL_STATE },
+      config: { ...CONFIG_INITIAL_STATE },
+      filter: { ...FILTER_INITIAL_STATE },
+      ui: { ...uiSlice.getInitialState() },
+      projects: { projects: {} },
+      sidebar: {
+        ...SIDEBAR_INITIAL_STATE,
+        isVisible: true,
+        ...args,
+      },
+    },
+  });
+  const queryClient = new QueryClient();
+
+  return (
+    <TestContext store={sidebarStore} urlPrefix="/c" routerMap={{ cluster: 'test-cluster' }}>
+      <SnackbarProvider>
+        <QueryClientProvider client={queryClient}>
+          <Sidebar />
+        </QueryClientProvider>
+      </SnackbarProvider>
+    </TestContext>
+  );
+};
+
+export const GatewayAPIUnavailable = TemplateWithCluster.bind({});
+GatewayAPIUnavailable.args = {
+  isSidebarOpen: true,
+  selected: {
+    item: 'cluster',
+    sidebar: DefaultSidebars.IN_CLUSTER,
+  },
+};
+GatewayAPIUnavailable.parameters = {
+  msw: {
+    handlers: {
+      story: [
+        http.get(
+          `${API_BASE}/clusters/:cluster/apis/apiextensions.k8s.io/v1/customresourcedefinitions`,
+          () => HttpResponse.json({ kind: 'List', items: [], metadata: {} })
+        ),
+        http.get(
+          `${API_BASE}/clusters/:cluster/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions`,
+          () => HttpResponse.json({ kind: 'List', items: [], metadata: {} })
+        ),
+        http.get(`${API_BASE}/clusters/:cluster/apis/gateway.networking.k8s.io/v1`, () =>
+          HttpResponse.json({ message: 'Not Found' }, { status: 404 })
+        ),
+        http.get(`${API_BASE}/clusters/:cluster/apis/gateway.networking.k8s.io/v1beta1`, () =>
+          HttpResponse.json({ message: 'Not Found' }, { status: 404 })
+        ),
+        http.get(`${API_BASE}/clusters/:cluster/apis/gateway.networking.k8s.io/v1alpha2`, () =>
+          HttpResponse.json({ message: 'Not Found' }, { status: 404 })
+        ),
+        http.get(`${API_BASE}/clusters/:cluster/apis/scheduling.k8s.io/v1beta1`, () =>
+          HttpResponse.json({ message: 'Not Found' }, { status: 404 })
+        ),
+        http.get(`${API_BASE}/clusters/:cluster/apis/scheduling.k8s.io/v1alpha3`, () =>
+          HttpResponse.json({ message: 'Not Found' }, { status: 404 })
+        ),
+        http.get(`${API_BASE}/clusters/:cluster/apis/scheduling.k8s.io/v1alpha2`, () =>
+          HttpResponse.json({ message: 'Not Found' }, { status: 404 })
+        ),
+      ],
+    },
+  },
+};
+
+export const GatewayAPIAvailable = TemplateWithCluster.bind({});
+GatewayAPIAvailable.args = {
+  isSidebarOpen: true,
+  selected: {
+    item: 'cluster',
+    sidebar: DefaultSidebars.IN_CLUSTER,
+  },
+};
+GatewayAPIAvailable.parameters = {
+  msw: {
+    handlers: {
+      story: [
+        http.get(
+          `${API_BASE}/clusters/:cluster/apis/apiextensions.k8s.io/v1/customresourcedefinitions`,
+          () => HttpResponse.json({ kind: 'List', items: [], metadata: {} })
+        ),
+        http.get(
+          `${API_BASE}/clusters/:cluster/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions`,
+          () => HttpResponse.json({ kind: 'List', items: [], metadata: {} })
+        ),
+        http.get(`${API_BASE}/clusters/:cluster/apis/gateway.networking.k8s.io/v1`, () =>
+          HttpResponse.json({ kind: 'APIResourceList', resources: [] })
+        ),
+        http.get(`${API_BASE}/clusters/:cluster/apis/gateway.networking.k8s.io/v1beta1`, () =>
+          HttpResponse.json({ kind: 'APIResourceList', resources: [] })
+        ),
+        http.get(`${API_BASE}/clusters/:cluster/apis/gateway.networking.k8s.io/v1alpha2`, () =>
+          HttpResponse.json({ kind: 'APIResourceList', resources: [] })
+        ),
+        http.get(`${API_BASE}/clusters/:cluster/apis/scheduling.k8s.io/v1beta1`, () =>
+          HttpResponse.json({ message: 'Not Found' }, { status: 404 })
+        ),
+        http.get(`${API_BASE}/clusters/:cluster/apis/scheduling.k8s.io/v1alpha3`, () =>
+          HttpResponse.json({ message: 'Not Found' }, { status: 404 })
+        ),
+        http.get(`${API_BASE}/clusters/:cluster/apis/scheduling.k8s.io/v1alpha2`, () =>
+          HttpResponse.json({ message: 'Not Found' }, { status: 404 })
+        ),
+      ],
+    },
+  },
+};
+
 export const InClusterSidebarClosed = Template.bind({});
 InClusterSidebarClosed.args = {
   isSidebarOpen: false,

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.GatewayAPIAvailable.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.GatewayAPIAvailable.stories.storyshot
@@ -1,0 +1,469 @@
+<body>
+  <div>
+    <nav
+      aria-label="Navigation"
+      class="MuiBox-root css-qnyptn"
+    >
+      <div
+        class="MuiDrawer-root MuiDrawer-docked css-1k1thb6-MuiDrawer-docked"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiDrawer-paper MuiDrawer-paperAnchorLeft MuiDrawer-paperAnchorDockedLeft css-2vc5z5-MuiPaper-root-MuiDrawer-paper"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column MuiGrid-wrap-xs-nowrap css-opqjvv-MuiGrid-root"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <ul
+                class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
+              >
+                <li
+                  class="css-3knmzx"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiListItemIcon-root css-1blhdvq-MuiListItemIcon-root"
+                    />
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                      >
+                        Home
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </li>
+                <li
+                  class="css-3knmzx"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-eecfu2-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/c/test-cluster/"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiListItemIcon-root css-1blhdvq-MuiListItemIcon-root"
+                    />
+                    <div
+                      class="MuiListItemText-root MuiListItemText-multiline css-konndc-MuiListItemText-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                      >
+                        Clusters
+                      </span>
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+                      >
+                        <div
+                          style="display: flex; flex-direction: column; gap: 4px; margin-top: 4px;"
+                        >
+                          <div
+                            class="MuiBox-root css-172hjuw"
+                          >
+                            <span
+                              class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+                            >
+                              test-cluster
+                            </span>
+                          </div>
+                        </div>
+                      </p>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </li>
+                <li
+                  class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-entered css-1mhwl66-MuiCollapse-root"
+                  style="min-height: 0px;"
+                >
+                  <div
+                    class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
+                  >
+                    <div
+                      class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
+                    >
+                      <ul
+                        class="MuiList-root css-2l483y-MuiList-root"
+                      >
+                        <li
+                          class="css-1gktw5r"
+                        >
+                          <a
+                            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
+                            href="/c/test-cluster/namespaces"
+                            role="button"
+                            tabindex="0"
+                          >
+                            <div
+                              class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                            >
+                              <span
+                                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                              >
+                                Namespaces
+                              </span>
+                            </div>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </a>
+                        </li>
+                        <li
+                          class="css-1gktw5r"
+                        >
+                          <a
+                            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
+                            href="/c/test-cluster/nodes"
+                            role="button"
+                            tabindex="0"
+                          >
+                            <div
+                              class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                            >
+                              <span
+                                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                              >
+                                Nodes
+                              </span>
+                            </div>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </a>
+                        </li>
+                        <li
+                          class="css-1gktw5r"
+                        >
+                          <a
+                            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
+                            href="/c/test-cluster/advanced-search"
+                            role="button"
+                            tabindex="0"
+                          >
+                            <div
+                              class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                            >
+                              <span
+                                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                              >
+                                Advanced Search (Beta)
+                              </span>
+                            </div>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </a>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="css-3knmzx"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/c/test-cluster/map"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiListItemIcon-root css-1blhdvq-MuiListItemIcon-root"
+                    />
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                      >
+                        Map
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </li>
+                <li
+                  class="css-3knmzx"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/c/test-cluster/workloads"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiListItemIcon-root css-1blhdvq-MuiListItemIcon-root"
+                    />
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                      >
+                        Workloads
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </li>
+                <li
+                  class="css-3knmzx"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/c/test-cluster/storage/persistentvolumeclaims"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiListItemIcon-root css-1blhdvq-MuiListItemIcon-root"
+                    />
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                      >
+                        Storage
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </li>
+                <li
+                  class="css-3knmzx"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/c/test-cluster/services"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiListItemIcon-root css-1blhdvq-MuiListItemIcon-root"
+                    />
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                      >
+                        Network
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </li>
+                <li
+                  class="css-3knmzx"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/c/test-cluster/gateways"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiListItemIcon-root css-1blhdvq-MuiListItemIcon-root"
+                    />
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                      >
+                        Gateway (beta)
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </li>
+                <li
+                  class="css-3knmzx"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/c/test-cluster/serviceaccounts"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiListItemIcon-root css-1blhdvq-MuiListItemIcon-root"
+                    />
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                      >
+                        Security
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </li>
+                <li
+                  class="css-3knmzx"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/c/test-cluster/configmaps"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiListItemIcon-root css-1blhdvq-MuiListItemIcon-root"
+                    />
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                      >
+                        Configuration
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </li>
+                <li
+                  class="css-3knmzx"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/c/test-cluster/crds"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiListItemIcon-root css-1blhdvq-MuiListItemIcon-root"
+                    />
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                      >
+                        Custom Resources
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-xi606m"
+              >
+                <div
+                  class="MuiBox-root css-xi606m"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorSecondary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorSecondary MuiButton-disableElevation css-1n3iyy9-MuiButtonBase-root-MuiButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeLarge css-htszrh-MuiButton-startIcon"
+                    />
+                    Create
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                  <div
+                    class="MuiBox-root css-phsv6y"
+                  >
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <div
+                        class="MuiBox-root css-yncjbp"
+                      >
+                        <button
+                          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-751h87-MuiButtonBase-root-MuiButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <div
+                            class="MuiBox-root css-70qvj9"
+                          >
+                            <div
+                              class="MuiBox-root css-0"
+                            />
+                            <div
+                              class="MuiBox-root css-0"
+                            >
+                              v1.2.3
+                            </div>
+                          </div>
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <div
+                        class="MuiBox-root css-s2uf1z"
+                      >
+                        <button
+                          aria-label="Shrink sidebar"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-lr7sro-MuiButtonBase-root-MuiIconButton-root"
+                          data-mui-internal-clone-element="true"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </nav>
+  </div>
+</body>

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.GatewayAPIUnavailable.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.GatewayAPIUnavailable.stories.storyshot
@@ -1,0 +1,443 @@
+<body>
+  <div>
+    <nav
+      aria-label="Navigation"
+      class="MuiBox-root css-qnyptn"
+    >
+      <div
+        class="MuiDrawer-root MuiDrawer-docked css-1k1thb6-MuiDrawer-docked"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiDrawer-paper MuiDrawer-paperAnchorLeft MuiDrawer-paperAnchorDockedLeft css-2vc5z5-MuiPaper-root-MuiDrawer-paper"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column MuiGrid-wrap-xs-nowrap css-opqjvv-MuiGrid-root"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <ul
+                class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
+              >
+                <li
+                  class="css-3knmzx"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiListItemIcon-root css-1blhdvq-MuiListItemIcon-root"
+                    />
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                      >
+                        Home
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </li>
+                <li
+                  class="css-3knmzx"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-eecfu2-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/c/test-cluster/"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiListItemIcon-root css-1blhdvq-MuiListItemIcon-root"
+                    />
+                    <div
+                      class="MuiListItemText-root MuiListItemText-multiline css-konndc-MuiListItemText-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                      >
+                        Clusters
+                      </span>
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+                      >
+                        <div
+                          style="display: flex; flex-direction: column; gap: 4px; margin-top: 4px;"
+                        >
+                          <div
+                            class="MuiBox-root css-172hjuw"
+                          >
+                            <span
+                              class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+                            >
+                              test-cluster
+                            </span>
+                          </div>
+                        </div>
+                      </p>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </li>
+                <li
+                  class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-entered css-1mhwl66-MuiCollapse-root"
+                  style="min-height: 0px;"
+                >
+                  <div
+                    class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
+                  >
+                    <div
+                      class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
+                    >
+                      <ul
+                        class="MuiList-root css-2l483y-MuiList-root"
+                      >
+                        <li
+                          class="css-1gktw5r"
+                        >
+                          <a
+                            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
+                            href="/c/test-cluster/namespaces"
+                            role="button"
+                            tabindex="0"
+                          >
+                            <div
+                              class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                            >
+                              <span
+                                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                              >
+                                Namespaces
+                              </span>
+                            </div>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </a>
+                        </li>
+                        <li
+                          class="css-1gktw5r"
+                        >
+                          <a
+                            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
+                            href="/c/test-cluster/nodes"
+                            role="button"
+                            tabindex="0"
+                          >
+                            <div
+                              class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                            >
+                              <span
+                                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                              >
+                                Nodes
+                              </span>
+                            </div>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </a>
+                        </li>
+                        <li
+                          class="css-1gktw5r"
+                        >
+                          <a
+                            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
+                            href="/c/test-cluster/advanced-search"
+                            role="button"
+                            tabindex="0"
+                          >
+                            <div
+                              class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                            >
+                              <span
+                                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                              >
+                                Advanced Search (Beta)
+                              </span>
+                            </div>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </a>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="css-3knmzx"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/c/test-cluster/map"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiListItemIcon-root css-1blhdvq-MuiListItemIcon-root"
+                    />
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                      >
+                        Map
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </li>
+                <li
+                  class="css-3knmzx"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/c/test-cluster/workloads"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiListItemIcon-root css-1blhdvq-MuiListItemIcon-root"
+                    />
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                      >
+                        Workloads
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </li>
+                <li
+                  class="css-3knmzx"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/c/test-cluster/storage/persistentvolumeclaims"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiListItemIcon-root css-1blhdvq-MuiListItemIcon-root"
+                    />
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                      >
+                        Storage
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </li>
+                <li
+                  class="css-3knmzx"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/c/test-cluster/services"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiListItemIcon-root css-1blhdvq-MuiListItemIcon-root"
+                    />
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                      >
+                        Network
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </li>
+                <li
+                  class="css-3knmzx"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/c/test-cluster/serviceaccounts"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiListItemIcon-root css-1blhdvq-MuiListItemIcon-root"
+                    />
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                      >
+                        Security
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </li>
+                <li
+                  class="css-3knmzx"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/c/test-cluster/configmaps"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiListItemIcon-root css-1blhdvq-MuiListItemIcon-root"
+                    />
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                      >
+                        Configuration
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </li>
+                <li
+                  class="css-3knmzx"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/c/test-cluster/crds"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiListItemIcon-root css-1blhdvq-MuiListItemIcon-root"
+                    />
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                      >
+                        Custom Resources
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-xi606m"
+              >
+                <div
+                  class="MuiBox-root css-xi606m"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorSecondary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorSecondary MuiButton-disableElevation css-1n3iyy9-MuiButtonBase-root-MuiButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeLarge css-htszrh-MuiButton-startIcon"
+                    />
+                    Create
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                  <div
+                    class="MuiBox-root css-phsv6y"
+                  >
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <div
+                        class="MuiBox-root css-yncjbp"
+                      >
+                        <button
+                          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-751h87-MuiButtonBase-root-MuiButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <div
+                            class="MuiBox-root css-70qvj9"
+                          >
+                            <div
+                              class="MuiBox-root css-0"
+                            />
+                            <div
+                              class="MuiBox-root css-0"
+                            >
+                              v1.2.3
+                            </div>
+                          </div>
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <div
+                        class="MuiBox-root css-s2uf1z"
+                      >
+                        <button
+                          aria-label="Shrink sidebar"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-lr7sro-MuiButtonBase-root-MuiIconButton-root"
+                          data-mui-internal-clone-element="true"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </nav>
+  </div>
+</body>

--- a/frontend/src/components/Sidebar/useSidebarItems.test.tsx
+++ b/frontend/src/components/Sidebar/useSidebarItems.test.tsx
@@ -20,6 +20,7 @@ import { renderHook } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 import App from '../../App';
+import * as useApiGroupAvailableModule from '../../lib/k8s/api/v2/useApiGroupAvailable';
 import reducers from '../../redux/reducers/reducers';
 import { TestContext } from '../../test';
 import { DefaultSidebars, SidebarEntry } from './sidebarSlice';
@@ -251,5 +252,35 @@ describe('useSidebarItems', () => {
 
     // Check that home is still present
     expect(result.current.find(it => it.name === 'home')).toBeDefined();
+  });
+
+  it('should hide the Gateway API sidebar entry when its API group is not available on the cluster', () => {
+    const spy = vi.spyOn(useApiGroupAvailableModule, 'useApiGroupAvailable').mockReturnValue(false);
+
+    const store = mockStore({}, []);
+    const { result } = renderHook(() => useSidebarItems(), {
+      wrapper: wrapper(store),
+    });
+
+    const gatewayEntry = result.current.find(it => it.name === 'gatewayapi');
+    expect(gatewayEntry).toBeDefined();
+    expect(gatewayEntry?.hide).toBe(true);
+
+    spy.mockRestore();
+  });
+
+  it('should show the Gateway API sidebar entry when its API group is available on the cluster', () => {
+    const spy = vi.spyOn(useApiGroupAvailableModule, 'useApiGroupAvailable').mockReturnValue(true);
+
+    const store = mockStore({}, []);
+    const { result } = renderHook(() => useSidebarItems(), {
+      wrapper: wrapper(store),
+    });
+
+    const gatewayEntry = result.current.find(it => it.name === 'gatewayapi');
+    expect(gatewayEntry).toBeDefined();
+    expect(gatewayEntry?.hide).toBeFalsy();
+
+    spy.mockRestore();
   });
 });

--- a/frontend/src/components/Sidebar/useSidebarItems.test.tsx
+++ b/frontend/src/components/Sidebar/useSidebarItems.test.tsx
@@ -20,6 +20,7 @@ import { renderHook } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 import App from '../../App';
+import * as useApiGroupAvailableModule from '../../lib/k8s/api/v2/useApiGroupAvailable';
 import { useGatewayL4RouteAvailability } from '../../lib/k8s/gatewayL4RouteAvailability';
 import reducers from '../../redux/reducers/reducers';
 import { TestContext } from '../../test';
@@ -311,5 +312,35 @@ describe('useSidebarItems', () => {
 
     // Check that home is still present
     expect(result.current.find(it => it.name === 'home')).toBeDefined();
+  });
+
+  it('should hide the Gateway API sidebar entry when its API group is not available on the cluster', () => {
+    const spy = vi.spyOn(useApiGroupAvailableModule, 'useApiGroupAvailable').mockReturnValue(false);
+
+    const store = mockStore({}, []);
+    const { result } = renderHook(() => useSidebarItems(), {
+      wrapper: wrapper(store),
+    });
+
+    const gatewayEntry = result.current.find(it => it.name === 'gatewayapi');
+    expect(gatewayEntry).toBeDefined();
+    expect(gatewayEntry?.hide).toBe(true);
+
+    spy.mockRestore();
+  });
+
+  it('should show the Gateway API sidebar entry when its API group is available on the cluster', () => {
+    const spy = vi.spyOn(useApiGroupAvailableModule, 'useApiGroupAvailable').mockReturnValue(true);
+
+    const store = mockStore({}, []);
+    const { result } = renderHook(() => useSidebarItems(), {
+      wrapper: wrapper(store),
+    });
+
+    const gatewayEntry = result.current.find(it => it.name === 'gatewayapi');
+    expect(gatewayEntry).toBeDefined();
+    expect(gatewayEntry?.hide).toBeFalsy();
+
+    spy.mockRestore();
   });
 });

--- a/frontend/src/components/Sidebar/useSidebarItems.tsx
+++ b/frontend/src/components/Sidebar/useSidebarItems.tsx
@@ -20,7 +20,8 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getClusterAppearanceFromMeta } from '../../helpers/clusterAppearance';
 import { isElectron } from '../../helpers/isElectron';
-import { useClustersConf, useSelectedClusters } from '../../lib/k8s';
+import { useCluster, useClustersConf, useSelectedClusters } from '../../lib/k8s';
+import { useApiGroupAvailable } from '../../lib/k8s/api/v2/useApiGroupAvailable';
 import CRD from '../../lib/k8s/crd';
 import { createRouteURL } from '../../lib/router/createRouteURL';
 import { useTypedSelector } from '../../redux/hooks';
@@ -63,6 +64,16 @@ export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER
   const allClustersConf = useClustersConf();
   const { t } = useTranslation();
   const theme = useTheme();
+  const cluster = useCluster();
+  // useCluster() may return an arbitrary selected cluster when multiple clusters
+  // are selected, so skip the availability check in that case to avoid hiding
+  // the Gateway API section just because the (arbitrarily) picked cluster
+  // doesn't have it, even though other selected clusters might.
+  const isGatewayAPIAvailable = useApiGroupAvailable(
+    'gateway.networking.k8s.io',
+    'v1',
+    selectedClusters.length > 1 ? null : cluster
+  );
 
   const [crds, error] = CRD.useList();
   if (error !== null) {
@@ -327,6 +338,7 @@ export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER
         name: 'gatewayapi',
         label: t('glossary|Gateway (beta)'),
         icon: 'mdi:lan-connect',
+        hide: isGatewayAPIAvailable === false,
         subList: [
           {
             name: 'gateways',

--- a/frontend/src/components/Sidebar/useSidebarItems.tsx
+++ b/frontend/src/components/Sidebar/useSidebarItems.tsx
@@ -21,7 +21,8 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getClusterAppearanceFromMeta } from '../../helpers/clusterAppearance';
 import { isElectron } from '../../helpers/isElectron';
-import { useClustersConf, useSelectedClusters } from '../../lib/k8s';
+import { useCluster, useClustersConf, useSelectedClusters } from '../../lib/k8s';
+import { useApiGroupAvailable } from '../../lib/k8s/api/v2/useApiGroupAvailable';
 import CRD from '../../lib/k8s/crd';
 import { useGatewayL4RouteAvailability } from '../../lib/k8s/gatewayL4RouteAvailability';
 import PodGroup from '../../lib/k8s/podGroup';
@@ -66,6 +67,30 @@ export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER
   const allClustersConf = useClustersConf();
   const { t } = useTranslation();
   const theme = useTheme();
+  const cluster = useCluster();
+  // useCluster() may return an arbitrary selected cluster when multiple clusters
+  // are selected, so skip the availability check in that case to avoid hiding
+  // the Gateway API section just because the (arbitrarily) picked cluster
+  // doesn't have it, even though other selected clusters might.
+  const gatewayApiCluster = selectedClusters.length > 1 ? null : cluster;
+  const isGatewayAPIV1Available = useApiGroupAvailable(
+    'gateway.networking.k8s.io',
+    'v1',
+    gatewayApiCluster
+  );
+  // Headlamp's Gateway API resources (Gateway, GatewayClass, HTTPRoute) fall back to
+  // v1beta1 when v1 isn't served, so check both versions before hiding the section.
+  const isGatewayAPIV1Beta1Available = useApiGroupAvailable(
+    'gateway.networking.k8s.io',
+    'v1beta1',
+    gatewayApiCluster
+  );
+  const isGatewayAPIAvailable =
+    isGatewayAPIV1Available === true || isGatewayAPIV1Beta1Available === true
+      ? true
+      : isGatewayAPIV1Available === false && isGatewayAPIV1Beta1Available === false
+      ? false
+      : undefined;
 
   const { data: availableGatewayL4RouteKinds } = useGatewayL4RouteAvailability();
   const gatewayKinds = useMemo(
@@ -349,6 +374,7 @@ export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER
         name: 'gatewayapi',
         label: t('glossary|Gateway (beta)'),
         icon: 'mdi:lan-connect',
+        hide: isGatewayAPIAvailable === false,
         subList: [
           {
             name: 'gateways',
@@ -617,6 +643,7 @@ export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER
     crdsSidebarEntries,
     gatewayKinds,
     schedulingWorkloadsEnabled,
+    isGatewayAPIAvailable,
     t,
   ]);
 

--- a/frontend/src/lib/k8s/api/v2/useApiGroupAvailable.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/useApiGroupAvailable.test.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import { ApiError } from './ApiError';
+import { clusterFetch } from './fetch';
+import { useApiGroupAvailable } from './useApiGroupAvailable';
+
+vi.mock('./fetch', () => ({
+  clusterFetch: vi.fn(),
+}));
+
+describe('useApiGroupAvailable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+
+  it('returns true when the API group/version discovery request succeeds', async () => {
+    (clusterFetch as Mock).mockResolvedValue({ ok: true });
+
+    const { result } = renderHook(
+      () => useApiGroupAvailable('gateway.networking.k8s.io', 'v1', 'test-cluster'),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current).toBe(true));
+    expect(clusterFetch).toHaveBeenCalledWith('/apis/gateway.networking.k8s.io/v1', {
+      cluster: 'test-cluster',
+    });
+  });
+
+  it('returns false when the API group/version is not served by the cluster (404)', async () => {
+    (clusterFetch as Mock).mockRejectedValue(new ApiError('not found', { status: 404 }));
+
+    const { result } = renderHook(
+      () => useApiGroupAvailable('gateway.networking.k8s.io', 'v1', 'test-cluster'),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+
+  it('returns undefined when the discovery request fails for a reason other than a 404', async () => {
+    (clusterFetch as Mock).mockRejectedValue(new ApiError('forbidden', { status: 403 }));
+
+    const { result } = renderHook(
+      () => useApiGroupAvailable('gateway.networking.k8s.io', 'v1', 'test-cluster'),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(clusterFetch).toHaveBeenCalled());
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns undefined when the discovery request throws a non-ApiError (e.g. network error)', async () => {
+    (clusterFetch as Mock).mockRejectedValue(new Error('network error'));
+
+    const { result } = renderHook(
+      () => useApiGroupAvailable('gateway.networking.k8s.io', 'v1', 'test-cluster'),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(clusterFetch).toHaveBeenCalled());
+    expect(result.current).toBeUndefined();
+  });
+
+  it('does not run the discovery request when no cluster is given', () => {
+    const { result } = renderHook(
+      () => useApiGroupAvailable('gateway.networking.k8s.io', 'v1', null),
+      { wrapper }
+    );
+
+    expect(result.current).toBeUndefined();
+    expect(clusterFetch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/k8s/api/v2/useApiGroupAvailable.ts
+++ b/frontend/src/lib/k8s/api/v2/useApiGroupAvailable.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { ApiError } from './ApiError';
+import { clusterFetch } from './fetch';
+
+/**
+ * Checks whether the given API group/version is served by the connected cluster,
+ * by querying the cluster's `/apis/<group>/<version>` discovery endpoint.
+ *
+ * This is useful for optional, CRD-backed API groups (e.g. Gateway API) that may
+ * or may not be installed on a given cluster, so that UI relying on them (like
+ * sidebar entries) can be hidden or show a clear "not available" state instead of
+ * always rendering and leading to an empty or erroring resource list.
+ *
+ * @param group - The API group to check, e.g. `gateway.networking.k8s.io`.
+ * @param version - The API version to check, e.g. `v1`.
+ * @param cluster - The cluster to check against. The check is disabled (and this
+ * hook returns `undefined`) if no cluster is given.
+ *
+ * @returns `true` if the API group/version is available, `false` if it is confirmed
+ * not to be served (e.g. a 404 from the discovery endpoint), and `undefined` while
+ * the check is still in progress, no cluster is set, or the check failed for a
+ * reason other than the API group not being served (e.g. a network error or an
+ * authorization failure).
+ */
+export function useApiGroupAvailable(
+  group: string,
+  version: string,
+  cluster?: string | null
+): boolean | undefined {
+  const { data } = useQuery<boolean | null, unknown>({
+    queryKey: ['apiGroupAvailable', cluster, group, version],
+    enabled: !!cluster,
+    staleTime: 60_000,
+    queryFn: async () => {
+      try {
+        await clusterFetch(`/apis/${group}/${version}`, {
+          cluster: cluster as string,
+        });
+        return true;
+      } catch (e) {
+        // Only a 404 reliably means the API group/version isn't served by the
+        // cluster. Other failures (network errors, RBAC/403, etc.) shouldn't be
+        // treated as "not available", so we leave them as unknown (null, mapped
+        // to undefined below) and let the UI keep its default behavior.
+        if (e instanceof ApiError && e.status === 404) {
+          return false;
+        }
+        return null;
+      }
+    },
+  });
+
+  return data ?? undefined;
+}


### PR DESCRIPTION
## Summary

This PR adds a reusable API-group availability hook by adding `useApiGroupAvailable` and uses it to hide the Gateway API sidebar section when the Gateway API CRDs are not installed on the connected cluster.

**Update:** while putting together screen-recording proof for this PR, I found the hide logic never actually took effect in the running app. The `sidebars` `useMemo` in `useSidebarItems.tsx` builds the Gateway sidebar entry's `hide` flag from `isGatewayAPIAvailable`, but never listed it in the memo's dependency array. Since the availability check resolves asynchronously after the first render, the memo never recomputed once the check settled, so the entry stayed visible regardless of the result. Fixed by adding `isGatewayAPIAvailable` to the deps array, and added two permanent Storybook stories (`GatewayAPIAvailable`/`GatewayAPIUnavailable`) with a real selected cluster to exercise this going forward, since `useCluster()` reads `window.location` directly and ignores `TestContext`'s `routerMap`.

## Related Issue

Fixes #6762

## Changes

- Added `useApiGroupAvailable(group, version, cluster)` in `frontend/src/lib/k8s/api/v2/useApiGroupAvailable.ts`, a hook that checks a cluster's `/apis/<group>/<version>` discovery endpoint via the existing `clusterFetch` proxy, cached per cluster/group/version with react-query.
- Wired the Gateway API sidebar entry in `frontend/src/components/Sidebar/useSidebarItems.tsx` to hide when the API group is not available.
- Added unit tests for the new hook and for the sidebar hide/show behavior.
- Fixed the missing `isGatewayAPIAvailable` dependency in the `sidebars` memo (see update above) and added `GatewayAPIAvailable`/`GatewayAPIUnavailable` Storybook stories covering it.

## Steps to Test

1. Connect Headlamp to a cluster without the Gateway API CRDs installed.
2. Observe that the "Gateway (beta)" sidebar section is no longer shown.
3. Connect to a cluster with Gateway API CRDs installed and confirm the section still appears as before.

Screen recordings against the new Storybook stories (mocking the discovery endpoint, one 200 and one 404), with a real selected cluster so the hook actually runs:
- Available: https://github.com/rootp1/headlamp/blob/gateway-gate-demo-media/docs/media/available/demo.mp4
- Unavailable: https://github.com/rootp1/headlamp/blob/gateway-gate-demo-media/docs/media/unavailable/demo.mp4

## Screenshots (if applicable)


## Notes for the Reviewer

- No backend changes were needed; the existing cluster-proxy path already forwards `GET /apis/...` discovery requests.
- Scoped to wiring the Gateway API sidebar entry only, per the issue; route-level gating and other optional API groups are left for follow-up work.
- The memo-dependency bug above meant the original unit tests passed (they mock `useApiGroupAvailable` directly via `vi.spyOn`, bypassing the memo entirely) while the actual browser behavior was broken; the new stories exercise the real hook end to end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The Gateway API sidebar entry now appears only when supported by the selected cluster.
  - API availability is checked per cluster and cached for faster results.
  - When multiple clusters are selected, availability checks are skipped to avoid relying on a single cluster.

- **Bug Fixes**
  - Unsupported Gateway API options no longer appear in the sidebar.
  - Improved handling when API availability cannot be determined or no cluster is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


