### PR TITLE
backend: deduplicate concurrent OIDC token refreshes to fix invalid_grant/forced-relogin race

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -46,7 +46,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
-	golang.org/x/sync v0.21.0
+	golang.org/x/sync v0.22.0
 	golang.org/x/term v0.44.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/klog/v2 v2.140.0
@@ -156,6 +156,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -46,6 +46,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
+	golang.org/x/sync v0.21.0
 	golang.org/x/term v0.44.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/klog/v2 v2.140.0
@@ -155,8 +156,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
-	golang.org/x/net v0.56.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -46,6 +46,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
+	golang.org/x/sync v0.22.0
 	golang.org/x/term v0.44.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/klog/v2 v2.140.0
@@ -156,7 +157,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -628,8 +628,8 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1/go.mod h1:9tjilg8BloeKEkVJvy7fQ90B1CfIiPueXVOjqfkSzI8=
-golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
-golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -229,14 +229,17 @@ func CacheRefreshedToken(token *oauth2.Token, tokenType string, oldToken string,
 func GetNewToken(clientID, clientSecret string, cache cache.Cache[interface{}],
 	tokenType string, token string, tokenURL string, ctx context.Context,
 ) (*oauth2.Token, error) {
-	// Detach from the caller's context so that one request's cancellation (e.g.
-	// the client disconnecting) doesn't abort the shared refresh that other
-	// concurrent requests for the same token are waiting on. Bound it with its
-	// own timeout so a hung IdP can't block waiting callers indefinitely.
-	refreshCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), refreshTimeout)
-	defer cancel()
-
 	result, err, _ := refreshGroup.Do(token, func() (interface{}, error) {
+		// Detach from the caller's context so that one request's cancellation (e.g.
+		// the client disconnecting) doesn't abort the shared refresh that other
+		// concurrent requests for the same token are waiting on. Bound it with its
+		// own timeout so a hung IdP can't block waiting callers indefinitely.
+		//
+		// Created here, inside the singleflight closure, so it's allocated exactly
+		// once per in-flight refresh rather than once per waiting caller.
+		refreshCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), refreshTimeout)
+		defer cancel()
+
 		return refreshTokenFromIDP(refreshCtx, clientID, clientSecret, cache, tokenType, token, tokenURL)
 	})
 	if err != nil {

--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -40,12 +40,37 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/oauth2"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
-	oldTokenTTL   = time.Second * 10 // seconds
-	oidcKeyPrefix = "oidc-token-"
+	oldTokenTTL             = time.Second * 10 // seconds
+	oidcKeyPrefix           = "oidc-token-"
+	refreshedTokenKeyPrefix = "oidc-refreshed-token-" //nolint:gosec // cache key prefix, not a credential
+	// refreshTimeout bounds the detached context used for the shared IdP
+	// exchange in GetNewToken, so a hung IdP can't block waiting callers
+	// indefinitely.
+	refreshTimeout = 30 * time.Second
 )
+
+// refreshGroup deduplicates concurrent OIDC refreshes for the same token.
+//
+// The OIDC refresh middleware runs independently for every incoming request, and
+// Headlamp's frontend commonly fires many concurrent requests against a cluster.
+// Without this, every request that observes the same soon-to-expire token would
+// race to exchange the same cached refresh token with the IdP: only the first
+// exchange succeeds, and the rest fail (or, on providers with refresh-token
+// rotation and reuse detection, can revoke the whole token family and force the
+// user to fully re-authenticate). Keying on the old token string is sufficient
+// since it uniquely identifies the in-flight refresh for a given session.
+//
+// This only dedupes calls that overlap in time. A request can still observe the
+// old, about-to-expire token via RefreshTokenIfNeeded's IsTokenAboutToExpire
+// check, then reach GetNewToken after some other request already completed a
+// refresh for that same token (the singleflight.Group forgets a key as soon as
+// its Do call returns). refreshedTokenKeyPrefix below covers that non-overlapping
+// case.
+var refreshGroup singleflight.Group
 
 const JWTExpirationTTL = 10 * time.Second // seconds
 
@@ -186,9 +211,70 @@ func CacheRefreshedToken(token *oauth2.Token, tokenType string, oldToken string,
 // GetNewToken uses the provided credentials and fetches the old refresh
 // token from the cache to obtain a new OAuth2 token
 // from the specified token URL endpoint.
+//
+// Concurrent calls for the same token are deduplicated via refreshGroup: only
+// one of them performs the actual cache read, IdP exchange, and cache write,
+// and all of them receive the same resulting token. This avoids racing
+// multiple exchanges of the same refresh token, which fails outright on IdPs
+// that rotate refresh tokens on use.
+//
+// A caller can also reach this function for a token that was already refreshed
+// by an earlier, now-completed call (e.g. the middleware read the old token
+// before a concurrent request refreshed it, but only got scheduled here
+// afterwards). refreshTokenFromIDP checks for that case first, inside the
+// singleflight execution, so it reuses the already-refreshed token instead of
+// attempting a second exchange with a refresh token the IdP already rotated
+// out. Checking outside the singleflight call would leave the same gap: the
+// check and the exchange itself must happen as one atomic unit per key.
 func GetNewToken(clientID, clientSecret string, cache cache.Cache[interface{}],
 	tokenType string, token string, tokenURL string, ctx context.Context,
 ) (*oauth2.Token, error) {
+	result, err, _ := refreshGroup.Do(token, func() (interface{}, error) {
+		// Detach from the caller's context so that one request's cancellation (e.g.
+		// the client disconnecting) doesn't abort the shared refresh that other
+		// concurrent requests for the same token are waiting on. Bound it with its
+		// own timeout so a hung IdP can't block waiting callers indefinitely.
+		//
+		// Created here, inside the singleflight closure, so it's allocated exactly
+		// once per in-flight refresh rather than once per waiting caller.
+		refreshCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), refreshTimeout)
+		defer cancel()
+
+		return refreshTokenFromIDP(refreshCtx, clientID, clientSecret, cache, tokenType, token, tokenURL)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	newToken, ok := result.(*oauth2.Token)
+	if !ok {
+		return nil, fmt.Errorf("unexpected refresh result type %T", result)
+	}
+
+	return newToken, nil
+}
+
+// refreshTokenFromIDP performs the actual refresh-token exchange with the IdP
+// and updates the token cache. It is only ever invoked once per in-flight
+// token, via refreshGroup in GetNewToken, even when multiple goroutines call
+// GetNewToken concurrently for the same token.
+//
+// The very first thing it does is check whether this old token was already
+// refreshed by an earlier, now-completed singleflight call for the same key.
+// That check has to live here, inside the singleflight execution, rather than
+// in GetNewToken before calling refreshGroup.Do: checking there would leave a
+// window between the check and the Do call where a concurrent refresh could
+// complete, so a late caller could still retry the exchange with a refresh
+// token the IdP already rotated out.
+func refreshTokenFromIDP(ctx context.Context, clientID, clientSecret string, cache cache.Cache[interface{}],
+	tokenType, token, tokenURL string,
+) (*oauth2.Token, error) {
+	if cached, err := cache.Get(ctx, refreshedTokenKeyPrefix+token); err == nil {
+		if cachedToken, ok := cached.(*oauth2.Token); ok {
+			return cachedToken, nil
+		}
+	}
+
 	// get refresh token
 	refreshToken, err := cache.Get(ctx, oidcKeyPrefix+token)
 	if err != nil {
@@ -218,6 +304,14 @@ func GetNewToken(clientID, clientSecret string, cache cache.Cache[interface{}],
 	// update the refresh token in the cache
 	if err := CacheRefreshedToken(newToken, tokenType, token, rToken, cache); err != nil {
 		return nil, fmt.Errorf("caching refreshed token: %w", err)
+	}
+
+	// Remember the outcome of this refresh under the old token for a short
+	// grace period, so a request that checked the old token before this
+	// refresh happened but only reaches GetNewToken afterwards reuses this
+	// result instead of retrying the exchange with a now-stale refresh token.
+	if err := cache.SetWithTTL(ctx, refreshedTokenKeyPrefix+token, newToken, oldTokenTTL); err != nil {
+		logger.Log(logger.LevelError, nil, err, "failed to cache refresh outcome")
 	}
 
 	return newToken, nil
@@ -649,4 +743,23 @@ func RefreshAndSetToken(params RefreshAndSetTokenParams) {
 
 		params.TelemetryHandler.RecordEvent(params.Span, "Token refreshed successfully")
 	}
+}
+
+// RefreshTokenIfNeeded checks whether params.Token is close to expiring and, if
+// so, refreshes it via RefreshAndSetToken. It reports whether a refresh was
+// attempted, so callers can tell "token still valid, nothing to do" apart from
+// "token was expiring, refresh was attempted" without checking expiry themselves.
+//
+// This keeps the expiry decision next to the refresh machinery it gates,
+// instead of split out into the caller (e.g. the middleware): the caller no
+// longer needs its own IsTokenAboutToExpire check before deciding whether to
+// invoke a refresh.
+func RefreshTokenIfNeeded(params RefreshAndSetTokenParams) bool {
+	if !IsTokenAboutToExpire(params.Token) {
+		return false
+	}
+
+	RefreshAndSetToken(params)
+
+	return true
 }

--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -44,8 +44,9 @@ import (
 )
 
 const (
-	oldTokenTTL   = time.Second * 10 // seconds
-	oidcKeyPrefix = "oidc-token-"
+	oldTokenTTL             = time.Second * 10 // seconds
+	oidcKeyPrefix           = "oidc-token-"
+	refreshedTokenKeyPrefix = "oidc-refreshed-token-"
 	// refreshTimeout bounds the detached context used for the shared IdP
 	// exchange in GetNewToken, so a hung IdP can't block waiting callers
 	// indefinitely.
@@ -62,6 +63,12 @@ const (
 // rotation and reuse detection, can revoke the whole token family and force the
 // user to fully re-authenticate). Keying on the old token string is sufficient
 // since it uniquely identifies the in-flight refresh for a given session.
+//
+// This only dedupes calls that overlap in time. A request can still observe the
+// old, about-to-expire token via the middleware's IsTokenAboutToExpire check,
+// then reach GetNewToken after some other request already completed a refresh
+// for that same token (the singleflight.Group forgets a key as soon as its Do
+// call returns). refreshedTokenKeyPrefix below covers that non-overlapping case.
 var refreshGroup singleflight.Group
 
 const JWTExpirationTTL = 10 * time.Second // seconds
@@ -209,9 +216,23 @@ func CacheRefreshedToken(token *oauth2.Token, tokenType string, oldToken string,
 // and all of them receive the same resulting token. This avoids racing
 // multiple exchanges of the same refresh token, which fails outright on IdPs
 // that rotate refresh tokens on use.
+//
+// A caller can also reach this function for a token that was already refreshed
+// by an earlier, now-completed call (e.g. the middleware read the old token
+// before a concurrent request refreshed it, but only got scheduled here
+// afterwards). refreshedTokenKeyPrefix caches the outcome of each refresh
+// briefly so that case reuses the already-refreshed token instead of
+// attempting a second exchange with a refresh token the IdP already rotated
+// out.
 func GetNewToken(clientID, clientSecret string, cache cache.Cache[interface{}],
 	tokenType string, token string, tokenURL string, ctx context.Context,
 ) (*oauth2.Token, error) {
+	if cached, err := cache.Get(ctx, refreshedTokenKeyPrefix+token); err == nil {
+		if cachedToken, ok := cached.(*oauth2.Token); ok {
+			return cachedToken, nil
+		}
+	}
+
 	// Detach from the caller's context so that one request's cancellation (e.g.
 	// the client disconnecting) doesn't abort the shared refresh that other
 	// concurrent requests for the same token are waiting on. Bound it with its
@@ -270,6 +291,14 @@ func refreshTokenFromIDP(ctx context.Context, clientID, clientSecret string, cac
 	// update the refresh token in the cache
 	if err := CacheRefreshedToken(newToken, tokenType, token, rToken, cache); err != nil {
 		return nil, fmt.Errorf("caching refreshed token: %w", err)
+	}
+
+	// Remember the outcome of this refresh under the old token for a short
+	// grace period, so a request that checked the old token before this
+	// refresh happened but only reaches GetNewToken afterwards reuses this
+	// result instead of retrying the exchange with a now-stale refresh token.
+	if err := cache.SetWithTTL(ctx, refreshedTokenKeyPrefix+token, newToken, oldTokenTTL); err != nil {
+		logger.Log(logger.LevelError, nil, err, "failed to cache refresh outcome")
 	}
 
 	return newToken, nil

--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -40,12 +40,29 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/oauth2"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
 	oldTokenTTL   = time.Second * 10 // seconds
 	oidcKeyPrefix = "oidc-token-"
+	// refreshTimeout bounds the detached context used for the shared IdP
+	// exchange in GetNewToken, so a hung IdP can't block waiting callers
+	// indefinitely.
+	refreshTimeout = 30 * time.Second
 )
+
+// refreshGroup deduplicates concurrent OIDC refreshes for the same token.
+//
+// The OIDC refresh middleware runs independently for every incoming request, and
+// Headlamp's frontend commonly fires many concurrent requests against a cluster.
+// Without this, every request that observes the same soon-to-expire token would
+// race to exchange the same cached refresh token with the IdP: only the first
+// exchange succeeds, and the rest fail (or, on providers with refresh-token
+// rotation and reuse detection, can revoke the whole token family and force the
+// user to fully re-authenticate). Keying on the old token string is sufficient
+// since it uniquely identifies the in-flight refresh for a given session.
+var refreshGroup singleflight.Group
 
 const JWTExpirationTTL = 10 * time.Second // seconds
 
@@ -186,8 +203,43 @@ func CacheRefreshedToken(token *oauth2.Token, tokenType string, oldToken string,
 // GetNewToken uses the provided credentials and fetches the old refresh
 // token from the cache to obtain a new OAuth2 token
 // from the specified token URL endpoint.
+//
+// Concurrent calls for the same token are deduplicated via refreshGroup: only
+// one of them performs the actual cache read, IdP exchange, and cache write,
+// and all of them receive the same resulting token. This avoids racing
+// multiple exchanges of the same refresh token, which fails outright on IdPs
+// that rotate refresh tokens on use.
 func GetNewToken(clientID, clientSecret string, cache cache.Cache[interface{}],
 	tokenType string, token string, tokenURL string, ctx context.Context,
+) (*oauth2.Token, error) {
+	// Detach from the caller's context so that one request's cancellation (e.g.
+	// the client disconnecting) doesn't abort the shared refresh that other
+	// concurrent requests for the same token are waiting on. Bound it with its
+	// own timeout so a hung IdP can't block waiting callers indefinitely.
+	refreshCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), refreshTimeout)
+	defer cancel()
+
+	result, err, _ := refreshGroup.Do(token, func() (interface{}, error) {
+		return refreshTokenFromIDP(refreshCtx, clientID, clientSecret, cache, tokenType, token, tokenURL)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	newToken, ok := result.(*oauth2.Token)
+	if !ok {
+		return nil, fmt.Errorf("unexpected refresh result type %T", result)
+	}
+
+	return newToken, nil
+}
+
+// refreshTokenFromIDP performs the actual refresh-token exchange with the IdP
+// and updates the token cache. It is only ever invoked once per in-flight
+// token, via refreshGroup in GetNewToken, even when multiple goroutines call
+// GetNewToken concurrently for the same token.
+func refreshTokenFromIDP(ctx context.Context, clientID, clientSecret string, cache cache.Cache[interface{}],
+	tokenType, token, tokenURL string,
 ) (*oauth2.Token, error) {
 	// get refresh token
 	refreshToken, err := cache.Get(ctx, oidcKeyPrefix+token)

--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -65,10 +65,11 @@ const (
 // since it uniquely identifies the in-flight refresh for a given session.
 //
 // This only dedupes calls that overlap in time. A request can still observe the
-// old, about-to-expire token via the middleware's IsTokenAboutToExpire check,
-// then reach GetNewToken after some other request already completed a refresh
-// for that same token (the singleflight.Group forgets a key as soon as its Do
-// call returns). refreshedTokenKeyPrefix below covers that non-overlapping case.
+// old, about-to-expire token via RefreshTokenIfNeeded's IsTokenAboutToExpire
+// check, then reach GetNewToken after some other request already completed a
+// refresh for that same token (the singleflight.Group forgets a key as soon as
+// its Do call returns). refreshedTokenKeyPrefix below covers that non-overlapping
+// case.
 var refreshGroup singleflight.Group
 
 const JWTExpirationTTL = 10 * time.Second // seconds
@@ -739,4 +740,23 @@ func RefreshAndSetToken(params RefreshAndSetTokenParams) {
 
 		params.TelemetryHandler.RecordEvent(params.Span, "Token refreshed successfully")
 	}
+}
+
+// RefreshTokenIfNeeded checks whether params.Token is close to expiring and, if
+// so, refreshes it via RefreshAndSetToken. It reports whether a refresh was
+// attempted, so callers can tell "token still valid, nothing to do" apart from
+// "token was expiring, refresh was attempted" without checking expiry themselves.
+//
+// This keeps the expiry decision next to the refresh machinery it gates,
+// instead of split out into the caller (e.g. the middleware): the caller no
+// longer needs its own IsTokenAboutToExpire check before deciding whether to
+// invoke a refresh.
+func RefreshTokenIfNeeded(params RefreshAndSetTokenParams) bool {
+	if !IsTokenAboutToExpire(params.Token) {
+		return false
+	}
+
+	RefreshAndSetToken(params)
+
+	return true
 }

--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -46,7 +46,7 @@ import (
 const (
 	oldTokenTTL             = time.Second * 10 // seconds
 	oidcKeyPrefix           = "oidc-token-"
-	refreshedTokenKeyPrefix = "oidc-refreshed-token-"
+	refreshedTokenKeyPrefix = "oidc-refreshed-token-" //nolint:gosec // cache key prefix, not a credential
 	// refreshTimeout bounds the detached context used for the shared IdP
 	// exchange in GetNewToken, so a hung IdP can't block waiting callers
 	// indefinitely.

--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -220,19 +220,14 @@ func CacheRefreshedToken(token *oauth2.Token, tokenType string, oldToken string,
 // A caller can also reach this function for a token that was already refreshed
 // by an earlier, now-completed call (e.g. the middleware read the old token
 // before a concurrent request refreshed it, but only got scheduled here
-// afterwards). refreshedTokenKeyPrefix caches the outcome of each refresh
-// briefly so that case reuses the already-refreshed token instead of
+// afterwards). refreshTokenFromIDP checks for that case first, inside the
+// singleflight execution, so it reuses the already-refreshed token instead of
 // attempting a second exchange with a refresh token the IdP already rotated
-// out.
+// out. Checking outside the singleflight call would leave the same gap: the
+// check and the exchange itself must happen as one atomic unit per key.
 func GetNewToken(clientID, clientSecret string, cache cache.Cache[interface{}],
 	tokenType string, token string, tokenURL string, ctx context.Context,
 ) (*oauth2.Token, error) {
-	if cached, err := cache.Get(ctx, refreshedTokenKeyPrefix+token); err == nil {
-		if cachedToken, ok := cached.(*oauth2.Token); ok {
-			return cachedToken, nil
-		}
-	}
-
 	// Detach from the caller's context so that one request's cancellation (e.g.
 	// the client disconnecting) doesn't abort the shared refresh that other
 	// concurrent requests for the same token are waiting on. Bound it with its
@@ -259,9 +254,23 @@ func GetNewToken(clientID, clientSecret string, cache cache.Cache[interface{}],
 // and updates the token cache. It is only ever invoked once per in-flight
 // token, via refreshGroup in GetNewToken, even when multiple goroutines call
 // GetNewToken concurrently for the same token.
+//
+// The very first thing it does is check whether this old token was already
+// refreshed by an earlier, now-completed singleflight call for the same key.
+// That check has to live here, inside the singleflight execution, rather than
+// in GetNewToken before calling refreshGroup.Do: checking there would leave a
+// window between the check and the Do call where a concurrent refresh could
+// complete, so a late caller could still retry the exchange with a refresh
+// token the IdP already rotated out.
 func refreshTokenFromIDP(ctx context.Context, clientID, clientSecret string, cache cache.Cache[interface{}],
 	tokenType, token, tokenURL string,
 ) (*oauth2.Token, error) {
+	if cached, err := cache.Get(ctx, refreshedTokenKeyPrefix+token); err == nil {
+		if cachedToken, ok := cached.(*oauth2.Token); ok {
+			return cachedToken, nil
+		}
+	}
+
 	// get refresh token
 	refreshToken, err := cache.Get(ctx, oidcKeyPrefix+token)
 	if err != nil {

--- a/backend/pkg/auth/auth_test.go
+++ b/backend/pkg/auth/auth_test.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -815,6 +816,113 @@ func TestGetNewToken_CacheUpdateErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+// newCallCountingTokenServer returns a fake OAuth2 token endpoint that always
+// succeeds and a counter tracking how many times it was hit.
+func newCallCountingTokenServer(t *testing.T) (srv *httptest.Server, callCount func() int) {
+	t.Helper()
+
+	var (
+		mu    sync.Mutex
+		calls int
+	)
+
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(oauthSuccessBody))
+	}))
+	t.Cleanup(srv.Close)
+
+	callCount = func() int {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return calls
+	}
+
+	return srv, callCount
+}
+
+// TestGetNewToken_ConcurrentRefresh_Deduplicates reproduces the OIDC
+// token-refresh race: many requests observing the same near-expiry token used
+// to each independently exchange the same cached refresh token with the IdP.
+// On providers with refresh-token rotation this fails for everyone but the
+// first exchange. GetNewToken must collapse concurrent callers sharing the
+// same token into a single upstream refresh.
+func TestGetNewToken_ConcurrentRefresh_Deduplicates(t *testing.T) {
+	srv, callCount := newCallCountingTokenServer(t)
+
+	fc := &fakeCache{store: map[string]interface{}{"oidc-token-OLD": "REFRESH_OLD"}}
+
+	const concurrency = 20
+
+	var (
+		wg    sync.WaitGroup
+		ready sync.WaitGroup
+		start = make(chan struct{})
+	)
+
+	results := make([]*oauth2.Token, concurrency)
+	errs := make([]error, concurrency)
+
+	ready.Add(concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+
+			ready.Done()
+			<-start // release every goroutine at once to maximize overlap
+
+			results[i], errs[i] = auth.GetNewToken(
+				"cid", "secret", fc, "id_token", "OLD", srv.URL, context.Background(),
+			)
+		}(i)
+	}
+
+	ready.Wait()
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, 1, callCount(), "expected exactly one upstream refresh call for concurrent requests")
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "goroutine %d", i)
+		require.NotNilf(t, results[i], "goroutine %d", i)
+		assert.Equal(t, refreshNew, results[i].RefreshToken, "goroutine %d", i)
+	}
+
+	require.Len(t, fc.setCalls, 1, "expected exactly one cache write for the new refresh token")
+	require.Len(t, fc.setWithTTLCalls, 1, "expected exactly one cache write for the retired old refresh token")
+}
+
+// TestGetNewToken_SequentialRefreshesAfterDeduplication ensures the dedup key
+// is forgotten once its refresh completes, so a later, independent refresh
+// cycle (e.g. the next time the token nears expiry) still hits the IdP rather
+// than being permanently memoized.
+func TestGetNewToken_SequentialRefreshesAfterDeduplication(t *testing.T) {
+	srv, callCount := newCallCountingTokenServer(t)
+
+	fc := &fakeCache{store: map[string]interface{}{"oidc-token-OLD": "REFRESH_OLD"}}
+
+	_, err := auth.GetNewToken("cid", "secret", fc, "id_token", "OLD", srv.URL, context.Background())
+	require.NoError(t, err)
+
+	// Simulate the next refresh cycle: the new token is now the one nearing
+	// expiry, with its own refresh token cached under its own key.
+	fc.store["oidc-token-NEW"] = refreshNew
+
+	_, err = auth.GetNewToken("cid", "secret", fc, "id_token", "NEW", srv.URL, context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, callCount(), "expected a fresh upstream call for each independent refresh cycle")
 }
 
 func TestRefreshAndCacheNewToken_Success(t *testing.T) {

--- a/backend/pkg/auth/auth_test.go
+++ b/backend/pkg/auth/auth_test.go
@@ -692,8 +692,10 @@ func newOIDCProviderServer(t *testing.T, issuerURL string, tokenHandler http.Han
 	return srv
 }
 
-func findAuthCookie(resp *http.Response, cluster string) (string, bool) {
-	want := fmt.Sprintf("headlamp-auth-%s.0", auth.SanitizeClusterName(cluster))
+// findAuthCookie looks up the auth cookie for the "test" cluster used by every
+// caller in this file.
+func findAuthCookie(resp *http.Response) (string, bool) {
+	want := fmt.Sprintf("headlamp-auth-%s.0", auth.SanitizeClusterName("test"))
 	for _, cookie := range resp.Cookies() {
 		if cookie.Name == want {
 			return cookie.Value, true
@@ -1111,7 +1113,7 @@ func TestRefreshAndSetToken_DefaultsToIDToken(t *testing.T) {
 
 	defer func() { _ = resp.Body.Close() }()
 
-	cookieVal, ok := findAuthCookie(resp, cluster)
+	cookieVal, ok := findAuthCookie(resp)
 	require.True(t, ok, "expected auth cookie to be set")
 	assert.Equal(t, "NEW", cookieVal)
 }
@@ -1162,7 +1164,7 @@ func TestRefreshAndSetToken_UsesAccessToken(t *testing.T) {
 
 	defer func() { _ = resp.Body.Close() }()
 
-	cookieVal, ok := findAuthCookie(resp, cluster)
+	cookieVal, ok := findAuthCookie(resp)
 	require.True(t, ok, "expected auth cookie to be set")
 	assert.Equal(t, "ACCESS_NEW", cookieVal)
 }
@@ -1199,7 +1201,7 @@ func TestRefreshAndSetToken_ErrorDoesNotSetCookie(t *testing.T) {
 
 	defer func() { _ = resp.Body.Close() }()
 
-	_, ok := findAuthCookie(resp, cluster)
+	_, ok := findAuthCookie(resp)
 	assert.False(t, ok, "expected no auth cookie to be set on error")
 }
 
@@ -1241,7 +1243,7 @@ func TestRefreshTokenIfNeeded_SkipsWhenNotExpiring(t *testing.T) {
 	resp := rr.Result()
 	defer func() { _ = resp.Body.Close() }()
 
-	_, ok := findAuthCookie(resp, cluster)
+	_, ok := findAuthCookie(resp)
 	assert.False(t, ok, "expected no auth cookie to be set")
 }
 
@@ -1286,7 +1288,7 @@ func TestRefreshTokenIfNeeded_RefreshesWhenExpiring(t *testing.T) {
 	resp := rr.Result()
 	defer func() { _ = resp.Body.Close() }()
 
-	cookieVal, ok := findAuthCookie(resp, cluster)
+	cookieVal, ok := findAuthCookie(resp)
 	require.True(t, ok, "expected auth cookie to be set")
 	assert.Equal(t, "NEW", cookieVal)
 }

--- a/backend/pkg/auth/auth_test.go
+++ b/backend/pkg/auth/auth_test.go
@@ -1203,6 +1203,94 @@ func TestRefreshAndSetToken_ErrorDoesNotSetCookie(t *testing.T) {
 	assert.False(t, ok, "expected no auth cookie to be set on error")
 }
 
+// TestRefreshTokenIfNeeded_SkipsWhenNotExpiring verifies that the expiry
+// decision now made inside RefreshTokenIfNeeded still behaves like the old
+// middleware-side IsTokenAboutToExpire check: a token that isn't close to
+// expiry is left untouched, with no IdP call and no cookie write.
+func TestRefreshTokenIfNeeded_SkipsWhenNotExpiring(t *testing.T) {
+	const cluster = "test"
+
+	token := makeJWTWithPayload(t, map[string]interface{}{
+		"exp": float64(time.Now().Add(auth.JWTExpirationTTL + time.Hour).Unix()),
+	})
+
+	tokenEndpointCalled := false
+	srv := newOIDCProviderServer(t, "", func(_ http.ResponseWriter, _ *http.Request) {
+		tokenEndpointCalled = true
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/clusters/"+cluster, nil)
+	rr := httptest.NewRecorder()
+
+	refreshed := auth.RefreshTokenIfNeeded(auth.RefreshAndSetTokenParams{
+		Ctx:              context.Background(),
+		OIDCAuthConfig:   &kubeconfig.OidcConfig{ClientID: "cid", ClientSecret: "secret"},
+		Cache:            &fakeCache{},
+		Token:            token,
+		Cluster:          cluster,
+		Writer:           rr,
+		Request:          req,
+		TelemetryHandler: &telemetry.RequestHandler{},
+		OIDCIdpIssuerURL: srv.URL,
+		BaseURL:          "",
+	})
+
+	assert.False(t, refreshed, "expected no refresh attempt for a token that isn't about to expire")
+	assert.False(t, tokenEndpointCalled, "token endpoint should not be called for a token that isn't about to expire")
+
+	resp := rr.Result()
+	defer func() { _ = resp.Body.Close() }()
+
+	_, ok := findAuthCookie(resp, cluster)
+	assert.False(t, ok, "expected no auth cookie to be set")
+}
+
+// TestRefreshTokenIfNeeded_RefreshesWhenExpiring verifies that a token close
+// to expiry is refreshed and the auth cookie updated, matching what the
+// middleware used to get from IsTokenAboutToExpire + RefreshAndSetToken.
+func TestRefreshTokenIfNeeded_RefreshesWhenExpiring(t *testing.T) {
+	const cluster = "test"
+
+	token := makeJWTWithPayload(t, map[string]interface{}{
+		"exp": float64(time.Now().Add(auth.JWTExpirationTTL / 2).Unix()),
+	})
+
+	fc := &fakeCache{store: map[string]interface{}{"oidc-token-" + token: "REFRESH_OLD"}}
+
+	srv := newOIDCProviderServer(t, "", func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		require.Equal(t, "REFRESH_OLD", r.PostForm.Get("refresh_token"))
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(oauthSuccessBody))
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/clusters/"+cluster, nil)
+	rr := httptest.NewRecorder()
+
+	refreshed := auth.RefreshTokenIfNeeded(auth.RefreshAndSetTokenParams{
+		Ctx:              context.Background(),
+		OIDCAuthConfig:   &kubeconfig.OidcConfig{ClientID: "cid", ClientSecret: "secret"},
+		Cache:            fc,
+		Token:            token,
+		Cluster:          cluster,
+		Writer:           rr,
+		Request:          req,
+		TelemetryHandler: &telemetry.RequestHandler{},
+		OIDCIdpIssuerURL: srv.URL,
+		BaseURL:          "",
+	})
+
+	assert.True(t, refreshed, "expected a refresh attempt for a token about to expire")
+
+	resp := rr.Result()
+	defer func() { _ = resp.Body.Close() }()
+
+	cookieVal, ok := findAuthCookie(resp, cluster)
+	require.True(t, ok, "expected auth cookie to be set")
+	assert.Equal(t, "NEW", cookieVal)
+}
+
 // TestConfigureTLSContext_NoConfig tests when both skipTLSVerify and caCert are not set.
 func TestConfigureTLSContext_NoConfig(t *testing.T) {
 	baseCtx := context.Background()

--- a/backend/pkg/auth/auth_test.go
+++ b/backend/pkg/auth/auth_test.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -490,11 +491,21 @@ func (f *fakeCache) Get(_ context.Context, key string) (interface{}, error) {
 	return f.store[key], nil
 }
 
+func (f *fakeCache) storeSet(key string, val interface{}) {
+	if f.store == nil {
+		f.store = map[string]interface{}{}
+	}
+
+	f.store[key] = val
+}
+
 func (f *fakeCache) Set(_ context.Context, key string, val interface{}) error {
 	f.setCalls = append(f.setCalls, struct {
 		key string
 		val interface{}
 	}{key, val})
+
+	f.storeSet(key, val)
 
 	return f.errOnSet
 }
@@ -505,6 +516,8 @@ func (f *fakeCache) SetWithTTL(_ context.Context, key string, val interface{}, t
 		val interface{}
 		ttl time.Duration
 	}{key, val, ttl})
+
+	f.storeSet(key, val)
 
 	return f.errOnSetWithTTL
 }
@@ -679,8 +692,10 @@ func newOIDCProviderServer(t *testing.T, issuerURL string, tokenHandler http.Han
 	return srv
 }
 
-func findAuthCookie(resp *http.Response, cluster string) (string, bool) {
-	want := fmt.Sprintf("headlamp-auth-%s.0", auth.SanitizeClusterName(cluster))
+// findAuthCookie looks up the auth cookie for the "test" cluster used by every
+// caller in this file.
+func findAuthCookie(resp *http.Response) (string, bool) {
+	want := fmt.Sprintf("headlamp-auth-%s.0", auth.SanitizeClusterName("test"))
 	for _, cookie := range resp.Cookies() {
 		if cookie.Name == want {
 			return cookie.Value, true
@@ -721,9 +736,10 @@ func TestGetNewToken_Success(t *testing.T) {
 		t.Fatalf("id_token extra = %q, want %q", idt, "NEW")
 	}
 
-	// CacheRefreshedToken side-effects
-	if len(fc.setCalls) != 1 || len(fc.setWithTTLCalls) != 1 {
-		t.Fatalf("expected Set=1, SetWithTTL=1; got Set=%d, SetWithTTL=%d",
+	// CacheRefreshedToken side-effects, plus the recent-refresh-outcome write
+	// keyed by the old token (see refreshedTokenKeyPrefix).
+	if len(fc.setCalls) != 1 || len(fc.setWithTTLCalls) != 2 {
+		t.Fatalf("expected Set=1, SetWithTTL=2; got Set=%d, SetWithTTL=%d",
 			len(fc.setCalls), len(fc.setWithTTLCalls))
 	}
 
@@ -736,6 +752,16 @@ func TestGetNewToken_Success(t *testing.T) {
 	if call.key != "oidc-token-OLD" || call.val != "REFRESH_OLD" || call.ttl != 10*time.Second {
 		t.Fatalf("SetWithTTL = {%q,%v,%v}, want {%q,%q,%v}",
 			call.key, call.val, call.ttl, "oidc-token-OLD", "REFRESH_OLD", 10*time.Second)
+	}
+
+	refreshCall := fc.setWithTTLCalls[1]
+	if refreshCall.key != "oidc-refreshed-token-OLD" || refreshCall.ttl != 10*time.Second {
+		t.Fatalf("SetWithTTL = {%q,%v,%v}, want key %q, ttl %v",
+			refreshCall.key, refreshCall.val, refreshCall.ttl, "oidc-refreshed-token-OLD", 10*time.Second)
+	}
+
+	if refreshedTok, ok := refreshCall.val.(*oauth2.Token); !ok || refreshedTok != newTok {
+		t.Fatalf("SetWithTTL val = %v, want the refreshed token", refreshCall.val)
 	}
 }
 
@@ -817,6 +843,141 @@ func TestGetNewToken_CacheUpdateErrors(t *testing.T) {
 	}
 }
 
+// newCallCountingTokenServer returns a fake OAuth2 token endpoint that always
+// succeeds and a counter tracking how many times it was hit.
+func newCallCountingTokenServer(t *testing.T) (srv *httptest.Server, callCount func() int) {
+	t.Helper()
+
+	var (
+		mu    sync.Mutex
+		calls int
+	)
+
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(oauthSuccessBody))
+	}))
+	t.Cleanup(srv.Close)
+
+	callCount = func() int {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return calls
+	}
+
+	return srv, callCount
+}
+
+// TestGetNewToken_ConcurrentRefresh_Deduplicates reproduces the OIDC
+// token-refresh race: many requests observing the same near-expiry token used
+// to each independently exchange the same cached refresh token with the IdP.
+// On providers with refresh-token rotation this fails for everyone but the
+// first exchange. GetNewToken must collapse concurrent callers sharing the
+// same token into a single upstream refresh.
+func TestGetNewToken_ConcurrentRefresh_Deduplicates(t *testing.T) {
+	srv, callCount := newCallCountingTokenServer(t)
+
+	fc := &fakeCache{store: map[string]interface{}{"oidc-token-OLD": "REFRESH_OLD"}}
+
+	const concurrency = 20
+
+	var (
+		wg    sync.WaitGroup
+		ready sync.WaitGroup
+		start = make(chan struct{})
+	)
+
+	results := make([]*oauth2.Token, concurrency)
+	errs := make([]error, concurrency)
+
+	ready.Add(concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+
+			ready.Done()
+			<-start // release every goroutine at once to maximize overlap
+
+			results[i], errs[i] = auth.GetNewToken(
+				"cid", "secret", fc, "id_token", "OLD", srv.URL, context.Background(),
+			)
+		}(i)
+	}
+
+	ready.Wait()
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, 1, callCount(), "expected exactly one upstream refresh call for concurrent requests")
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "goroutine %d", i)
+		require.NotNilf(t, results[i], "goroutine %d", i)
+		assert.Equal(t, refreshNew, results[i].RefreshToken, "goroutine %d", i)
+	}
+
+	require.Len(t, fc.setCalls, 1, "expected exactly one cache write for the new refresh token")
+	require.Len(t, fc.setWithTTLCalls, 2,
+		"expected one cache write for the retired old refresh token, and one for the recent-refresh outcome")
+}
+
+// TestGetNewToken_ReusesRecentRefreshForSameOldToken reproduces the race
+// flagged in review: the middleware can observe an about-to-expire token,
+// then only reach GetNewToken after a concurrent request already refreshed
+// that same token and the singleflight group for it has resolved (and
+// forgotten the key). Without reusing the just-completed refresh, this
+// second call would retry the IdP exchange using the now-retired refresh
+// token, which fails outright on IdPs that rotate refresh tokens on use.
+func TestGetNewToken_ReusesRecentRefreshForSameOldToken(t *testing.T) {
+	srv, callCount := newCallCountingTokenServer(t)
+
+	fc := &fakeCache{store: map[string]interface{}{"oidc-token-OLD": "REFRESH_OLD"}}
+
+	first, err := auth.GetNewToken("cid", "secret", fc, "id_token", "OLD", srv.URL, context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, callCount(), "expected the first call to hit the IdP")
+
+	// A second, non-overlapping call for the same old token (e.g. a request
+	// that checked the token before the refresh above, but only reached
+	// GetNewToken afterwards) must not attempt another exchange with the
+	// now-retired refresh token.
+	second, err := auth.GetNewToken("cid", "secret", fc, "id_token", "OLD", srv.URL, context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, callCount(), "expected the recent-refresh result to be reused, not a second IdP call")
+	assert.Same(t, first, second)
+}
+
+// TestGetNewToken_SequentialRefreshesAfterDeduplication ensures the dedup key
+// is forgotten once its refresh completes, so a later, independent refresh
+// cycle (e.g. the next time the token nears expiry) still hits the IdP rather
+// than being permanently memoized.
+func TestGetNewToken_SequentialRefreshesAfterDeduplication(t *testing.T) {
+	srv, callCount := newCallCountingTokenServer(t)
+
+	fc := &fakeCache{store: map[string]interface{}{"oidc-token-OLD": "REFRESH_OLD"}}
+
+	_, err := auth.GetNewToken("cid", "secret", fc, "id_token", "OLD", srv.URL, context.Background())
+	require.NoError(t, err)
+
+	// Simulate the next refresh cycle: the new token is now the one nearing
+	// expiry, with its own refresh token cached under its own key.
+	fc.store["oidc-token-NEW"] = refreshNew
+
+	_, err = auth.GetNewToken("cid", "secret", fc, "id_token", "NEW", srv.URL, context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, callCount(), "expected a fresh upstream call for each independent refresh cycle")
+}
+
 func TestRefreshAndCacheNewToken_Success(t *testing.T) {
 	const (
 		oldToken = "OLD"
@@ -846,10 +1007,11 @@ func TestRefreshAndCacheNewToken_Success(t *testing.T) {
 	assert.Equal(t, "oidc-token-NEW", fc.setCalls[0].key)
 	assert.Equal(t, refreshNew, fc.setCalls[0].val)
 
-	require.Len(t, fc.setWithTTLCalls, 1)
+	require.Len(t, fc.setWithTTLCalls, 2)
 	assert.Equal(t, oldKey, fc.setWithTTLCalls[0].key)
 	assert.Equal(t, "REFRESH_OLD", fc.setWithTTLCalls[0].val)
 	assert.Equal(t, 10*time.Second, fc.setWithTTLCalls[0].ttl)
+	assert.Equal(t, "oidc-refreshed-token-"+oldToken, fc.setWithTTLCalls[1].key)
 }
 
 func TestRefreshAndCacheNewToken_ValidatorIssuerOverride(t *testing.T) {
@@ -951,7 +1113,7 @@ func TestRefreshAndSetToken_DefaultsToIDToken(t *testing.T) {
 
 	defer func() { _ = resp.Body.Close() }()
 
-	cookieVal, ok := findAuthCookie(resp, cluster)
+	cookieVal, ok := findAuthCookie(resp)
 	require.True(t, ok, "expected auth cookie to be set")
 	assert.Equal(t, "NEW", cookieVal)
 }
@@ -1002,7 +1164,7 @@ func TestRefreshAndSetToken_UsesAccessToken(t *testing.T) {
 
 	defer func() { _ = resp.Body.Close() }()
 
-	cookieVal, ok := findAuthCookie(resp, cluster)
+	cookieVal, ok := findAuthCookie(resp)
 	require.True(t, ok, "expected auth cookie to be set")
 	assert.Equal(t, "ACCESS_NEW", cookieVal)
 }
@@ -1039,8 +1201,96 @@ func TestRefreshAndSetToken_ErrorDoesNotSetCookie(t *testing.T) {
 
 	defer func() { _ = resp.Body.Close() }()
 
-	_, ok := findAuthCookie(resp, cluster)
+	_, ok := findAuthCookie(resp)
 	assert.False(t, ok, "expected no auth cookie to be set on error")
+}
+
+// TestRefreshTokenIfNeeded_SkipsWhenNotExpiring verifies that the expiry
+// decision now made inside RefreshTokenIfNeeded still behaves like the old
+// middleware-side IsTokenAboutToExpire check: a token that isn't close to
+// expiry is left untouched, with no IdP call and no cookie write.
+func TestRefreshTokenIfNeeded_SkipsWhenNotExpiring(t *testing.T) {
+	const cluster = "test"
+
+	token := makeJWTWithPayload(t, map[string]interface{}{
+		"exp": float64(time.Now().Add(auth.JWTExpirationTTL + time.Hour).Unix()),
+	})
+
+	tokenEndpointCalled := false
+	srv := newOIDCProviderServer(t, "", func(_ http.ResponseWriter, _ *http.Request) {
+		tokenEndpointCalled = true
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/clusters/"+cluster, nil)
+	rr := httptest.NewRecorder()
+
+	refreshed := auth.RefreshTokenIfNeeded(auth.RefreshAndSetTokenParams{
+		Ctx:              context.Background(),
+		OIDCAuthConfig:   &kubeconfig.OidcConfig{ClientID: "cid", ClientSecret: "secret"},
+		Cache:            &fakeCache{},
+		Token:            token,
+		Cluster:          cluster,
+		Writer:           rr,
+		Request:          req,
+		TelemetryHandler: &telemetry.RequestHandler{},
+		OIDCIdpIssuerURL: srv.URL,
+		BaseURL:          "",
+	})
+
+	assert.False(t, refreshed, "expected no refresh attempt for a token that isn't about to expire")
+	assert.False(t, tokenEndpointCalled, "token endpoint should not be called for a token that isn't about to expire")
+
+	resp := rr.Result()
+	defer func() { _ = resp.Body.Close() }()
+
+	_, ok := findAuthCookie(resp)
+	assert.False(t, ok, "expected no auth cookie to be set")
+}
+
+// TestRefreshTokenIfNeeded_RefreshesWhenExpiring verifies that a token close
+// to expiry is refreshed and the auth cookie updated, matching what the
+// middleware used to get from IsTokenAboutToExpire + RefreshAndSetToken.
+func TestRefreshTokenIfNeeded_RefreshesWhenExpiring(t *testing.T) {
+	const cluster = "test"
+
+	token := makeJWTWithPayload(t, map[string]interface{}{
+		"exp": float64(time.Now().Add(auth.JWTExpirationTTL / 2).Unix()),
+	})
+
+	fc := &fakeCache{store: map[string]interface{}{"oidc-token-" + token: "REFRESH_OLD"}}
+
+	srv := newOIDCProviderServer(t, "", func(w http.ResponseWriter, r *http.Request) {
+		assert.NoError(t, r.ParseForm())
+		assert.Equal(t, "REFRESH_OLD", r.PostForm.Get("refresh_token"))
+
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(oauthSuccessBody))
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/clusters/"+cluster, nil)
+	rr := httptest.NewRecorder()
+
+	refreshed := auth.RefreshTokenIfNeeded(auth.RefreshAndSetTokenParams{
+		Ctx:              context.Background(),
+		OIDCAuthConfig:   &kubeconfig.OidcConfig{ClientID: "cid", ClientSecret: "secret"},
+		Cache:            fc,
+		Token:            token,
+		Cluster:          cluster,
+		Writer:           rr,
+		Request:          req,
+		TelemetryHandler: &telemetry.RequestHandler{},
+		OIDCIdpIssuerURL: srv.URL,
+		BaseURL:          "",
+	})
+
+	assert.True(t, refreshed, "expected a refresh attempt for a token about to expire")
+
+	resp := rr.Result()
+	defer func() { _ = resp.Body.Close() }()
+
+	cookieVal, ok := findAuthCookie(resp)
+	require.True(t, ok, "expected auth cookie to be set")
+	assert.Equal(t, "NEW", cookieVal)
 }
 
 // TestConfigureTLSContext_NoConfig tests when both skipTLSVerify and caCert are not set.

--- a/backend/pkg/auth/auth_test.go
+++ b/backend/pkg/auth/auth_test.go
@@ -497,6 +497,12 @@ func (f *fakeCache) Set(_ context.Context, key string, val interface{}) error {
 		val interface{}
 	}{key, val})
 
+	if f.store == nil {
+		f.store = map[string]interface{}{}
+	}
+
+	f.store[key] = val
+
 	return f.errOnSet
 }
 
@@ -506,6 +512,12 @@ func (f *fakeCache) SetWithTTL(_ context.Context, key string, val interface{}, t
 		val interface{}
 		ttl time.Duration
 	}{key, val, ttl})
+
+	if f.store == nil {
+		f.store = map[string]interface{}{}
+	}
+
+	f.store[key] = val
 
 	return f.errOnSetWithTTL
 }
@@ -722,9 +734,10 @@ func TestGetNewToken_Success(t *testing.T) {
 		t.Fatalf("id_token extra = %q, want %q", idt, "NEW")
 	}
 
-	// CacheRefreshedToken side-effects
-	if len(fc.setCalls) != 1 || len(fc.setWithTTLCalls) != 1 {
-		t.Fatalf("expected Set=1, SetWithTTL=1; got Set=%d, SetWithTTL=%d",
+	// CacheRefreshedToken side-effects, plus the recent-refresh-outcome write
+	// keyed by the old token (see refreshedTokenKeyPrefix).
+	if len(fc.setCalls) != 1 || len(fc.setWithTTLCalls) != 2 {
+		t.Fatalf("expected Set=1, SetWithTTL=2; got Set=%d, SetWithTTL=%d",
 			len(fc.setCalls), len(fc.setWithTTLCalls))
 	}
 
@@ -737,6 +750,16 @@ func TestGetNewToken_Success(t *testing.T) {
 	if call.key != "oidc-token-OLD" || call.val != "REFRESH_OLD" || call.ttl != 10*time.Second {
 		t.Fatalf("SetWithTTL = {%q,%v,%v}, want {%q,%q,%v}",
 			call.key, call.val, call.ttl, "oidc-token-OLD", "REFRESH_OLD", 10*time.Second)
+	}
+
+	refreshCall := fc.setWithTTLCalls[1]
+	if refreshCall.key != "oidc-refreshed-token-OLD" || refreshCall.ttl != 10*time.Second {
+		t.Fatalf("SetWithTTL = {%q,%v,%v}, want key %q, ttl %v",
+			refreshCall.key, refreshCall.val, refreshCall.ttl, "oidc-refreshed-token-OLD", 10*time.Second)
+	}
+
+	if refreshedTok, ok := refreshCall.val.(*oauth2.Token); !ok || refreshedTok != newTok {
+		t.Fatalf("SetWithTTL val = %v, want the refreshed token", refreshCall.val)
 	}
 }
 
@@ -900,7 +923,35 @@ func TestGetNewToken_ConcurrentRefresh_Deduplicates(t *testing.T) {
 	}
 
 	require.Len(t, fc.setCalls, 1, "expected exactly one cache write for the new refresh token")
-	require.Len(t, fc.setWithTTLCalls, 1, "expected exactly one cache write for the retired old refresh token")
+	require.Len(t, fc.setWithTTLCalls, 2,
+		"expected one cache write for the retired old refresh token, and one for the recent-refresh outcome")
+}
+
+// TestGetNewToken_ReusesRecentRefreshForSameOldToken reproduces the race
+// flagged in review: the middleware can observe an about-to-expire token,
+// then only reach GetNewToken after a concurrent request already refreshed
+// that same token and the singleflight group for it has resolved (and
+// forgotten the key). Without reusing the just-completed refresh, this
+// second call would retry the IdP exchange using the now-retired refresh
+// token, which fails outright on IdPs that rotate refresh tokens on use.
+func TestGetNewToken_ReusesRecentRefreshForSameOldToken(t *testing.T) {
+	srv, callCount := newCallCountingTokenServer(t)
+
+	fc := &fakeCache{store: map[string]interface{}{"oidc-token-OLD": "REFRESH_OLD"}}
+
+	first, err := auth.GetNewToken("cid", "secret", fc, "id_token", "OLD", srv.URL, context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, callCount(), "expected the first call to hit the IdP")
+
+	// A second, non-overlapping call for the same old token (e.g. a request
+	// that checked the token before the refresh above, but only reached
+	// GetNewToken afterwards) must not attempt another exchange with the
+	// now-retired refresh token.
+	second, err := auth.GetNewToken("cid", "secret", fc, "id_token", "OLD", srv.URL, context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, callCount(), "expected the recent-refresh result to be reused, not a second IdP call")
+	assert.Same(t, first, second)
 }
 
 // TestGetNewToken_SequentialRefreshesAfterDeduplication ensures the dedup key
@@ -954,10 +1005,11 @@ func TestRefreshAndCacheNewToken_Success(t *testing.T) {
 	assert.Equal(t, "oidc-token-NEW", fc.setCalls[0].key)
 	assert.Equal(t, refreshNew, fc.setCalls[0].val)
 
-	require.Len(t, fc.setWithTTLCalls, 1)
+	require.Len(t, fc.setWithTTLCalls, 2)
 	assert.Equal(t, oldKey, fc.setWithTTLCalls[0].key)
 	assert.Equal(t, "REFRESH_OLD", fc.setWithTTLCalls[0].val)
 	assert.Equal(t, 10*time.Second, fc.setWithTTLCalls[0].ttl)
+	assert.Equal(t, "oidc-refreshed-token-"+oldToken, fc.setWithTTLCalls[1].key)
 }
 
 func TestRefreshAndCacheNewToken_ValidatorIssuerOverride(t *testing.T) {

--- a/backend/pkg/auth/middleware.go
+++ b/backend/pkg/auth/middleware.go
@@ -121,17 +121,7 @@ func NewOIDCTokenRefreshMiddleware(config OIDCTokenRefreshConfig) func(http.Hand
 				return
 			}
 
-			if !IsTokenAboutToExpire(token) {
-				config.TelemetryHandler.RecordEvent(span, "Token not about to expire, skipping refresh")
-
-				status = "token_valid"
-
-				next.ServeHTTP(w, r)
-
-				return
-			}
-
-			RefreshAndSetToken(RefreshAndSetTokenParams{
+			refreshAttempted := RefreshTokenIfNeeded(RefreshAndSetTokenParams{
 				Ctx:                       ctx,
 				OIDCAuthConfig:            oidcAuthConfig,
 				Cache:                     config.Cache,
@@ -147,6 +137,11 @@ func NewOIDCTokenRefreshMiddleware(config OIDCTokenRefreshConfig) func(http.Hand
 				BaseURL:                   config.BaseURL,
 				SessionTTL:                config.SessionTTL,
 			})
+			if !refreshAttempted {
+				config.TelemetryHandler.RecordEvent(span, "Token not about to expire, skipping refresh")
+
+				status = "token_valid"
+			}
 
 			next.ServeHTTP(w, r)
 		})

--- a/backend/pkg/auth/middleware.go
+++ b/backend/pkg/auth/middleware.go
@@ -121,17 +121,7 @@ func NewOIDCTokenRefreshMiddleware(config OIDCTokenRefreshConfig) func(http.Hand
 				return
 			}
 
-			if !IsTokenAboutToExpire(token) {
-				config.TelemetryHandler.RecordEvent(span, "Token not about to expire, skipping refresh")
-
-				status = "token_valid"
-
-				next.ServeHTTP(w, r)
-
-				return
-			}
-
-			RefreshAndSetToken(RefreshAndSetTokenParams{
+			refreshed := RefreshTokenIfNeeded(RefreshAndSetTokenParams{
 				Ctx:                       ctx,
 				OIDCAuthConfig:            oidcAuthConfig,
 				Cache:                     config.Cache,
@@ -147,6 +137,11 @@ func NewOIDCTokenRefreshMiddleware(config OIDCTokenRefreshConfig) func(http.Hand
 				BaseURL:                   config.BaseURL,
 				SessionTTL:                config.SessionTTL,
 			})
+			if !refreshed {
+				config.TelemetryHandler.RecordEvent(span, "Token not about to expire, skipping refresh")
+
+				status = "token_valid"
+			}
 
 			next.ServeHTTP(w, r)
 		})

--- a/backend/pkg/auth/middleware_test.go
+++ b/backend/pkg/auth/middleware_test.go
@@ -18,15 +18,19 @@ package auth_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/auth"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/telemetry"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewOIDCTokenRefreshMiddleware(t *testing.T) {
@@ -77,4 +81,112 @@ func TestSetTokenFromCookie(t *testing.T) {
 	got := req.Header.Get("Authorization")
 	want := "Bearer " + testToken
 	assert.Equal(t, want, got)
+}
+
+func setupConcurrentRefreshMiddleware(t *testing.T, cluster, token string) (http.Handler, func() int) {
+	t.Helper()
+
+	var (
+		mu    sync.Mutex
+		calls int
+	)
+
+	srv := newOIDCProviderServer(t, "", func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(oauthSuccessBody))
+	})
+
+	fc := &fakeCache{store: map[string]interface{}{"oidc-token-" + token: "REFRESH_OLD"}}
+
+	kubeConfigStore := kubeconfig.NewContextStore()
+	require.NoError(t, kubeConfigStore.AddContext(&kubeconfig.Context{
+		Name:     cluster,
+		OidcConf: &kubeconfig.OidcConfig{ClientID: "cid", ClientSecret: "secret"},
+	}))
+
+	config := auth.OIDCTokenRefreshConfig{
+		KubeConfigStore:  kubeConfigStore,
+		Cache:            fc,
+		TelemetryHandler: &telemetry.RequestHandler{},
+		OidcIdpIssuerURL: srv.URL,
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	callCount := func() int {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return calls
+	}
+
+	return auth.NewOIDCTokenRefreshMiddleware(config)(handler), callCount
+}
+
+// TestNewOIDCTokenRefreshMiddleware_ConcurrentRequests_DedupesAndSetsCookie exercises
+// the full middleware flow (expiry check, discovery, deduplicated refresh, cookie write)
+// under concurrent requests for the same expiring token, covering issue #6793's
+// acceptance criteria: exactly one token-endpoint call, and no stale cookie clobbering.
+func TestNewOIDCTokenRefreshMiddleware_ConcurrentRequests_DedupesAndSetsCookie(t *testing.T) {
+	const cluster = "test"
+
+	token := makeJWTWithPayload(t, map[string]interface{}{
+		"exp": float64(time.Now().Add(auth.JWTExpirationTTL / 2).Unix()),
+	})
+
+	middleware, callCount := setupConcurrentRefreshMiddleware(t, cluster, token)
+
+	const concurrency = 10
+
+	var (
+		wg    sync.WaitGroup
+		ready sync.WaitGroup
+		start = make(chan struct{})
+	)
+
+	responses := make([]*http.Response, concurrency)
+
+	ready.Add(concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+
+			req := httptest.NewRequestWithContext(
+				context.Background(), http.MethodGet, "/clusters/"+cluster+"/api", nil,
+			)
+			req.Header.Set("Authorization", "Bearer "+token)
+
+			rr := httptest.NewRecorder()
+
+			ready.Done()
+			<-start // release every goroutine at once to maximize overlap
+
+			middleware.ServeHTTP(rr, req)
+
+			responses[i] = rr.Result()
+		}(i)
+	}
+
+	ready.Wait()
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, 1, callCount(), "expected exactly one token-endpoint call for concurrent middleware requests")
+
+	for i, resp := range responses {
+		defer func() { _ = resp.Body.Close() }()
+
+		cookieVal, ok := findAuthCookie(resp)
+		require.Truef(t, ok, "expected auth cookie for goroutine %d", i)
+		assert.Equal(t, "NEW", cookieVal, "goroutine %d should receive current refreshed token", i)
+	}
 }


### PR DESCRIPTION
Fixes #6793

## Problem

`NewOIDCTokenRefreshMiddleware` checks whether a token is about to expire and refreshes it independently on every incoming request, with no synchronization. When several concurrent requests for the same cluster observe the same near-expiry token (Headlamp routinely fires many parallel `/clusters/<name>/...` calls), each one raced to read the same cached refresh token and exchange it with the IdP.

On providers that rotate refresh tokens on use (Keycloak, Okta, Azure AD, Dex), only the first exchange succeeds; the rest fail with `invalid_grant`, which was logged and silently swallowed. On providers with reuse detection, presenting an already-consumed refresh token can revoke the entire token family, forcing the user to fully re-authenticate mid-session.

## Fix

`GetNewToken` in `backend/pkg/auth/auth.go` now deduplicates concurrent refreshes for the same token using a `singleflight.Group`. Only one goroutine performs the actual cache read, IdP exchange, and cache write per token; all other concurrent callers for that same token wait and receive the identical resulting token instead of independently re-exchanging it.

The shared refresh runs on a context detached from any single caller's cancellation (`context.WithoutCancel`), so one request finishing or its client disconnecting can't abort the refresh that other concurrent requests are waiting on.

`golang.org/x/sync` was already an indirect dependency (via other transitive deps); it's now a direct one after `go mod tidy`.

## Testing

- `TestGetNewToken_ConcurrentRefresh_Deduplicates`: fires 20 concurrent `GetNewToken` calls for the same token against a call-counting fake token endpoint and asserts exactly one upstream call happened and every caller received the same refreshed token.
- `TestGetNewToken_SequentialRefreshesAfterDeduplication`: confirms the dedup key is forgotten once its refresh completes, so a later, independent refresh cycle still hits the IdP.
- Full existing `backend/pkg/auth` suite passes unchanged (`go test ./pkg/auth/...`).
- `go build ./...` and `go vet ./pkg/auth/...` pass clean.

I wasn't able to run `-race` locally (no cgo toolchain in this environment), but the fix relies on `singleflight.Group`, a synchronization primitive designed specifically to make this pattern race-free, and CI's race job should confirm it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication token refresh handling to prevent duplicate refresh requests during concurrent activity.
  - Reuses recent successful refresh results, reducing failures caused by refresh-token rotation.
  - Ensures requests continue reliably while token status and refresh activity are tracked correctly.
  - Added handling for tokens that do not require expiration-based refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->