### PR TITLE
backend: auth: Fix cluster name cookie collision for long cluster names

### DIFF
--- a/backend/pkg/auth/cookies.go
+++ b/backend/pkg/auth/cookies.go
@@ -17,6 +17,7 @@ limitations under the License.
 package auth
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"net/http"
@@ -45,9 +46,11 @@ func SanitizeClusterName(cluster string) string {
 	reg := regexp.MustCompile(`[^a-zA-Z0-9\-_]`)
 	sanitized := reg.ReplaceAllString(cluster, "")
 
-	// Limit length to prevent issues
+	// Limit length to prevent issues, appending a short hash slice for uniqueness when truncated.
 	if len(sanitized) > 50 {
-		sanitized = sanitized[:50]
+		hashBytes := sha256.Sum256([]byte(cluster))
+		hash := fmt.Sprintf("%x", hashBytes[:16])
+		sanitized = sanitized[:17] + "-" + hash
 	}
 
 	return sanitized

--- a/backend/pkg/auth/cookies.go
+++ b/backend/pkg/auth/cookies.go
@@ -17,6 +17,7 @@ limitations under the License.
 package auth
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"net/http"
@@ -45,9 +46,10 @@ func SanitizeClusterName(cluster string) string {
 	reg := regexp.MustCompile(`[^a-zA-Z0-9\-_]`)
 	sanitized := reg.ReplaceAllString(cluster, "")
 
-	// Limit length to prevent issues
+	// Limit length to prevent issues, appending a short hash slice for uniqueness when truncated.
 	if len(sanitized) > 50 {
-		sanitized = sanitized[:50]
+		hash := fmt.Sprintf("%x", sha256.Sum256([]byte(cluster)))[:8]
+		sanitized = sanitized[:41] + "-" + hash
 	}
 
 	return sanitized

--- a/backend/pkg/auth/cookies_test.go
+++ b/backend/pkg/auth/cookies_test.go
@@ -33,6 +33,20 @@ const (
 )
 
 func TestSanitizeClusterName(t *testing.T) {
+	longInput := "very-long-cluster-name-that-exceeds-fifty-characters-limit"
+	longInput2 := "very-long-cluster-name-that-exceeds-fifty-characters-different"
+
+	sanitizedLong1 := auth.SanitizeClusterName(longInput)
+	sanitizedLong2 := auth.SanitizeClusterName(longInput2)
+
+	if len(sanitizedLong1) != 50 {
+		t.Errorf("expected length 50 for long input, got %d (%q)", len(sanitizedLong1), sanitizedLong1)
+	}
+
+	if sanitizedLong1 == sanitizedLong2 {
+		t.Errorf("expected distinct sanitized names for different long cluster inputs, both got %q", sanitizedLong1)
+	}
+
 	tests := []struct {
 		input    string
 		expected string
@@ -42,7 +56,7 @@ func TestSanitizeClusterName(t *testing.T) {
 		{"cluster123", "cluster123"},
 		{"my-cluster@#$%", "my-cluster"},
 		{"", ""},
-		{"very-long-cluster-name-that-exceeds-fifty-characters-limit", "very-long-cluster-name-that-exceeds-fifty-characte"},
+		{longInput, sanitizedLong1},
 	}
 
 	for _, test := range tests {

--- a/backend/pkg/auth/cookies_test.go
+++ b/backend/pkg/auth/cookies_test.go
@@ -33,6 +33,24 @@ const (
 )
 
 func TestSanitizeClusterName(t *testing.T) {
+	longInput := "very-long-cluster-name-that-exceeds-fifty-characters-limit"
+	longInput2 := "very-long-cluster-name-that-exceeds-fifty-characters-different"
+
+	sanitizedLong1 := auth.SanitizeClusterName(longInput)
+	sanitizedLong2 := auth.SanitizeClusterName(longInput2)
+
+	if len(sanitizedLong1) != 50 {
+		t.Errorf("expected length 50 for long input, got %d (%q)", len(sanitizedLong1), sanitizedLong1)
+	}
+
+	if len(sanitizedLong2) != 50 {
+		t.Errorf("expected length 50 for long input2, got %d (%q)", len(sanitizedLong2), sanitizedLong2)
+	}
+
+	if sanitizedLong1 == sanitizedLong2 {
+		t.Errorf("expected distinct sanitized names for different long cluster inputs, both got %q", sanitizedLong1)
+	}
+
 	tests := []struct {
 		input    string
 		expected string
@@ -42,7 +60,7 @@ func TestSanitizeClusterName(t *testing.T) {
 		{"cluster123", "cluster123"},
 		{"my-cluster@#$%", "my-cluster"},
 		{"", ""},
-		{"very-long-cluster-name-that-exceeds-fifty-characters-limit", "very-long-cluster-name-that-exceeds-fifty-characte"},
+		{longInput, sanitizedLong1},
 	}
 
 	for _, test := range tests {

--- a/backend/pkg/k8cache/cacheStore_bench_test.go
+++ b/backend/pkg/k8cache/cacheStore_bench_test.go
@@ -39,7 +39,7 @@ func BenchmarkStoreK8sResponseInCache(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		b.StopTimer()
 
 		rw := httptest.NewRecorder()
@@ -72,7 +72,7 @@ func BenchmarkStoreK8sResponseInCache_FailureSkip(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		b.StopTimer()
 
 		rw := httptest.NewRecorder()
@@ -108,7 +108,7 @@ func BenchmarkGenerateKey(b *testing.B) {
 
 	var err error
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		benchBuildCacheKeySink, err = k8cache.GenerateKey(
 			targetURL, contextID,
 		)


### PR DESCRIPTION
## Summary

This PR fixes an authentication cookie collision in `backend/pkg/auth` caused by `SanitizeClusterName()` truncating long cluster names to a fixed 50-character prefix. When two cluster names shared the same first 50 sanitized characters, they generated identical authentication cookie names, allowing one cluster's session cookie to overwrite another's.

The fix preserves the 50-character limit while ensuring distinct long cluster names generate unique cookie names.

## Related issue

Fixes #6800 

## Changes

- **Updated `backend/pkg/auth/cookies.go`**
  - Modified `SanitizeClusterName()` to preserve uniqueness for cluster names longer than 50 characters by truncating the sanitized prefix and appending a deterministic 8-character SHA-256 hash suffix.

- **Added `backend/pkg/auth/cookies_test.go`**
  - Added unit tests verifying that:
    - Long cluster names with identical prefixes generate unique sanitized names.
    - Sanitized output remains within the 50-character limit.
    - Existing behavior for shorter cluster names is preserved.

- **Updated `backend/pkg/k8cache/cacheStore_bench_test.go`**
  - Modernized benchmark loops to use Go 1.24's `b.Loop()` API.

## Steps to Test

1. Run the authentication package tests:

   ```bash
   go test -v ./pkg/auth/...
   ```

2. Configure two Kubernetes clusters with names longer than 50 characters that share the same prefix, for example:

   - `production-k8s-us-east-1-apps-microservices-cluster-alpha`
   - `production-k8s-us-east-1-apps-microservices-cluster-bravo`

3. Authenticate to both clusters.

4. Verify that each cluster receives a distinct authentication cookie and that authenticating to one cluster does not overwrite the other's session cookie.

## Screenshots (if applicable)

N/A (backend authentication logic change).

## Notes for the Reviewer

- The maximum sanitized cluster name length remains 50 characters.
- The hash suffix is deterministic, so the same cluster name always produces the same sanitized value.
- Existing behavior for cluster names of 50 characters or fewer is unchanged.
- All authentication package tests, including the new collision tests, pass successfully.