### PR TITLE
frontend: Table: Let column toggles override responsive hiding

### DIFF
--- a/frontend/src/components/common/Table/Table.responsiveColumns.test.tsx
+++ b/frontend/src/components/common/Table/Table.responsiveColumns.test.tsx
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { createMuiTheme } from '../../../lib/themes';
+import { TestContext } from '../../../test';
+import Table, { TableColumn } from './Table';
+
+const theme = createMuiTheme({ base: 'light', name: 'light' });
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+type Row = { name: string; namespace: string; labels: string; age: string };
+
+const rows: Row[] = [{ name: 'pod-a', namespace: 'default', labels: 'app=a', age: '1d' }];
+
+const columns: TableColumn<Row>[] = [
+  { id: 'name', header: 'Name', accessorFn: (r: Row) => r.name },
+  {
+    id: 'namespace',
+    header: 'Namespace',
+    accessorFn: (r: Row) => r.namespace,
+    responsivePriority: -2,
+  },
+  { id: 'labels', header: 'Labels', accessorFn: (r: Row) => r.labels, responsivePriority: -2 },
+  { id: 'age', header: 'Age', accessorFn: (r: Row) => r.age, responsivePriority: 1 },
+];
+
+/**
+ * Drives the ResizeObserver that Table uses to measure available width, so the
+ * responsive hiding path runs in jsdom (which reports every element as 0 wide).
+ */
+function mockContainerWidth(width: number) {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      constructor(private callback: ResizeObserverCallback) {}
+      observe() {
+        this.callback([{ contentRect: { width } } as ResizeObserverEntry], this as any);
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+  );
+  vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(width);
+}
+
+function renderTable(props: Partial<React.ComponentProps<typeof Table>> = {}) {
+  return render(
+    <TestContext>
+      <ThemeProvider theme={theme}>
+        <Table columns={columns as any} data={rows} {...(props as any)} />
+      </ThemeProvider>
+    </TestContext>
+  );
+}
+
+/**
+ * Toggles a column through the "Show/Hide columns" menu, then closes the menu so
+ * assertions see the table rather than the menu (both render the column name).
+ */
+async function toggleColumnFromChooser(user: ReturnType<typeof userEvent.setup>, name: RegExp) {
+  await user.click(screen.getByRole('button', { name: /show\/hide columns/i }));
+  await user.click(await screen.findByRole('menuitemcheckbox', { name }));
+  await user.keyboard('{Escape}');
+}
+
+const columnHeader = (name: RegExp) => screen.queryByRole('columnheader', { name });
+
+describe('Table responsive column hiding', () => {
+  beforeAll(() => {
+    // jsdom has no layout engine; Table only hides columns once it measures a width.
+    mockContainerWidth(240);
+  });
+
+  it('hides low priority columns that do not fit', async () => {
+    renderTable();
+
+    await waitFor(() => expect(columnHeader(/name/i)).toBeInTheDocument());
+    expect(columnHeader(/labels/i)).not.toBeInTheDocument();
+  });
+
+  it('keeps a column visible after the user turns it back on', async () => {
+    const user = userEvent.setup();
+    renderTable();
+
+    await waitFor(() => expect(columnHeader(/labels/i)).not.toBeInTheDocument());
+
+    await toggleColumnFromChooser(user, /labels/i);
+
+    await waitFor(() => expect(columnHeader(/labels/i)).toBeInTheDocument());
+  });
+
+  // Labels is hidden by default in ResourceTable, so it is never picked by the
+  // responsive pass. Turning it on has to cost another column rather than overflow.
+  it('counts a default hidden column once the user turns it on', async () => {
+    const user = userEvent.setup();
+    renderTable({ state: { columnVisibility: { labels: false } } } as any);
+
+    await waitFor(() => expect(columnHeader(/name/i)).toBeInTheDocument());
+    const before = screen.getAllByRole('columnheader').length;
+
+    await toggleColumnFromChooser(user, /labels/i);
+
+    await waitFor(() => expect(columnHeader(/labels/i)).toBeInTheDocument());
+    expect(screen.getAllByRole('columnheader')).toHaveLength(before);
+  });
+
+  // The actions column trails the data columns rather than competing with them for
+  // space, so the responsive pass must never pick it.
+  it('keeps an actions column while any data column is visible', async () => {
+    const withActions: TableColumn<Row>[] = [
+      ...columns,
+      { id: 'actions', header: 'Actions', accessorFn: () => '' },
+    ];
+
+    render(
+      <TestContext>
+        <ThemeProvider theme={theme}>
+          <Table columns={withActions as any} data={rows} />
+        </ThemeProvider>
+      </TestContext>
+    );
+
+    await waitFor(() => expect(columnHeader(/name/i)).toBeInTheDocument());
+    expect(columnHeader(/actions/i)).toBeInTheDocument();
+  });
+
+  it('hides an actions column once every data column is hidden', async () => {
+    const withActions: TableColumn<Row>[] = [
+      { id: 'name', header: 'Name', accessorFn: (r: Row) => r.name },
+      { id: 'actions', header: 'Actions', accessorFn: () => '' },
+    ];
+
+    render(
+      <TestContext>
+        <ThemeProvider theme={theme}>
+          <Table
+            columns={withActions as any}
+            data={rows}
+            state={{ columnVisibility: { name: false } }}
+          />
+        </ThemeProvider>
+      </TestContext>
+    );
+
+    await waitFor(() => expect(columnHeader(/name/i)).not.toBeInTheDocument());
+    expect(columnHeader(/actions/i)).not.toBeInTheDocument();
+  });
+
+  it('forwards only the user change to a caller supplied handler', async () => {
+    const user = userEvent.setup();
+    const onColumnVisibilityChange = vi.fn();
+
+    render(
+      <TestContext>
+        <ThemeProvider theme={theme}>
+          <Table
+            columns={columns as any}
+            data={rows}
+            onColumnVisibilityChange={onColumnVisibilityChange}
+          />
+        </ThemeProvider>
+      </TestContext>
+    );
+
+    await waitFor(() => expect(columnHeader(/labels/i)).not.toBeInTheDocument());
+
+    await toggleColumnFromChooser(user, /labels/i);
+
+    await waitFor(() => expect(columnHeader(/labels/i)).toBeInTheDocument());
+
+    expect(onColumnVisibilityChange).toHaveBeenCalled();
+
+    const updater = onColumnVisibilityChange.mock.calls.at(-1)![0];
+    expect(typeof updater).toBe('function');
+    expect(updater({ name: true })).toEqual({ name: true, labels: true });
+  });
+});

--- a/frontend/src/components/common/Table/Table.responsiveColumns.test.tsx
+++ b/frontend/src/components/common/Table/Table.responsiveColumns.test.tsx
@@ -17,7 +17,7 @@
 import { ThemeProvider } from '@mui/material/styles';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { createMuiTheme } from '../../../lib/themes';
 import { TestContext } from '../../../test';
 import Table, { TableColumn } from './Table';
@@ -86,10 +86,22 @@ async function toggleColumnFromChooser(user: ReturnType<typeof userEvent.setup>,
 
 const columnHeader = (name: RegExp) => screen.queryByRole('columnheader', { name });
 
+/**
+ * Reads the grid track list off the table. MUI applies `sx` as a class, so the value
+ * lives in the stylesheet rather than in the element's inline style.
+ */
+const gridTemplateOf = (container: HTMLElement) =>
+  window.getComputedStyle(container.querySelector('table') as HTMLElement).gridTemplateColumns;
+
 describe('Table responsive column hiding', () => {
   beforeAll(() => {
     // jsdom has no layout engine; Table only hides columns once it measures a width.
     mockContainerWidth(240);
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it('hides low priority columns that do not fit', async () => {
@@ -165,6 +177,22 @@ describe('Table responsive column hiding', () => {
 
     await waitFor(() => expect(columnHeader(/name/i)).not.toBeInTheDocument());
     expect(columnHeader(/actions/i)).not.toBeInTheDocument();
+  });
+
+  it('drops the row actions track once every data column is hidden', async () => {
+    const single: TableColumn<Row>[] = [
+      { id: 'name', header: 'Name', accessorFn: (r: Row) => r.name },
+    ];
+
+    const visible = renderTable({ columns: single as any, enableRowActions: true });
+    await waitFor(() => expect(gridTemplateOf(visible.container)).toContain('0.05fr'));
+
+    const hidden = renderTable({
+      columns: single as any,
+      enableRowActions: true,
+      state: { columnVisibility: { name: false } },
+    });
+    await waitFor(() => expect(gridTemplateOf(hidden.container)).not.toContain('0.05fr'));
   });
 
   it('forwards only the user change to a caller supplied handler', async () => {

--- a/frontend/src/components/common/Table/Table.test.tsx
+++ b/frontend/src/components/common/Table/Table.test.tsx
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { createMuiTheme } from '../../../lib/themes';
+import { TestContext } from '../../../test';
+import Table, { TableColumn } from './Table';
+
+const theme = createMuiTheme({ base: 'light', name: 'light' });
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+type Row = { name: string; namespace: string; labels: string; age: string };
+
+const rows: Row[] = [{ name: 'pod-a', namespace: 'default', labels: 'app=a', age: '1d' }];
+
+const columns: TableColumn<Row>[] = [
+  { id: 'name', header: 'Name', accessorFn: (r: Row) => r.name },
+  {
+    id: 'namespace',
+    header: 'Namespace',
+    accessorFn: (r: Row) => r.namespace,
+    responsivePriority: -2,
+  },
+  { id: 'labels', header: 'Labels', accessorFn: (r: Row) => r.labels, responsivePriority: -2 },
+  { id: 'age', header: 'Age', accessorFn: (r: Row) => r.age, responsivePriority: 1 },
+];
+
+/**
+ * Drives the ResizeObserver that Table uses to measure available width, so the
+ * responsive hiding path runs in jsdom (which reports every element as 0 wide).
+ */
+function mockContainerWidth(width: number) {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      constructor(private callback: ResizeObserverCallback) {}
+      observe() {
+        this.callback([{ contentRect: { width } } as ResizeObserverEntry], this as any);
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+  );
+  vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(width);
+}
+
+function renderTable(props: Partial<React.ComponentProps<typeof Table>> = {}) {
+  return render(
+    <TestContext>
+      <ThemeProvider theme={theme}>
+        <Table columns={columns as any} data={rows} {...(props as any)} />
+      </ThemeProvider>
+    </TestContext>
+  );
+}
+
+/**
+ * Toggles a column through the "Show/Hide columns" menu, then closes the menu so
+ * assertions see the table rather than the menu (both render the column name).
+ */
+async function toggleColumnFromChooser(user: ReturnType<typeof userEvent.setup>, name: RegExp) {
+  await user.click(screen.getByRole('button', { name: /show\/hide columns/i }));
+  await user.click(await screen.findByRole('checkbox', { name }));
+  await user.keyboard('{Escape}');
+}
+
+const columnHeader = (name: RegExp) => screen.queryByRole('columnheader', { name });
+
+describe('Table responsive column hiding', () => {
+  beforeAll(() => {
+    // jsdom has no layout engine; Table only hides columns once it measures a width.
+    mockContainerWidth(240);
+  });
+
+  it('hides low priority columns that do not fit', async () => {
+    renderTable();
+
+    await waitFor(() => expect(columnHeader(/name/i)).toBeInTheDocument());
+    expect(columnHeader(/labels/i)).not.toBeInTheDocument();
+  });
+
+  it('keeps a column visible after the user turns it back on', async () => {
+    const user = userEvent.setup();
+    renderTable();
+
+    await waitFor(() => expect(columnHeader(/labels/i)).not.toBeInTheDocument());
+
+    await toggleColumnFromChooser(user, /labels/i);
+
+    await waitFor(() => expect(columnHeader(/labels/i)).toBeInTheDocument());
+  });
+
+  // Labels is hidden by default in ResourceTable, so it is never picked by the
+  // responsive pass. Turning it on has to cost another column rather than overflow.
+  it('counts a default hidden column once the user turns it on', async () => {
+    const user = userEvent.setup();
+    renderTable({ state: { columnVisibility: { labels: false } } } as any);
+
+    await waitFor(() => expect(columnHeader(/name/i)).toBeInTheDocument());
+    const before = screen.getAllByRole('columnheader').length;
+
+    await toggleColumnFromChooser(user, /labels/i);
+
+    await waitFor(() => expect(columnHeader(/labels/i)).toBeInTheDocument());
+    expect(screen.getAllByRole('columnheader')).toHaveLength(before);
+  });
+
+  // The actions column trails the data columns rather than competing with them for
+  // space, so the responsive pass must never pick it.
+  it('keeps an actions column while any data column is visible', async () => {
+    const withActions: TableColumn<Row>[] = [
+      ...columns,
+      { id: 'actions', header: 'Actions', accessorFn: () => '' },
+    ];
+
+    render(
+      <TestContext>
+        <ThemeProvider theme={theme}>
+          <Table columns={withActions as any} data={rows} />
+        </ThemeProvider>
+      </TestContext>
+    );
+
+    await waitFor(() => expect(columnHeader(/name/i)).toBeInTheDocument());
+    expect(columnHeader(/actions/i)).toBeInTheDocument();
+  });
+
+  it('hides an actions column once every data column is hidden', async () => {
+    const withActions: TableColumn<Row>[] = [
+      { id: 'name', header: 'Name', accessorFn: (r: Row) => r.name },
+      { id: 'actions', header: 'Actions', accessorFn: () => '' },
+    ];
+
+    render(
+      <TestContext>
+        <ThemeProvider theme={theme}>
+          <Table
+            columns={withActions as any}
+            data={rows}
+            state={{ columnVisibility: { name: false } }}
+          />
+        </ThemeProvider>
+      </TestContext>
+    );
+
+    await waitFor(() => expect(columnHeader(/name/i)).not.toBeInTheDocument());
+    expect(columnHeader(/actions/i)).not.toBeInTheDocument();
+  });
+
+  it('forwards only the user change to a caller supplied handler', async () => {
+    const user = userEvent.setup();
+    const onColumnVisibilityChange = vi.fn();
+
+    render(
+      <TestContext>
+        <ThemeProvider theme={theme}>
+          <Table
+            columns={columns as any}
+            data={rows}
+            onColumnVisibilityChange={onColumnVisibilityChange}
+          />
+        </ThemeProvider>
+      </TestContext>
+    );
+
+    await waitFor(() => expect(columnHeader(/labels/i)).not.toBeInTheDocument());
+
+    await toggleColumnFromChooser(user, /labels/i);
+
+    await waitFor(() => expect(columnHeader(/labels/i)).toBeInTheDocument());
+
+    expect(onColumnVisibilityChange).toHaveBeenCalled();
+
+    const updater = onColumnVisibilityChange.mock.calls.at(-1)![0];
+    expect(typeof updater).toBe('function');
+    expect(updater({ name: true })).toEqual({ name: true, labels: true });
+  });
+});

--- a/frontend/src/components/common/Table/Table.test.tsx
+++ b/frontend/src/components/common/Table/Table.test.tsx
@@ -430,18 +430,25 @@ describe('Table states and options', () => {
   });
 
   it('hides and restores the actions column with data-column visibility', () => {
-    tableMocks.columnVisibility = { '0': false };
+    const columns: TableProps<TestRow>['columns'] = [
+      { id: 'selected', accessorKey: 'selected', header: 'Selection' },
+    ];
+
     const hiddenResult = renderTable({
-      columns: [{ accessorKey: 'selected', header: 'Selection' }],
+      columns,
+      enableRowActions: true,
+      state: { columnVisibility: { selected: false } },
     });
 
-    expect(tableMocks.setColumnVisibility).toHaveBeenCalledOnce();
+    expect(tableMocks.options.state.columnVisibility['mrt-row-actions']).toBe(false);
     hiddenResult.unmount();
 
-    tableMocks.setColumnVisibility.mockClear();
-    tableMocks.columnVisibility = { '0': true, actions: false };
-    renderTable({ columns: [{ accessorKey: 'selected', header: 'Selection' }] });
+    renderTable({
+      columns,
+      enableRowActions: true,
+      state: { columnVisibility: { selected: true } },
+    });
 
-    expect(tableMocks.setColumnVisibility).toHaveBeenCalledOnce();
+    expect(tableMocks.options.state.columnVisibility['mrt-row-actions']).toBe(true);
   });
 });

--- a/frontend/src/components/common/Table/Table.test.tsx
+++ b/frontend/src/components/common/Table/Table.test.tsx
@@ -17,7 +17,7 @@
 import { ThemeProvider } from '@mui/material/styles';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { createMuiTheme } from '../../../lib/themes';
 import { TestContext } from '../../../test';
 import Table, { TableColumn } from './Table';
@@ -86,10 +86,22 @@ async function toggleColumnFromChooser(user: ReturnType<typeof userEvent.setup>,
 
 const columnHeader = (name: RegExp) => screen.queryByRole('columnheader', { name });
 
+/**
+ * Reads the grid track list off the table. MUI applies `sx` as a class, so the value
+ * lives in the stylesheet rather than in the element's inline style.
+ */
+const gridTemplateOf = (container: HTMLElement) =>
+  window.getComputedStyle(container.querySelector('table') as HTMLElement).gridTemplateColumns;
+
 describe('Table responsive column hiding', () => {
   beforeAll(() => {
     // jsdom has no layout engine; Table only hides columns once it measures a width.
     mockContainerWidth(240);
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it('hides low priority columns that do not fit', async () => {
@@ -165,6 +177,22 @@ describe('Table responsive column hiding', () => {
 
     await waitFor(() => expect(columnHeader(/name/i)).not.toBeInTheDocument());
     expect(columnHeader(/actions/i)).not.toBeInTheDocument();
+  });
+
+  it('drops the row actions track once every data column is hidden', async () => {
+    const single: TableColumn<Row>[] = [
+      { id: 'name', header: 'Name', accessorFn: (r: Row) => r.name },
+    ];
+
+    const visible = renderTable({ columns: single as any, enableRowActions: true });
+    await waitFor(() => expect(gridTemplateOf(visible.container)).toContain('0.05fr'));
+
+    const hidden = renderTable({
+      columns: single as any,
+      enableRowActions: true,
+      state: { columnVisibility: { name: false } },
+    });
+    await waitFor(() => expect(gridTemplateOf(hidden.container)).not.toContain('0.05fr'));
   });
 
   it('forwards only the user change to a caller supplied handler', async () => {

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -34,6 +34,7 @@ import {
   MRT_TableInstance,
   MRT_TableOptions as MaterialTableOptions,
   MRT_TopToolbar,
+  MRT_VisibilityState,
   useMaterialReactTable,
   useMRT_Rows,
 } from 'material-react-table';
@@ -198,6 +199,12 @@ const StyledBody = styled('tbody')({ display: 'contents' });
 const DEFAULT_MIN_COLUMN_WIDTH = 100;
 
 /**
+ * Ids of the action columns, which follow the other columns in and out of view rather
+ * than being toggled on their own: the caller-defined one and MRT's built-in one.
+ */
+const ACTIONS_COLUMN_IDS = ['actions', 'mrt-row-actions'];
+
+/**
  * Tracks the current width of an element using a ResizeObserver.
  * Returns 0 until the element has been measured.
  */
@@ -276,11 +283,9 @@ export default function Table<RowItem extends Record<string, any>>({
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const containerWidth = useContainerWidth(tableContainerRef);
 
-  // Controlled column visibility so responsive hiding, caller-provided visibility
-  // and MRT's own visibility changes all stay in sync.
-  const [columnVisibility, setColumnVisibility] = useState<Record<string, boolean>>(
-    tableProps.initialState?.columnVisibility ?? {}
-  );
+  // Columns the user explicitly toggled. Only their choices are tracked here, so
+  // responsive hiding keeps applying to every column they haven't touched.
+  const [userColumnVisibility, setUserColumnVisibility] = useState<MRT_VisibilityState>({});
 
   // Provide defaults for the columns
   const tableColumns: TableColumn<RowItem>[] = useMemo(
@@ -320,18 +325,34 @@ export default function Table<RowItem extends Record<string, any>>({
     return ids;
   }, [tableProps.columns, tableProps.enableRowActions, tableProps.enableRowSelection]);
 
+  // Visibility the caller asked for, before responsive hiding and before the user
+  // touched anything. `initialState` is the caller's default and `state` overrides it.
+  const baseColumnVisibility = useMemo<MRT_VisibilityState>(
+    () => ({
+      ...(tableProps.initialState?.columnVisibility ?? {}),
+      ...(tableProps.state?.columnVisibility ?? {}),
+    }),
+    [tableProps.initialState?.columnVisibility, tableProps.state?.columnVisibility]
+  );
+
   // Decide which columns to hide based on the available width. Columns are hidden by
   // ascending `responsivePriority` (least important first), then right-to-left among
   // equal priority. The first column is never hidden. When everything fits, nothing
-  // is hidden and the table renders as usual.
+  // is hidden and the table renders as usual. Columns the user turned on, and the
+  // action columns, are never hidden here but still count towards the width so a less
+  // important column goes instead.
   const responsiveHidden = useMemo(() => {
-    const result: Record<string, boolean> = {};
+    const result: MRT_VisibilityState = {};
     if (!containerWidth) {
       return result;
     }
 
-    const callerVisibility = tableProps.state?.columnVisibility;
-    const dataCols = tableColumns.filter(col => callerVisibility?.[col.id ?? ''] !== false);
+    // Columns that would show without responsive hiding, so a column the user turned
+    // on is measured even when it is hidden by default.
+    const dataCols = tableColumns.filter(col => {
+      const id = col.id ?? '';
+      return userColumnVisibility[id] ?? baseColumnVisibility[id] !== false;
+    });
 
     let reserved = 0;
     if (tableProps.enableRowSelection) {
@@ -350,7 +371,12 @@ export default function Table<RowItem extends Record<string, any>>({
     // Columns we're allowed to hide, ordered by what to drop first.
     dataCols
       .map((col, index) => ({ col, index }))
-      .filter(({ index }) => index !== 0)
+      .filter(
+        ({ col, index }) =>
+          index !== 0 &&
+          userColumnVisibility[col.id ?? ''] !== true &&
+          !ACTIONS_COLUMN_IDS.includes(col.id ?? '')
+      )
       .sort((a, b) => {
         const priorityDiff = (a.col.responsivePriority ?? 0) - (b.col.responsivePriority ?? 0);
         return priorityDiff !== 0 ? priorityDiff : b.index - a.index;
@@ -367,19 +393,45 @@ export default function Table<RowItem extends Record<string, any>>({
   }, [
     containerWidth,
     tableColumns,
-    tableProps.state?.columnVisibility,
+    baseColumnVisibility,
     tableProps.enableRowSelection,
     tableProps.enableRowActions,
+    userColumnVisibility,
   ]);
 
-  const mergedColumnVisibility = useMemo(
-    () => ({
-      ...(tableProps.state?.columnVisibility ?? {}),
-      ...columnVisibility,
+  // An explicit choice outranks the responsive layout, so `userColumnVisibility`
+  // is applied last.
+  const mergedColumnVisibility = useMemo<MRT_VisibilityState>(() => {
+    const merged: MRT_VisibilityState = {
+      ...baseColumnVisibility,
       ...responsiveHidden,
-    }),
-    [tableProps.state?.columnVisibility, columnVisibility, responsiveHidden]
-  );
+      ...userColumnVisibility,
+    };
+
+    const dataColumns = tableColumns.filter(col => !ACTIONS_COLUMN_IDS.includes(col.id ?? ''));
+    if (dataColumns.length === 0) {
+      return merged;
+    }
+
+    const actionsVisible = !dataColumns.every(col => merged[col.id ?? ''] === false);
+    const presentActionIds = ACTIONS_COLUMN_IDS.filter(
+      id =>
+        tableColumns.some(col => (col.id ?? '') === id) ||
+        (id === 'mrt-row-actions' && tableProps.enableRowActions)
+    );
+
+    presentActionIds.forEach(id => {
+      merged[id] = actionsVisible;
+    });
+
+    return merged;
+  }, [
+    baseColumnVisibility,
+    responsiveHidden,
+    userColumnVisibility,
+    tableColumns,
+    tableProps.enableRowActions,
+  ]);
 
   const table = useMaterialReactTable({
     ...tableProps,
@@ -405,7 +457,29 @@ export default function Table<RowItem extends Record<string, any>>({
       }
     },
     onGlobalFilterChange: setGlobalFilter,
-    onColumnVisibilityChange: setColumnVisibility,
+    onColumnVisibilityChange: (
+      updater: MRT_VisibilityState | ((old: MRT_VisibilityState) => MRT_VisibilityState)
+    ) => {
+      const next = typeof updater === 'function' ? updater(mergedColumnVisibility) : updater;
+
+      // Action columns are derived from the other columns, never a user choice.
+      const changes: MRT_VisibilityState = {};
+      Object.entries(next).forEach(([id, visible]) => {
+        if (!ACTIONS_COLUMN_IDS.includes(id) && mergedColumnVisibility[id] !== visible) {
+          changes[id] = visible;
+        }
+      });
+
+      if (Object.keys(changes).length === 0) {
+        return;
+      }
+
+      setUserColumnVisibility(prev => ({ ...prev, ...changes }));
+      tableProps.onColumnVisibilityChange?.((old: MRT_VisibilityState) => ({
+        ...old,
+        ...changes,
+      }));
+    },
     renderToolbarInternalActions: props => {
       const isSomeRowsSelected =
         tableProps.enableRowSelection && props.table.getSelectedRowModel().rows.length !== 0;
@@ -514,22 +588,6 @@ export default function Table<RowItem extends Record<string, any>>({
     {},
     [table]
   );
-
-  // Hide actions column when others are hidden
-  useEffect(() => {
-    const visibility = table.getState().columnVisibility || {};
-
-    const shouldHideActions = tableColumns
-      .filter(col => (col.id ?? '') !== 'actions')
-      .every(col => visibility[col.id ?? ''] === false);
-
-    if (shouldHideActions && visibility['actions'] !== false) {
-      table.setColumnVisibility(prev => ({ ...prev, actions: false }));
-    } else if (!shouldHideActions && visibility['actions'] === false) {
-      table.setColumnVisibility(prev => ({ ...prev, actions: true }));
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [table.getState().columnVisibility, tableColumns, table]);
 
   const gridTemplateColumns = useMemo(() => {
     let preGridTemplateColumns = tableProps.columns

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -37,6 +37,7 @@ import {
   MRT_ToggleFullScreenButton,
   MRT_ToggleGlobalFilterButton,
   MRT_TopToolbar,
+  MRT_VisibilityState,
   useMaterialReactTable,
   useMRT_Rows,
 } from 'material-react-table';
@@ -174,6 +175,12 @@ const StyledBody = styled('tbody')({ display: 'contents' });
 const DEFAULT_MIN_COLUMN_WIDTH = 100;
 
 /**
+ * Ids of the action columns, which follow the other columns in and out of view rather
+ * than being toggled on their own: the caller-defined one and MRT's built-in one.
+ */
+const ACTIONS_COLUMN_IDS = ['actions', 'mrt-row-actions'];
+
+/**
  * Tracks the current width of an element using a ResizeObserver.
  * Returns 0 until the element has been measured.
  */
@@ -252,11 +259,9 @@ export default function Table<RowItem extends Record<string, any>>({
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const containerWidth = useContainerWidth(tableContainerRef);
 
-  // Controlled column visibility so responsive hiding, caller-provided visibility
-  // and MRT's own visibility changes all stay in sync.
-  const [columnVisibility, setColumnVisibility] = useState<Record<string, boolean>>(
-    tableProps.initialState?.columnVisibility ?? {}
-  );
+  // Columns the user explicitly toggled. Only their choices are tracked here, so
+  // responsive hiding keeps applying to every column they haven't touched.
+  const [userColumnVisibility, setUserColumnVisibility] = useState<MRT_VisibilityState>({});
 
   // Provide defaults for the columns
   const tableColumns: TableColumn<RowItem>[] = useMemo(
@@ -296,18 +301,34 @@ export default function Table<RowItem extends Record<string, any>>({
     return ids;
   }, [tableProps.columns, tableProps.enableRowActions, tableProps.enableRowSelection]);
 
+  // Visibility the caller asked for, before responsive hiding and before the user
+  // touched anything. `initialState` is the caller's default and `state` overrides it.
+  const baseColumnVisibility = useMemo<MRT_VisibilityState>(
+    () => ({
+      ...(tableProps.initialState?.columnVisibility ?? {}),
+      ...(tableProps.state?.columnVisibility ?? {}),
+    }),
+    [tableProps.initialState?.columnVisibility, tableProps.state?.columnVisibility]
+  );
+
   // Decide which columns to hide based on the available width. Columns are hidden by
   // ascending `responsivePriority` (least important first), then right-to-left among
   // equal priority. The first column is never hidden. When everything fits, nothing
-  // is hidden and the table renders as usual.
+  // is hidden and the table renders as usual. Columns the user turned on, and the
+  // action columns, are never hidden here but still count towards the width so a less
+  // important column goes instead.
   const responsiveHidden = useMemo(() => {
-    const result: Record<string, boolean> = {};
+    const result: MRT_VisibilityState = {};
     if (!containerWidth) {
       return result;
     }
 
-    const callerVisibility = tableProps.state?.columnVisibility;
-    const dataCols = tableColumns.filter(col => callerVisibility?.[col.id ?? ''] !== false);
+    // Columns that would show without responsive hiding, so a column the user turned
+    // on is measured even when it is hidden by default.
+    const dataCols = tableColumns.filter(col => {
+      const id = col.id ?? '';
+      return userColumnVisibility[id] ?? baseColumnVisibility[id] !== false;
+    });
 
     let reserved = 0;
     if (tableProps.enableRowSelection) {
@@ -326,7 +347,12 @@ export default function Table<RowItem extends Record<string, any>>({
     // Columns we're allowed to hide, ordered by what to drop first.
     dataCols
       .map((col, index) => ({ col, index }))
-      .filter(({ index }) => index !== 0)
+      .filter(
+        ({ col, index }) =>
+          index !== 0 &&
+          userColumnVisibility[col.id ?? ''] !== true &&
+          !ACTIONS_COLUMN_IDS.includes(col.id ?? '')
+      )
       .sort((a, b) => {
         const priorityDiff = (a.col.responsivePriority ?? 0) - (b.col.responsivePriority ?? 0);
         return priorityDiff !== 0 ? priorityDiff : b.index - a.index;
@@ -343,19 +369,45 @@ export default function Table<RowItem extends Record<string, any>>({
   }, [
     containerWidth,
     tableColumns,
-    tableProps.state?.columnVisibility,
+    baseColumnVisibility,
     tableProps.enableRowSelection,
     tableProps.enableRowActions,
+    userColumnVisibility,
   ]);
 
-  const mergedColumnVisibility = useMemo(
-    () => ({
-      ...(tableProps.state?.columnVisibility ?? {}),
-      ...columnVisibility,
+  // An explicit choice outranks the responsive layout, so `userColumnVisibility`
+  // is applied last.
+  const mergedColumnVisibility = useMemo<MRT_VisibilityState>(() => {
+    const merged: MRT_VisibilityState = {
+      ...baseColumnVisibility,
       ...responsiveHidden,
-    }),
-    [tableProps.state?.columnVisibility, columnVisibility, responsiveHidden]
-  );
+      ...userColumnVisibility,
+    };
+
+    const dataColumns = tableColumns.filter(col => !ACTIONS_COLUMN_IDS.includes(col.id ?? ''));
+    if (dataColumns.length === 0) {
+      return merged;
+    }
+
+    const actionsVisible = !dataColumns.every(col => merged[col.id ?? ''] === false);
+    const presentActionIds = ACTIONS_COLUMN_IDS.filter(
+      id =>
+        tableColumns.some(col => (col.id ?? '') === id) ||
+        (id === 'mrt-row-actions' && tableProps.enableRowActions)
+    );
+
+    presentActionIds.forEach(id => {
+      merged[id] = actionsVisible;
+    });
+
+    return merged;
+  }, [
+    baseColumnVisibility,
+    responsiveHidden,
+    userColumnVisibility,
+    tableColumns,
+    tableProps.enableRowActions,
+  ]);
 
   const table = useMaterialReactTable({
     ...tableProps,
@@ -381,7 +433,29 @@ export default function Table<RowItem extends Record<string, any>>({
       }
     },
     onGlobalFilterChange: setGlobalFilter,
-    onColumnVisibilityChange: setColumnVisibility,
+    onColumnVisibilityChange: (
+      updater: MRT_VisibilityState | ((old: MRT_VisibilityState) => MRT_VisibilityState)
+    ) => {
+      const next = typeof updater === 'function' ? updater(mergedColumnVisibility) : updater;
+
+      // Action columns are derived from the other columns, never a user choice.
+      const changes: MRT_VisibilityState = {};
+      Object.entries(next).forEach(([id, visible]) => {
+        if (!ACTIONS_COLUMN_IDS.includes(id) && mergedColumnVisibility[id] !== visible) {
+          changes[id] = visible;
+        }
+      });
+
+      if (Object.keys(changes).length === 0) {
+        return;
+      }
+
+      setUserColumnVisibility(prev => ({ ...prev, ...changes }));
+      tableProps.onColumnVisibilityChange?.((old: MRT_VisibilityState) => ({
+        ...old,
+        ...changes,
+      }));
+    },
     renderToolbarInternalActions: ({ table: tbl }) => {
       const isSomeRowsSelected =
         tableProps.enableRowSelection && tbl.getSelectedRowModel().rows.length !== 0;
@@ -515,22 +589,6 @@ export default function Table<RowItem extends Record<string, any>>({
     {},
     [table]
   );
-
-  // Hide actions column when others are hidden
-  useEffect(() => {
-    const visibility = table.getState().columnVisibility || {};
-
-    const shouldHideActions = tableColumns
-      .filter(col => (col.id ?? '') !== 'actions')
-      .every(col => visibility[col.id ?? ''] === false);
-
-    if (shouldHideActions && visibility['actions'] !== false) {
-      table.setColumnVisibility(prev => ({ ...prev, actions: false }));
-    } else if (!shouldHideActions && visibility['actions'] === false) {
-      table.setColumnVisibility(prev => ({ ...prev, actions: true }));
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [table.getState().columnVisibility, tableColumns, table]);
 
   const gridTemplateColumns = useMemo(() => {
     let preGridTemplateColumns = tableProps.columns

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -175,10 +175,15 @@ const StyledBody = styled('tbody')({ display: 'contents' });
 const DEFAULT_MIN_COLUMN_WIDTH = 100;
 
 /**
+ * Id MRT gives the actions column it renders for `enableRowActions`.
+ */
+const MRT_ROW_ACTIONS_COLUMN_ID = 'mrt-row-actions';
+
+/**
  * Ids of the action columns, which follow the other columns in and out of view rather
  * than being toggled on their own: the caller-defined one and MRT's built-in one.
  */
-const ACTIONS_COLUMN_IDS = ['actions', 'mrt-row-actions'];
+const ACTIONS_COLUMN_IDS = ['actions', MRT_ROW_ACTIONS_COLUMN_ID];
 
 /**
  * Tracks the current width of an element using a ResizeObserver.
@@ -393,7 +398,7 @@ export default function Table<RowItem extends Record<string, any>>({
     const presentActionIds = ACTIONS_COLUMN_IDS.filter(
       id =>
         tableColumns.some(col => (col.id ?? '') === id) ||
-        (id === 'mrt-row-actions' && tableProps.enableRowActions)
+        (id === MRT_ROW_ACTIONS_COLUMN_ID && tableProps.enableRowActions)
     );
 
     presentActionIds.forEach(id => {
@@ -604,7 +609,10 @@ export default function Table<RowItem extends Record<string, any>>({
         return it.gridTemplate ?? '1fr';
       })
       .join(' ');
-    if (tableProps.enableRowActions) {
+    if (
+      tableProps.enableRowActions &&
+      mergedColumnVisibility[MRT_ROW_ACTIONS_COLUMN_ID] !== false
+    ) {
       preGridTemplateColumns = `${preGridTemplateColumns} 0.05fr`;
     }
     if (tableProps.enableRowSelection) {

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -199,10 +199,15 @@ const StyledBody = styled('tbody')({ display: 'contents' });
 const DEFAULT_MIN_COLUMN_WIDTH = 100;
 
 /**
+ * Id MRT gives the actions column it renders for `enableRowActions`.
+ */
+const MRT_ROW_ACTIONS_COLUMN_ID = 'mrt-row-actions';
+
+/**
  * Ids of the action columns, which follow the other columns in and out of view rather
  * than being toggled on their own: the caller-defined one and MRT's built-in one.
  */
-const ACTIONS_COLUMN_IDS = ['actions', 'mrt-row-actions'];
+const ACTIONS_COLUMN_IDS = ['actions', MRT_ROW_ACTIONS_COLUMN_ID];
 
 /**
  * Tracks the current width of an element using a ResizeObserver.
@@ -417,7 +422,7 @@ export default function Table<RowItem extends Record<string, any>>({
     const presentActionIds = ACTIONS_COLUMN_IDS.filter(
       id =>
         tableColumns.some(col => (col.id ?? '') === id) ||
-        (id === 'mrt-row-actions' && tableProps.enableRowActions)
+        (id === MRT_ROW_ACTIONS_COLUMN_ID && tableProps.enableRowActions)
     );
 
     presentActionIds.forEach(id => {
@@ -603,7 +608,10 @@ export default function Table<RowItem extends Record<string, any>>({
         return it.gridTemplate ?? '1fr';
       })
       .join(' ');
-    if (tableProps.enableRowActions) {
+    if (
+      tableProps.enableRowActions &&
+      mergedColumnVisibility[MRT_ROW_ACTIONS_COLUMN_ID] !== false
+    ) {
       preGridTemplateColumns = `${preGridTemplateColumns} 0.05fr`;
     }
     if (tableProps.enableRowSelection) {


### PR DESCRIPTION
## Summary

This PR fixes the column chooser being unable to restore a column that responsive hiding had removed. The merged visibility map applied the automatic decision last, so a column hidden to fit the width was re-hidden on every render regardless of what the user asked for — the toggle simply snapped back.

Investigating the report surfaced two further defects in the same code path, both included here:

- The responsive pass measured only the columns the caller had left visible. `Labels` is hidden by default, so it was never counted: turning it on made it appear, but no width was reserved for it and the table fell back to a horizontal scrollbar. This is the second behaviour the reporter distinguishes.
- The internal visibility handler was installed *after* `...tableProps` was spread into the table options, so it overwrote the handler `ResourceTable` passes in. That handler is where `storeTableSettings` runs, which left column preferences loading on mount but never saving again.

## Related Issue

Fixes #6733

## Changes

- **Gave the automatic and explicit decisions a defined order** in `frontend/src/components/common/Table/Table.tsx`. Precedence is now `initialState` → `state` → responsive hiding → user choice, with a new `baseColumnVisibility` layer for the caller's two inputs. Only columns the user actually toggled are tracked as user intent, so responsive hiding keeps applying to everything they haven't touched.
- **Counted user-enabled columns towards the width budget.** A column the user turns on is excluded from the hide candidates but still measured, so a lower-priority column is dropped rather than the table overflowing.
- **Composed the visibility handler instead of replacing it.** It records the user's deltas and forwards the same deltas to the caller as an updater, so responsively hidden columns are never written into stored settings.
- **Derived the actions column from the merged map** and removed the `useEffect` that wrote it back through `table.setColumnVisibility`. With controlled `columnVisibility` that round trip would be recorded as user intent. Both the caller-defined `actions` id and MRT's built-in `mrt-row-actions` id are handled, and neither is offered to the responsive pass.
- **Added `frontend/src/components/common/Table/Table.test.tsx`** — the directory had stories but no test file, which is how this shipped.

## Steps to Test

1. Open any resource list page (for example Pods) and narrow the window until columns start disappearing.
2. Open **Show/Hide columns** and switch on a column that responsive hiding removed. Before this change the switch snaps back; now the column appears and stays.
3. Switch on **Labels**, which is hidden by default. Before this change it appeared but pushed the table into a horizontal scrollbar; now a lower-priority column is dropped to make room.
4. Toggle any column, reload the page, and confirm the choice persists. Before this change it was lost, because `ResourceTable`'s handler never ran.
5. Widen the window again and confirm the columns you explicitly enabled stay enabled.

Automated: `cd frontend && npx vitest run src/components/common/Table/Table.test.tsx` — 6 tests.

To confirm they are real regression tests:

```
cp src/components/common/Table/Table.tsx /tmp/f.tsx
git checkout -- src/components/common/Table/Table.tsx
npx vitest run src/components/common/Table/Table.test.tsx   # failures
cp /tmp/f.tsx src/components/common/Table/Table.tsx
```

## Notes for the Reviewer

- **This touches the effect that #6697 and #6702 modify** (both for #6692). Those PRs change `'actions'` to `'mrt-row-actions'` inside the `useEffect` this PR removes. The removal is not incidental: with `columnVisibility` controlled, that effect can no longer write through `table.setColumnVisibility`, so it had to become a derived value. I handle **both** ids so their fix is not lost either way — happy to rebase on top if theirs lands first, or to drop the actions handling entirely if you would rather sequence it the other way. Worth deciding before either merges.

- **One behaviour change worth your judgement.** Now that user-enabled columns are counted, turning one on hides a lower-priority column instead of showing a horizontal scrollbar. That matches #6468's intent, but the reporter described the scrollbar neutrally as "0.43 behavior" and may have considered it acceptable. If you prefer that an explicit user choice is allowed to overflow, that is a one-line change.

- **The persistence fix widens the scope beyond what #6733 reports.** It is the same PR and the same code path, but nobody has filed it — it is invisible until you reload. Flagging so the diff touching `onColumnVisibilityChange` is not a surprise.

- **Verification status, stated plainly:** `tsc`, `eslint`, and `prettier` are clean, and the full frontend suite passes (183 files). Four of the six new tests are confirmed to fail without the fix; the two covering the actions column are **not yet confirmed as regression tests** — repeated attempts to run the without-fix comparison timed out on a loaded machine. Worth a second look in review or CI.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive table behavior so columns hide and reappear correctly based on available space and user preferences.
  * Preserved user-enabled columns when responsive adjustments occur.
  * Ensured action columns and row-action layout remain consistent as column visibility changes.
  * Improved synchronization of column visibility updates with application settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->