### PR TITLE
frontend: shortcutsSlice: Fix i18next uninitialized warning

### DIFF
--- a/frontend/src/components/App/Settings/ShortcutsSettings.test.tsx
+++ b/frontend/src/components/App/Settings/ShortcutsSettings.test.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
+import { setShortcutsDialogOpen } from '../../../redux/shortcutsSlice';
+import defaultStore from '../../../redux/stores/store';
+import { TestContext } from '../../../test';
+import ShortcutsSettings from './ShortcutsSettings';
+
+let mockLang = 'en';
+let changeLanguageMock: (lang: string) => void;
+
+vi.mock('react-i18next', async () => {
+  return {
+    useTranslation: () => {
+      const [, setTick] = React.useState(0);
+
+      React.useEffect(() => {
+        changeLanguageMock = (lang: string) => {
+          mockLang = lang;
+          setTick(t => t + 1);
+        };
+      }, []);
+
+      return {
+        t: (key: string) => (mockLang === 'en' ? key : `[${mockLang}] ${key}`),
+        i18n: {
+          changeLanguage: (lang: string) => {
+            if (changeLanguageMock) {
+              changeLanguageMock(lang);
+            }
+          },
+          language: mockLang,
+        },
+      };
+    },
+  };
+});
+
+vi.mock('../../common/NameValueTable', () => ({
+  default: ({ rows }: any) => (
+    <div data-testid="mock-name-value-table">
+      {rows.map((r: any, i: number) => (
+        <div key={i}>
+          {r.name}
+          {r.value}
+        </div>
+      ))}
+    </div>
+  ),
+  __esModule: true,
+}));
+
+describe('ShortcutsSettings Localization', () => {
+  beforeEach(() => {
+    mockLang = 'en';
+  });
+
+  it('updates translated shortcut labels and descriptions when language changes', async () => {
+    // Open the shortcuts dialog so it renders
+    defaultStore.dispatch(setShortcutsDialogOpen(true));
+
+    render(
+      <TestContext store={defaultStore}>
+        <ShortcutsSettings />
+      </TestContext>
+    );
+
+    // Initial render in English
+    expect(screen.getByText('Global Search')).toBeInTheDocument();
+
+    // Simulate language change to Russian (ru)
+    act(() => {
+      if (changeLanguageMock) {
+        changeLanguageMock('ru');
+      }
+    });
+
+    // Verify the label correctly updates to the new locale string
+    expect(screen.getByText('[ru] Global Search')).toBeInTheDocument();
+    // Verify the description correctly updates as well
+    expect(screen.getByText('[ru] Open the global search dialog')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/App/Settings/ShortcutsSettings.tsx
+++ b/frontend/src/components/App/Settings/ShortcutsSettings.tsx
@@ -149,7 +149,7 @@ function ShortcutEditor({
           />
           {conflict && (
             <Typography variant="caption" color="error">
-              {t('Conflicts with: {{name}}', { name: conflict })}
+              {t('Conflicts with: {{name}}', { name: t(conflict) })}
             </Typography>
           )}
         </Box>
@@ -232,7 +232,7 @@ export function ShortcutsList() {
       const lowerNewKey = newKey.toLowerCase();
       for (const id in shortcuts) {
         if (id !== currentId && shortcuts[id].key.toLowerCase() === lowerNewKey) {
-          return shortcuts[id].name;
+          return shortcuts[id].labelKey;
         }
       }
       return undefined;
@@ -278,10 +278,10 @@ export function ShortcutsList() {
       name: (
         <Box>
           <Typography variant="body2" sx={{ fontWeight: 500, color: 'text.primary' }}>
-            {shortcut.name}
+            {t(shortcut.labelKey)}
           </Typography>
           <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block' }}>
-            {shortcut.description}
+            {t(shortcut.descriptionKey)}
           </Typography>
         </Box>
       ),

--- a/frontend/src/components/App/Settings/ShortcutsSettings.tsx
+++ b/frontend/src/components/App/Settings/ShortcutsSettings.tsx
@@ -149,7 +149,7 @@ function ShortcutEditor({
           />
           {conflict && (
             <Typography variant="caption" color="error">
-              {t('Conflicts with: {{name}}', { name: conflict })}
+              {t('Conflicts with: {{name}}', { name: t(conflict) })}
             </Typography>
           )}
         </Box>
@@ -278,10 +278,10 @@ export function ShortcutsList() {
       name: (
         <Box>
           <Typography variant="body2" sx={{ fontWeight: 500, color: 'text.primary' }}>
-            {shortcut.name}
+            {t(shortcut.name)}
           </Typography>
           <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block' }}>
-            {shortcut.description}
+            {t(shortcut.description)}
           </Typography>
         </Box>
       ),

--- a/frontend/src/redux/shortcutsSlice.test.ts
+++ b/frontend/src/redux/shortcutsSlice.test.ts
@@ -100,7 +100,7 @@ describe('shortcutsSlice', () => {
       expect(DEFAULT_SHORTCUTS.GLOBAL_SEARCH.key).toBe('/');
       expect(DEFAULT_SHORTCUTS.GLOBAL_SEARCH.defaultKey).toBe('/');
       expect(DEFAULT_SHORTCUTS.GLOBAL_SEARCH.category).toBe('search');
-      expect(DEFAULT_SHORTCUTS.GLOBAL_SEARCH.name).toBe('Global Search');
+      expect(DEFAULT_SHORTCUTS.GLOBAL_SEARCH.labelKey).toBe('Global Search');
     });
 
     it('should have CLUSTER_CHOOSER shortcut with correct defaults', () => {
@@ -124,8 +124,8 @@ describe('shortcutsSlice', () => {
     it('should have all shortcuts with required properties', () => {
       Object.values(DEFAULT_SHORTCUTS).forEach(shortcut => {
         expect(shortcut.id).toBeDefined();
-        expect(shortcut.name).toBeDefined();
-        expect(shortcut.description).toBeDefined();
+        expect(shortcut.labelKey).toBeDefined();
+        expect(shortcut.descriptionKey).toBeDefined();
         expect(shortcut.key).toBeDefined();
         expect(shortcut.defaultKey).toBeDefined();
         expect(shortcut.category).toBeDefined();

--- a/frontend/src/redux/shortcutsSlice.ts
+++ b/frontend/src/redux/shortcutsSlice.ts
@@ -23,10 +23,10 @@ import { createSlice } from '@reduxjs/toolkit';
 export interface ShortcutConfig {
   /** The unique identifier for the shortcut */
   id: string;
-  /** The human-readable name of the shortcut */
-  name: string;
-  /** A description of what the shortcut does */
-  description: string;
+  /** The translation key for the human-readable name of the shortcut */
+  labelKey: string;
+  /** The translation key for the description of what the shortcut does */
+  descriptionKey: string;
   /** The current key combination assigned to the shortcut */
   key: string;
   /** The default key combination for the shortcut */
@@ -35,40 +35,46 @@ export interface ShortcutConfig {
   category: 'navigation' | 'search' | 'general';
 }
 
-import i18next from 'i18next';
-
 /**
  * All available shortcuts with their default configurations
  */
+// t('Global Search')
+// t('Open the global search dialog')
+// t('Cluster Chooser')
+// t('Open the cluster chooser popup')
+// t('Toggle Table Filters')
+// t('Toggle column filters in tables')
+// t('Log Viewer Search')
+// t('Toggle search in log viewer')
 export const DEFAULT_SHORTCUTS: Record<string, ShortcutConfig> = {
   GLOBAL_SEARCH: {
     id: 'GLOBAL_SEARCH',
-    name: i18next.t('Global Search'),
-    description: i18next.t('Open the global search dialog'),
+    labelKey: 'Global Search',
+    descriptionKey: 'Open the global search dialog',
     key: '/',
     defaultKey: '/',
     category: 'search',
   },
   CLUSTER_CHOOSER: {
     id: 'CLUSTER_CHOOSER',
-    name: i18next.t('Cluster Chooser'),
-    description: i18next.t('Open the cluster chooser popup'),
+    labelKey: 'Cluster Chooser',
+    descriptionKey: 'Open the cluster chooser popup',
     key: 'ctrl+shift+l',
     defaultKey: 'ctrl+shift+l',
     category: 'navigation',
   },
   TABLE_COLUMN_FILTERS: {
     id: 'TABLE_COLUMN_FILTERS',
-    name: i18next.t('Toggle Table Filters'),
-    description: i18next.t('Toggle column filters in tables'),
+    labelKey: 'Toggle Table Filters',
+    descriptionKey: 'Toggle column filters in tables',
     key: 'alt+shift+t',
     defaultKey: 'alt+shift+t',
     category: 'general',
   },
   LOG_VIEWER_SEARCH: {
     id: 'LOG_VIEWER_SEARCH',
-    name: i18next.t('Log Viewer Search'),
-    description: i18next.t('Toggle search in log viewer'),
+    labelKey: 'Log Viewer Search',
+    descriptionKey: 'Toggle search in log viewer',
     key: 'ctrl+shift+f',
     defaultKey: 'ctrl+shift+f',
     category: 'search',

--- a/frontend/src/redux/shortcutsSlice.ts
+++ b/frontend/src/redux/shortcutsSlice.ts
@@ -35,7 +35,7 @@ export interface ShortcutConfig {
   category: 'navigation' | 'search' | 'general';
 }
 
-import i18next from 'i18next';
+const t = (s: string) => s;
 
 /**
  * All available shortcuts with their default configurations
@@ -43,32 +43,32 @@ import i18next from 'i18next';
 export const DEFAULT_SHORTCUTS: Record<string, ShortcutConfig> = {
   GLOBAL_SEARCH: {
     id: 'GLOBAL_SEARCH',
-    name: i18next.t('Global Search'),
-    description: i18next.t('Open the global search dialog'),
+    name: t('Global Search'),
+    description: t('Open the global search dialog'),
     key: '/',
     defaultKey: '/',
     category: 'search',
   },
   CLUSTER_CHOOSER: {
     id: 'CLUSTER_CHOOSER',
-    name: i18next.t('Cluster Chooser'),
-    description: i18next.t('Open the cluster chooser popup'),
+    name: t('Cluster Chooser'),
+    description: t('Open the cluster chooser popup'),
     key: 'ctrl+shift+l',
     defaultKey: 'ctrl+shift+l',
     category: 'navigation',
   },
   TABLE_COLUMN_FILTERS: {
     id: 'TABLE_COLUMN_FILTERS',
-    name: i18next.t('Toggle Table Filters'),
-    description: i18next.t('Toggle column filters in tables'),
+    name: t('Toggle Table Filters'),
+    description: t('Toggle column filters in tables'),
     key: 'alt+shift+t',
     defaultKey: 'alt+shift+t',
     category: 'general',
   },
   LOG_VIEWER_SEARCH: {
     id: 'LOG_VIEWER_SEARCH',
-    name: i18next.t('Log Viewer Search'),
-    description: i18next.t('Toggle search in log viewer'),
+    name: t('Log Viewer Search'),
+    description: t('Toggle search in log viewer'),
     key: 'ctrl+shift+f',
     defaultKey: 'ctrl+shift+f',
     category: 'search',


### PR DESCRIPTION
This fixes the `i18next was not initialized` and `missingKey` warnings that spam the console on app startup. 

### What changed
The issue was that `DEFAULT_SHORTCUTS` in `shortcutsSlice.ts` was calling `i18next.t()` directly when the Redux store first initialized. Since i18next isn't ready at that point, it threw warnings and cached the English strings before the actual locale could load.

To fix it:
- I deferred the actual translation to render-time in `ShortcutsSettings.tsx` using the `useTranslation` hook.
- Renamed `.name` and `.description` in the config to `.labelKey` and `.descriptionKey` so it's obvious they just hold translation keys, not the actual display strings.
- Added `// t('...')` comment markers above `DEFAULT_SHORTCUTS` so `i18next-parser` can still extract the strings properly during `npm run i18n` without us having to write a fake identity function.

### Steps to test
1. Start the frontend (`npm run frontend:start`) and check the browser console on startup — you shouldn't see those `i18next was not initialized` warnings anymore.
2. Go to **Settings > Keyboard Shortcuts**, switch the app language, and confirm the shortcut names/descriptions actually translate now (they used to just stay in English).
3. Run `npm run frontend:test -- src/redux/shortcutsSlice.test.ts` and `cd frontend && npm run i18n` to make sure the tests pass and the parser still extracts everything correctly.
