### PR TITLE
frontend: BindingList: Show service account namespace when it differs

### DIFF
--- a/frontend/src/components/role/BindingList.tsx
+++ b/frontend/src/components/role/BindingList.tsx
@@ -165,14 +165,22 @@ export default function RoleBindingList() {
           getValue: item =>
             item?.subjects
               ?.filter(subject => subject.kind === 'ServiceAccount')
-              ?.map(subject => subject.name)
+              ?.map(subject =>
+                subject.namespace && subject.namespace !== item.getNamespace()
+                  ? `${subject.name} (${subject.namespace})`
+                  : subject.name
+              )
               ?.join(' '),
           render: item => (
             <LabelListItem
               labels={
                 item?.subjects
                   ?.filter(subject => subject.kind === 'ServiceAccount')
-                  .map(subject => subject.name) || []
+                  .map(subject =>
+                    subject.namespace && subject.namespace !== item.getNamespace()
+                      ? `${subject.name} (${subject.namespace})`
+                      : subject.name
+                  ) || []
               }
             />
           ),

--- a/frontend/src/components/role/BindingList.tsx
+++ b/frontend/src/components/role/BindingList.tsx
@@ -134,7 +134,7 @@ export default function RoleBindingList() {
               labels={
                 item?.subjects
                   ?.filter(subject => subject.kind === 'User')
-                  .map(subject => subject.name) || []
+                  ?.map(subject => subject.name) || []
               }
             />
           ),
@@ -153,7 +153,7 @@ export default function RoleBindingList() {
               labels={
                 item?.subjects
                   ?.filter(subject => subject.kind === 'Group')
-                  .map(subject => subject.name) || []
+                  ?.map(subject => subject.name) || []
               }
             />
           ),
@@ -176,7 +176,7 @@ export default function RoleBindingList() {
               labels={
                 item?.subjects
                   ?.filter(subject => subject.kind === 'ServiceAccount')
-                  .map(subject =>
+                  ?.map(subject =>
                     subject.namespace && subject.namespace !== item.getNamespace()
                       ? `${subject.name} (${subject.namespace})`
                       : subject.name


### PR DESCRIPTION
## Summary

This PR fixes the RoleBindings/ClusterRoleBindings list view not showing which namespace a service account subject belongs to, so cross-namespace subjects were indistinguishable from same-namespace ones in the UI.

## Related Issue

Fixes #6794

## Changes

- Updated the Service Accounts column in `BindingList.tsx` to append `(namespace)` to a service account subject's name whenever that namespace differs from the binding's own namespace.
- For ClusterRoleBindings, the namespace is always shown, since the binding itself has no namespace to compare against.

## Steps to Test

1. Apply a RoleBinding whose subject is a ServiceAccount in a different namespace:
```yaml
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: cert-manager-cainjector:leaderelection
  namespace: kube-system
subjects:
  - kind: ServiceAccount
    name: cert-manager-cainjector
    namespace: cert-manager
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: cert-manager-cainjector:leaderelection
  ```
2. Go to the RoleBindings list.
3. Verify the Service Accounts column shows `cert-manager-cainjector (cert-manager)` instead of just the unqualified name.
4. Check a ClusterRoleBinding and confirm its service account subjects always show their namespace.

## Screenshots (if applicable)

<img width="1497" height="441" alt="image" src="https://github.com/user-attachments/assets/a0534881-6da0-4a99-a1dd-94a93c60c4ae" />