### PR TITLE
app: Make plugin updates atomic to prevent plugin corruption on failed updates

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -58,6 +58,7 @@ import {
   getMatchingExtraFiles,
   getPluginBinDirectories,
   PluginManager,
+  recoverInterruptedUpdate,
   setAppConfigDirName,
 } from './plugin-management';
 import { readProtocolScheme } from './protocol';
@@ -1368,6 +1369,10 @@ ipcMain.on('route-changed', () => {
 function startElectron() {
   console.info('App starting...');
 
+  // Force a single instance. This must happen before any work that could
+  // race with another instance (e.g. recovering interrupted plugin update
+  // transactions) so a second instance can never interfere with a live
+  // update transaction in the first instance.
   const gotTheLock = app.requestSingleInstanceLock();
   if (!gotTheLock) {
     app.quit();
@@ -1826,6 +1831,9 @@ function startElectron() {
   }
 
   app.on('ready', async () => {
+    // Restore any plugins left broken by an update that was interrupted
+    // mid-swap, before the backend starts serving the plugins directory.
+    recoverInterruptedUpdate(defaultUserPluginsDir());
     await Promise.all([startServerIfNeeded(), createWindow()]);
     hasTray = createHeadlampTray(buildTrayOptions());
   });

--- a/app/electron/plugin-management.test.ts
+++ b/app/electron/plugin-management.test.ts
@@ -20,6 +20,7 @@
  * These tests focus on downloading and installing plugins from local artifacthub pkg files,
  * including testing platform-specific annotations that allow additional binaries to be included.
  */
+import { spawnSync } from 'child_process';
 import crypto from 'crypto';
 import fs from 'fs';
 import nock from 'nock';
@@ -40,6 +41,8 @@ import {
 const TEST_DATA_BASE_DIR = path.join(os.tmpdir(), 'headlamp-test-data');
 const PLUGIN_DEST_BASE_DIR = path.join(os.tmpdir(), 'headlamp-test-plugins');
 const HEADLAMP_VERSION = '0.30.0';
+const TXN_ID = '0123456789abcdef';
+const TXN_DIR = '.headlamp-txn';
 const ORIGINAL_PLATFORM = process.platform;
 
 describe('default plugin directories', () => {
@@ -126,6 +129,15 @@ function getUniqueTestDir(basePath: string, testName: string): string {
     fs.mkdirSync(dir, { recursive: true });
   }
   return dir;
+}
+
+/**
+ * Returns the pid of a process that has already exited, so a lock file
+ * recording it is treated as belonging to a dead process.
+ */
+function getDeadPid(): number {
+  const child = spawnSync(process.execPath, ['-e', '']);
+  return child.pid!;
 }
 
 describe('PluginManager', () => {
@@ -289,6 +301,330 @@ describe('PluginManager', () => {
       fs.rmSync(testDataDir, { recursive: true });
     }
   }, 30000);
+
+  it('should update a plugin via a staging/backup swap without leftover transaction state', async () => {
+    const testDataDir = getUniqueTestDir(TEST_DATA_BASE_DIR, 'update-swap-data');
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'update-swap-plugins');
+
+    await createMinimalPluginTarball(testDataDir);
+
+    const pluginURL = 'https://artifacthub.io/packages/headlamp/test-repo/headlamp_minikube';
+    const progress: any[] = [];
+    const progressCallback = (update: any) => {
+      progress.push(update);
+    };
+
+    // Install version 0.1.0
+    mockArtifactHubAPIWithoutPlatformSpecific(testDataDir, '0.1.0');
+    await PluginManager.install(pluginURL, pluginDestDir, HEADLAMP_VERSION, progressCallback, null);
+
+    const pluginDir = path.join(pluginDestDir, 'headlamp_minikube');
+    expect(fs.existsSync(pluginDir)).toBe(true);
+    const installedPackageJson = JSON.parse(
+      fs.readFileSync(path.join(pluginDir, 'package.json'), 'utf8')
+    );
+    expect(installedPackageJson.artifacthub.version).toBe('0.1.0');
+
+    // Update to version 0.2.0
+    progress.length = 0;
+    mockArtifactHubAPIWithoutPlatformSpecific(testDataDir, '0.2.0');
+    await PluginManager.update(
+      'headlamp_minikube',
+      pluginDestDir,
+      HEADLAMP_VERSION,
+      progressCallback,
+      null
+    );
+
+    // The plugin directory must exist with the new version
+    expect(fs.existsSync(pluginDir)).toBe(true);
+    const updatedPackageJson = JSON.parse(
+      fs.readFileSync(path.join(pluginDir, 'package.json'), 'utf8')
+    );
+    expect(updatedPackageJson.artifacthub.version).toBe('0.2.0');
+
+    // No transaction state may be left behind
+    expect(fs.existsSync(path.join(pluginDestDir, TXN_DIR))).toBe(false);
+    const leftoverEntries = fs
+      .readdirSync(pluginDestDir, { withFileTypes: true })
+      .filter(entry => entry.name.includes('staging') || entry.name.includes('backup'));
+    expect(leftoverEntries).toHaveLength(0);
+
+    const successMessages = progress.filter(p => p.type === 'success');
+    expect(successMessages.length).toBe(1);
+    expect(successMessages[0].message).toBe('Plugin Updated');
+
+    if (fs.existsSync(pluginDestDir)) {
+      fs.rmSync(pluginDestDir, { recursive: true });
+    }
+    if (fs.existsSync(testDataDir)) {
+      fs.rmSync(testDataDir, { recursive: true });
+    }
+  }, 30000);
+
+  it('should roll back to the previous version when the swap rename fails', async () => {
+    const testDataDir = getUniqueTestDir(TEST_DATA_BASE_DIR, 'update-rollback-data');
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'update-rollback-plugins');
+
+    await createMinimalPluginTarball(testDataDir);
+
+    const pluginURL = 'https://artifacthub.io/packages/headlamp/test-repo/headlamp_minikube';
+    const progress: any[] = [];
+    const progressCallback = (update: any) => {
+      progress.push(update);
+    };
+
+    // Install version 0.1.0
+    mockArtifactHubAPIWithoutPlatformSpecific(testDataDir, '0.1.0');
+    await PluginManager.install(pluginURL, pluginDestDir, HEADLAMP_VERSION, progressCallback, null);
+
+    const pluginDir = path.join(pluginDestDir, 'headlamp_minikube');
+    expect(fs.existsSync(pluginDir)).toBe(true);
+
+    // Update to version 0.2.0, but force the staging -> plugin rename to fail
+    progress.length = 0;
+    mockArtifactHubAPIWithoutPlatformSpecific(testDataDir, '0.2.0');
+
+    const realRenameSync = fs.renameSync.bind(fs);
+    const renameSpy = vi.spyOn(fs, 'renameSync').mockImplementation(((
+      src: fs.PathLike,
+      dst: fs.PathLike
+    ) => {
+      if (String(src).includes('.staging.') && String(dst) === pluginDir) {
+        throw new Error('simulated rename failure');
+      }
+      realRenameSync(src, dst);
+    }) as typeof fs.renameSync);
+
+    await PluginManager.update(
+      'headlamp_minikube',
+      pluginDestDir,
+      HEADLAMP_VERSION,
+      progressCallback,
+      null
+    );
+    renameSpy.mockRestore();
+
+    // The failure must be reported
+    const errorMessages = progress.filter(p => p.type === 'error');
+    expect(errorMessages.some(e => e.message.includes('simulated rename failure'))).toBe(true);
+
+    // The previous version must still be in place and usable
+    expect(fs.existsSync(pluginDir)).toBe(true);
+    const packageJson = JSON.parse(fs.readFileSync(path.join(pluginDir, 'package.json'), 'utf8'));
+    expect(packageJson.artifacthub.version).toBe('0.1.0');
+
+    // No transaction state may be left behind
+    expect(fs.existsSync(path.join(pluginDestDir, TXN_DIR))).toBe(false);
+
+    if (fs.existsSync(pluginDestDir)) {
+      fs.rmSync(pluginDestDir, { recursive: true });
+    }
+    if (fs.existsSync(testDataDir)) {
+      fs.rmSync(testDataDir, { recursive: true });
+    }
+  }, 30000);
+
+  it('should reject installing a plugin named .headlamp-txn', async () => {
+    const testDataDir = getUniqueTestDir(TEST_DATA_BASE_DIR, 'reserved-name-data');
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'reserved-name-plugins');
+
+    await createMinimalPluginTarball(testDataDir);
+    mockArtifactHubAPIWithoutPlatformSpecific(testDataDir, '0.1.0', TXN_DIR);
+
+    const pluginURL = `https://artifacthub.io/packages/headlamp/test-repo/${TXN_DIR}`;
+    const progress: any[] = [];
+
+    await PluginManager.install(
+      pluginURL,
+      pluginDestDir,
+      HEADLAMP_VERSION,
+      update => {
+        progress.push(update);
+      },
+      null
+    );
+
+    const errorMessages = progress.filter(p => p.type === 'error');
+    expect(errorMessages.some(e => e.message.includes('Invalid plugin name'))).toBe(true);
+    expect(fs.existsSync(path.join(pluginDestDir, TXN_DIR))).toBe(false);
+
+    if (fs.existsSync(pluginDestDir)) {
+      fs.rmSync(pluginDestDir, { recursive: true });
+    }
+    if (fs.existsSync(testDataDir)) {
+      fs.rmSync(testDataDir, { recursive: true });
+    }
+  }, 30000);
+});
+
+describe('PluginManager.list interrupted update recovery', () => {
+  it('should not touch legitimate plugin directories named *.backup or *.staging', () => {
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'recovery-suffix-collision');
+    fs.mkdirSync(path.join(pluginDestDir, 'foo.backup'), { recursive: true });
+    fs.mkdirSync(path.join(pluginDestDir, 'foo.staging'), { recursive: true });
+
+    PluginManager.list(pluginDestDir);
+
+    expect(fs.existsSync(path.join(pluginDestDir, 'foo.backup'))).toBe(true);
+    expect(fs.existsSync(path.join(pluginDestDir, 'foo.staging'))).toBe(true);
+    expect(fs.existsSync(path.join(pluginDestDir, 'foo'))).toBe(false);
+
+    fs.rmSync(pluginDestDir, { recursive: true });
+  });
+
+  it('should not touch a legitimate plugin named like a transaction directory', () => {
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'recovery-txn-name-collision');
+    const pluginDir = path.join(pluginDestDir, `foo.staging.${TXN_ID}`);
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(path.join(pluginDir, 'main.js'), '// plugin');
+
+    PluginManager.list(pluginDestDir);
+
+    expect(fs.existsSync(pluginDir)).toBe(true);
+    expect(fs.existsSync(path.join(pluginDestDir, 'foo'))).toBe(false);
+
+    fs.rmSync(pluginDestDir, { recursive: true });
+  });
+
+  it('should defensively leave a directory occupying the .headlamp-txn name alone', () => {
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'recovery-txn-dir-plugin');
+    const txnPluginDir = path.join(pluginDestDir, TXN_DIR);
+    fs.mkdirSync(txnPluginDir, { recursive: true });
+    fs.writeFileSync(path.join(txnPluginDir, 'package.json'), '{}');
+    fs.writeFileSync(path.join(txnPluginDir, 'main.js'), '// plugin');
+
+    PluginManager.list(pluginDestDir);
+
+    expect(fs.existsSync(txnPluginDir)).toBe(true);
+    expect(fs.existsSync(path.join(txnPluginDir, 'main.js'))).toBe(true);
+
+    fs.rmSync(pluginDestDir, { recursive: true });
+  });
+
+  it('should restore a backup whose plugin directory is missing', () => {
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'recovery-backup-restore');
+    const backupDir = path.join(pluginDestDir, TXN_DIR, `bar.backup.${TXN_ID}`);
+    fs.mkdirSync(backupDir, { recursive: true });
+    fs.writeFileSync(path.join(backupDir, 'main.js'), '// old plugin');
+
+    PluginManager.list(pluginDestDir);
+
+    expect(fs.existsSync(backupDir)).toBe(false);
+    expect(fs.existsSync(path.join(pluginDestDir, 'bar'))).toBe(true);
+    expect(fs.existsSync(path.join(pluginDestDir, TXN_DIR))).toBe(false);
+
+    fs.rmSync(pluginDestDir, { recursive: true });
+  });
+
+  it('should remove a stale backup whose plugin directory exists', () => {
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'recovery-backup-stale');
+    const backupDir = path.join(pluginDestDir, TXN_DIR, `qux.backup.${TXN_ID}`);
+    const pluginDir = path.join(pluginDestDir, 'qux');
+    fs.mkdirSync(backupDir, { recursive: true });
+    fs.mkdirSync(pluginDir, { recursive: true });
+
+    PluginManager.list(pluginDestDir);
+
+    expect(fs.existsSync(backupDir)).toBe(false);
+    expect(fs.existsSync(pluginDir)).toBe(true);
+
+    fs.rmSync(pluginDestDir, { recursive: true });
+  });
+
+  it('should remove a stale staging directory', () => {
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'recovery-staging-stale');
+    const stagingDir = path.join(pluginDestDir, TXN_DIR, `baz.staging.${TXN_ID}`);
+    fs.mkdirSync(stagingDir, { recursive: true });
+
+    PluginManager.list(pluginDestDir);
+
+    expect(fs.existsSync(stagingDir)).toBe(false);
+    expect(fs.existsSync(path.join(pluginDestDir, 'baz'))).toBe(false);
+
+    fs.rmSync(pluginDestDir, { recursive: true });
+  });
+
+  it('should remove a stale staging directory even when the plugin directory exists', () => {
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'recovery-staging-with-plugin');
+    const stagingDir = path.join(pluginDestDir, TXN_DIR, `quux.staging.${TXN_ID}`);
+    const pluginDir = path.join(pluginDestDir, 'quux');
+    fs.mkdirSync(stagingDir, { recursive: true });
+    fs.mkdirSync(pluginDir, { recursive: true });
+
+    PluginManager.list(pluginDestDir);
+
+    expect(fs.existsSync(stagingDir)).toBe(false);
+    expect(fs.existsSync(pluginDir)).toBe(true);
+
+    fs.rmSync(pluginDestDir, { recursive: true });
+  });
+
+  it('should not touch an active staging transaction owned by a live process', () => {
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'recovery-active-staging');
+    const txnRoot = path.join(pluginDestDir, TXN_DIR);
+    const stagingDir = path.join(txnRoot, `baz.staging.${TXN_ID}`);
+    const lockFile = path.join(txnRoot, `${TXN_ID}.lock`);
+    fs.mkdirSync(stagingDir, { recursive: true });
+    fs.writeFileSync(lockFile, JSON.stringify({ pid: process.pid }));
+
+    PluginManager.list(pluginDestDir);
+
+    expect(fs.existsSync(stagingDir)).toBe(true);
+    expect(fs.existsSync(lockFile)).toBe(true);
+    expect(fs.existsSync(path.join(pluginDestDir, 'baz'))).toBe(false);
+
+    fs.rmSync(pluginDestDir, { recursive: true });
+  });
+
+  it('should not restore a backup owned by a live process', () => {
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'recovery-active-backup');
+    const txnRoot = path.join(pluginDestDir, TXN_DIR);
+    const backupDir = path.join(txnRoot, `bar.backup.${TXN_ID}`);
+    const lockFile = path.join(txnRoot, `${TXN_ID}.lock`);
+    fs.mkdirSync(backupDir, { recursive: true });
+    fs.writeFileSync(path.join(backupDir, 'main.js'), '// old plugin');
+    fs.writeFileSync(lockFile, JSON.stringify({ pid: process.pid }));
+
+    PluginManager.list(pluginDestDir);
+
+    expect(fs.existsSync(backupDir)).toBe(true);
+    expect(fs.existsSync(path.join(pluginDestDir, 'bar'))).toBe(false);
+
+    fs.rmSync(pluginDestDir, { recursive: true });
+  });
+
+  it('should recover a transaction whose lock owner is dead', () => {
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'recovery-dead-lock');
+    const txnRoot = path.join(pluginDestDir, TXN_DIR);
+    const stagingDir = path.join(txnRoot, `baz.staging.${TXN_ID}`);
+    const lockFile = path.join(txnRoot, `${TXN_ID}.lock`);
+    fs.mkdirSync(stagingDir, { recursive: true });
+    fs.writeFileSync(lockFile, JSON.stringify({ pid: getDeadPid() }));
+
+    PluginManager.list(pluginDestDir);
+
+    expect(fs.existsSync(stagingDir)).toBe(false);
+    expect(fs.existsSync(lockFile)).toBe(false);
+    expect(fs.existsSync(txnRoot)).toBe(false);
+
+    fs.rmSync(pluginDestDir, { recursive: true });
+  });
+
+  it('should remove an orphan lock file whose owner is dead', () => {
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'recovery-orphan-lock');
+    const txnRoot = path.join(pluginDestDir, TXN_DIR);
+    const lockFile = path.join(txnRoot, `${TXN_ID}.lock`);
+    fs.mkdirSync(txnRoot, { recursive: true });
+    fs.writeFileSync(lockFile, JSON.stringify({ pid: getDeadPid() }));
+
+    PluginManager.list(pluginDestDir);
+
+    expect(fs.existsSync(lockFile)).toBe(false);
+    expect(fs.existsSync(txnRoot)).toBe(false);
+
+    fs.rmSync(pluginDestDir, { recursive: true });
+  });
 });
 
 /**
@@ -458,7 +794,11 @@ function mockArtifactHubAPI(testDataDir: string) {
 /**
  * Mock the ArtifactHub API without platform-specific archives
  */
-function mockArtifactHubAPIWithoutPlatformSpecific(testDataDir: string) {
+function mockArtifactHubAPIWithoutPlatformSpecific(
+  testDataDir: string,
+  version = '0.1.0',
+  name = 'headlamp_minikube'
+) {
   try {
     // Calculate checksums for the tarball
     const pluginTarballPath = path.join(testDataDir, 'plugin-tarball.tar.gz');
@@ -478,11 +818,11 @@ function mockArtifactHubAPIWithoutPlatformSpecific(testDataDir: string) {
 
     // Mock the ArtifactHub API response without platform-specific data
     nock('https://artifacthub.io')
-      .get('/api/v1/packages/headlamp/test-repo/headlamp_minikube')
+      .get('/api/v1/packages/headlamp/test-repo/' + name)
       .reply(200, {
-        name: 'headlamp_minikube',
+        name: name,
         display_name: 'Minikube',
-        version: '0.1.0',
+        version: version,
         repository: {
           name: 'test-repo',
           user_alias: 'tester',

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -312,14 +312,48 @@ export class PluginManager {
         fs.mkdirSync(destinationFolder, { recursive: true });
       }
 
-      // remove the existing plugin folder
-      fs.rmSync(pluginDir, { recursive: true, force: true });
+      // Stage the new content alongside the existing plugin directory so
+      // a failure during the move does not leave the plugin in a broken
+      // state. The rename from the staging directory to the real plugin
+      // directory is atomic when both reside on the same filesystem.
+      const stagingDir = pluginDir + '.staging';
 
-      // create the plugin folder
-      fs.mkdirSync(pluginDir, { recursive: true });
+      if (fs.existsSync(stagingDir)) {
+        fs.rmSync(stagingDir, { recursive: true, force: true });
+      }
+      fs.mkdirSync(stagingDir, { recursive: true });
 
-      // move the plugin to the destination folder
-      moveDirs(tempFolder, pluginDir);
+      try {
+        moveDirs(tempFolder, stagingDir);
+
+        const backupDir = pluginDir + '.backup';
+
+        if (fs.existsSync(backupDir)) {
+          fs.rmSync(backupDir, { recursive: true, force: true });
+        }
+
+        if (fs.existsSync(pluginDir)) {
+          fs.renameSync(pluginDir, backupDir);
+        }
+
+        try {
+          fs.renameSync(stagingDir, pluginDir);
+        } catch (err) {
+          if (fs.existsSync(backupDir)) {
+            fs.renameSync(backupDir, pluginDir);
+          }
+          throw err;
+        }
+
+        if (fs.existsSync(backupDir)) {
+          fs.rmSync(backupDir, { recursive: true, force: true });
+        }
+      } finally {
+        if (fs.existsSync(stagingDir)) {
+          fs.rmSync(stagingDir, { recursive: true, force: true });
+        }
+      }
+
       if (progressCallback) {
         progressCallback({ type: 'success', message: 'Plugin Updated' });
       }

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -185,6 +185,207 @@ function moveDirs(currentPath: string, newPath: string) {
   }
 }
 
+/**
+ * Name of the directory inside a plugins directory used for update
+ * transactions.
+ *
+ * Staging and backup directories for an update live under this directory.
+ * Installed plugins never use it, so recovery can unambiguously identify
+ * update transactions without having to distinguish them from legitimate
+ * plugin directories: everything under this directory is owned by the update
+ * flow, while plugin directories always live directly in the plugins
+ * directory.
+ */
+const UPDATE_TXN_DIR_NAME = '.headlamp-txn';
+
+/**
+ * Matches transaction directories created by PluginManager.update().
+ *
+ * Transaction directories are named `<pluginName>.(backup|staging).<txnId>`
+ * where `<txnId>` is a random 16-character hex string unique to each update
+ * attempt. They only ever appear under UPDATE_TXN_DIR_NAME, so a legitimate
+ * plugin whose name happens to end in `.backup` or `.staging` (or even
+ * `.staging.<16 hex chars>`) can never be mistaken for an interrupted update
+ * transaction.
+ */
+const UPDATE_TXN_DIR_PATTERN = /^(.+)\.(backup|staging)\.([0-9a-f]{16})$/;
+
+/** Suffix of a transaction lock file, which is named `<txnId>.lock`. */
+const UPDATE_TXN_LOCK_SUFFIX = '.lock';
+
+/** Matches a transaction lock file, named `<txnId>.lock`. */
+const UPDATE_TXN_LOCK_PATTERN = /^([0-9a-f]{16})\.lock$/;
+
+/**
+ * Checks whether a process is currently running.
+ *
+ * @param pid - The process id to check.
+ * @returns true if a process with the given pid exists.
+ */
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM means the process exists but we cannot signal it.
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+/**
+ * Reads the pid recorded in a transaction lock file.
+ *
+ * @param lockFile - The path to the lock file.
+ * @returns The recorded pid, or null if the file is missing or unreadable.
+ */
+function lockOwnerPid(lockFile: string): number | null {
+  try {
+    const lock = JSON.parse(fs.readFileSync(lockFile, 'utf8'));
+    return typeof lock.pid === 'number' ? lock.pid : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Checks whether a transaction is still owned by a live process.
+ *
+ * @param lockFile - The path to the transaction's lock file.
+ * @returns true if the lock file exists and its recorded pid is alive.
+ */
+function isActiveTransaction(lockFile: string): boolean {
+  const pid = lockOwnerPid(lockFile);
+  return pid !== null && isProcessAlive(pid);
+}
+
+/**
+ * Recovers plugins left broken by an update that crashed mid-swap.
+ *
+ * The swap renames the plugin to `<txnDir>/<name>.backup.<txnId>` before
+ * renaming the staged content into place, so a crash between those two
+ * renames leaves the backup behind with no plugin directory. On the next
+ * listing or app startup, restore the backup so the previous version is
+ * usable again. Stale `<txnDir>/<name>.staging.<txnId>` directories are
+ * removed. Transaction directories live under a dedicated `.headlamp-txn`
+ * subdirectory, so recovery never inspects user-controlled plugin directory
+ * names.
+ *
+ * A transaction is only recovered when its `<txnId>.lock` file is missing or
+ * records a pid that is no longer alive. A live owner means the update is
+ * still in progress (possibly from another process, such as the
+ * headlamp-plugin CLI), so recovery leaves the transaction untouched. This is
+ * deliberately conservative: a stale lock whose pid has been reused by an
+ * unrelated process leaves the transaction in place (a leak, not a loss), and
+ * the update flow never reads these locks, so such a leak cannot block future
+ * updates.
+ *
+ * Note that this recovery cannot make the swap itself atomic: the plugin
+ * directory is briefly absent between the two renames, so a concurrent reader
+ * such as the backend serving the user plugins directory may observe the
+ * plugin as missing in that window. Calling this function at startup (before
+ * the backend starts serving) and on every plugin listing keeps that window
+ * from turning into a permanent break.
+ */
+export function recoverInterruptedUpdate(pluginsDir: string) {
+  const txnRoot = path.join(pluginsDir, UPDATE_TXN_DIR_NAME);
+  let entries: fs.Dirent[];
+
+  try {
+    entries = fs.readdirSync(txnRoot, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  // If a plugin directory occupies the transaction directory name, never
+  // touch its contents.
+  if (fs.existsSync(path.join(txnRoot, 'package.json'))) {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const txnMatch = UPDATE_TXN_DIR_PATTERN.exec(entry.name);
+    if (!txnMatch) {
+      continue;
+    }
+
+    const lockFile = path.join(txnRoot, `${txnMatch[3]}${UPDATE_TXN_LOCK_SUFFIX}`);
+    if (isActiveTransaction(lockFile)) {
+      // The update owning this transaction is still running; leave it alone.
+      continue;
+    }
+
+    const pluginDir = path.join(pluginsDir, txnMatch[1]);
+    const txnDir = path.join(txnRoot, entry.name);
+
+    if (txnMatch[2] === 'backup') {
+      if (!fs.existsSync(pluginDir)) {
+        try {
+          fs.renameSync(txnDir, pluginDir);
+          console.log(`Recovered plugin directory ${pluginDir} from interrupted update`);
+        } catch (err) {
+          console.error(`Error recovering plugin directory ${pluginDir}:`, err);
+        }
+      } else {
+        // The updated plugin is already in place, so the backup is stale.
+        try {
+          fs.rmSync(txnDir, { recursive: true, force: true });
+          console.log(`Removed stale backup directory for ${pluginDir}`);
+        } catch (err) {
+          console.error(`Error removing stale backup directory for ${pluginDir}:`, err);
+        }
+      }
+    } else {
+      // Staging content is never put into place until the final rename, so
+      // any staging directory left behind is incomplete and safe to remove.
+      try {
+        fs.rmSync(txnDir, { recursive: true, force: true });
+        console.log(`Removed stale staging directory for ${pluginDir}`);
+      } catch (err) {
+        console.error(`Error removing stale staging directory for ${pluginDir}:`, err);
+      }
+    }
+
+    // Clean up the lock file of the recovered transaction.
+    try {
+      fs.rmSync(lockFile, { force: true });
+    } catch {
+      // Ignore: the lock file may already be gone.
+    }
+  }
+
+  // Remove lock files left behind by transactions whose directories are
+  // already gone, but leave locks owned by live processes untouched.
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      continue;
+    }
+
+    if (!UPDATE_TXN_LOCK_PATTERN.exec(entry.name)) {
+      continue;
+    }
+
+    const lockFile = path.join(txnRoot, entry.name);
+    if (!isActiveTransaction(lockFile)) {
+      try {
+        fs.rmSync(lockFile, { force: true });
+      } catch {
+        // Ignore: the lock file may already be gone.
+      }
+    }
+  }
+
+  // Remove the transaction directory if it is now empty.
+  try {
+    fs.rmdirSync(txnRoot);
+  } catch {
+    // Ignore: the directory either does not exist or still has content.
+  }
+}
+
 export class PluginManager {
   /**
    * Installs a plugin from the specified URL.
@@ -333,14 +534,98 @@ export class PluginManager {
         fs.mkdirSync(destinationFolder, { recursive: true });
       }
 
-      // remove the existing plugin folder
-      fs.rmSync(pluginDir, { recursive: true, force: true });
+      // Stage the new content alongside the existing plugin directory so
+      // a failure during the move does not leave the plugin in a broken
+      // state. The individual rename from the staging directory to the real
+      // plugin directory is atomic when both reside on the same filesystem,
+      // but the swap as a whole is not: the plugin directory is briefly
+      // absent between the two renames. A crash in that window is repaired
+      // by recoverInterruptedUpdate() on the next app startup or plugin
+      // listing. Transaction directories live under a dedicated
+      // `.headlamp-txn` subdirectory with a random id, so recovery never
+      // mistakes a real plugin directory (e.g. `foo.backup` or
+      // `foo.staging.<id>`) for a transaction.
+      const txnId = crypto.randomBytes(8).toString('hex');
+      const txnRoot = path.join(destinationFolder, UPDATE_TXN_DIR_NAME);
+      const stagingDir = path.join(txnRoot, `${plugin.folderName}.staging.${txnId}`);
+      const backupDir = path.join(txnRoot, `${plugin.folderName}.backup.${txnId}`);
+      const lockFile = path.join(txnRoot, `${txnId}${UPDATE_TXN_LOCK_SUFFIX}`);
 
-      // create the plugin folder
-      fs.mkdirSync(pluginDir, { recursive: true });
+      // The transaction directory is reserved for update transactions; if a
+      // plugin directory occupies its name, refuse rather than mixing the two.
+      if (fs.existsSync(path.join(txnRoot, 'package.json'))) {
+        throw new Error(
+          `Cannot update plugin: '${UPDATE_TXN_DIR_NAME}' is occupied by a plugin directory`
+        );
+      }
 
-      // move the plugin to the destination folder
-      moveDirs(tempFolder, pluginDir);
+      fs.mkdirSync(txnRoot, { recursive: true });
+
+      try {
+        // Mark the transaction as active so recovery never treats it as an
+        // interrupted one while this process is still working on it.
+        fs.writeFileSync(lockFile, JSON.stringify({ pid: process.pid }));
+
+        if (fs.existsSync(stagingDir)) {
+          fs.rmSync(stagingDir, { recursive: true, force: true });
+        }
+        fs.mkdirSync(stagingDir, { recursive: true });
+
+        moveDirs(tempFolder, stagingDir);
+
+        if (fs.existsSync(backupDir)) {
+          fs.rmSync(backupDir, { recursive: true, force: true });
+        }
+
+        if (fs.existsSync(pluginDir)) {
+          fs.renameSync(pluginDir, backupDir);
+        }
+
+        try {
+          fs.renameSync(stagingDir, pluginDir);
+        } catch (err) {
+          // Roll the previous version back so the update failure leaves the
+          // plugin usable. A rollback failure must not mask the original
+          // error, so log it and rethrow the original one.
+          try {
+            if (fs.existsSync(backupDir)) {
+              fs.renameSync(backupDir, pluginDir);
+            }
+          } catch (rollbackErr) {
+            console.error(`Error rolling back backup directory ${backupDir}:`, rollbackErr);
+          }
+          throw err;
+        }
+
+        if (fs.existsSync(backupDir)) {
+          try {
+            fs.rmSync(backupDir, { recursive: true, force: true });
+          } catch (err) {
+            console.error(`Error cleaning up backup directory ${backupDir}:`, err);
+          }
+        }
+      } finally {
+        if (fs.existsSync(stagingDir)) {
+          try {
+            fs.rmSync(stagingDir, { recursive: true, force: true });
+          } catch (err) {
+            console.error(`Error cleaning up staging directory ${stagingDir}:`, err);
+          }
+        }
+        // The transaction is done; release its lock.
+        try {
+          fs.rmSync(lockFile, { force: true });
+        } catch (err) {
+          console.error(`Error cleaning up transaction lock file ${lockFile}:`, err);
+        }
+        // Remove the transaction directory if it is now empty.
+        try {
+          fs.rmdirSync(txnRoot);
+        } catch {
+          // Ignore: the directory either does not exist or still has content.
+        }
+      }
+
       if (progressCallback) {
         progressCallback({ type: 'success', message: 'Plugin Updated' });
       }
@@ -408,6 +693,9 @@ export class PluginManager {
     try {
       const pluginsData: PluginData[] = [];
 
+      // Restore plugins left broken by an update that crashed mid-swap.
+      recoverInterruptedUpdate(folder);
+
       // Read all entries in the specified folder
       const entries = fs.readdirSync(folder, { withFileTypes: true });
 
@@ -471,7 +759,9 @@ export class PluginManager {
 /**
  * Checks the plugin name is a valid one.
  *
- * Look for "..", "/", or "\" in the plugin name.
+ * Look for "..", "/", or "\" in the plugin name, and reject the name
+ * reserved for update transaction directories so that a plugin can never
+ * occupy it.
  *
  * @param {string} pluginName
  *
@@ -479,7 +769,12 @@ export class PluginManager {
  */
 function validatePluginName(pluginName: string): boolean {
   const invalidPattern = /[\/\\]|(\.\.)/;
-  return !invalidPattern.test(pluginName);
+  if (invalidPattern.test(pluginName)) {
+    return false;
+  }
+
+  // Reserved for update transaction directories (see UPDATE_TXN_DIR_NAME).
+  return pluginName !== UPDATE_TXN_DIR_NAME;
 }
 
 /**


### PR DESCRIPTION
# Pull Request: Atomic and Recoverable Plugin Update Strategy

## Summary
Previously, the `update()` method deleted the existing plugin directory before moving the new version into place. If any step failed after deletion, there was no way to recover the previous plugin version. 

## Changes
This PR replaces the destructive update flow with a **staging-and-swap** approach:

* **Staging Area**: New plugin contents are staged in a dedicated `.headlamp-txn/<plugin>.staging.<txnId>` directory.
* **Backup Creation**: The existing plugin directory is renamed to `.headlamp-txn/<plugin>.backup.<txnId>`.
* **Atomic Swap**: The staged content is renamed into place as `pluginDir`.
* **Rollback Mechanism**: If the final rename fails, the original plugin is restored by renaming the backup back to `pluginDir`.
* **Cleanup**: Removes the backup after a successful update, and deletes the `.headlamp-txn` directory once it is empty.
* **Process Locking**: Each transaction writes a `<txnId>.lock` file containing the updating process PID, ensuring recovery never touches an ongoing transaction.
* **Interrupted Update Recovery**: The `recoverInterruptedUpdate()` function runs at app startup and on every plugin listing. It restores a backup if the main plugin directory is missing and clears stale staging/backup directories or orphan locks.
* **Safe Isolation**: Transaction directories live under `.headlamp-txn`. Legitimate plugins named `foo.backup` or `foo.staging.<id>` are never mistaken for interrupted transactions.
* **Concurrency Protection**: The single-instance lock is acquired at the start of `startElectron()` before any recovery runs, preventing a second application instance from interfering with a live transaction.

Because each `renameSync()` is atomic when operating on the same filesystem, individual rename steps are safe. The swap as a whole may briefly expose a missing plugin directory, but a crash in that window is now recovered on the next startup or listing instead of requiring a full reinstall.

## Testing
* Relevant tests passed.

## Note for Reviewers
This change only modifies the update strategy and is intended to preserve the existing behavior while improving failure safety. 

Recovery is conservative by design: a stale lock whose PID has been reused leaves the transaction in place (resulting in a directory leak rather than data loss) and cannot block future updates.
