### PR TITLE
frontend: Fix recent search item eviction

### DIFF
--- a/frontend/src/components/globalSearch/useRecent.test.tsx
+++ b/frontend/src/components/globalSearch/useRecent.test.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { useRecent } from './useRecent';
+
+describe('useRecent', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('does not evict an item when bumping an existing entry at capacity', () => {
+    localStorage.setItem(
+      'recent-test',
+      JSON.stringify({
+        oldest: 1,
+        newest: 2,
+      })
+    );
+
+    const { result } = renderHook(() => useRecent('recent-test', 2));
+
+    act(() => {
+      result.current[1]('newest');
+    });
+
+    expect(Object.keys(result.current[0])).toHaveLength(2);
+    expect(result.current[0]).toHaveProperty('oldest', 1);
+    expect(result.current[0].newest).toBeGreaterThan(2);
+  });
+
+  it('evicts the oldest entry when adding a new item at capacity', () => {
+    localStorage.setItem(
+      'recent-test',
+      JSON.stringify({
+        oldest: 1,
+        newest: 2,
+      })
+    );
+
+    const { result } = renderHook(() => useRecent('recent-test', 2));
+
+    act(() => {
+      result.current[1]('new-item');
+    });
+
+    expect(Object.keys(result.current[0])).toHaveLength(2);
+    expect(result.current[0]).not.toHaveProperty('oldest');
+    expect(result.current[0]).toHaveProperty('newest', 2);
+    expect(result.current[0]).toHaveProperty('new-item');
+  });
+
+  it('keeps the list empty when maxItems is zero', () => {
+    localStorage.setItem('recent-test', JSON.stringify({ existing: 123 }));
+
+    const { result } = renderHook(() => useRecent('recent-test', 0));
+
+    expect(result.current[0]).toEqual({});
+
+    act(() => {
+      result.current[1]('new-item');
+    });
+
+    expect(result.current[0]).toEqual({});
+  });
+});

--- a/frontend/src/components/globalSearch/useRecent.test.tsx
+++ b/frontend/src/components/globalSearch/useRecent.test.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { useRecent } from './useRecent';
+
+describe('useRecent', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('does not evict an item when bumping an existing entry at capacity', () => {
+    localStorage.setItem(
+      'recent-test',
+      JSON.stringify({
+        oldest: 1,
+        newest: 2,
+      })
+    );
+
+    const { result } = renderHook(() => useRecent('recent-test', 2));
+
+    act(() => {
+      result.current[1]('newest');
+    });
+
+    expect(Object.keys(result.current[0])).toHaveLength(2);
+    expect(result.current[0]).toHaveProperty('oldest', 1);
+    expect(result.current[0].newest).toBeGreaterThan(2);
+  });
+
+  it('evicts the oldest entry when adding a new item at capacity', () => {
+    localStorage.setItem(
+      'recent-test',
+      JSON.stringify({
+        oldest: 1,
+        newest: 2,
+      })
+    );
+
+    const { result } = renderHook(() => useRecent('recent-test', 2));
+
+    act(() => {
+      result.current[1]('new-item');
+    });
+
+    expect(Object.keys(result.current[0])).toHaveLength(2);
+    expect(result.current[0]).not.toHaveProperty('oldest');
+    expect(result.current[0]).toHaveProperty('newest', 2);
+    expect(result.current[0]).toHaveProperty('new-item');
+  });
+
+  it('keeps the list empty when maxItems is zero', () => {
+    const { result } = renderHook(() => useRecent('recent-test', 0));
+
+    act(() => {
+      result.current[1]('new-item');
+    });
+
+    expect(result.current[0]).toEqual({});
+  });
+});

--- a/frontend/src/components/globalSearch/useRecent.tsx
+++ b/frontend/src/components/globalSearch/useRecent.tsx
@@ -35,28 +35,30 @@ export function useRecent(
 
   const bump = useCallback((id: string) => {
     setRecent(recent => {
+      if (maxItems <= 0) {
+        return {};
+      }
+
       const entries = Object.entries(recent);
       const newRecent: Record<string, number> = { ...recent };
+      const isNewItem = !Object.prototype.hasOwnProperty.call(recent, id);
 
-      if (entries.length + 1 > maxItems) {
+      if (isNewItem && entries.length >= maxItems) {
         // Find oldest entry
-        let oldestEntry = entries[0];
-        entries.forEach(entry => {
-          if (entry[1] < oldestEntry[1]) {
-            oldestEntry = entry;
-          }
-        });
+        const oldestEntry = entries.reduce((oldest, entry) =>
+          entry[1] < oldest[1] ? entry : oldest
+        );
 
         // Remove it
         delete newRecent[oldestEntry[0]];
       }
 
-      newRecent[id] = +new Date();
+      newRecent[id] = Date.now();
 
       return newRecent;
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return [recent, bump] as const;
+  return [maxItems <= 0 ? {} : recent, bump] as const;
 }

--- a/frontend/src/components/globalSearch/useRecent.tsx
+++ b/frontend/src/components/globalSearch/useRecent.tsx
@@ -35,23 +35,25 @@ export function useRecent(
 
   const bump = useCallback((id: string) => {
     setRecent(recent => {
+      if (maxItems <= 0) {
+        return {};
+      }
+
       const entries = Object.entries(recent);
       const newRecent: Record<string, number> = { ...recent };
+      const isNewItem = !(id in recent);
 
-      if (entries.length + 1 > maxItems) {
+      if (isNewItem && entries.length >= maxItems) {
         // Find oldest entry
-        let oldestEntry = entries[0];
-        entries.forEach(entry => {
-          if (entry[1] < oldestEntry[1]) {
-            oldestEntry = entry;
-          }
-        });
+        const oldestEntry = entries.reduce((oldest, entry) =>
+          entry[1] < oldest[1] ? entry : oldest
+        );
 
         // Remove it
         delete newRecent[oldestEntry[0]];
       }
 
-      newRecent[id] = +new Date();
+      newRecent[id] = Date.now();
 
       return newRecent;
     });


### PR DESCRIPTION
## Summary

This PR fixes incorrect eviction from the Global Search recent-item list.

When the list was at capacity, selecting an item that was already present removed the oldest entry. Selecting an existing item should only refresh its timestamp without changing the number of stored items.

The change also prevents an error when `maxItems` is set to zero.

## Related Issue

Fixes #6778

## Changes

- Check whether a selected item is new before evicting an entry.
- Evict the oldest entry only when adding a new item at capacity.
- Preserve all existing entries when refreshing a recent item.
- Safely keep the collection empty when `maxItems` is zero.
- Add unit tests covering updates, eviction, and zero capacity.

## Steps to Test

1. Start the Headlamp frontend and backend.
2. Open Global Search using the search bar or the `/` keyboard shortcut.
3. Select 10 distinct results to fill the recent-item list.
4. Open Global Search again with an empty query.
5. Select an existing recent item.
6. Confirm that the item is moved to the top without removing another entry.

The stored item count can also be verified in the browser console:

```js
Object.keys(
  JSON.parse(localStorage.getItem('search-recent-items') || '{}')
).length;
```

The count should remain unchanged after selecting an existing recent item.

Automated tests were run with:

```bash
cd frontend
npm test -- --run src/components/globalSearch/useRecent.test.tsx
npm test -- --run
```

Validation results:

- Focused tests: 3 passed
- Full frontend suite: 183 test files and 2398 tests passed
- TypeScript check passed
- Changed files passed ESLint and Prettier checks

## Screenshots (if applicable)

Not applicable. This change fixes state-management behavior and does not alter the visual layout.

## Notes for the Reviewer

The change is scoped to the recent-item eviction logic. It does not change any public APIs or add dependencies.