### PR TITLE
frontend: Honor EndpointSlice condition defaults

### DIFF
--- a/frontend/src/components/endpointSlices/Details.tsx
+++ b/frontend/src/components/endpointSlices/Details.tsx
@@ -20,6 +20,7 @@ import { useParams } from 'react-router-dom';
 import EndpointSlice from '../../lib/k8s/endpointSlices';
 import { SectionBox, SimpleTable, StatusLabel } from '../common';
 import { DetailsGrid } from '../common/Resource';
+import { resolveEndpointConditions } from './utils';
 
 export default function EndpointSliceDetails(props: {
   name?: string;
@@ -75,27 +76,31 @@ export default function EndpointSliceDetails(props: {
                     },
                     {
                       label: t('Conditions'),
-                      getter: endpoint => (
-                        <>
-                          <Box display="inline-block">
-                            <StatusLabel status={endpoint.conditions.ready ? 'success' : 'error'}>
-                              {t('Ready')}
-                            </StatusLabel>
-                          </Box>
-                          <Box display="inline-block">
-                            <StatusLabel status={endpoint.conditions.serving ? 'success' : 'error'}>
-                              {t('Serving')}
-                            </StatusLabel>
-                          </Box>
-                          <Box display="inline-block">
-                            <StatusLabel
-                              status={endpoint.conditions.terminating ? 'success' : 'error'}
-                            >
-                              {t('Terminating')}
-                            </StatusLabel>
-                          </Box>
-                        </>
-                      ),
+                      getter: endpoint => {
+                        const { ready, serving, terminating } = resolveEndpointConditions(
+                          endpoint.conditions
+                        );
+
+                        return (
+                          <>
+                            <Box display="inline-block">
+                              <StatusLabel status={ready ? 'success' : 'error'}>
+                                {t('Ready')}
+                              </StatusLabel>
+                            </Box>
+                            <Box display="inline-block">
+                              <StatusLabel status={serving ? 'success' : 'error'}>
+                                {t('Serving')}
+                              </StatusLabel>
+                            </Box>
+                            <Box display="inline-block">
+                              <StatusLabel status={terminating ? 'success' : 'error'}>
+                                {t('Terminating')}
+                              </StatusLabel>
+                            </Box>
+                          </>
+                        );
+                      },
                     },
                   ]}
                   defaultSortingColumn={1}

--- a/frontend/src/components/endpointSlices/List.tsx
+++ b/frontend/src/components/endpointSlices/List.tsx
@@ -20,6 +20,7 @@ import EndpointSlice from '../../lib/k8s/endpointSlices';
 import { LabelListItem } from '../common';
 import { StatusLabel } from '../common/Label';
 import ResourceListView from '../common/Resource/ResourceListView';
+import { resolveEndpointConditions } from './utils';
 
 function renderEndpoints(endpointSlice: EndpointSlice) {
   const endpoints = endpointSlice.spec.endpoints;
@@ -27,13 +28,15 @@ function renderEndpoints(endpointSlice: EndpointSlice) {
     return null;
   }
 
-  return endpoints.map((endpoint: any) => {
+  return endpoints.map((endpoint: any, index: number) => {
     const { addresses, conditions } = endpoint;
+    const { ready } = resolveEndpointConditions(conditions);
     return (
-      <Box display="inline-block">
-        <StatusLabel status={conditions?.ready ? 'success' : 'error'}>
-          {addresses.join(',')}
-        </StatusLabel>
+      <Box
+        display="inline-block"
+        key={`${endpoint.targetRef?.uid ?? addresses.join(',')}-${index}`}
+      >
+        <StatusLabel status={ready ? 'success' : 'error'}>{addresses.join(',')}</StatusLabel>
       </Box>
     );
   });

--- a/frontend/src/components/endpointSlices/List.tsx
+++ b/frontend/src/components/endpointSlices/List.tsx
@@ -20,6 +20,7 @@ import EndpointSlice from '../../lib/k8s/endpointSlices';
 import { LabelListItem } from '../common';
 import { StatusLabel } from '../common/Label';
 import ResourceListView from '../common/Resource/ResourceListView';
+import { resolveEndpointConditions } from './utils';
 
 function renderEndpoints(endpointSlice: EndpointSlice) {
   const endpoints = endpointSlice.spec.endpoints;
@@ -29,11 +30,10 @@ function renderEndpoints(endpointSlice: EndpointSlice) {
 
   return endpoints.map((endpoint: any) => {
     const { addresses, conditions } = endpoint;
+    const { ready } = resolveEndpointConditions(conditions);
     return (
       <Box display="inline-block">
-        <StatusLabel status={conditions?.ready ? 'success' : 'error'}>
-          {addresses.join(',')}
-        </StatusLabel>
+        <StatusLabel status={ready ? 'success' : 'error'}>{addresses.join(',')}</StatusLabel>
       </Box>
     );
   });

--- a/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceDetails.Default.stories.storyshot
+++ b/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceDetails.Default.stories.storyshot
@@ -196,7 +196,228 @@
       >
         <div
           class="MuiBox-root css-p0cik4"
-        />
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+                  >
+                    Endpoints
+                  </h2>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
+              <div
+                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-onzayo-MuiPaper-root-MuiTableContainer-root"
+                tabindex="0"
+              >
+                <table
+                  class="MuiTable-root css-r7i92b-MuiTable-root"
+                >
+                  <thead
+                    class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+                    >
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-d9iroo-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Hostname
+                        <button
+                          aria-label="Sort descending"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
+                          data-mui-internal-clone-element="true"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-d9iroo-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Node Name
+                        <button
+                          aria-label="Sort ascending"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
+                          data-mui-internal-clone-element="true"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-d9iroo-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Zone
+                        <button
+                          aria-label="Sort ascending"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
+                          data-mui-internal-clone-element="true"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Addresses
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Conditions
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        mynode
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        127.0.0.1
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <div
+                          class="MuiBox-root css-1baulvz"
+                        >
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
+                          >
+                            Ready
+                          </span>
+                        </div>
+                        <div
+                          class="MuiBox-root css-1baulvz"
+                        >
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
+                          >
+                            Serving
+                          </span>
+                        </div>
+                        <div
+                          class="MuiBox-root css-1baulvz"
+                        >
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 css-1ge3384-MuiTypography-root"
+                          >
+                            Terminating
+                          </span>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr
+                      class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        mynode
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        127.0.0.2
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <div
+                          class="MuiBox-root css-1baulvz"
+                        >
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
+                          >
+                            Ready
+                          </span>
+                        </div>
+                        <div
+                          class="MuiBox-root css-1baulvz"
+                        >
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
+                          >
+                            Serving
+                          </span>
+                        </div>
+                        <div
+                          class="MuiBox-root css-1baulvz"
+                        >
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 css-1ge3384-MuiTypography-root"
+                          >
+                            Terminating
+                          </span>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"

--- a/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
+++ b/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
@@ -729,7 +729,7 @@
                     class="MuiBox-root css-1baulvz"
                   >
                     <span
-                      class="MuiTypography-root MuiTypography-body1 css-1ge3384-MuiTypography-root"
+                      class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
                     >
                       127.0.0.1
                     </span>

--- a/frontend/src/components/endpointSlices/utils.test.ts
+++ b/frontend/src/components/endpointSlices/utils.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { resolveEndpointConditions } from './utils';
+
+describe('resolveEndpointConditions', () => {
+  it.each([undefined, {}])('uses the Kubernetes defaults when conditions are %j', conditions => {
+    expect(resolveEndpointConditions(conditions)).toEqual({
+      ready: true,
+      serving: true,
+      terminating: false,
+    });
+  });
+
+  it('preserves explicit condition values', () => {
+    expect(
+      resolveEndpointConditions({
+        ready: false,
+        serving: false,
+        terminating: true,
+      })
+    ).toEqual({
+      ready: false,
+      serving: false,
+      terminating: true,
+    });
+  });
+
+  it('only defaults omitted condition values', () => {
+    expect(resolveEndpointConditions({ ready: false })).toEqual({
+      ready: false,
+      serving: true,
+      terminating: false,
+    });
+  });
+});

--- a/frontend/src/components/endpointSlices/utils.ts
+++ b/frontend/src/components/endpointSlices/utils.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KubeEndpointSliceEndpointConditions } from '../../lib/k8s/endpointSlices';
+
+export interface ResolvedKubeEndpointSliceEndpointConditions {
+  ready: boolean;
+  serving: boolean;
+  terminating: boolean;
+}
+
+export function resolveEndpointConditions(
+  conditions?: KubeEndpointSliceEndpointConditions
+): ResolvedKubeEndpointSliceEndpointConditions {
+  return {
+    ready: conditions?.ready ?? true,
+    serving: conditions?.serving ?? true,
+    terminating: conditions?.terminating ?? false,
+  };
+}

--- a/frontend/src/lib/k8s/endpointSlices.ts
+++ b/frontend/src/lib/k8s/endpointSlices.ts
@@ -18,9 +18,9 @@ import { KubeMetadata } from './KubeMetadata';
 import { KubeObject, KubeObjectInterface } from './KubeObject';
 
 export interface KubeEndpointSliceEndpointConditions {
-  ready: boolean;
-  serving: boolean;
-  terminating: boolean;
+  ready?: boolean;
+  serving?: boolean;
+  terminating?: boolean;
 }
 
 export interface KubeEndpointSliceEndpoint {


### PR DESCRIPTION
## Summary

This PR fixes how EndpointSlice condition values are interpreted when they are omitted from the Kubernetes API response.

Kubernetes defines missing `ready` and `serving` values as `true`, and a missing `terminating` value as `false`. Headlamp previously relied on JavaScript truthiness, causing omitted `ready` and `serving` values to be displayed as failures.

The change applies the Kubernetes-defined defaults consistently in the EndpointSlice list and details views.

## Related Issue

Fixes #6784

## Changes

- Added a shared helper for resolving EndpointSlice condition defaults.
- Updated the EndpointSlice details view to use the resolved condition values.
- Updated the EndpointSlice list to use the resolved `ready` value.
- Updated the EndpointSlice condition types to allow omitted values returned by the Kubernetes API.
- Added regression tests for missing, empty, partial, and explicit condition values.

## Steps to Test

1. Start Headlamp and connect it to a Kubernetes cluster.
2. Create an EndpointSlice without explicit endpoint condition values:

```yaml
apiVersion: discovery.k8s.io/v1
kind: EndpointSlice
metadata:
  name: headlamp-missing-conditions
  namespace: default
  labels:
    kubernetes.io/service-name: headlamp-condition-test
addressType: IPv4
ports:
  - name: http
    protocol: TCP
    port: 8080
endpoints:
  - addresses:
      - "10.244.0.250"
    hostname: no-conditions
    nodeName: minikube
```

3. Open `headlamp-missing-conditions` in the EndpointSlice details view.
4. Verify that `Ready` and `Serving` are displayed as success.
5. Verify that `Terminating` is displayed as false/error.
6. Open the EndpointSlice list and verify that the endpoint is displayed as ready.

The automated regression tests can be run with:

```bash
cd frontend
npm test -- --run src/components/endpointSlices/utils.test.ts
npm run tsc
```

Validation completed locally:

- Focused regression tests: 4 passed
- TypeScript checks: passed
- Scoped ESLint checks: passed
- Prettier checks: passed
- Manual verification with Minikube: passed

## Screenshots (if applicable)

### Before

<img width="716" height="392" alt="Screenshot 2026-08-01 015514" src="https://github.com/user-attachments/assets/a2c2c45b-b0e0-4563-9672-8bff802ef988" />

### After

<img width="946" height="504" alt="Screenshot 2026-08-01 015226" src="https://github.com/user-attachments/assets/17b9e33f-f3dc-4c09-b92e-0d002b078fea" />

## Notes for the Reviewer

- The defaults follow the Kubernetes EndpointSlice API semantics: missing `ready` and `serving` values are interpreted as `true`, while a missing `terminating` value is interpreted as `false`.
- Explicit boolean values are preserved.
- The change does not add dependencies or modify public APIs.