### PR TITLE
frontend: useLocalStorageState: Fix react-hooks/exhaustive-deps

### DIFF
--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -342,6 +342,8 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [appThemes]);
 
+  const [, setAdvancedSearchQueryKey] = useLocalStorageState(ADVANCED_SEARCH_QUERY_KEY, '');
+
   // Advanced Search
   const advancedSearchSuggestion = useMemo(() => {
     if (!query.trim() || selectedClusters.length === 0) return;
@@ -352,7 +354,7 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
       label: `Search "${query}" with Advanced Search`,
       onClick: () => {
         // Set the search query in localStorage for the Advanced Search
-        useLocalStorageState.update(ADVANCED_SEARCH_QUERY_KEY, `metadata.name === "${query}"`);
+        setAdvancedSearchQueryKey(() => `metadata.name === "${query}"`);
 
         const params = new URLSearchParams(history.location.search);
         history.push(createRouteURL('advancedSearch') + '?' + params.toString());

--- a/frontend/src/components/globalSearch/useLocalStorageState.test.tsx
+++ b/frontend/src/components/globalSearch/useLocalStorageState.test.tsx
@@ -33,6 +33,21 @@ describe('useLocalStorageState', () => {
       expect(result.current[0]).toBe('default');
     });
 
+    it('returns cloned defaultValue when key does not exist in localStorage', () => {
+      const defaultValue = [{ a: 1 }];
+      const { result } = renderHook(() => useLocalStorageState('test-key', defaultValue));
+
+      act(() => {
+        result.current[0].push({ a: 2 });
+      });
+
+      // Check that the passed value is not changed
+      expect(defaultValue).toEqual([{ a: 1 }]);
+      // Check that deep clone is performed
+      expect(result.current[0][0]).toEqual(defaultValue[0]);
+      expect(result.current[0][0]).not.toBe(defaultValue[0]);
+    });
+
     it('returns parsed localStorage value when key exists', () => {
       localStorage.setItem('test-key', JSON.stringify('stored-value'));
 

--- a/frontend/src/components/globalSearch/useLocalStorageState.test.tsx
+++ b/frontend/src/components/globalSearch/useLocalStorageState.test.tsx
@@ -15,6 +15,7 @@
  */
 
 import { act, renderHook } from '@testing-library/react';
+import { useEffect } from 'react';
 import { useLocalStorageState } from './useLocalStorageState';
 
 describe('useLocalStorageState', () => {
@@ -63,6 +64,17 @@ describe('useLocalStorageState', () => {
       const { result } = renderHook(() => useLocalStorageState('test-key', { name: '', count: 0 }));
 
       expect(result.current[0]).toEqual(stored);
+    });
+
+    it('keeps a returned complex object stable across rerenders', () => {
+      const { result, rerender } = renderHook(() =>
+        useLocalStorageState('test-key', { filters: [{ name: 'namespace', values: ['default'] }] })
+      );
+      const value = result.current[0];
+
+      rerender();
+
+      expect(result.current[0]).toBe(value);
     });
 
     it('returns defaultValue and logs warning when localStorage contains malformed JSON', () => {
@@ -114,6 +126,46 @@ describe('useLocalStorageState', () => {
       expect(JSON.parse(localStorage.getItem('test-key') || '""')).toBe('updated');
     });
 
+    it('composes consecutive updates using a retained setter', () => {
+      const { result } = renderHook(() => useLocalStorageState('test-key', 0));
+      const set = result.current[1];
+
+      act(() => {
+        set(old => old + 1);
+        set(old => old + 1);
+      });
+
+      expect(result.current[0]).toBe(2);
+      expect(JSON.parse(localStorage.getItem('test-key')!)).toBe(2);
+      expect(result.current[1]).toBe(set);
+    });
+
+    it('keeps the setter stable so effects depending on it do not loop', () => {
+      let effectRuns = 0;
+
+      const { result, rerender } = renderHook(() => {
+        const [value, setValue] = useLocalStorageState('test-key', 0);
+
+        useEffect(() => {
+          effectRuns += 1;
+          setValue(old => old + 1);
+        }, [setValue]);
+
+        return [value, setValue] as const;
+      });
+
+      const set = result.current[1];
+
+      expect(result.current[0]).toBe(1);
+      expect(effectRuns).toBe(1);
+
+      rerender();
+
+      expect(result.current[0]).toBe(1);
+      expect(result.current[1]).toBe(set);
+      expect(effectRuns).toBe(1);
+    });
+
     it('catches and logs errors when localStorage.setItem throws', () => {
       const spyError = vi.spyOn(console, 'error').mockImplementation(() => {});
       const { result } = renderHook(() => useLocalStorageState('test-key', 'initial'));
@@ -132,6 +184,24 @@ describe('useLocalStorageState', () => {
         'Error occurred while setting test-key in local storage:',
         expect.any(Error)
       );
+    });
+
+    it('composes consecutive updates when localStorage.setItem throws', () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      const { result } = renderHook(() => useLocalStorageState('test-key', 0));
+      const set = result.current[1];
+
+      vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+        throw new Error('Quota exceeded');
+      });
+
+      act(() => {
+        set(old => old + 1);
+        set(old => old + 1);
+      });
+
+      expect(result.current[0]).toBe(2);
+      expect(result.current[1]).toBe(set);
     });
 
     it('updates all hook instances using the same key', () => {

--- a/frontend/src/components/globalSearch/useLocalStorageState.test.tsx
+++ b/frontend/src/components/globalSearch/useLocalStorageState.test.tsx
@@ -133,5 +133,18 @@ describe('useLocalStorageState', () => {
         expect.any(Error)
       );
     });
+
+    it('updates all hook instances using the same key', () => {
+      const first = renderHook(() => useLocalStorageState('shared-key', 'initial'));
+      const second = renderHook(() => useLocalStorageState('shared-key', 'initial'));
+
+      act(() => {
+        first.result.current[1](() => 'updated');
+      });
+
+      expect(first.result.current[0]).toBe('updated');
+      expect(second.result.current[0]).toBe('updated');
+      expect(JSON.parse(localStorage.getItem('shared-key')!)).toBe('updated');
+    });
   });
 });

--- a/frontend/src/components/globalSearch/useLocalStorageState.test.tsx
+++ b/frontend/src/components/globalSearch/useLocalStorageState.test.tsx
@@ -18,8 +18,13 @@ import { act, renderHook } from '@testing-library/react';
 import { useEffect } from 'react';
 import { useLocalStorageState } from './useLocalStorageState';
 
+let nextStorageKey = 0;
+
 describe('useLocalStorageState', () => {
+  let storageKey: string;
+
   beforeEach(() => {
+    storageKey = `test-key-${nextStorageKey++}`;
     localStorage.clear();
   });
 
@@ -29,14 +34,14 @@ describe('useLocalStorageState', () => {
 
   describe('initialization', () => {
     it('returns defaultValue when key does not exist in localStorage', () => {
-      const { result } = renderHook(() => useLocalStorageState('test-key', 'default'));
+      const { result } = renderHook(() => useLocalStorageState(storageKey, 'default'));
 
       expect(result.current[0]).toBe('default');
     });
 
     it('returns cloned defaultValue when key does not exist in localStorage', () => {
       const defaultValue = [{ a: 1 }];
-      const { result } = renderHook(() => useLocalStorageState('test-key', defaultValue));
+      const { result } = renderHook(() => useLocalStorageState(storageKey, defaultValue));
 
       act(() => {
         result.current[0].push({ a: 2 });
@@ -50,25 +55,27 @@ describe('useLocalStorageState', () => {
     });
 
     it('returns parsed localStorage value when key exists', () => {
-      localStorage.setItem('test-key', JSON.stringify('stored-value'));
+      localStorage.setItem(storageKey, JSON.stringify('stored-value'));
 
-      const { result } = renderHook(() => useLocalStorageState('test-key', 'default'));
+      const { result } = renderHook(() => useLocalStorageState(storageKey, 'default'));
 
       expect(result.current[0]).toBe('stored-value');
     });
 
     it('returns parsed object from localStorage', () => {
       const stored = { name: 'test', count: 42 };
-      localStorage.setItem('test-key', JSON.stringify(stored));
+      localStorage.setItem(storageKey, JSON.stringify(stored));
 
-      const { result } = renderHook(() => useLocalStorageState('test-key', { name: '', count: 0 }));
+      const { result } = renderHook(() => useLocalStorageState(storageKey, { name: '', count: 0 }));
 
       expect(result.current[0]).toEqual(stored);
     });
 
     it('keeps a returned complex object stable across rerenders', () => {
       const { result, rerender } = renderHook(() =>
-        useLocalStorageState('test-key', { filters: [{ name: 'namespace', values: ['default'] }] })
+        useLocalStorageState(storageKey, {
+          filters: [{ name: 'namespace', values: ['default'] }],
+        })
       );
       const value = result.current[0];
 
@@ -79,21 +86,21 @@ describe('useLocalStorageState', () => {
 
     it('returns defaultValue and logs warning when localStorage contains malformed JSON', () => {
       const spyWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      localStorage.setItem('test-key', '{ malformed json ]');
+      localStorage.setItem(storageKey, '{ malformed json ]');
 
-      const { result } = renderHook(() => useLocalStorageState('test-key', 'default'));
+      const { result } = renderHook(() => useLocalStorageState(storageKey, 'default'));
 
       expect(result.current[0]).toBe('default');
       expect(spyWarn).toHaveBeenCalledWith(
-        'Failed to parse test-key from local storage, falling back to default value:',
+        `Failed to parse ${storageKey} from local storage, falling back to default value:`,
         expect.any(Error)
       );
     });
 
     it('returns parsed boolean false correctly from localStorage', () => {
-      localStorage.setItem('test-key', JSON.stringify(false));
+      localStorage.setItem(storageKey, JSON.stringify(false));
 
-      const { result } = renderHook(() => useLocalStorageState('test-key', true));
+      const { result } = renderHook(() => useLocalStorageState(storageKey, true));
 
       expect(result.current[0]).toBe(false);
     });
@@ -104,11 +111,11 @@ describe('useLocalStorageState', () => {
         throw new Error('Storage disabled');
       });
 
-      const { result } = renderHook(() => useLocalStorageState('test-key', 'default'));
+      const { result } = renderHook(() => useLocalStorageState(storageKey, 'default'));
 
       expect(result.current[0]).toBe('default');
       expect(spyWarn).toHaveBeenCalledWith(
-        'Failed to read test-key from local storage, falling back to default value:',
+        `Failed to read ${storageKey} from local storage, falling back to default value:`,
         expect.any(Error)
       );
     });
@@ -116,18 +123,18 @@ describe('useLocalStorageState', () => {
 
   describe('set', () => {
     it('updates state and writes to localStorage', () => {
-      const { result } = renderHook(() => useLocalStorageState('test-key', 'initial'));
+      const { result } = renderHook(() => useLocalStorageState(storageKey, 'initial'));
 
       act(() => {
         result.current[1](() => 'updated');
       });
 
       expect(result.current[0]).toBe('updated');
-      expect(JSON.parse(localStorage.getItem('test-key') || '""')).toBe('updated');
+      expect(JSON.parse(localStorage.getItem(storageKey) || '""')).toBe('updated');
     });
 
     it('composes consecutive updates using a retained setter', () => {
-      const { result } = renderHook(() => useLocalStorageState('test-key', 0));
+      const { result } = renderHook(() => useLocalStorageState(storageKey, 0));
       const set = result.current[1];
 
       act(() => {
@@ -136,7 +143,7 @@ describe('useLocalStorageState', () => {
       });
 
       expect(result.current[0]).toBe(2);
-      expect(JSON.parse(localStorage.getItem('test-key')!)).toBe(2);
+      expect(JSON.parse(localStorage.getItem(storageKey)!)).toBe(2);
       expect(result.current[1]).toBe(set);
     });
 
@@ -144,7 +151,7 @@ describe('useLocalStorageState', () => {
       let effectRuns = 0;
 
       const { result, rerender } = renderHook(() => {
-        const [value, setValue] = useLocalStorageState('test-key', 0);
+        const [value, setValue] = useLocalStorageState(storageKey, 0);
 
         useEffect(() => {
           effectRuns += 1;
@@ -168,7 +175,7 @@ describe('useLocalStorageState', () => {
 
     it('catches and logs errors when localStorage.setItem throws', () => {
       const spyError = vi.spyOn(console, 'error').mockImplementation(() => {});
-      const { result } = renderHook(() => useLocalStorageState('test-key', 'initial'));
+      const { result } = renderHook(() => useLocalStorageState(storageKey, 'initial'));
 
       vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
         throw new Error('Quota exceeded');
@@ -181,14 +188,14 @@ describe('useLocalStorageState', () => {
       // State should still update even if localStorage write fails
       expect(result.current[0]).toBe('updated');
       expect(spyError).toHaveBeenCalledWith(
-        'Error occurred while setting test-key in local storage:',
+        `Error occurred while setting ${storageKey} in local storage:`,
         expect.any(Error)
       );
     });
 
     it('composes consecutive updates when localStorage.setItem throws', () => {
       vi.spyOn(console, 'error').mockImplementation(() => {});
-      const { result } = renderHook(() => useLocalStorageState('test-key', 0));
+      const { result } = renderHook(() => useLocalStorageState(storageKey, 0));
       const set = result.current[1];
 
       vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
@@ -205,8 +212,8 @@ describe('useLocalStorageState', () => {
     });
 
     it('updates all hook instances using the same key', () => {
-      const first = renderHook(() => useLocalStorageState('shared-key', 'initial'));
-      const second = renderHook(() => useLocalStorageState('shared-key', 'initial'));
+      const first = renderHook(() => useLocalStorageState(storageKey, 'initial'));
+      const second = renderHook(() => useLocalStorageState(storageKey, 'initial'));
 
       act(() => {
         first.result.current[1](() => 'updated');
@@ -214,7 +221,46 @@ describe('useLocalStorageState', () => {
 
       expect(first.result.current[0]).toBe('updated');
       expect(second.result.current[0]).toBe('updated');
-      expect(JSON.parse(localStorage.getItem('shared-key')!)).toBe('updated');
+      expect(JSON.parse(localStorage.getItem(storageKey)!)).toBe('updated');
+    });
+
+    it('applies retained setters to the latest value from another hook instance', () => {
+      const first = renderHook(() => useLocalStorageState(storageKey, 0));
+      const second = renderHook(() => useLocalStorageState(storageKey, 0));
+      const firstSet = first.result.current[1];
+
+      act(() => {
+        second.result.current[1](() => 10);
+        firstSet(old => old + 1);
+      });
+
+      expect(first.result.current[0]).toBe(11);
+      expect(second.result.current[0]).toBe(11);
+      expect(JSON.parse(localStorage.getItem(storageKey)!)).toBe(11);
+    });
+
+    it('switches reads and writes when the key changes', () => {
+      const firstKey = `${storageKey}-first`;
+      const secondKey = `${storageKey}-second`;
+      localStorage.setItem(firstKey, JSON.stringify('first'));
+      localStorage.setItem(secondKey, JSON.stringify('second'));
+      const { result, rerender } = renderHook(
+        ({ storageKey }) => useLocalStorageState(storageKey, 'default'),
+        { initialProps: { storageKey: firstKey } }
+      );
+
+      expect(result.current[0]).toBe('first');
+
+      rerender({ storageKey: secondKey });
+
+      expect(result.current[0]).toBe('second');
+
+      act(() => {
+        result.current[1](() => 'updated');
+      });
+
+      expect(JSON.parse(localStorage.getItem(firstKey)!)).toBe('first');
+      expect(JSON.parse(localStorage.getItem(secondKey)!)).toBe('updated');
     });
   });
 });

--- a/frontend/src/components/globalSearch/useLocalStorageState.tsx
+++ b/frontend/src/components/globalSearch/useLocalStorageState.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 /** Store listeners to allow updates outside of the hook */
 const updateListeners: Record<string, Array<(newValue: any) => void>> = {};
@@ -33,7 +33,11 @@ const updateListeners: Record<string, Array<(newValue: any) => void>> = {};
  * setValue((oldValue) => 'newValue');
  */
 export function useLocalStorageState<T>(key: string, defaultValue: T) {
-  const get = () => {
+  // This ensures that defaultValue, if the value (not the reference) does not change, is stable across render.
+  // It also has the side effect of cloning the defaultValue to ensure it cannot be polluted.
+  const serializedDefaultValue = JSON.stringify(defaultValue);
+
+  const get = useCallback(() => {
     let maybeValue: string | null = null;
 
     try {
@@ -43,11 +47,11 @@ export function useLocalStorageState<T>(key: string, defaultValue: T) {
         `Failed to read ${key} from local storage, falling back to default value:`,
         error
       );
-      return defaultValue;
+      return JSON.parse(serializedDefaultValue);
     }
 
     if (maybeValue === null) {
-      return defaultValue;
+      return JSON.parse(serializedDefaultValue);
     }
 
     try {
@@ -57,24 +61,30 @@ export function useLocalStorageState<T>(key: string, defaultValue: T) {
         `Failed to parse ${key} from local storage, falling back to default value:`,
         error
       );
-      return defaultValue;
+      return JSON.parse(serializedDefaultValue);
     }
-  };
-  const put = (value: T) => {
-    try {
-      localStorage.setItem(key, JSON.stringify(value));
-    } catch (error) {
-      console.error(`Error occurred while setting ${key} in local storage:`, error);
-    }
-  };
+  }, [key, serializedDefaultValue]);
+  const put = useCallback(
+    (value: T) => {
+      try {
+        localStorage.setItem(key, JSON.stringify(value));
+      } catch (error) {
+        console.error(`Error occurred while setting ${key} in local storage:`, error);
+      }
+    },
+    [key]
+  );
 
   const [state, setState] = useState<T>(() => get());
 
-  const set = (updater: (old: T) => T) => {
-    const newValue = updater(state);
-    put(newValue);
-    setState(newValue);
-  };
+  const set = useCallback(
+    (updater: (old: T) => T) => {
+      const newValue = updater(state);
+      put(newValue);
+      setState(newValue);
+    },
+    [put, state]
+  );
 
   // Listen to any updates to local storage
   useEffect(() => {
@@ -86,8 +96,7 @@ export function useLocalStorageState<T>(key: string, defaultValue: T) {
     return () => {
       updateListeners[key] = updateListeners[key].filter(it => it !== listener);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [key]);
+  }, [key, set]);
 
   return [state, set] as const;
 }

--- a/frontend/src/components/globalSearch/useLocalStorageState.tsx
+++ b/frontend/src/components/globalSearch/useLocalStorageState.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { SetStateAction, useCallback, useEffect, useState } from 'react';
 
 /** Store listeners to allow updates outside of the hook */
-const updateListeners: Record<string, Array<(newValue: any) => void>> = {};
+const updateListeners: Record<string, Array<SetStateAction<any>>> = {};
 
 /**
  * Custom hook to manage state synchronized with localStorage.
@@ -82,31 +82,25 @@ export function useLocalStorageState<T>(key: string, defaultValue: T) {
       const newValue = updater(state);
       put(newValue);
       setState(newValue);
+
+      if (updateListeners[key].length > 1) {
+        for (const updateListener of updateListeners[key]) {
+          updateListener(() => newValue);
+        }
+      }
     },
-    [put, state]
+    [state, put, key]
   );
 
   // Listen to any updates to local storage
   useEffect(() => {
-    const listener = (newValue: any) => set(() => newValue);
-
     updateListeners[key] ??= [];
-    updateListeners[key].push(listener);
+    updateListeners[key].push(setState);
 
     return () => {
-      updateListeners[key] = updateListeners[key].filter(it => it !== listener);
+      updateListeners[key] = updateListeners[key].filter(it => it !== setState);
     };
   }, [key, set]);
 
   return [state, set] as const;
 }
-
-/**
- * Update the value in local storage and notify all `useLocalStorageState` hooks
- *
- * @param key - local storage key
- * @param value - local storage value
- */
-useLocalStorageState.update = (key: string, value: any) => {
-  updateListeners[key]?.forEach(fn => fn(value));
-};

--- a/frontend/src/components/globalSearch/useLocalStorageState.tsx
+++ b/frontend/src/components/globalSearch/useLocalStorageState.tsx
@@ -14,122 +14,114 @@
  * limitations under the License.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
 
-interface StorageEntry<T> {
-  value: T;
-  listeners: Set<(value: T) => void>;
+type Listener = () => void;
+
+interface StorageEntry {
+  value: unknown;
+  listeners: Set<Listener>;
 }
 
-// This is the cache storage between getters/setters and localStorage, shared between hooks.
-const storageEntries = new Map<string, StorageEntry<any>>();
+// localStorage does not notify listeners in the same window, so hook instances
+// using the same key share an in-memory entry.
+const storageEntries = new Map<string, StorageEntry>();
 
-function getStorageEntry<T>(key: string, initialize: () => T): StorageEntry<T> {
-  let entry = storageEntries.get(key) as StorageEntry<T> | undefined;
+function readStoredValue<T>(key: string, serializedDefaultValue: string): T {
+  let serializedValue: string | null;
 
-  if (typeof entry === 'undefined') {
-    entry = {
-      value: initialize(),
-      listeners: new Set(),
-    };
-    storageEntries.set(key, entry);
+  try {
+    serializedValue = localStorage.getItem(key);
+  } catch (error) {
+    console.warn(`Failed to read ${key} from local storage, falling back to default value:`, error);
+    return JSON.parse(serializedDefaultValue);
   }
 
-  return entry;
+  if (serializedValue === null) {
+    return JSON.parse(serializedDefaultValue);
+  }
+
+  try {
+    return JSON.parse(serializedValue);
+  } catch (error) {
+    console.warn(
+      `Failed to parse ${key} from local storage, falling back to default value:`,
+      error
+    );
+    return JSON.parse(serializedDefaultValue);
+  }
+}
+
+function writeStoredValue(key: string, value: unknown) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.error(`Error occurred while setting ${key} in local storage:`, error);
+  }
+}
+
+function getStorageEntry<T>(key: string, serializedDefaultValue: string): StorageEntry {
+  const entry = storageEntries.get(key);
+  if (entry) {
+    return entry;
+  }
+
+  const newEntry: StorageEntry = {
+    value: readStoredValue<T>(key, serializedDefaultValue),
+    listeners: new Set(),
+  };
+  storageEntries.set(key, newEntry);
+
+  return newEntry;
+}
+
+function subscribe(entry: StorageEntry, listener: Listener) {
+  entry.listeners.add(listener);
+  return () => void entry.listeners.delete(listener);
+}
+
+function updateEntry<T>(key: string, entry: StorageEntry, updater: (oldValue: T) => T) {
+  const newValue = updater(entry.value as T);
+  entry.value = newValue;
+
+  for (const listener of entry.listeners) {
+    listener();
+  }
+
+  writeStoredValue(key, newValue);
 }
 
 /**
- * Custom hook to manage state synchronized with localStorage and multiple instances of the same hook.
- * This hook does not yet handle changes across window.
- * Value must by serializable to JSON.
+ * Custom hook to manage state synchronized with localStorage and other hook instances
+ * in the same window. Values must be serializable to JSON.
+ *
+ * It returns a reference to the same object for calls with the same key, so care
+ * must be taken to not accidentally modify the returned object.
  *
  * @template T - The type of the state value.
- * @param {string} key - The key under which the state is stored in localStorage.
- * @param {T} defaultValue - The default value to use if no value is found in localStorage.
- * @returns Returns a tuple containing the current state and a function to update the state.
+ * @param key - The key under which the state is stored in localStorage.
+ * @param defaultValue - The default value to use if no value is found in localStorage.
+ * @returns The current state and a function that updates it.
  *
  * @example
  * const [value, setValue] = useLocalStorageState<string>('myKey', 'default');
- * setValue((oldValue) => 'newValue');
+ * setValue(() => 'newValue');
  */
 export function useLocalStorageState<T>(key: string, defaultValue: T) {
-  // This ensures that defaultValue, if the value (not the reference) does not change, is stable across render.
-  // It also has the side effect of cloning the defaultValue to ensure it cannot be polluted.
+  // Serializing also gives each new entry its own deep clone of the default value.
   const serializedDefaultValue = JSON.stringify(defaultValue);
-
-  const get = useCallback(() => {
-    let maybeValue: string | null = null;
-
-    try {
-      maybeValue = localStorage.getItem(key);
-    } catch (error) {
-      console.warn(
-        `Failed to read ${key} from local storage, falling back to default value:`,
-        error
-      );
-      return JSON.parse(serializedDefaultValue);
-    }
-
-    if (maybeValue === null) {
-      return JSON.parse(serializedDefaultValue);
-    }
-
-    try {
-      return JSON.parse(maybeValue);
-    } catch (error) {
-      console.warn(
-        `Failed to parse ${key} from local storage, falling back to default value:`,
-        error
-      );
-      return JSON.parse(serializedDefaultValue);
-    }
-  }, [key, serializedDefaultValue]);
-  const put = useCallback(
-    (value: T) => {
-      try {
-        localStorage.setItem(key, JSON.stringify(value));
-      } catch (error) {
-        console.error(`Error occurred while setting ${key} in local storage:`, error);
-      }
-    },
-    [key]
+  const entry = useMemo(
+    () => getStorageEntry<T>(key, serializedDefaultValue),
+    [key, serializedDefaultValue]
   );
 
-  const entry = useMemo(() => getStorageEntry(key, get), [get, key]);
-  const [state, setState] = useState<T>(() => entry.value);
-
-  const set = useCallback(
-    (updater: (old: T) => T) => {
-      const newValue = updater(entry.value);
-
-      entry.value = newValue;
-      setState(newValue);
-
-      for (const listener of entry.listeners) {
-        listener(newValue);
-      }
-
-      put(newValue);
-    },
-    [entry, put]
+  const subscribeToEntry = useCallback((listener: Listener) => subscribe(entry, listener), [entry]);
+  const getSnapshot = useCallback(() => entry.value as T, [entry]);
+  const state = useSyncExternalStore(subscribeToEntry, getSnapshot, getSnapshot);
+  const setState = useCallback(
+    (updater: (oldValue: T) => T) => updateEntry(key, entry, updater),
+    [entry, key]
   );
 
-  // Listen to updates from other hook instances using the same key.
-  useEffect(() => {
-    const listener = (newValue: T) => setState(newValue);
-
-    storageEntries.set(key, entry);
-    entry.listeners.add(listener);
-    setState(entry.value);
-
-    return () => {
-      entry.listeners.delete(listener);
-
-      if (entry.listeners.size === 0 && storageEntries.get(key) === entry) {
-        storageEntries.delete(key);
-      }
-    };
-  }, [entry, key]);
-
-  return [state, set] as const;
+  return [state, setState] as const;
 }

--- a/frontend/src/components/globalSearch/useLocalStorageState.tsx
+++ b/frontend/src/components/globalSearch/useLocalStorageState.tsx
@@ -75,9 +75,14 @@ function getStorageEntry<T>(key: string, serializedDefaultValue: string): Storag
   return newEntry;
 }
 
-function subscribe(entry: StorageEntry, listener: Listener) {
+function subscribe(key: string, entry: StorageEntry, listener: Listener) {
   entry.listeners.add(listener);
-  return () => void entry.listeners.delete(listener);
+  return () => {
+    entry.listeners.delete(listener);
+    if (entry.listeners.size === 0) {
+      storageEntries.delete(key);
+    }
+  };
 }
 
 function updateEntry<T>(key: string, entry: StorageEntry, updater: (oldValue: T) => T) {
@@ -115,7 +120,10 @@ export function useLocalStorageState<T>(key: string, defaultValue: T) {
     [key, serializedDefaultValue]
   );
 
-  const subscribeToEntry = useCallback((listener: Listener) => subscribe(entry, listener), [entry]);
+  const subscribeToEntry = useCallback(
+    (listener: Listener) => subscribe(key, entry, listener),
+    [key, entry]
+  );
   const getSnapshot = useCallback(() => entry.value as T, [entry]);
   const state = useSyncExternalStore(subscribeToEntry, getSnapshot, getSnapshot);
   const setState = useCallback(

--- a/frontend/src/components/globalSearch/useLocalStorageState.tsx
+++ b/frontend/src/components/globalSearch/useLocalStorageState.tsx
@@ -14,13 +14,33 @@
  * limitations under the License.
  */
 
-import { SetStateAction, useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
-/** Store listeners to allow updates outside of the hook */
-const updateListeners: Record<string, Array<SetStateAction<any>>> = {};
+interface StorageEntry<T> {
+  value: T;
+  listeners: Set<(value: T) => void>;
+}
+
+// This is the cache storage between getters/setters and localStorage, shared between hooks.
+const storageEntries = new Map<string, StorageEntry<any>>();
+
+function getStorageEntry<T>(key: string, initialize: () => T): StorageEntry<T> {
+  let entry = storageEntries.get(key) as StorageEntry<T> | undefined;
+
+  if (typeof entry === 'undefined') {
+    entry = {
+      value: initialize(),
+      listeners: new Set(),
+    };
+    storageEntries.set(key, entry);
+  }
+
+  return entry;
+}
 
 /**
- * Custom hook to manage state synchronized with localStorage.
+ * Custom hook to manage state synchronized with localStorage and multiple instances of the same hook.
+ * This hook does not yet handle changes across window.
  * Value must by serializable to JSON.
  *
  * @template T - The type of the state value.
@@ -75,32 +95,41 @@ export function useLocalStorageState<T>(key: string, defaultValue: T) {
     [key]
   );
 
-  const [state, setState] = useState<T>(() => get());
+  const entry = useMemo(() => getStorageEntry(key, get), [get, key]);
+  const [state, setState] = useState<T>(() => entry.value);
 
   const set = useCallback(
     (updater: (old: T) => T) => {
-      const newValue = updater(state);
-      put(newValue);
+      const newValue = updater(entry.value);
+
+      entry.value = newValue;
       setState(newValue);
 
-      if (updateListeners[key].length > 1) {
-        for (const updateListener of updateListeners[key]) {
-          updateListener(() => newValue);
-        }
+      for (const listener of entry.listeners) {
+        listener(newValue);
       }
+
+      put(newValue);
     },
-    [state, put, key]
+    [entry, put]
   );
 
-  // Listen to any updates to local storage
+  // Listen to updates from other hook instances using the same key.
   useEffect(() => {
-    updateListeners[key] ??= [];
-    updateListeners[key].push(setState);
+    const listener = (newValue: T) => setState(newValue);
+
+    storageEntries.set(key, entry);
+    entry.listeners.add(listener);
+    setState(entry.value);
 
     return () => {
-      updateListeners[key] = updateListeners[key].filter(it => it !== setState);
+      entry.listeners.delete(listener);
+
+      if (entry.listeners.size === 0 && storageEntries.get(key) === entry) {
+        storageEntries.delete(key);
+      }
     };
-  }, [key, set]);
+  }, [entry, key]);
 
   return [state, set] as const;
 }

--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -101,7 +101,7 @@ export function PodLogViewer(props: PodLogViewerProps) {
   const { t } = useTranslation();
   const [selectedSeverities, setSelectedSeverities] = useLocalStorageState<LogSeverity[]>(
     'headlamp.logs.severityFilter',
-    [...ALL_SEVERITIES]
+    ALL_SEVERITIES
   );
   const selectedSeveritiesRef = React.useRef(selectedSeverities);
 


### PR DESCRIPTION
## Summary

This PR rewrites the `useLocalStorageState` to simplify the behavior and resolve lint errors.

## Related Issue

Fixes #6777 (part of #5183)  

## Changes

* Simplify the behavior: the original hook has non-inter-hook-synced `useLocalStorageState(...)[1]` and synced `useLocalStroageState.update`. In then new version, all 
* Enable batched updates to the same value
* Use `useSyncExternalStore`
* Fix the suppressed lint error below (#6777 part of #5183)
  > frontend: useLocalStorageState: Fix react-hooks/exhaustive-deps — missing dependency. File: frontend/src/components/globalSearch/useLocalStorageState.tsx

## Steps to Test

Visiting all pages that use the hook and ensure there are no regressions.

## Screenshots (if applicable)

No UI changes

## Notes for the Reviewer

N/A