### PR TITLE
app: validate URL scheme before shell.openExternal and loadURL in Electron navigation handlers

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -68,6 +68,7 @@ import {
   isTrayIconEnabled,
   setTrayIconEnabled,
 } from './tray';
+import { isAppInternalUrl, isSafeExternalUrl } from './urlValidation';
 import windowSize from './windowSize';
 
 if (process.env.APPIMAGE) {
@@ -1295,10 +1296,10 @@ function menusToTemplate(mainWindow: BrowserWindow | null, menusFromPlugins: App
       };
     } else if (!!url) {
       menu.click = async () => {
-        // Open external links in the external browser.
-        if (!!mainWindow && !url.startsWith('http')) {
-          mainWindow.webContents.loadURL(url);
-        } else {
+        // Only follow http/https menu links, opened in the external browser.
+        // Other schemes (file://, data:, javascript:, …) are ignored so a menu
+        // URL can't navigate the app window to untrusted content.
+        if (isSafeExternalUrl(url)) {
           await shell.openExternal(url);
         }
       };
@@ -1608,11 +1609,15 @@ function startElectron() {
 
     mainWindow.webContents.setWindowOpenHandler(({ url }) => {
       // allow all urls starting with app startUrl to open in electron
-      if (url.startsWith(startUrl)) {
+      if (isAppInternalUrl(url, startUrl)) {
         return { action: 'allow' };
       }
-      // otherwise open url in a browser and prevent default
-      shell.openExternal(url);
+      // otherwise open http/https urls in a browser and prevent default. Other
+      // schemes (file://, smb://, custom protocols) are dropped so an untrusted
+      // URL can't reach the OS handler.
+      if (isSafeExternalUrl(url)) {
+        shell.openExternal(url);
+      }
       return { action: 'deny' };
     });
 
@@ -1698,11 +1703,13 @@ function startElectron() {
     */
     mainWindow.webContents.on('will-navigate', (event, encodedUrl) => {
       const url = decodeURI(encodedUrl);
-      if (url.startsWith(startUrl)) {
+      if (isAppInternalUrl(url, startUrl)) {
         return;
       }
       event.preventDefault();
-      shell.openExternal(url);
+      if (isSafeExternalUrl(url)) {
+        shell.openExternal(url);
+      }
     });
 
     app.on('open-url', (event, url) => {

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -79,6 +79,7 @@ import {
   isTrayIconEnabled,
   setTrayIconEnabled,
 } from './tray';
+import { isAppInternalUrl, isSafeExternalUrl } from './urlValidation';
 import windowSize from './windowSize';
 import {
   clampZoom,
@@ -1629,11 +1630,15 @@ function startElectron() {
 
     mainWindow.webContents.setWindowOpenHandler(({ url }) => {
       // allow all urls starting with app startUrl to open in electron
-      if (url.startsWith(startUrl)) {
+      if (isAppInternalUrl(url, startUrl)) {
         return { action: 'allow' };
       }
-      // otherwise open url in a browser and prevent default
-      shell.openExternal(url);
+      // otherwise open http/https urls in a browser and prevent default. Other
+      // schemes (file://, smb://, custom protocols) are dropped so an untrusted
+      // URL can't reach the OS handler.
+      if (isSafeExternalUrl(url)) {
+        shell.openExternal(url);
+      }
       return { action: 'deny' };
     });
 
@@ -1729,11 +1734,13 @@ function startElectron() {
     */
     mainWindow.webContents.on('will-navigate', (event, encodedUrl) => {
       const url = decodeURI(encodedUrl);
-      if (url.startsWith(startUrl)) {
+      if (isAppInternalUrl(url, startUrl)) {
         return;
       }
       event.preventDefault();
-      shell.openExternal(url);
+      if (isSafeExternalUrl(url)) {
+        shell.openExternal(url);
+      }
     });
 
     i18n.on('languageChanged', () => {

--- a/app/electron/menu.test.ts
+++ b/app/electron/menu.test.ts
@@ -80,7 +80,8 @@ describe('menusToTemplate', () => {
     expect(actions.setZoom).toHaveBeenCalledWith(1);
   });
 
-  it('loads internal URLs in the app window', async () => {
+  it('ignores non-http URLs instead of loading them in the app window', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const loadURL = vi.fn().mockResolvedValue(undefined);
     const mainWindow = { webContents: { loadURL } } as unknown as BrowserWindow;
     const { actions, convert } = setup(mainWindow);
@@ -88,8 +89,9 @@ describe('menusToTemplate', () => {
 
     await internal.click?.({} as never, {} as never, {} as never);
 
-    expect(loadURL).toHaveBeenCalledWith('file:///settings');
+    expect(loadURL).not.toHaveBeenCalled();
     expect(actions.openExternal).not.toHaveBeenCalled();
+    consoleError.mockRestore();
   });
 
   it('opens HTTP URLs externally even when an app window exists', async () => {
@@ -106,11 +108,27 @@ describe('menusToTemplate', () => {
 
   it('opens URLs externally when there is no app window', async () => {
     const { actions, convert } = setup();
+    const [external] = convert([{ id: 'external', url: 'https://headlamp.dev/docs' }]);
+
+    await external.click?.({} as never, {} as never, {} as never);
+
+    expect(actions.openExternal).toHaveBeenCalledWith('https://headlamp.dev/docs');
+  });
+
+  // A menu item can come from a plugin, so a custom scheme must not reach the OS
+  // handler and launch whatever application is registered for it.
+  it('ignores custom scheme URLs', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { actions, convert } = setup();
     const [external] = convert([{ id: 'external', url: 'headlamp://cluster' }]);
 
     await external.click?.({} as never, {} as never, {} as never);
 
-    expect(actions.openExternal).toHaveBeenCalledWith('headlamp://cluster');
+    expect(actions.openExternal).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(
+      'Ignoring menu URL headlamp://cluster: only http and https are allowed'
+    );
+    consoleError.mockRestore();
   });
 
   it('logs rejected URL actions', async () => {

--- a/app/electron/menu.ts
+++ b/app/electron/menu.ts
@@ -15,9 +15,10 @@
  */
 
 import type { BrowserWindow, MenuItemConstructorOptions } from 'electron';
+import { isSafeExternalUrl } from './urlValidation';
 
 export interface AppMenu extends Omit<Partial<MenuItemConstructorOptions>, 'click'> {
-  /** A URL to open (if not starting with http, then it'll be opened in the app window) */
+  /** A URL to open in the external browser. Only http and https URLs are followed. */
   url?: string;
   /** The submenus of this menu */
   submenu?: AppMenu[];
@@ -61,11 +62,19 @@ export function menusToTemplate(
       menu.click = () => actions.setZoom(1.0);
     } else if (url) {
       menu.click = () => {
-        const openUrl =
-          mainWindow && !url.startsWith('http')
-            ? mainWindow.webContents.loadURL(url)
-            : actions.openExternal(url);
-        void openUrl.catch(error => console.error(`Failed to open menu URL ${url}:`, error));
+        // Only http and https menu URLs are followed, and always in the external
+        // browser. Other schemes (file://, smb://, data:, custom protocols) are
+        // ignored: a menu item can come from a plugin, and handing such a URL to
+        // the OS or loading it into the app window would run untrusted content
+        // with the app's privileges.
+        if (!isSafeExternalUrl(url)) {
+          console.error(`Ignoring menu URL ${url}: only http and https are allowed`);
+          return;
+        }
+
+        void actions
+          .openExternal(url)
+          .catch(error => console.error(`Failed to open menu URL ${url}:`, error));
       };
     }
 

--- a/app/electron/urlValidation.test.ts
+++ b/app/electron/urlValidation.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isAppInternalUrl, isSafeExternalUrl } from './urlValidation';
+
+describe('isSafeExternalUrl', () => {
+  it('allows http and https URLs', () => {
+    expect(isSafeExternalUrl('http://example.com')).toBe(true);
+    expect(isSafeExternalUrl('https://headlamp.dev/docs/latest/')).toBe(true);
+  });
+
+  it('rejects file, smb and other OS-handler schemes', () => {
+    expect(isSafeExternalUrl('file:///etc/passwd')).toBe(false);
+    expect(isSafeExternalUrl('smb://attacker/share')).toBe(false);
+    expect(isSafeExternalUrl('vscode://file/etc/passwd')).toBe(false);
+  });
+
+  it('rejects javascript and data URLs', () => {
+    expect(isSafeExternalUrl('javascript:alert(1)')).toBe(false);
+    expect(isSafeExternalUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+  });
+
+  it('rejects malformed input', () => {
+    expect(isSafeExternalUrl('not a url')).toBe(false);
+    expect(isSafeExternalUrl('')).toBe(false);
+  });
+});
+
+describe('isAppInternalUrl', () => {
+  const startUrl = 'http://localhost:3000';
+
+  it('accepts the app URL itself and its pages', () => {
+    expect(isAppInternalUrl(startUrl, startUrl)).toBe(true);
+    expect(isAppInternalUrl(`${startUrl}/cluster/foo`, startUrl)).toBe(true);
+    expect(isAppInternalUrl(`${startUrl}#/route`, startUrl)).toBe(true);
+    expect(isAppInternalUrl(`${startUrl}?query=1`, startUrl)).toBe(true);
+  });
+
+  it('rejects prefix look-alikes that are not the app origin', () => {
+    expect(isAppInternalUrl('http://localhost:3000.evil.com', startUrl)).toBe(false);
+    expect(isAppInternalUrl('http://localhost:3000@evil.com', startUrl)).toBe(false);
+    expect(isAppInternalUrl('http://localhost:30000', startUrl)).toBe(false);
+    expect(isAppInternalUrl('http://evil.com', startUrl)).toBe(false);
+  });
+
+  it('handles a file:// start URL and its look-alikes', () => {
+    const fileStart = 'file:///Applications/Headlamp.app/frontend/index.html';
+    expect(isAppInternalUrl(`${fileStart}#/route`, fileStart)).toBe(true);
+    expect(isAppInternalUrl(`${fileStart}.evil`, fileStart)).toBe(false);
+  });
+
+  // ELECTRON_START_URL is a data: URL in the e2e app tests. An opaque URL has no
+  // path to extend, so anything appended to it is more content rather than a
+  // route within the app.
+  it('only accepts a fragment after an opaque start URL', () => {
+    const dataStart = 'data:text/html,<title>Headlamp zoom test</title>';
+
+    expect(isAppInternalUrl(dataStart, dataStart)).toBe(true);
+    expect(isAppInternalUrl(`${dataStart}#/route`, dataStart)).toBe(true);
+    expect(isAppInternalUrl(`${dataStart}/<script>alert(1)</script>`, dataStart)).toBe(false);
+    expect(isAppInternalUrl(`${dataStart}?<script>alert(1)</script>`, dataStart)).toBe(false);
+  });
+
+  it('rejects everything when the start URL cannot be parsed', () => {
+    expect(isAppInternalUrl('not a url/route', 'not a url')).toBe(false);
+  });
+});

--- a/app/electron/urlValidation.test.ts
+++ b/app/electron/urlValidation.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isAppInternalUrl, isSafeExternalUrl } from './urlValidation';
+
+describe('isSafeExternalUrl', () => {
+  it('allows http and https URLs', () => {
+    expect(isSafeExternalUrl('http://example.com')).toBe(true);
+    expect(isSafeExternalUrl('https://headlamp.dev/docs/latest/')).toBe(true);
+  });
+
+  it('rejects file, smb and other OS-handler schemes', () => {
+    expect(isSafeExternalUrl('file:///etc/passwd')).toBe(false);
+    expect(isSafeExternalUrl('smb://attacker/share')).toBe(false);
+    expect(isSafeExternalUrl('vscode://file/etc/passwd')).toBe(false);
+  });
+
+  it('rejects javascript and data URLs', () => {
+    expect(isSafeExternalUrl('javascript:alert(1)')).toBe(false);
+    expect(isSafeExternalUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+  });
+
+  it('rejects malformed input', () => {
+    expect(isSafeExternalUrl('not a url')).toBe(false);
+    expect(isSafeExternalUrl('')).toBe(false);
+  });
+});
+
+describe('isAppInternalUrl', () => {
+  const startUrl = 'http://localhost:3000';
+
+  it('accepts the app URL itself and its pages', () => {
+    expect(isAppInternalUrl(startUrl, startUrl)).toBe(true);
+    expect(isAppInternalUrl(`${startUrl}/cluster/foo`, startUrl)).toBe(true);
+    expect(isAppInternalUrl(`${startUrl}#/route`, startUrl)).toBe(true);
+    expect(isAppInternalUrl(`${startUrl}?query=1`, startUrl)).toBe(true);
+  });
+
+  it('rejects prefix look-alikes that are not the app origin', () => {
+    expect(isAppInternalUrl('http://localhost:3000.evil.com', startUrl)).toBe(false);
+    expect(isAppInternalUrl('http://localhost:3000@evil.com', startUrl)).toBe(false);
+    expect(isAppInternalUrl('http://localhost:30000', startUrl)).toBe(false);
+    expect(isAppInternalUrl('http://evil.com', startUrl)).toBe(false);
+  });
+
+  it('handles a file:// start URL and its look-alikes', () => {
+    const fileStart = 'file:///Applications/Headlamp.app/frontend/index.html';
+    expect(isAppInternalUrl(`${fileStart}#/route`, fileStart)).toBe(true);
+    expect(isAppInternalUrl(`${fileStart}.evil`, fileStart)).toBe(false);
+  });
+});

--- a/app/electron/urlValidation.ts
+++ b/app/electron/urlValidation.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Returns true when url uses a scheme that is safe to hand to the OS or to
+ * navigate to. Only http and https are allowed; other schemes such as file://,
+ * smb://, data:, javascript: and custom protocol handlers are rejected so an
+ * untrusted URL cannot open a local file, reach a network share, or launch
+ * another installed application via shell.openExternal or loadURL.
+ *
+ * @param url - The URL to check.
+ * @returns True if the URL uses the http or https scheme.
+ */
+export function isSafeExternalUrl(url: string): boolean {
+  try {
+    const { protocol } = new URL(url);
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns true when url points at the app's own content (startUrl) and can be
+ * opened inside the app window. A plain `startsWith` check is not enough: with
+ * startUrl "http://localhost:3000", it would also match
+ * "http://localhost:3000.evil.com" or "http://localhost:3000@evil.com". So the
+ * prefix must be followed by a path, query or fragment delimiter (or be an
+ * exact match).
+ *
+ * Which delimiters count depends on the scheme. ELECTRON_START_URL can be an
+ * opaque URL such as "data:text/html,<title>x</title>", and an opaque URL has
+ * no hierarchical path to extend: everything after the prefix is more content,
+ * not a route, so "data:text/html,<title>x</title>/<script>…</script>" would
+ * otherwise be treated as a page of the app and loaded into the window. Only a
+ * fragment, which is not part of the payload, may follow such a start URL.
+ *
+ * @param url - The URL being navigated to or opened.
+ * @param startUrl - The app's start URL.
+ * @returns True if url is the app's own URL or a page/route within it.
+ */
+export function isAppInternalUrl(url: string, startUrl: string): boolean {
+  if (!url.startsWith(startUrl)) {
+    return false;
+  }
+
+  if (url.length === startUrl.length) {
+    return true;
+  }
+
+  let startPathname: string;
+  try {
+    startPathname = new URL(startUrl).pathname;
+  } catch {
+    return false;
+  }
+
+  // A hierarchical URL (http:, https:, file:, …) has a path-absolute pathname;
+  // an opaque one (data:, and other schemes without an authority) does not.
+  if (!startPathname.startsWith('/')) {
+    return url.charAt(startUrl.length) === '#';
+  }
+
+  // A startUrl that already ends at a boundary is internal.
+  if (/[/#?]$/.test(startUrl)) {
+    return true;
+  }
+
+  const nextChar = url.charAt(startUrl.length);
+  return nextChar === '/' || nextChar === '#' || nextChar === '?';
+}

--- a/app/electron/urlValidation.ts
+++ b/app/electron/urlValidation.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Returns true when url uses a scheme that is safe to hand to the OS or to
+ * navigate to. Only http and https are allowed; other schemes such as file://,
+ * smb://, data:, javascript: and custom protocol handlers are rejected so an
+ * untrusted URL cannot open a local file, reach a network share, or launch
+ * another installed application via shell.openExternal or loadURL.
+ *
+ * @param url - The URL to check.
+ * @returns True if the URL uses the http or https scheme.
+ */
+export function isSafeExternalUrl(url: string): boolean {
+  try {
+    const { protocol } = new URL(url);
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns true when url points at the app's own content (startUrl) and can be
+ * opened inside the app window. A plain `startsWith` check is not enough: with
+ * startUrl "http://localhost:3000", it would also match
+ * "http://localhost:3000.evil.com" or "http://localhost:3000@evil.com". So the
+ * prefix must be followed by a path, query or fragment delimiter (or be an
+ * exact match).
+ *
+ * @param url - The URL being navigated to or opened.
+ * @param startUrl - The app's start URL.
+ * @returns True if url is the app's own URL or a page/route within it.
+ */
+export function isAppInternalUrl(url: string, startUrl: string): boolean {
+  if (!url.startsWith(startUrl)) {
+    return false;
+  }
+
+  // An exact match, or a startUrl that already ends at a boundary, is internal.
+  if (url.length === startUrl.length || /[/#?]$/.test(startUrl)) {
+    return true;
+  }
+
+  const nextChar = url.charAt(startUrl.length);
+  return nextChar === '/' || nextChar === '#' || nextChar === '?';
+}


### PR DESCRIPTION
## Summary

The main process handed URLs to shell.openExternal and, in the menu click handler, webContents.loadURL without checking the scheme. Any URL that isn't the app's own reached these sinks, so a file://, smb://, or custom-scheme URL could open a local file, reach a network share, or launch another app, and a non-http url loaded into the main window runs untrusted content in the app origin. Such URLs can come from a link rendered from cluster data or a plugin-supplied menu item.

This adds an isSafeExternalUrl helper that only allows http and https, and uses it in setWindowOpenHandler, will-navigate, and the menu click handler. Non-http menu links that previously loaded into the window are now ignored.

## Related Issue

Fixes #6765

## Changes

- Added app/electron/urlValidation.ts with isSafeExternalUrl, which only allows http and https URLs
- Guarded shell.openExternal in setWindowOpenHandler and the will-navigate handler in app/electron/main.ts
- Gated the menu click handler so only http/https links open (its non-http loadURL-into-window branch, which only fired for unsafe schemes, is removed)
- Added app/electron/urlValidation.test.ts

## Steps to Test

1. Run `npx vitest run electron/urlValidation.test.ts` from app/ and confirm it passes
2. In the running desktop app, click the Help menu links (Documentation, Report an Issue) and confirm they still open in the external browser
3. Confirm a normal external http/https link still opens in the browser, while a file:// / non-http URL is now ignored instead of being opened or loaded into the window

## Screenshots (if applicable)


## Notes for the Reviewer

- The menu click handler previously loaded non-http URLs into the main window with webContents.loadURL. Since that branch only ever fired for non-http schemes (the default menu items are all https and take the openExternal path), it's removed rather than kept as dead code. If you'd prefer I keep a guarded loadURL path for some intended in-app use, let me know
- Defense-in-depth, not a one-click RCE. It needs a dangerous-scheme URL to become clickable in the renderer (planted in cluster data, or a malicious plugin's menu item)
