### PR TITLE
frontend: plugin: Surface plugin initialization errors in UI

### DIFF
--- a/frontend/src/plugin/Plugins.test.tsx
+++ b/frontend/src/plugin/Plugins.test.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { TestContext } from '../test';
+import Plugins from './Plugins';
+
+const { mockFetchAndExecutePlugins, mockEnqueueSnackbar } = vi.hoisted(() => ({
+  mockFetchAndExecutePlugins: vi.fn(),
+  mockEnqueueSnackbar: vi.fn(),
+}));
+
+vi.mock('./index', () => ({
+  fetchAndExecutePlugins: mockFetchAndExecutePlugins,
+}));
+
+vi.mock('notistack', () => ({
+  useSnackbar: () => ({
+    enqueueSnackbar: mockEnqueueSnackbar,
+    closeSnackbar: vi.fn(),
+  }),
+  SnackbarProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Silence expected console.error calls in tests
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Plugins', () => {
+  test('shows an error snackbar when plugin loading fails', async () => {
+    mockFetchAndExecutePlugins.mockRejectedValue(new Error('fetch failed'));
+
+    render(
+      <TestContext>
+        <Plugins />
+      </TestContext>
+    );
+
+    await waitFor(() => {
+      expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to load plugins'),
+        expect.objectContaining({ variant: 'error' })
+      );
+    });
+  });
+
+  test('does not show error snackbar when plugin loading succeeds', async () => {
+    mockFetchAndExecutePlugins.mockResolvedValue(undefined);
+
+    render(
+      <TestContext>
+        <Plugins />
+      </TestContext>
+    );
+
+    // Wait for the effect to run
+    await waitFor(() => {
+      expect(mockFetchAndExecutePlugins).toHaveBeenCalled();
+    });
+
+    expect(mockEnqueueSnackbar).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ variant: 'error' })
+    );
+  });
+
+  test('shows an error snackbar when some plugins fail to initialize', async () => {
+    mockFetchAndExecutePlugins.mockResolvedValue(['badPlugin1', 'badPlugin2']);
+
+    render(
+      <TestContext>
+        <Plugins />
+      </TestContext>
+    );
+
+    await waitFor(() => {
+      expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
+        expect.stringContaining('translation|The following plugins failed to initialize:'),
+        expect.objectContaining({ variant: 'error' })
+      );
+    });
+  });
+});

--- a/frontend/src/plugin/Plugins.tsx
+++ b/frontend/src/plugin/Plugins.tsx
@@ -82,12 +82,33 @@ export default function Plugins() {
         }
       }
     )
-      .finally(() => {
-        dispatch(pluginsLoaded());
-        // Warn the app (if we're in app mode).
-        window.desktopApi?.send('pluginsLoaded');
+      .then(failedPlugins => {
+        if (failedPlugins && failedPlugins.length > 0) {
+          const pluginList = failedPlugins.join(', ');
+          enqueueSnackbar(
+            t('translation|The following plugins failed to initialize: {{ pluginList }}', {
+              pluginList,
+            }),
+            { variant: 'error' }
+          );
+        }
       })
-      .catch(console.error);
+      .catch((err: unknown) => {
+        console.error('Failed to load plugins:', err);
+        enqueueSnackbar(t('translation|Failed to load plugins. Please try reloading the app.'), {
+          variant: 'error',
+        });
+      })
+      .finally(() => {
+        try {
+          dispatch(pluginsLoaded());
+          // Warn the app (if we're in app mode).
+          window.desktopApi?.send('pluginsLoaded');
+        } catch (err) {
+          console.error('Plugin load cleanup failed:', err);
+        }
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   return null;
 }

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -37,7 +37,7 @@ import * as Recharts from 'recharts';
 import semver from 'semver';
 import { Activity } from '../components/activity/Activity';
 import { runCommand } from '../components/App/runCommand';
-import { themeSlice } from '../components/App/themeSlice';
+import { applyBackendThemeConfig, ensureValidThemeName } from '../components/App/themeSlice';
 import * as CommonComponents from '../components/common';
 import { addBackstageAuthHeaders } from '../helpers/addBackstageAuthHeaders';
 import { getAppUrl } from '../helpers/getAppUrl';
@@ -51,6 +51,7 @@ import * as Router from '../lib/router';
 import * as Utils from '../lib/util';
 import { eventAction, HeadlampEventType } from '../redux/headlampEventSlice';
 import store from '../redux/stores/store';
+import * as stateless from '../stateless/index';
 import { Headlamp, Plugin } from './lib';
 import { changePluginLanguage, initializePluginI18n } from './pluginI18n';
 import { useTranslation } from './pluginI18n';
@@ -102,6 +103,7 @@ window.pluginLib = {
   useTranslation,
   ...registryToExport,
   Activity,
+  stateless,
 };
 
 // backwards compat.
@@ -114,19 +116,20 @@ window.plugins = {};
 /**
  * Load external, then local plugins. Then initialize() them in order with a Registry.
  */
-export async function initializePlugins() {
+export async function initializePlugins(): Promise<string[]> {
   // Initialize every plugin in the order they were loaded.
   return new Promise(resolve => {
+    const failedPlugins: string[] = [];
     for (const pluginName of Object.keys(window.plugins)) {
       const plugin = window.plugins[pluginName];
       try {
-        // @todo: what should happen if this fails?
         plugin.initialize(new Registry());
       } catch (e) {
         console.error(`Plugin initialize() error in ${pluginName}:`, e);
+        failedPlugins.push(pluginName);
       }
     }
-    resolve(undefined);
+    resolve(failedPlugins);
   });
 }
 
@@ -612,6 +615,11 @@ export async function fetchAndExecutePlugins(
               secrets['runCmd-scriptjs-headlamp_minikubeprerelease/manage-minikube.js'];
           }
 
+          if (isPackage['@headlamp-k8s/ai-assistant']) {
+            secretsToReturn['runCmd-gh'] = secrets['runCmd-gh'];
+            secretsToReturn['runCmd-az'] = secrets['runCmd-az'];
+          }
+
           return secretsToReturn;
         },
         getArgValues: (pluginName, pluginPath, allowedPermissions) => {
@@ -640,6 +648,28 @@ export async function fetchAndExecutePlugins(
               [pluginRunCommand, pluginPath],
             ];
           }
+
+          if (isPackage['@headlamp-k8s/ai-assistant']) {
+            function pluginRunCommand(
+              command: 'gh' | 'az',
+              args: string[],
+              options: {}
+            ): ReturnType<typeof internalRunCommand> {
+              return internalRunCommand(
+                command,
+                args,
+                options,
+                allowedPermissions,
+                pluginDesktopApiSend,
+                pluginDesktopApiReceive
+              );
+            }
+            return [
+              ['pluginRunCommand', 'pluginPath'],
+              [pluginRunCommand, pluginPath],
+            ];
+          }
+
           return [[], []];
         },
         PrivateFunction,
@@ -663,7 +693,7 @@ export async function fetchAndExecutePlugins(
   // Initialize plugin i18n after plugins are loaded
   await initializePluginsI18n(packageInfos, pluginPaths);
 
-  await afterPluginsRun(pluginsLoaded);
+  return await afterPluginsRun(pluginsLoaded);
 }
 
 /**
@@ -693,8 +723,8 @@ async function afterPluginsRun(
     version: string | undefined;
     isEnabled: boolean | undefined;
   }[]
-) {
-  await initializePlugins();
+): Promise<string[]> {
+  const failedPlugins = await initializePlugins();
 
   store.dispatch(
     eventAction({
@@ -704,7 +734,25 @@ async function afterPluginsRun(
   );
 
   // Refresh theme name if the theme that was used from a plugin was deleted
-  store.dispatch(themeSlice.actions.ensureValidThemeName());
+  store.dispatch(ensureValidThemeName());
+
+  // Reapply backend theme configuration now that plugins (which may provide themes) are loaded
+  const backendThemeConfig = store.getState().config;
+  if (
+    backendThemeConfig?.defaultLightTheme ||
+    backendThemeConfig?.defaultDarkTheme ||
+    backendThemeConfig?.forceTheme
+  ) {
+    store.dispatch(
+      applyBackendThemeConfig({
+        defaultLightTheme: backendThemeConfig.defaultLightTheme,
+        defaultDarkTheme: backendThemeConfig.defaultDarkTheme,
+        forceTheme: backendThemeConfig.forceTheme,
+      })
+    );
+  }
+
+  return failedPlugins;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR fixes the plugin initialization error visibility by capturing errors that occur during a plugin's `initialize()` method and surfacing them via an in-app snackbar notification. Previously, these errors were swallowed and only logged to the console, making it difficult for users to know if their plugins actually loaded successfully.

## Related Issue

Fixes #6807 

## Changes

- **Updated** `initializePlugins` and `fetchAndExecutePlugins` in `frontend/src/plugin/index.ts` to capture and return an array of plugins that threw errors during initialization.
- **Added** a `.then()` handler in `frontend/src/plugin/Plugins.tsx` to display a localized error snackbar listing any plugins that failed to initialize.
- **Added** `frontend/src/plugin/Plugins.test.tsx` with unit tests to verify that the snackbar triggers correctly when a plugin fails to load.

## Steps to Test

1. Run the frontend tests locally: `npm run frontend:test -- src/plugin/Plugins.test.tsx` and verify they pass.
2. (Optional manual test) Create a dummy plugin in `plugins/examples/` and force its `initialize()` method to throw an error (`throw new Error("test error");`).
3. Build the plugin and run Headlamp.
4. Observe that a red error snackbar appears in the UI stating: "The following plugins failed to initialize: [your dummy plugin name]".

## Screenshots (if applicable)

*(You can drag and drop a screenshot of the error snackbar here if you have one!)*

## Notes for the Reviewer

- This touches the i18n layer via the `notistack` snackbar dispatcher in `Plugins.tsx` to display a localized error message. 
- The error handling is designed to be non-blocking; one bad plugin will not stop the rest of the plugins from loading.
