### PR TITLE
frontend: Table: Preserve scroll position across auto refresh

### DIFF
--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -59,6 +59,7 @@ import { useSettings } from '../../App/Settings/hook';
 import { useQueryParamsState } from '../../resourceMap/useQueryParamsState';
 import Empty from '../EmptyContent';
 import Loader from '../Loader';
+import { useScrollPreservationOnDataChange } from './useScrollPreservation';
 
 /**
  * Column definition
@@ -298,6 +299,11 @@ export default function Table<RowItem extends Record<string, any>>({
     return (tableProps.data ?? []).filter(it => filterFunction(it));
   }, [tableProps.data, filterFunction]);
 
+  // Preserve scroll position across auto-refresh re-renders where React Query
+  // hands us a fresh array reference (kubernetes-sigs/headlamp#5701).
+  const { ref: scrollContainerRef, onScroll: onScrollContainer } =
+    useScrollPreservationOnDataChange(tableData);
+
   const paginationSelectProps = import.meta.env.UNDER_TEST
     ? {
         inputProps: {
@@ -458,6 +464,10 @@ export default function Table<RowItem extends Record<string, any>>({
       showFirstButton: false,
       showLastButton: false,
       SelectProps: paginationSelectProps,
+    },
+    muiTableContainerProps: {
+      ref: scrollContainerRef,
+      onScroll: onScrollContainer,
     },
     muiTableBodyCellProps: {
       sx: {

--- a/frontend/src/components/common/Table/useScrollPreservation.test.tsx
+++ b/frontend/src/components/common/Table/useScrollPreservation.test.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render } from '@testing-library/react';
+import { useEffect } from 'react';
+import { describe, expect, it } from 'vitest';
+import { useScrollPreservationOnDataChange } from './useScrollPreservation';
+
+// jsdom doesn't compute layout, so scrollHeight / clientHeight default to 0.
+// Force sensible values on any div we create so the hook's "container is
+// scrollable" branch runs the way it would in a real browser.
+function makeScrollable(el: HTMLElement, scrollHeight = 1000, clientHeight = 100) {
+  Object.defineProperty(el, 'scrollHeight', { value: scrollHeight, configurable: true });
+  Object.defineProperty(el, 'clientHeight', { value: clientHeight, configurable: true });
+}
+
+function makeUnscrollable(el: HTMLElement) {
+  Object.defineProperty(el, 'scrollHeight', { value: 0, configurable: true });
+  Object.defineProperty(el, 'clientHeight', { value: 0, configurable: true });
+}
+
+function TestHarness({ data }: { data: unknown }) {
+  const { ref, onScroll } = useScrollPreservationOnDataChange(data);
+  return (
+    <div
+      data-testid="scroll"
+      ref={ref}
+      onScroll={onScroll}
+      style={{ height: 100, overflow: 'auto' }}
+    >
+      <div style={{ height: 1000 }}>content</div>
+    </div>
+  );
+}
+
+describe('useScrollPreservationOnDataChange', () => {
+  it('restores scrollTop when the container is reset to 0 while data changes', () => {
+    const { getByTestId, rerender } = render(<TestHarness data={[1, 2, 3]} />);
+    const scroll = getByTestId('scroll') as HTMLDivElement;
+    makeScrollable(scroll);
+
+    // User scrolls down.
+    scroll.scrollTop = 250;
+    fireEvent.scroll(scroll);
+
+    // Simulate the production trigger: the same DOM node stays mounted, but
+    // scrollTop is reset to 0 (as MRT's re-render does on a data reference
+    // change). Then rerender with a fresh data reference so the layout
+    // effect runs.
+    scroll.scrollTop = 0;
+    rerender(<TestHarness data={[1, 2, 3, 4]} />);
+
+    expect(scroll.scrollTop).toBe(250);
+  });
+
+  it('does not fight subsequent renders once the user has scrolled to top', () => {
+    const { getByTestId, rerender } = render(<TestHarness data={[1, 2, 3]} />);
+    const scroll = getByTestId('scroll') as HTMLDivElement;
+    makeScrollable(scroll);
+
+    // User scrolls, then the app resets scrollTop to 0 as part of a legit
+    // action (paging, sorting) which also fires a scroll event.
+    scroll.scrollTop = 300;
+    fireEvent.scroll(scroll);
+    scroll.scrollTop = 0;
+    fireEvent.scroll(scroll);
+
+    rerender(<TestHarness data={[1, 2, 3, 4]} />);
+
+    expect(scroll.scrollTop).toBe(0);
+  });
+
+  it('drops the saved position when the container becomes unscrollable', () => {
+    const { getByTestId, rerender } = render(<TestHarness data={[1, 2, 3]} />);
+    const scroll = getByTestId('scroll') as HTMLDivElement;
+    makeScrollable(scroll);
+
+    // User scrolls down in a populated list.
+    scroll.scrollTop = 250;
+    fireEvent.scroll(scroll);
+
+    // Data goes empty; container isn't scrollable anymore.
+    makeUnscrollable(scroll);
+    scroll.scrollTop = 0;
+    rerender(<TestHarness data={[]} />);
+
+    // Data comes back. The prior saved position must not be applied to the
+    // new dataset.
+    makeScrollable(scroll);
+    rerender(<TestHarness data={[9, 10, 11]} />);
+
+    expect(scroll.scrollTop).toBe(0);
+  });
+
+  it('seeds the saved position when the container mounts already scrolled', () => {
+    // Simulates hydration or deep-link restore: the container is mounted at
+    // a non-zero scrollTop, and no scroll event has fired yet.
+    const { getByTestId, rerender } = render(<TestHarness data={[1, 2, 3]} />);
+    const scroll = getByTestId('scroll') as HTMLDivElement;
+    makeScrollable(scroll);
+    scroll.scrollTop = 180;
+
+    // Force the effect to run once so the seed branch fires.
+    rerender(<TestHarness data={[1, 2, 3, 4]} />);
+    expect(scroll.scrollTop).toBe(180);
+
+    // Now a data-driven reset to 0 should restore to the seeded position.
+    scroll.scrollTop = 0;
+    rerender(<TestHarness data={[1, 2, 3, 4, 5]} />);
+    expect(scroll.scrollTop).toBe(180);
+  });
+
+  it('returns stable ref and onScroll identities across renders', () => {
+    const captured: { ref: unknown; onScroll: unknown } = { ref: null, onScroll: null };
+
+    function Capture({ data }: { data: unknown }) {
+      const { ref, onScroll } = useScrollPreservationOnDataChange(data);
+      useEffect(() => {
+        captured.ref = ref;
+        captured.onScroll = onScroll;
+      });
+      return null;
+    }
+
+    const { rerender } = render(<Capture data={[1]} />);
+    const firstRef = captured.ref;
+    const firstOnScroll = captured.onScroll;
+
+    rerender(<Capture data={[1, 2]} />);
+    expect(captured.ref).toBe(firstRef);
+    expect(captured.onScroll).toBe(firstOnScroll);
+  });
+});

--- a/frontend/src/components/common/Table/useScrollPreservation.ts
+++ b/frontend/src/components/common/Table/useScrollPreservation.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useLayoutEffect, useRef } from 'react';
+
+/**
+ * Preserves a scrollable element's vertical `scrollTop` across re-renders
+ * triggered by a changing `data` reference.
+ *
+ * React Query hands us a fresh array on every poll, which can cause the
+ * scroll container to jump back to the top even when the user has scrolled
+ * down (kubernetes-sigs/headlamp#5701). The returned `ref`/`onScroll`
+ * should be wired to the scroll container so the last observed position
+ * can be reapplied after a data-driven re-render that zeroed it.
+ *
+ * Behavior notes:
+ * - Restoration fires only when the container has just been reset to 0
+ *   while a non-zero position was previously observed, so a user (or the
+ *   caller) that intentionally scrolls to the top is not fought.
+ * - The saved position is cleared when the container becomes unscrollable
+ *   (e.g. data goes empty), so a later refill does not restore a position
+ *   that no longer maps to what the user was looking at.
+ * - Only vertical scroll is preserved; horizontal is intentionally not
+ *   tracked.
+ */
+export function useScrollPreservationOnDataChange<T, E extends HTMLElement = HTMLDivElement>(
+  data: T
+) {
+  const ref = useRef<E | null>(null);
+  const savedScrollTop = useRef(0);
+
+  const onScroll = useCallback((event: React.UIEvent<E>) => {
+    savedScrollTop.current = event.currentTarget.scrollTop;
+  }, []);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    // If the container isn't scrollable (data went empty, or is smaller than
+    // the viewport), drop the saved position so a future refill doesn't
+    // jump the user to a position from a previous dataset.
+    if (el.scrollHeight <= el.clientHeight) {
+      savedScrollTop.current = 0;
+      return;
+    }
+
+    // Seed the saved position when the container is already scrolled but
+    // no scroll event has recorded a value yet (e.g. hydration or deep
+    // link put the user mid-list). Later scrolls refresh via `onScroll`.
+    if (savedScrollTop.current === 0 && el.scrollTop > 0) {
+      savedScrollTop.current = el.scrollTop;
+      return;
+    }
+
+    if (savedScrollTop.current > 0 && el.scrollTop === 0) {
+      el.scrollTop = savedScrollTop.current;
+    }
+  }, [data]);
+
+  return { ref, onScroll };
+}


### PR DESCRIPTION
Fixes #5701

## Summary
- Resource tables using React Query polling receive a fresh array on every refresh, which caused the MRT scroll container to jump back to the top even when the user had scrolled down.
- Adds a small hook `useScrollPreservationOnDataChange` that captures `scrollTop` via `onScroll` into a ref and, in a layout effect keyed on the data reference, restores that value when the container has just been reset to 0.
- Wires the hook into `muiTableContainerProps` on the `useMaterialReactTable` call in `Table.tsx`.
- Clears the saved position when the container becomes unscrollable (data went empty) so a later refill does not restore a position that no longer maps to the new dataset.
- Seeds the saved position from a non-zero mounted `scrollTop` before any scroll event fires, so hydration or deep links that land the user mid-list are preserved on the first refresh too.

## Test plan
- [x] `npx vitest run src/components/common/Table src/components/common/Resource` (94 tests pass, includes 5 new tests for the hook: restore after reset, does not fight scroll-to-top, empty then refill drop, mount seed then restore, ref/onScroll identity stability)
- [x] `npm run tsc` (clean)
- [x] `npx eslint -c .eslintrc.ci.cjs --max-warnings 0` on changed files (clean)
- [ ] Manual: open any resource list with more rows than fit on screen, scroll partway down, wait for the auto refresh interval, confirm the scroll position is preserved
- [ ] Manual: on the same list, scroll partway down then change the search filter, confirm the container still shows the filtered results near where the user was (not fought back to a stale offset)
- [ ] Manual: on a list that goes empty and then repopulates (e.g. namespace switch), confirm the new list starts at the top