### PR TITLE
frontend: plugin: Surface plugin initialization errors in UI

### DIFF
--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -1028,6 +1028,7 @@
   "resource {{resourceName}} on pods": "المورد {{resourceName}} على البودات",
   "resource {{resourceName}} of container {{containerName}} on pods": "المورد {{resourceName}} للحاوية {{containerName}} على البودات",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "تحذير تم تعطيل الإضافات غير المتوافقة: ({{ pluginList }})",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "البحث العام",
   "Open the global search dialog": "فتح نافذة البحث العام",

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -1010,6 +1010,7 @@
   "resource {{resourceName}} on pods": "المورد {{resourceName}} على البودات",
   "resource {{resourceName}} of container {{containerName}} on pods": "المورد {{resourceName}} للحاوية {{containerName}} على البودات",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "تحذير تم تعطيل الإضافات غير المتوافقة: ({{ pluginList }})",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "البحث العام",
   "Open the global search dialog": "فتح نافذة البحث العام",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -970,6 +970,7 @@
   "resource {{resourceName}} on pods": "resource {{resourceName}} pod এ",
   "resource {{resourceName}} of container {{containerName}} on pods": "resource {{resourceName}} of container {{containerName}} on pods",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "সতর্কতা। অ-সঙ্গতিপূর্ণ plugin গুলো বন্ধ: {{ pluginList }})",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "গ্লোবাল অনুসন্ধান",
   "Open the global search dialog": "গ্লোবাল অনুসন্ধান ডায়ালগ খুলুন",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -988,6 +988,7 @@
   "resource {{resourceName}} on pods": "resource {{resourceName}} pod এ",
   "resource {{resourceName}} of container {{containerName}} on pods": "resource {{resourceName}} of container {{containerName}} on pods",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "সতর্কতা। অ-সঙ্গতিপূর্ণ plugin গুলো বন্ধ: {{ pluginList }})",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "গ্লোবাল অনুসন্ধান",
   "Open the global search dialog": "গ্লোবাল অনুসন্ধান ডায়ালগ খুলুন",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -988,6 +988,7 @@
   "resource {{resourceName}} on pods": "Ressource {{resourceName}} auf Pods",
   "resource {{resourceName}} of container {{containerName}} on pods": "Ressource {{resourceName}} des Containers {{containerName}} auf Pods",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "Warnung. Inkompatible Plugins deaktiviert: ({{ pluginList }})",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "",
   "Open the global search dialog": "",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -970,6 +970,7 @@
   "resource {{resourceName}} on pods": "",
   "resource {{resourceName}} of container {{containerName}} on pods": "",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "",
   "Open the global search dialog": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -970,6 +970,7 @@
   "resource {{resourceName}} on pods": "resource {{resourceName}} on pods",
   "resource {{resourceName}} of container {{containerName}} on pods": "resource {{resourceName}} of container {{containerName}} on pods",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "Warning. Incompatible plugins disabled: ({{ pluginList }})",
+  "The following plugins failed to initialize: {{ pluginList }}": "The following plugins failed to initialize: {{ pluginList }}",
   "Failed to load plugins. Please try reloading the app.": "Failed to load plugins. Please try reloading the app.",
   "Global Search": "Global Search",
   "Open the global search dialog": "Open the global search dialog",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -988,6 +988,7 @@
   "resource {{resourceName}} on pods": "resource {{resourceName}} on pods",
   "resource {{resourceName}} of container {{containerName}} on pods": "resource {{resourceName}} of container {{containerName}} on pods",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "Warning. Incompatible plugins disabled: ({{ pluginList }})",
+  "The following plugins failed to initialize: {{ pluginList }}": "The following plugins failed to initialize: {{ pluginList }}",
   "Failed to load plugins. Please try reloading the app.": "Failed to load plugins. Please try reloading the app.",
   "Global Search": "Global Search",
   "Open the global search dialog": "Open the global search dialog",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -998,6 +998,7 @@
   "resource {{resourceName}} on pods": "recurso {{resourceName}} en pods",
   "resource {{resourceName}} of container {{containerName}} on pods": "recurso {{resourceName}} del contenedor {{containerName}} en pods",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "Advertencia. Plugins incompatibles deshabilitados: ({{ pluginList }})",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "",
   "Open the global search dialog": "",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -980,6 +980,7 @@
   "resource {{resourceName}} on pods": "",
   "resource {{resourceName}} of container {{containerName}} on pods": "",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "",
   "Open the global search dialog": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -998,6 +998,7 @@
   "resource {{resourceName}} on pods": "ressource {{resourceName}} sur les pods",
   "resource {{resourceName}} of container {{containerName}} on pods": "ressource {{resourceName}} du conteneur {{containerName}} sur les pods",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "Attention. Plugins incompatibles désactivés : ({{ pluginList }})",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "Recherche globale",
   "Open the global search dialog": "Ouvrir la boîte de recherche globale",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -980,6 +980,7 @@
   "resource {{resourceName}} on pods": "",
   "resource {{resourceName}} of container {{containerName}} on pods": "",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "",
   "Open the global search dialog": "",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -998,6 +998,7 @@
   "resource {{resourceName}} on pods": "resource {{resourceName}} on pods",
   "resource {{resourceName}} of container {{containerName}} on pods": "resource {{resourceName}} of container {{containerName}} on pods",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "Warning. Incompatible plugins disabled: ({{ pluginList }})",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "Global Search",
   "Open the global search dialog": "Open the global search dialog",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -980,6 +980,7 @@
   "resource {{resourceName}} on pods": "resource {{resourceName}} on pods",
   "resource {{resourceName}} of container {{containerName}} on pods": "resource {{resourceName}} of container {{containerName}} on pods",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "Warning. Incompatible plugins disabled: ({{ pluginList }})",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "Global Search",
   "Open the global search dialog": "Open the global search dialog",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -988,6 +988,7 @@
   "resource {{resourceName}} on pods": "",
   "resource {{resourceName}} of container {{containerName}} on pods": "",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "",
   "Open the global search dialog": "",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -970,6 +970,7 @@
   "resource {{resourceName}} on pods": "",
   "resource {{resourceName}} of container {{containerName}} on pods": "",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "",
   "Open the global search dialog": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -998,6 +998,7 @@
   "resource {{resourceName}} on pods": "risorsa {{resourceName}} su pod",
   "resource {{resourceName}} of container {{containerName}} on pods": "risorsa {{resourceName}} del container {{containerName}} su pod",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "Attenzione. Estensioni incompatibili disabilitate: ({{ pluginList }})",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "",
   "Open the global search dialog": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -980,6 +980,7 @@
   "resource {{resourceName}} on pods": "",
   "resource {{resourceName}} of container {{containerName}} on pods": "",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "",
   "Open the global search dialog": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -960,6 +960,7 @@
   "resource {{resourceName}} on pods": "",
   "resource {{resourceName}} of container {{containerName}} on pods": "",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "",
   "Open the global search dialog": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -978,6 +978,7 @@
   "resource {{resourceName}} on pods": "ポッドのリソース {{resourceName}} on pods",
   "resource {{resourceName}} of container {{containerName}} on pods": "ポッドのコンテナー {{containerName}} のリソース {{resourceName}}",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "警告。互換性のないプラグインを無効にしました: ({{ pluginList }})",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "",
   "Open the global search dialog": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -978,6 +978,7 @@
   "resource {{resourceName}} on pods": "resource {{resourceName}} on pods",
   "resource {{resourceName}} of container {{containerName}} on pods": "container {{containerName}}의 resource {{resourceName}} on pods",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "경고. 호환되지 않는 플러그인이 비활성화되었습니다: ({{ pluginList }})",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "",
   "Open the global search dialog": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -960,6 +960,7 @@
   "resource {{resourceName}} on pods": "",
   "resource {{resourceName}} of container {{containerName}} on pods": "",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "",
   "Open the global search dialog": "",

--- a/frontend/src/i18n/locales/pt-br/translation.json
+++ b/frontend/src/i18n/locales/pt-br/translation.json
@@ -998,6 +998,7 @@
   "resource {{resourceName}} on pods": "resource {{resourceName}} em pods",
   "resource {{resourceName}} of container {{containerName}} on pods": "resource {{resourceName}} do container {{containerName}} em pods",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "Aviso. Plugins incompatíveis desactivados: ({{ pluginList }})",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "",
   "Open the global search dialog": "",

--- a/frontend/src/i18n/locales/pt-pt/translation.json
+++ b/frontend/src/i18n/locales/pt-pt/translation.json
@@ -998,6 +998,7 @@
   "resource {{resourceName}} on pods": "",
   "resource {{resourceName}} of container {{containerName}} on pods": "",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "",
   "Open the global search dialog": "",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -980,6 +980,7 @@
   "resource {{resourceName}} on pods": "",
   "resource {{resourceName}} of container {{containerName}} on pods": "",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "",
   "Open the global search dialog": "",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -1008,6 +1008,7 @@
   "resource {{resourceName}} on pods": "ресурс {{resourceName}} для Pod",
   "resource {{resourceName}} of container {{containerName}} on pods": "ресурс {{resourceName}} контейнера {{containerName}} для Pod",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "Предупреждение. Несовместимые плагины отключены: ({{ pluginList }})",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "Глобальный поиск",
   "Open the global search dialog": "Откройте диалоговое окно глобального поиска",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -990,6 +990,7 @@
   "resource {{resourceName}} on pods": "ресурс {{resourceName}} для Pod",
   "resource {{resourceName}} of container {{containerName}} on pods": "ресурс {{resourceName}} контейнера {{containerName}} для Pod",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "Предупреждение. Несовместимые плагины отключены: ({{ pluginList }})",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "Глобальный поиск",
   "Open the global search dialog": "Откройте диалоговое окно глобального поиска",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -988,6 +988,7 @@
   "resource {{resourceName}} on pods": "பாட்களில் {{resourceName}} வளம்",
   "resource {{resourceName}} of container {{containerName}} on pods": "பாட்களில் {{containerName}} கண்டெய்னரின் {{resourceName}} வளம்",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "எச்சரிக்கை: பொருந்தாத செருகுநிரல்கள் முடக்கப்பட்டுள்ளன ({{ pluginList }})",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "",
   "Open the global search dialog": "",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -970,6 +970,7 @@
   "resource {{resourceName}} on pods": "",
   "resource {{resourceName}} of container {{containerName}} on pods": "",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "",
   "Open the global search dialog": "",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -988,6 +988,7 @@
   "resource {{resourceName}} on pods": "وسیلہ {{resourceName}} پوڈز پر",
   "resource {{resourceName}} of container {{containerName}} on pods": "وسیلہ {{resourceName}} کنٹینر {{containerName}} کا پوڈز پر",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "انتباہ غیر مطابقت رکھنے والے پلگ ان غیر فعال کر دیے گئے: ({{ pluginList }})",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "عالمی تلاش",
   "Open the global search dialog": "عالمی تلاش کا ڈائیلاگ کھولیں",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -970,6 +970,7 @@
   "resource {{resourceName}} on pods": "وسیلہ {{resourceName}} پوڈز پر",
   "resource {{resourceName}} of container {{containerName}} on pods": "وسیلہ {{resourceName}} کنٹینر {{containerName}} کا پوڈز پر",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "انتباہ غیر مطابقت رکھنے والے پلگ ان غیر فعال کر دیے گئے: ({{ pluginList }})",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "عالمی تلاش",
   "Open the global search dialog": "عالمی تلاش کا ڈائیلاگ کھولیں",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -960,6 +960,7 @@
   "resource {{resourceName}} on pods": "",
   "resource {{resourceName}} of container {{containerName}} on pods": "",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "",
   "Open the global search dialog": "",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -978,6 +978,7 @@
   "resource {{resourceName}} on pods": "資源 {{resourceName}} 在 pods",
   "resource {{resourceName}} of container {{containerName}} on pods": "容器 {{containerName}} 的資源 {{resourceName}} 在 pods",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "警告。不相容的外掛已禁用：（{{ pluginList }}）",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "",
   "Open the global search dialog": "",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -960,6 +960,7 @@
   "resource {{resourceName}} on pods": "",
   "resource {{resourceName}} of container {{containerName}} on pods": "",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "",
   "Open the global search dialog": "",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -978,6 +978,7 @@
   "resource {{resourceName}} on pods": "资源 {{resourceName}} 在 pods",
   "resource {{resourceName}} of container {{containerName}} on pods": "容器 {{containerName}} 的资源 {{resourceName}} 在 pods",
   "Warning. Incompatible plugins disabled: ({{ pluginList }})": "警告。不兼容的插件已禁用：（{{ pluginList }}）",
+  "The following plugins failed to initialize: {{ pluginList }}": "",
   "Failed to load plugins. Please try reloading the app.": "",
   "Global Search": "",
   "Open the global search dialog": "",

--- a/frontend/src/plugin/Plugins.test.tsx
+++ b/frontend/src/plugin/Plugins.test.tsx
@@ -24,6 +24,20 @@ const { mockFetchAndExecutePlugins, mockEnqueueSnackbar } = vi.hoisted(() => ({
   mockEnqueueSnackbar: vi.fn(),
 }));
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options: any) => {
+      let text = key.split('|').pop() ?? key;
+      if (options && typeof options === 'object') {
+        for (const [k, v] of Object.entries(options)) {
+          text = text.replace(`{{ ${k} }}`, String(v));
+        }
+      }
+      return text;
+    },
+  }),
+}));
+
 vi.mock('./index', () => ({
   fetchAndExecutePlugins: mockFetchAndExecutePlugins,
 }));
@@ -82,5 +96,24 @@ describe('Plugins', () => {
       expect.anything(),
       expect.objectContaining({ variant: 'error' })
     );
+  });
+
+  test('shows an error snackbar when some plugins fail to initialize', async () => {
+    mockFetchAndExecutePlugins.mockResolvedValue(['badPlugin1', 'badPlugin2']);
+
+    render(
+      <TestContext>
+        <Plugins />
+      </TestContext>
+    );
+
+    await waitFor(() => {
+      expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /The following plugins failed to initialize:.*badPlugin1.*badPlugin2/
+        ),
+        expect.objectContaining({ variant: 'error' })
+      );
+    });
   });
 });

--- a/frontend/src/plugin/Plugins.tsx
+++ b/frontend/src/plugin/Plugins.tsx
@@ -82,6 +82,17 @@ export default function Plugins() {
         }
       }
     )
+      .then(failedPlugins => {
+        if (failedPlugins && failedPlugins.length > 0) {
+          const pluginList = failedPlugins.join(', ');
+          enqueueSnackbar(
+            t('translation|The following plugins failed to initialize: {{ pluginList }}', {
+              pluginList,
+            }),
+            { variant: 'error' }
+          );
+        }
+      })
       .catch((err: unknown) => {
         console.error('Failed to load plugins:', err);
         enqueueSnackbar(t('translation|Failed to load plugins. Please try reloading the app.'), {

--- a/frontend/src/plugin/index.test.ts
+++ b/frontend/src/plugin/index.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { initializePlugins } from './index';
+
+describe('initializePlugins', () => {
+  let originalPlugins: any;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    originalPlugins = window.plugins;
+    window.plugins = {};
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    window.plugins = originalPlugins;
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('collects failing plugins and continues initializing others', async () => {
+    const successPlugin1 = {
+      initialize: vi.fn(),
+    };
+    const failingPlugin = {
+      initialize: vi.fn().mockImplementation(() => {
+        throw new Error('Test error');
+      }),
+    };
+    const successPlugin2 = {
+      initialize: vi.fn(),
+    };
+
+    window.plugins = {
+      success1: successPlugin1,
+      failing: failingPlugin,
+      success2: successPlugin2,
+    };
+
+    const failedPlugins = await initializePlugins();
+
+    // Verify it collected the failing plugin
+    expect(failedPlugins).toEqual(['failing']);
+
+    // Verify it attempted to initialize all plugins
+    expect(successPlugin1.initialize).toHaveBeenCalled();
+    expect(failingPlugin.initialize).toHaveBeenCalled();
+    expect(successPlugin2.initialize).toHaveBeenCalled();
+
+    // Verify console.error was called for the failing plugin
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Plugin initialize() error in failing:',
+      expect.any(Error)
+    );
+  });
+});

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -118,20 +118,19 @@ window.plugins = {};
 /**
  * Load external, then local plugins. Then initialize() them in order with a Registry.
  */
-export async function initializePlugins() {
+export async function initializePlugins(): Promise<string[]> {
   // Initialize every plugin in the order they were loaded.
-  return new Promise(resolve => {
-    for (const pluginName of Object.keys(window.plugins)) {
-      const plugin = window.plugins[pluginName];
-      try {
-        // @todo: what should happen if this fails?
-        plugin.initialize(new Registry());
-      } catch (e) {
-        console.error(`Plugin initialize() error in ${pluginName}:`, e);
-      }
+  const failedPlugins: string[] = [];
+  for (const pluginName of Object.keys(window.plugins)) {
+    const plugin = window.plugins[pluginName];
+    try {
+      plugin.initialize(new Registry());
+    } catch (e) {
+      console.error(`Plugin initialize() error in ${pluginName}:`, e);
+      failedPlugins.push(pluginName);
     }
-    resolve(undefined);
-  });
+  }
+  return failedPlugins;
 }
 
 /**
@@ -694,7 +693,7 @@ export async function fetchAndExecutePlugins(
   // Initialize plugin i18n after plugins are loaded
   await initializePluginsI18n(packageInfos, pluginPaths);
 
-  await afterPluginsRun(pluginsLoaded);
+  return await afterPluginsRun(pluginsLoaded);
 }
 
 /**
@@ -724,8 +723,8 @@ async function afterPluginsRun(
     version: string | undefined;
     isEnabled: boolean | undefined;
   }[]
-) {
-  await initializePlugins();
+): Promise<string[]> {
+  const failedPlugins = await initializePlugins();
 
   store.dispatch(
     eventAction({
@@ -752,6 +751,8 @@ async function afterPluginsRun(
       })
     );
   }
+
+  return failedPlugins;
 }
 
 /**

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -116,20 +116,19 @@ window.plugins = {};
 /**
  * Load external, then local plugins. Then initialize() them in order with a Registry.
  */
-export async function initializePlugins() {
+export async function initializePlugins(): Promise<string[]> {
   // Initialize every plugin in the order they were loaded.
-  return new Promise(resolve => {
-    for (const pluginName of Object.keys(window.plugins)) {
-      const plugin = window.plugins[pluginName];
-      try {
-        // @todo: what should happen if this fails?
-        plugin.initialize(new Registry());
-      } catch (e) {
-        console.error(`Plugin initialize() error in ${pluginName}:`, e);
-      }
+  const failedPlugins: string[] = [];
+  for (const pluginName of Object.keys(window.plugins)) {
+    const plugin = window.plugins[pluginName];
+    try {
+      plugin.initialize(new Registry());
+    } catch (e) {
+      console.error(`Plugin initialize() error in ${pluginName}:`, e);
+      failedPlugins.push(pluginName);
     }
-    resolve(undefined);
-  });
+  }
+  return failedPlugins;
 }
 
 /**
@@ -692,7 +691,7 @@ export async function fetchAndExecutePlugins(
   // Initialize plugin i18n after plugins are loaded
   await initializePluginsI18n(packageInfos, pluginPaths);
 
-  await afterPluginsRun(pluginsLoaded);
+  return await afterPluginsRun(pluginsLoaded);
 }
 
 /**
@@ -722,8 +721,8 @@ async function afterPluginsRun(
     version: string | undefined;
     isEnabled: boolean | undefined;
   }[]
-) {
-  await initializePlugins();
+): Promise<string[]> {
+  const failedPlugins = await initializePlugins();
 
   store.dispatch(
     eventAction({
@@ -750,6 +749,8 @@ async function afterPluginsRun(
       })
     );
   }
+
+  return failedPlugins;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR fixes the plugin initialization error visibility by capturing errors that occur during a plugin's `initialize()` method and surfacing them via an in-app snackbar notification. Previously, these errors were swallowed and only logged to the console, making it difficult for users to know if their plugins actually loaded successfully.

## Related Issue

Fixes #6807 

## Changes

- **Updated** `initializePlugins` and `fetchAndExecutePlugins` in `frontend/src/plugin/index.ts` to capture and return an array of plugins that threw errors during initialization.
- **Added** a `.then()` handler in `frontend/src/plugin/Plugins.tsx` to display a localized error snackbar listing any plugins that failed to initialize.
- **Added** `frontend/src/plugin/Plugins.test.tsx` with unit tests to verify that the snackbar triggers correctly when a plugin fails to load.

## Steps to Test

1. Run the frontend tests locally: `npm run frontend:test -- src/plugin/Plugins.test.tsx` and verify they pass.
2. (Optional manual test) Create a dummy plugin in `plugins/examples/` and force its `initialize()` method to throw an error (`throw new Error("test error");`).
3. Build the plugin and run Headlamp.
4. Observe that a red error snackbar appears in the UI stating: "The following plugins failed to initialize: [your dummy plugin name]".

## Screenshots (if applicable)

*(You can drag and drop a screenshot of the error snackbar here if you have one!)*

## Notes for the Reviewer

- This touches the i18n layer via the `notistack` snackbar dispatcher in `Plugins.tsx` to display a localized error message. 
- The error handling is designed to be non-blocking; one bad plugin will not stop the rest of the plugins from loading.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized notifications identifying plugins that fail to initialize.
  * Failure notifications list the affected plugin names.
  * Plugin loading continues for remaining plugins when one fails.
* **Bug Fixes**
  * Improved visibility and reporting of plugin initialization failures.
  * Prevented unnecessary notifications when all plugins initialize successfully.
* **Documentation**
  * Added translation entries for the new failure message across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->