### PR TITLE
frontend: clusterRequests: Reject with the real request failure

### DIFF
--- a/backend/cmd/cluster.go
+++ b/backend/cmd/cluster.go
@@ -26,6 +26,9 @@ type Cluster struct {
 	AuthType string                 `json:"auth_type"`
 	Metadata map[string]interface{} `json:"meta_data"`
 	Error    string                 `json:"error,omitempty"`
+	// UsesServiceAccountToken reports that requests to this cluster are authenticated with
+	// the backend's own service account token, so a user-supplied token is never applied.
+	UsesServiceAccountToken bool `json:"usesServiceAccountToken,omitempty"`
 }
 
 type ClusterReq struct {

--- a/backend/cmd/cluster.go
+++ b/backend/cmd/cluster.go
@@ -26,6 +26,9 @@ type Cluster struct {
 	AuthType string                 `json:"auth_type"`
 	Metadata map[string]interface{} `json:"meta_data"`
 	Error    string                 `json:"error,omitempty"`
+	// UsesServiceAccountToken reports that requests to this cluster are authenticated with
+	// the backend's own service account token, so a user-supplied token is never applied.
+	UsesServiceAccountToken bool `json:"uses_service_account_token,omitempty"`
 }
 
 type ClusterReq struct {

--- a/backend/cmd/cluster.go
+++ b/backend/cmd/cluster.go
@@ -28,7 +28,7 @@ type Cluster struct {
 	Error    string                 `json:"error,omitempty"`
 	// UsesServiceAccountToken reports that requests to this cluster are authenticated with
 	// the backend's own service account token, so a user-supplied token is never applied.
-	UsesServiceAccountToken bool `json:"usesServiceAccountToken,omitempty"`
+	UsesServiceAccountToken bool `json:"uses_service_account_token,omitempty"`
 }
 
 type ClusterReq struct {

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1988,6 +1988,26 @@ func (c *HeadlampConfig) handleClusterRequests(router *mux.Router) {
 	handleClusterAPI(c, router)
 }
 
+// clusterMetadata builds the metadata the frontend receives for a context.
+func clusterMetadata(context *kubeconfig.Context) map[string]interface{} {
+	metadata := map[string]interface{}{
+		"source":     context.SourceStr(),
+		"namespace":  context.KubeContext.Namespace,
+		"extensions": context.KubeContext.Extensions,
+		"origin": map[string]interface{}{
+			"kubeconfig": context.KubeConfigPath,
+		},
+		"originalName":    context.Name,
+		logFieldClusterID: context.ClusterID,
+	}
+
+	if context.Source == kubeconfig.ClusterInventory && context.ClusterInventory != nil {
+		metadata["clusterInventory"] = context.ClusterInventory
+	}
+
+	return metadata
+}
+
 func (c *HeadlampConfig) getClusters() []Cluster {
 	clusters := []Cluster{}
 
@@ -2021,32 +2041,14 @@ func (c *HeadlampConfig) getClusters() []Cluster {
 			continue
 		}
 
-		kubeconfigPath := context.KubeConfigPath
-
-		source := context.SourceStr()
-
-		clusterID := context.ClusterID
-
-		metadata := map[string]interface{}{
-			"source":     source,
-			"namespace":  context.KubeContext.Namespace,
-			"extensions": context.KubeContext.Extensions,
-			"origin": map[string]interface{}{
-				"kubeconfig": kubeconfigPath,
-			},
-			"originalName":    context.Name,
-			logFieldClusterID: clusterID,
-		}
-
-		if context.Source == kubeconfig.ClusterInventory && context.ClusterInventory != nil {
-			metadata["clusterInventory"] = context.ClusterInventory
-		}
+		metadata := clusterMetadata(context)
 
 		clusters = append(clusters, Cluster{
-			Name:     context.Name,
-			Server:   context.Cluster.Server,
-			AuthType: context.AuthType(),
-			Metadata: metadata,
+			Name:                    context.Name,
+			Server:                  context.Cluster.Server,
+			AuthType:                context.AuthType(),
+			Metadata:                metadata,
+			UsesServiceAccountToken: c.shouldUseUnsafeServiceAccountTokenForContext(context),
 		})
 	}
 

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -2115,6 +2115,26 @@ func (c *HeadlampConfig) handleClusterRequests(router *mux.Router) {
 	handleClusterAPI(c, router)
 }
 
+// clusterMetadata builds the metadata the frontend receives for a context.
+func clusterMetadata(context *kubeconfig.Context) map[string]interface{} {
+	metadata := map[string]interface{}{
+		"source":     context.SourceStr(),
+		"namespace":  context.KubeContext.Namespace,
+		"extensions": context.KubeContext.Extensions,
+		"origin": map[string]interface{}{
+			"kubeconfig": context.KubeConfigPath,
+		},
+		"originalName":    context.Name,
+		logFieldClusterID: context.ClusterID,
+	}
+
+	if context.Source == kubeconfig.ClusterInventory && context.ClusterInventory != nil {
+		metadata["clusterInventory"] = context.ClusterInventory
+	}
+
+	return metadata
+}
+
 func (c *HeadlampConfig) getClusters() []Cluster {
 	clusters := []Cluster{}
 
@@ -2148,32 +2168,14 @@ func (c *HeadlampConfig) getClusters() []Cluster {
 			continue
 		}
 
-		kubeconfigPath := context.KubeConfigPath
-
-		source := context.SourceStr()
-
-		clusterID := context.ClusterID
-
-		metadata := map[string]interface{}{
-			"source":     source,
-			"namespace":  context.KubeContext.Namespace,
-			"extensions": context.KubeContext.Extensions,
-			"origin": map[string]interface{}{
-				"kubeconfig": kubeconfigPath,
-			},
-			"originalName":    context.Name,
-			logFieldClusterID: clusterID,
-		}
-
-		if context.Source == kubeconfig.ClusterInventory && context.ClusterInventory != nil {
-			metadata["clusterInventory"] = context.ClusterInventory
-		}
+		metadata := clusterMetadata(context)
 
 		clusters = append(clusters, Cluster{
-			Name:     context.Name,
-			Server:   context.Cluster.Server,
-			AuthType: context.AuthType(),
-			Metadata: metadata,
+			Name:                    context.Name,
+			Server:                  context.Cluster.Server,
+			AuthType:                context.AuthType(),
+			Metadata:                metadata,
+			UsesServiceAccountToken: c.shouldUseUnsafeServiceAccountTokenForContext(context),
 		})
 	}
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -492,6 +492,49 @@ func TestGetClustersClusterInventorySource(t *testing.T) {
 }
 
 // clusterInventoryConfigContext returns a minimal discovered context with Cluster Inventory metadata.
+// TestGetClustersUsesServiceAccountToken checks the signal the auth chooser relies on to
+// know that a user-supplied token would never be applied to a cluster.
+func TestGetClustersUsesServiceAccountToken(t *testing.T) {
+	inClusterContext := func() *kubeconfig.Context {
+		return &kubeconfig.Context{
+			Name:        "in-cluster",
+			KubeContext: &api.Context{Cluster: "in-cluster", AuthInfo: "in-cluster"},
+			Cluster:     &api.Cluster{Server: "https://kubernetes.default.svc"},
+			//nolint:gosec // G101: a path to the mounted service account token, not a credential.
+			AuthInfo: &api.AuthInfo{TokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"},
+			Source:   kubeconfig.InCluster,
+		}
+	}
+
+	for _, tc := range []struct {
+		name     string
+		unsafe   bool
+		expected bool
+	}{
+		{name: "reported when the backend authenticates with its own token", unsafe: true, expected: true},
+		{name: "not reported when per-user auth is in effect", unsafe: false, expected: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := kubeconfig.NewContextStore()
+			require.NoError(t, store.AddContext(inClusterContext()))
+
+			c := &HeadlampConfig{
+				HeadlampConfig: &headlampconfig.HeadlampConfig{
+					HeadlampCFG: &headlampconfig.HeadlampCFG{
+						KubeConfigStore:              store,
+						UseInCluster:                 true,
+						UnsafeUseServiceAccountToken: tc.unsafe,
+					},
+				},
+			}
+
+			clusters := c.getClusters()
+			require.Len(t, clusters, 1)
+			assert.Equal(t, tc.expected, clusters[0].UsesServiceAccountToken)
+		})
+	}
+}
+
 func clusterInventoryConfigContext() *kubeconfig.Context {
 	return &kubeconfig.Context{
 		Name:        "cluster-inventory-in-cluster--default--spoke-a--dbdb0aa95e5d",

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -491,7 +491,6 @@ func TestGetClustersClusterInventorySource(t *testing.T) {
 	assert.Equal(t, "False", configCondition["status"])
 }
 
-// clusterInventoryConfigContext returns a minimal discovered context with Cluster Inventory metadata.
 // TestGetClustersUsesServiceAccountToken checks the signal the auth chooser relies on to
 // know that a user-supplied token would never be applied to a cluster.
 func TestGetClustersUsesServiceAccountToken(t *testing.T) {
@@ -535,6 +534,7 @@ func TestGetClustersUsesServiceAccountToken(t *testing.T) {
 	}
 }
 
+// clusterInventoryConfigContext returns a minimal discovered context with Cluster Inventory metadata.
 func clusterInventoryConfigContext() *kubeconfig.Context {
 	return &kubeconfig.Context{
 		Name:        "cluster-inventory-in-cluster--default--spoke-a--dbdb0aa95e5d",

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -709,6 +709,49 @@ func TestGetClustersClusterInventorySource(t *testing.T) {
 	assert.Equal(t, "False", configCondition["status"])
 }
 
+// TestGetClustersUsesServiceAccountToken checks the signal the auth chooser relies on to
+// know that a user-supplied token would never be applied to a cluster.
+func TestGetClustersUsesServiceAccountToken(t *testing.T) {
+	inClusterContext := func() *kubeconfig.Context {
+		return &kubeconfig.Context{
+			Name:        "in-cluster",
+			KubeContext: &api.Context{Cluster: "in-cluster", AuthInfo: "in-cluster"},
+			Cluster:     &api.Cluster{Server: "https://kubernetes.default.svc"},
+			//nolint:gosec // G101: a path to the mounted service account token, not a credential.
+			AuthInfo: &api.AuthInfo{TokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"},
+			Source:   kubeconfig.InCluster,
+		}
+	}
+
+	for _, tc := range []struct {
+		name     string
+		unsafe   bool
+		expected bool
+	}{
+		{name: "reported when the backend authenticates with its own token", unsafe: true, expected: true},
+		{name: "not reported when per-user auth is in effect", unsafe: false, expected: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := kubeconfig.NewContextStore()
+			require.NoError(t, store.AddContext(inClusterContext()))
+
+			c := &HeadlampConfig{
+				HeadlampConfig: &headlampconfig.HeadlampConfig{
+					HeadlampCFG: &headlampconfig.HeadlampCFG{
+						KubeConfigStore:              store,
+						UseInCluster:                 true,
+						UnsafeUseServiceAccountToken: tc.unsafe,
+					},
+				},
+			}
+
+			clusters := c.getClusters()
+			require.Len(t, clusters, 1)
+			assert.Equal(t, tc.expected, clusters[0].UsesServiceAccountToken)
+		})
+	}
+}
+
 // clusterInventoryConfigContext returns a minimal discovered context with Cluster Inventory metadata.
 func clusterInventoryConfigContext() *kubeconfig.Context {
 	return &kubeconfig.Context{

--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -25,7 +25,6 @@ import { generatePath, useHistory, useLocation } from 'react-router-dom';
 import { getAppUrl } from '../../helpers/getAppUrl';
 import { getCluster, getClusterPrefixedPath } from '../../lib/cluster';
 import { useClustersConf } from '../../lib/k8s';
-import { testAuth } from '../../lib/k8s/api/v1/clusterApi';
 import { queryClient } from '../../lib/queryClient';
 import { createRouteURL } from '../../lib/router/createRouteURL';
 import { getRoute } from '../../lib/router/getRoute';
@@ -37,6 +36,7 @@ import Empty from '../common/EmptyContent';
 import Link from '../common/Link';
 import Loader from '../common/Loader';
 import OauthPopup from '../oidcauth/OauthPopup';
+import { testAuthWithRetry, TRANSIENT_STATUSES } from './testAuthWithRetry';
 
 function ColorButton({ children, ...rest }: ComponentProps<typeof Button>) {
   return (
@@ -106,7 +106,9 @@ function AuthChooser({ children }: AuthChooserProps) {
       // With clusterAuthType == oidc,
       //   they are presented with a choice of login or enter token.
       if (clusterAuthType !== 'oidc' && cluster.useToken === undefined) {
-        let useToken = true;
+        // When the backend authenticates with its own service account, a user token is
+        // never applied, so a failed check must not fall back to asking for one.
+        let useToken = !cluster.usesServiceAccountToken;
 
         setTestingAuth(true);
 
@@ -114,20 +116,24 @@ function AuthChooser({ children }: AuthChooserProps) {
 
         console.debug('Testing auth at authchooser');
 
-        testAuth(clusterName)
+        testAuthWithRetry(clusterName)
           .then(() => {
             console.debug('Not requiring token as testing auth succeeded');
             useToken = false;
           })
           .catch(err => {
             if (!cancelledRef.current) {
-              console.debug(`Requiring token for ${clusterName} as testing auth failed:`, err);
-
               // Ideally we'd only not assign the error if it was 401 or 403 (so we let the logic
               // proceed to request a token), but let's first check whether this is all we get
               // from clusters that require a token.
-              if ([408, 504, 502].includes(err.status)) {
+              if (TRANSIENT_STATUSES.includes(err.status)) {
+                // The request did not reach the cluster, so whether a token is needed is still
+                // unknown. Surfacing this as a connection error keeps it apart from the auth
+                // failures below, which do require one.
+                console.debug(`Could not reach ${clusterName} while testing auth:`, err);
                 errorObj = err;
+              } else {
+                console.debug(`Requiring token for ${clusterName} as testing auth failed:`, err);
               }
 
               setTestingAuth(false);

--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -132,6 +132,12 @@ function AuthChooser({ children }: AuthChooserProps) {
                 // failures below, which do require one.
                 console.debug(`Could not reach ${clusterName} while testing auth:`, err);
                 errorObj = err;
+              } else if (cluster.uses_service_account_token) {
+                // A user token is never applied to this cluster, so asking for one is not a
+                // recovery. The failure is the answer, and hiding it would send the user on
+                // into a cluster they cannot read.
+                console.debug(`Auth failed for ${clusterName} and no token can be applied:`, err);
+                errorObj = err;
               } else {
                 console.debug(`Requiring token for ${clusterName} as testing auth failed:`, err);
               }

--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -25,7 +25,6 @@ import { generatePath, useHistory, useLocation } from 'react-router-dom';
 import { getAppUrl } from '../../helpers/getAppUrl';
 import { getCluster, getClusterPrefixedPath } from '../../lib/cluster';
 import { useClustersConf } from '../../lib/k8s';
-import { testAuth } from '../../lib/k8s/api/v1/clusterApi';
 import { queryClient } from '../../lib/queryClient';
 import { createRouteURL } from '../../lib/router/createRouteURL';
 import { getRoute } from '../../lib/router/getRoute';
@@ -37,6 +36,7 @@ import Empty from '../common/EmptyContent';
 import Link from '../common/Link';
 import Loader from '../common/Loader';
 import OauthPopup from '../oidcauth/OauthPopup';
+import { testAuthWithRetry, TRANSIENT_STATUSES } from './testAuthWithRetry';
 
 function ColorButton({ children, ...rest }: ComponentProps<typeof Button>) {
   return (
@@ -117,7 +117,10 @@ function AuthChooser({ children }: AuthChooserProps) {
       // With clusterAuthType == oidc,
       //   they are presented with a choice of login or enter token.
       if (clusterAuthType !== 'oidc' && cluster.useToken === undefined) {
-        let useToken = true;
+        // Running in-cluster with --unsafe-use-service-account-token, the backend
+        // authenticates every request with the pod's own service account and discards
+        // whatever token the user supplies. Asking for one cannot change the outcome.
+        let useToken = !cluster.uses_service_account_token;
 
         setTestingAuth(true);
 
@@ -125,20 +128,30 @@ function AuthChooser({ children }: AuthChooserProps) {
 
         console.debug('Testing auth at authchooser');
 
-        testAuth(clusterName)
+        testAuthWithRetry(clusterName)
           .then(() => {
             console.debug('Not requiring token as testing auth succeeded');
             useToken = false;
           })
           .catch(err => {
             if (!cancelledRef.current) {
-              console.debug(`Requiring token for ${clusterName} as testing auth failed:`, err);
-
               // Ideally we'd only not assign the error if it was 401 or 403 (so we let the logic
               // proceed to request a token), but let's first check whether this is all we get
               // from clusters that require a token.
-              if ([408, 504, 502].includes(err.status)) {
+              if (TRANSIENT_STATUSES.includes(err.status)) {
+                // The request did not reach the cluster, so whether a token is needed is still
+                // unknown. Surfacing this as a connection error keeps it apart from the auth
+                // failures below, which do require one.
+                console.debug(`Could not reach ${clusterName} while testing auth:`, err);
                 errorObj = err;
+              } else if (cluster.uses_service_account_token) {
+                // A user token is never applied to this cluster, so asking for one is not a
+                // recovery. The failure is the answer, and hiding it would send the user on
+                // into a cluster they cannot read.
+                console.debug(`Auth failed for ${clusterName} and no token can be applied:`, err);
+                errorObj = err;
+              } else {
+                console.debug(`Requiring token for ${clusterName} as testing auth failed:`, err);
               }
 
               setTestingAuth(false);

--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -108,7 +108,7 @@ function AuthChooser({ children }: AuthChooserProps) {
       if (clusterAuthType !== 'oidc' && cluster.useToken === undefined) {
         // When the backend authenticates with its own service account, a user token is
         // never applied, so a failed check must not fall back to asking for one.
-        let useToken = !cluster.usesServiceAccountToken;
+        let useToken = !cluster.uses_service_account_token;
 
         setTestingAuth(true);
 

--- a/frontend/src/components/authchooser/testAuthWithRetry.test.ts
+++ b/frontend/src/components/authchooser/testAuthWithRetry.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { testAuth } from '../../lib/k8s/api/v1/clusterApi';
+import type { ApiError } from '../../lib/k8s/api/v2/ApiError';
+import { testAuthWithRetry } from './testAuthWithRetry';
+
+vi.mock('../../lib/k8s/api/v1/clusterApi', () => ({
+  testAuth: vi.fn(),
+}));
+
+const testAuthMock = vi.mocked(testAuth);
+
+function apiError(status?: number) {
+  const err = new Error(`failed with ${status}`) as ApiError;
+  err.status = status;
+  return err;
+}
+
+describe('testAuthWithRetry', () => {
+  beforeEach(() => {
+    testAuthMock.mockReset();
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not retry when the first attempt succeeds', async () => {
+    testAuthMock.mockResolvedValueOnce({});
+
+    await expect(testAuthWithRetry('my-cluster')).resolves.toEqual({});
+    expect(testAuthMock).toHaveBeenCalledTimes(1);
+  });
+
+  // A request that never reached the cluster says nothing about whether a token is
+  // needed, so it gets one more attempt before the session is interrupted.
+  it.each([408, 502, 504])('retries once after a transient %i', async status => {
+    testAuthMock.mockRejectedValueOnce(apiError(status)).mockResolvedValueOnce({});
+
+    await expect(testAuthWithRetry('my-cluster')).resolves.toEqual({});
+    expect(testAuthMock).toHaveBeenCalledTimes(2);
+  });
+
+  // The retry gets a shorter budget so a hanging cluster still reports promptly.
+  it('retries with a shorter timeout than the first attempt', async () => {
+    testAuthMock.mockRejectedValueOnce(apiError(408)).mockResolvedValueOnce({});
+
+    await testAuthWithRetry('my-cluster');
+
+    const firstTimeout = testAuthMock.mock.calls[0][2];
+    const retryTimeout = testAuthMock.mock.calls[1][2];
+
+    expect(retryTimeout).toBeLessThan(firstTimeout ?? 5 * 1000);
+  });
+
+  it('rejects when the retry also fails', async () => {
+    testAuthMock.mockRejectedValueOnce(apiError(408)).mockRejectedValueOnce(apiError(408));
+
+    await expect(testAuthWithRetry('my-cluster')).rejects.toMatchObject({ status: 408 });
+    expect(testAuthMock).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([401, 403])('does not retry a genuine %i auth failure', async status => {
+    testAuthMock.mockRejectedValueOnce(apiError(status));
+
+    await expect(testAuthWithRetry('my-cluster')).rejects.toMatchObject({ status });
+    expect(testAuthMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry an error carrying no status', async () => {
+    testAuthMock.mockRejectedValueOnce(apiError(undefined));
+
+    await expect(testAuthWithRetry('my-cluster')).rejects.toBeInstanceOf(Error);
+    expect(testAuthMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/authchooser/testAuthWithRetry.test.ts
+++ b/frontend/src/components/authchooser/testAuthWithRetry.test.ts
@@ -70,9 +70,11 @@ describe('testAuthWithRetry', () => {
   });
 
   it('rejects when the retry also fails', async () => {
-    testAuthMock.mockRejectedValueOnce(apiError(408)).mockRejectedValueOnce(apiError(408));
+    const firstError = apiError(408);
+    const retryError = apiError(408);
+    testAuthMock.mockRejectedValueOnce(firstError).mockRejectedValueOnce(retryError);
 
-    await expect(testAuthWithRetry('my-cluster')).rejects.toMatchObject({ status: 408 });
+    await expect(testAuthWithRetry('my-cluster')).rejects.toBe(retryError);
     expect(testAuthMock).toHaveBeenCalledTimes(2);
   });
 

--- a/frontend/src/components/authchooser/testAuthWithRetry.test.ts
+++ b/frontend/src/components/authchooser/testAuthWithRetry.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { testAuth } from '../../lib/k8s/api/v1/clusterApi';
+import type { ApiError } from '../../lib/k8s/api/v2/ApiError';
+import { testAuthWithRetry } from './testAuthWithRetry';
+
+vi.mock('../../lib/k8s/api/v1/clusterApi', () => ({
+  testAuth: vi.fn(),
+}));
+
+const testAuthMock = vi.mocked(testAuth);
+
+function apiError(status?: number) {
+  const err = new Error(`failed with ${status}`) as ApiError;
+  err.status = status;
+  return err;
+}
+
+describe('testAuthWithRetry', () => {
+  beforeEach(() => {
+    testAuthMock.mockReset();
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not retry when the first attempt succeeds', async () => {
+    testAuthMock.mockResolvedValueOnce({});
+
+    await expect(testAuthWithRetry('my-cluster')).resolves.toEqual({});
+    expect(testAuthMock).toHaveBeenCalledTimes(1);
+  });
+
+  // A request that never reached the cluster says nothing about whether a token is
+  // needed, so it gets one more attempt before the session is interrupted.
+  it.each([408, 502, 504])('retries once after a transient %i', async status => {
+    testAuthMock.mockRejectedValueOnce(apiError(status)).mockResolvedValueOnce({});
+
+    await expect(testAuthWithRetry('my-cluster')).resolves.toEqual({});
+    expect(testAuthMock).toHaveBeenCalledTimes(2);
+  });
+
+  // The retry gets a shorter budget so a hanging cluster still reports promptly.
+  it('retries with a shorter timeout than the first attempt', async () => {
+    testAuthMock.mockRejectedValueOnce(apiError(408)).mockResolvedValueOnce({});
+
+    await testAuthWithRetry('my-cluster');
+
+    const firstTimeout = testAuthMock.mock.calls[0][2];
+    const retryTimeout = testAuthMock.mock.calls[1][2];
+
+    expect(retryTimeout).toBeLessThan(firstTimeout ?? 5 * 1000);
+  });
+
+  it('rejects when the retry also fails', async () => {
+    const firstError = apiError(408);
+    const retryError = apiError(408);
+    testAuthMock.mockRejectedValueOnce(firstError).mockRejectedValueOnce(retryError);
+
+    await expect(testAuthWithRetry('my-cluster')).rejects.toBe(retryError);
+    expect(testAuthMock).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([401, 403])('does not retry a genuine %i auth failure', async status => {
+    testAuthMock.mockRejectedValueOnce(apiError(status));
+
+    await expect(testAuthWithRetry('my-cluster')).rejects.toMatchObject({ status });
+    expect(testAuthMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry an error carrying no status', async () => {
+    testAuthMock.mockRejectedValueOnce(apiError(undefined));
+
+    await expect(testAuthWithRetry('my-cluster')).rejects.toBeInstanceOf(Error);
+    expect(testAuthMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/authchooser/testAuthWithRetry.ts
+++ b/frontend/src/components/authchooser/testAuthWithRetry.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { testAuth } from '../../lib/k8s/api/v1/clusterApi';
+import type { ApiError } from '../../lib/k8s/api/v2/ApiError';
+
+/** Statuses that mean the request never reached the cluster, so it may still succeed. */
+export const TRANSIENT_STATUSES = [408, 502, 504];
+
+/**
+ * Timeout for the retry. Shorter than the first attempt so that a cluster which hangs
+ * rather than refusing outright still reports its failure promptly.
+ */
+const RETRY_TIMEOUT = 3 * 1000;
+
+/**
+ * Tests auth, retrying once when the request never reached the cluster. A timed-out or
+ * unreachable request says nothing about whether the cluster needs a token, and failing
+ * on the first one interrupts a session that is otherwise working.
+ */
+export async function testAuthWithRetry(clusterName: string) {
+  try {
+    return await testAuth(clusterName);
+  } catch (err) {
+    const status = (err as ApiError).status;
+    if (status === undefined || !TRANSIENT_STATUSES.includes(status)) {
+      throw err;
+    }
+
+    console.debug(`Retrying auth test for ${clusterName} after a transient failure:`, err);
+
+    return testAuth(clusterName, undefined, RETRY_TIMEOUT);
+  }
+}

--- a/frontend/src/lib/k8s/api/v1/clusterApi.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterApi.ts
@@ -32,12 +32,12 @@ import { JSON_HEADERS } from './constants';
  * Test authentication for the given cluster.
  * Will throw an error if the user is not authenticated.
  */
-export async function testAuth(cluster = '', namespace = 'default') {
+export async function testAuth(cluster = '', namespace = 'default', timeout = 5 * 1000) {
   const spec = { namespace };
   const clusterName = cluster || getCluster();
 
   return post('/apis/authorization.k8s.io/v1/selfsubjectrulesreviews', { spec }, false, {
-    timeout: 5 * 1000,
+    timeout,
     cluster: clusterName,
   });
 }

--- a/frontend/src/lib/k8s/api/v1/clusterRequests.failures.test.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterRequests.failures.test.ts
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ApiError } from '../v2/ApiError';
+import { clusterRequest } from './clusterRequests';
+
+vi.mock('../../../../helpers/addBackstageAuthHeaders', () => ({
+  addBackstageAuthHeaders: vi.fn((headers: Record<string, string>) => headers),
+}));
+
+vi.mock('../../../../helpers/getHeadlampAPIHeaders', () => ({
+  getHeadlampAPIHeaders: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../../stateless/findKubeconfigByClusterName', () => ({
+  findKubeconfigByClusterName: vi.fn(async () => null),
+}));
+
+function abortError() {
+  const err = new Error('The operation was aborted.');
+  err.name = 'AbortError';
+  return err;
+}
+
+describe('clusterRequest failure handling', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it('reports an aborted request as a timeout', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(abortError()))
+    );
+
+    const err: ApiError = await clusterRequest('/version').catch(e => e);
+
+    expect(err.status).toBe(408);
+    expect(err.message).toMatch(/timed-out/i);
+  });
+
+  it('reports an abort as a timeout even when it is not an Error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject({ name: 'AbortError', message: 'The operation was aborted.' }))
+    );
+
+    const err: ApiError = await clusterRequest('/version').catch(e => e);
+
+    expect(err.status).toBe(408);
+    expect(err.message).toMatch(/timed-out/i);
+  });
+
+  it('does not report a cancellation through the caller signal as a timeout', async () => {
+    const caller = new AbortController();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => {
+        caller.abort();
+        return Promise.reject(abortError());
+      })
+    );
+
+    const err: ApiError = await clusterRequest('/version', { signal: caller.signal }).catch(e => e);
+
+    expect(err.name).toBe('AbortError');
+    expect(err.status).toBeUndefined();
+  });
+
+  it('applies the timeout even when the caller supplies a signal', async () => {
+    const caller = new AbortController();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        (_url: string, init: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            init.signal?.addEventListener('abort', () => reject(abortError()));
+          })
+      )
+    );
+
+    const err: ApiError = await clusterRequest('/version', {
+      signal: caller.signal,
+      timeout: 5,
+    }).catch(e => e);
+
+    expect(err.status).toBe(408);
+    expect(err.message).toMatch(/timed-out/i);
+  });
+
+  it('keeps the original message when the network fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new TypeError('Failed to fetch')))
+    );
+
+    const err: ApiError = await clusterRequest('/version').catch(e => e);
+
+    expect(err.status).toBe(502);
+    expect(err.message).toContain('Failed to fetch');
+  });
+
+  // A request that never produced a response has no body to read, so the failure path
+  // must not try to parse one and report the parse error instead of the real cause.
+  it('does not log a body parse failure when there was no response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(abortError()))
+    );
+
+    await clusterRequest('/version').catch(() => {});
+
+    const loggedParseFailure = consoleError.mock.calls.some(call =>
+      String(call[0]).includes('Unable to parse error json')
+    );
+    expect(loggedParseFailure).toBe(false);
+  });
+
+  it('still reads the message from a real error response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ message: 'forbidden by RBAC' }), {
+            status: 403,
+            statusText: 'Forbidden',
+          })
+        )
+      )
+    );
+
+    const err: ApiError = await clusterRequest('/version').catch(e => e);
+
+    expect(err.status).toBe(403);
+    expect(err.message).toContain('forbidden by RBAC');
+  });
+
+  // The message is rendered in the auth chooser, so the url belongs in the log only.
+  it('keeps the url out of the message and in the log', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(abortError()))
+    );
+
+    const err: ApiError = await clusterRequest('/version').catch(e => e);
+
+    expect(err.message).not.toContain('http');
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringMatching(/timed-out/i),
+      'at url:',
+      expect.stringContaining('/version'),
+      expect.anything()
+    );
+  });
+
+  it('resolves the parsed body on success', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(new Response(JSON.stringify({ gitVersion: 'v1.31.0' }))))
+    );
+
+    await expect(clusterRequest('/version')).resolves.toEqual({ gitVersion: 'v1.31.0' });
+  });
+});

--- a/frontend/src/lib/k8s/api/v1/clusterRequests.test.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterRequests.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ApiError } from '../v2/ApiError';
+import { clusterRequest } from './clusterRequests';
+
+vi.mock('../../../../helpers/addBackstageAuthHeaders', () => ({
+  addBackstageAuthHeaders: vi.fn((headers: Record<string, string>) => headers),
+}));
+
+vi.mock('../../../../helpers/getHeadlampAPIHeaders', () => ({
+  getHeadlampAPIHeaders: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../../stateless/findKubeconfigByClusterName', () => ({
+  findKubeconfigByClusterName: vi.fn(async () => null),
+}));
+
+function abortError() {
+  const err = new Error('The operation was aborted.');
+  err.name = 'AbortError';
+  return err;
+}
+
+describe('clusterRequest failure handling', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it('reports an aborted request as a timeout', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(abortError()))
+    );
+
+    const err: ApiError = await clusterRequest('/version').catch(e => e);
+
+    expect(err.status).toBe(408);
+    expect(err.message).toMatch(/timed-out/i);
+  });
+
+  it('keeps the original message when the network fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new TypeError('Failed to fetch')))
+    );
+
+    const err: ApiError = await clusterRequest('/version').catch(e => e);
+
+    expect(err.status).toBe(502);
+    expect(err.message).toContain('Failed to fetch');
+  });
+
+  // A request that never produced a response has no body to read, so the failure path
+  // must not try to parse one and report the parse error instead of the real cause.
+  it('does not log a body parse failure when there was no response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(abortError()))
+    );
+
+    await clusterRequest('/version').catch(() => {});
+
+    const loggedParseFailure = consoleError.mock.calls.some(call =>
+      String(call[0]).includes('Unable to parse error json')
+    );
+    expect(loggedParseFailure).toBe(false);
+  });
+
+  it('still reads the message from a real error response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ message: 'forbidden by RBAC' }), {
+            status: 403,
+            statusText: 'Forbidden',
+          })
+        )
+      )
+    );
+
+    const err: ApiError = await clusterRequest('/version').catch(e => e);
+
+    expect(err.status).toBe(403);
+    expect(err.message).toContain('forbidden by RBAC');
+  });
+
+  // The message is rendered in the auth chooser, so the url belongs in the log only.
+  it('keeps the url out of the message and in the log', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(abortError()))
+    );
+
+    const err: ApiError = await clusterRequest('/version').catch(e => e);
+
+    expect(err.message).not.toContain('http');
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringMatching(/timed-out/i),
+      'at url:',
+      expect.stringContaining('/version'),
+      expect.anything()
+    );
+  });
+
+  it('resolves the parsed body on success', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(new Response(JSON.stringify({ gitVersion: 'v1.31.0' }))))
+    );
+
+    await expect(clusterRequest('/version')).resolves.toEqual({ gitVersion: 'v1.31.0' });
+  });
+});

--- a/frontend/src/lib/k8s/api/v1/clusterRequests.test.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterRequests.test.ts
@@ -60,6 +60,55 @@ describe('clusterRequest failure handling', () => {
     expect(err.message).toMatch(/timed-out/i);
   });
 
+  it('reports an abort as a timeout even when it is not an Error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject({ name: 'AbortError', message: 'The operation was aborted.' }))
+    );
+
+    const err: ApiError = await clusterRequest('/version').catch(e => e);
+
+    expect(err.status).toBe(408);
+    expect(err.message).toMatch(/timed-out/i);
+  });
+
+  it('does not report a cancellation through the caller signal as a timeout', async () => {
+    const caller = new AbortController();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => {
+        caller.abort();
+        return Promise.reject(abortError());
+      })
+    );
+
+    const err: ApiError = await clusterRequest('/version', { signal: caller.signal }).catch(e => e);
+
+    expect(err.name).toBe('AbortError');
+    expect(err.status).toBeUndefined();
+  });
+
+  it('applies the timeout even when the caller supplies a signal', async () => {
+    const caller = new AbortController();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        (_url: string, init: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            init.signal?.addEventListener('abort', () => reject(abortError()));
+          })
+      )
+    );
+
+    const err: ApiError = await clusterRequest('/version', {
+      signal: caller.signal,
+      timeout: 5,
+    }).catch(e => e);
+
+    expect(err.status).toBe(408);
+    expect(err.message).toMatch(/timed-out/i);
+  });
+
   it('keeps the original message when the network fails', async () => {
     vi.stubGlobal(
       'fetch',

--- a/frontend/src/lib/k8s/api/v1/clusterRequests.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterRequests.ts
@@ -168,17 +168,33 @@ export async function clusterRequest(
   if (isBackstage()) {
     requestData.headers = addBackstageAuthHeaders(requestData.headers);
   }
-  let response: Response = new Response(undefined, { status: 502, statusText: 'Unreachable' });
+  let response: Response | undefined;
+  let requestError: Error | undefined;
+
   try {
     response = await fetch(url, requestData);
   } catch (err) {
-    if (err instanceof Error) {
-      if (err.name === 'AbortError') {
-        response = new Response(undefined, { status: 408, statusText: 'Request timed-out' });
-      }
-    }
+    requestError = err instanceof Error ? err : new Error(String(err));
   } finally {
     clearTimeout(id);
+  }
+
+  // The request never reached the point of producing a response, so there is no body to
+  // read an error message from. Reject with what actually went wrong instead of standing
+  // in a placeholder Response, whose empty body would only fail to parse later on. The
+  // message reaches the UI, so the url stays in the log rather than in the message.
+  if (!response) {
+    const timedOut = requestError?.name === 'AbortError';
+    const message = timedOut
+      ? `Request timed-out after ${timeout}ms`
+      : `Network error: ${requestError?.message ?? 'unreachable'}`;
+
+    console.error(message, 'at url:', url, { err: requestError });
+
+    const error = new Error(message) as ApiError;
+    error.status = timedOut ? 408 : 502;
+
+    return Promise.reject(error);
   }
 
   // The backend signals through this header that it wants a reload.

--- a/frontend/src/lib/k8s/api/v1/clusterRequests.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterRequests.ts
@@ -111,6 +111,15 @@ export async function request(
 }
 
 /**
+ * Whether a rejected request was aborted, read off the thrown value rather than an Error.
+ */
+function isAbortError(err: unknown): boolean {
+  return (
+    typeof err === 'object' && err !== null && (err as { name?: unknown }).name === 'AbortError'
+  );
+}
+
+/**
  * Sends a request to the backend. If the cluster is required in the params parameter, it will
  * be used as a request to the respective Kubernetes server.
  *
@@ -164,29 +173,68 @@ export async function clusterRequest(
   }
 
   const controller = new AbortController();
-  const id = setTimeout(() => controller.abort(), timeout);
+  let timedOut = false;
+  const id = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeout);
+
+  // The caller's signal is chained onto the timeout's rather than replacing it, so both
+  // can cancel the request and the two remain distinguishable afterwards.
+  const callerSignal = otherParams.signal;
+  const abortFromCaller = () => controller.abort();
+  if (callerSignal?.aborted) {
+    controller.abort();
+  } else {
+    callerSignal?.addEventListener('abort', abortFromCaller, { once: true });
+  }
 
   let url = combinePath(getAppUrl(), fullPath);
   url += asQuery(queryParams);
   const requestData = {
-    signal: controller.signal,
     credentials: 'include' as RequestCredentials,
     ...opts,
+    signal: controller.signal,
   };
   if (isBackstage()) {
     requestData.headers = addBackstageAuthHeaders(requestData.headers);
   }
-  let response: Response = new Response(undefined, { status: 502, statusText: 'Unreachable' });
+  let response: Response | undefined;
+  let caughtError: unknown;
+  let requestError: Error | undefined;
+
   try {
     response = await fetch(url, requestData);
   } catch (err) {
-    if (err instanceof Error) {
-      if (err.name === 'AbortError') {
-        response = new Response(undefined, { status: 408, statusText: 'Request timed-out' });
-      }
-    }
+    caughtError = err;
+    requestError = err instanceof Error ? err : new Error(String(err));
   } finally {
     clearTimeout(id);
+    callerSignal?.removeEventListener('abort', abortFromCaller);
+  }
+
+  // The request never reached the point of producing a response, so there is no body to
+  // read an error message from. Reject with what actually went wrong instead of standing
+  // in a placeholder Response, whose empty body would only fail to parse later on. The
+  // message reaches the UI, so the url stays in the log rather than in the message.
+  if (!response) {
+    // A caller cancelling through its own signal asked for this, so it is reported as the
+    // abort it is rather than as a failure of the request.
+    if (isAbortError(caughtError) && !timedOut && callerSignal?.aborted) {
+      return Promise.reject(caughtError);
+    }
+
+    const aborted = timedOut || isAbortError(caughtError);
+    const message = aborted
+      ? `Request timed-out after ${timeout}ms`
+      : `Network error: ${requestError?.message ?? 'unreachable'}`;
+
+    console.error(message, 'at url:', url, { err: requestError });
+
+    const error = new Error(message) as ApiError;
+    error.status = aborted ? 408 : 502;
+
+    return Promise.reject(error);
   }
 
   // The backend signals through this header that it wants a reload.

--- a/frontend/src/lib/k8s/api/v1/clusterRequests.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterRequests.ts
@@ -110,6 +110,15 @@ export async function request(
 }
 
 /**
+ * Whether a rejected request was aborted, read off the thrown value rather than an Error.
+ */
+function isAbortError(err: unknown): boolean {
+  return (
+    typeof err === 'object' && err !== null && (err as { name?: unknown }).name === 'AbortError'
+  );
+}
+
+/**
  * Sends a request to the backend. If the cluster is required in the params parameter, it will
  * be used as a request to the respective Kubernetes server.
  *
@@ -156,27 +165,44 @@ export async function clusterRequest(
   }
 
   const controller = new AbortController();
-  const id = setTimeout(() => controller.abort(), timeout);
+  let timedOut = false;
+  const id = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeout);
+
+  // The caller's signal is chained onto the timeout's rather than replacing it, so both
+  // can cancel the request and the two remain distinguishable afterwards.
+  const callerSignal = otherParams.signal;
+  const abortFromCaller = () => controller.abort();
+  if (callerSignal?.aborted) {
+    controller.abort();
+  } else {
+    callerSignal?.addEventListener('abort', abortFromCaller, { once: true });
+  }
 
   let url = combinePath(getAppUrl(), fullPath);
   url += asQuery(queryParams);
   const requestData = {
-    signal: controller.signal,
     credentials: 'include' as RequestCredentials,
     ...opts,
+    signal: controller.signal,
   };
   if (isBackstage()) {
     requestData.headers = addBackstageAuthHeaders(requestData.headers);
   }
   let response: Response | undefined;
+  let caughtError: unknown;
   let requestError: Error | undefined;
 
   try {
     response = await fetch(url, requestData);
   } catch (err) {
+    caughtError = err;
     requestError = err instanceof Error ? err : new Error(String(err));
   } finally {
     clearTimeout(id);
+    callerSignal?.removeEventListener('abort', abortFromCaller);
   }
 
   // The request never reached the point of producing a response, so there is no body to
@@ -184,15 +210,21 @@ export async function clusterRequest(
   // in a placeholder Response, whose empty body would only fail to parse later on. The
   // message reaches the UI, so the url stays in the log rather than in the message.
   if (!response) {
-    const timedOut = requestError?.name === 'AbortError';
-    const message = timedOut
+    // A caller cancelling through its own signal asked for this, so it is reported as the
+    // abort it is rather than as a failure of the request.
+    if (isAbortError(caughtError) && !timedOut && callerSignal?.aborted) {
+      return Promise.reject(caughtError);
+    }
+
+    const aborted = timedOut || isAbortError(caughtError);
+    const message = aborted
       ? `Request timed-out after ${timeout}ms`
       : `Network error: ${requestError?.message ?? 'unreachable'}`;
 
     console.error(message, 'at url:', url, { err: requestError });
 
     const error = new Error(message) as ApiError;
-    error.status = timedOut ? 408 : 502;
+    error.status = aborted ? 408 : 502;
 
     return Promise.reject(error);
   }

--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -63,6 +63,11 @@ export interface Cluster {
    * Either 'oidc' or ''. '' means unknown.
    */
   auth_type: string;
+  /**
+   * Whether requests to this cluster are authenticated with the backend's own service
+   * account token, in which case a user-supplied token is never applied.
+   */
+  usesServiceAccountToken?: boolean;
   [propName: string]: any;
 }
 

--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -62,6 +62,11 @@ export interface Cluster {
    * Either 'oidc' or ''. '' means unknown.
    */
   auth_type: string;
+  /**
+   * Whether requests to this cluster are authenticated with the backend's own service
+   * account token, in which case a user-supplied token is never applied.
+   */
+  uses_service_account_token?: boolean;
   [propName: string]: any;
 }
 

--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -67,7 +67,7 @@ export interface Cluster {
    * Whether requests to this cluster are authenticated with the backend's own service
    * account token, in which case a user-supplied token is never applied.
    */
-  usesServiceAccountToken?: boolean;
+  uses_service_account_token?: boolean;
   [propName: string]: any;
 }
 


### PR DESCRIPTION
## Summary

Fixes intermittent auth failures where a cluster that responded correctly was reported as timed out, alongside a misleading `SyntaxError: Unexpected end of input`.

`clusterRequest()` seeded its result with a placeholder response and only replaced it on abort:

```js
let response = new Response(undefined, { status: 502, statusText: 'Unreachable' });
try {
  response = await fetch(url, requestData);
} catch (err) {
  if (err.name === 'AbortError') {
    response = new Response(undefined, { status: 408, statusText: 'Request timed-out' });
  }
}
```

Both placeholders carry an **empty body**, and the failure path that follows reads that body to recover an error message — so every timed-out request ended in `Unexpected end of input`, logged against the request url as though the server had truncated its response. That reconciles the reporter's evidence: the ingress logs (`201`, 3992 bytes, 10–27ms) were correct, the response simply never reached the JS layer, and the code then parsed its own placeholder.

Two further defects in the same path:

- **Non-abort failures were discarded.** A `TypeError: Failed to fetch`, connection reset or TLS error left the placeholder 502 in place, so the real error was never logged or surfaced — which is what made this class undiagnosable.
- **A transient failure left the auth chooser demanding a token**, and the debug line claimed a token was required even on the branch that reports a connection error instead.

## Related Issue

Fixes #6804

## Changes

- **`clusterRequests.ts`** — track the failure instead of standing in a response for it, and reject with what actually happened. Same 408/502 status codes, so downstream consumers are unchanged. The url goes to the log, not the message, which is rendered in the auth chooser.
- **`authchooser/testAuthWithRetry.ts`** (new) — retry once on `408`/`502`/`504`. A check that never reached the cluster says nothing about whether a token is needed, so failing on the first attempt interrupts a working session. The retry uses a shorter timeout (3s vs 5s) so a hanging cluster still reports promptly.
- **`authchooser/index.tsx`** — the debug line now only claims a token is required on the branch that requires one.
- **`usesServiceAccountToken` per cluster** (`backend/cmd/cluster.go`, `headlamp.go`) — under `--unsafe-use-service-account-token` no user token is ever applied, so the chooser must not fall back to asking for one. Taken from the same helper the proxy uses to drop user credentials, so the two cannot disagree. Per cluster, since it is a property of the context.
- **Extracted `clusterMetadata()`** from `getClusters` to stay within the `funlen` limit.
- **Tests:** `clusterRequests.test.ts` (6), `testAuthWithRetry.test.ts` (9), `TestGetClustersUsesServiceAccountToken` (both directions).

## Steps to Test

1. `cd frontend && npx vitest run src/lib/k8s/api/v1/clusterRequests.test.ts src/components/authchooser/`
2. Confirm they are genuine regression tests — on `main` these fail:
   ```
   × keeps the original message when the network fails
     → expected 'Unreachable' to contain 'Failed to fetch'
   × does not log a body parse failure when there was no response
     → expected true to be false
   ```
3. `cd backend && go test ./cmd/ -run TestGetClustersUsesServiceAccountToken -v`
4. Against a live cluster, throttle or suspend the tab so the 5s abort fires during an auth check. Before: `Unable to parse error json … SyntaxError`. After: `Request timed-out after 5000ms at url: …`, and the check retries and recovers.
5. With `--unsafe-use-service-account-token`, confirm a failed auth check no longer routes to the token page.

## Notes for the Reviewer

- **The `frontend:` prefix undersells the commit** — it also touches `backend/cmd/` for the `usesServiceAccountToken` field. Happy to split that into its own `backend: cluster: …` commit.

- **The root trigger is not proven.** I believe the hardcoded 5s abort fires during background-tab timer throttling or an event-loop stall, which fits "intermittent, after the app has been open a while" — but it is not reliably reproducible and I could not demonstrate it. The retry recovers regardless of cause, which is why I chose it over simply raising the timeout.

- **Worth your judgement:** a genuinely unreachable cluster now takes up to 8s to report instead of 5s. I kept the retry budget shorter than the first attempt to bound it; retrying only on `408` is a one-line change if you disagree.

- **For the reporter:** a **Try Again** button already exists in that error state (wired to `runTestAuthAgain`), so "a full page reload is required" may not be accurate. If it genuinely was not visible, that is a separate bug.

- **Verification:** backend builds clean, `golangci-lint` 0 issues; frontend `tsc`, `ci-lint` (`--max-warnings 0`) and prettier clean; 2408 tests pass. Two pre-existing failures confirmed on a clean tree and unrelated: `pkg/spa`'s `TestURLToRelAcceptsSafeRelativePath` (Windows path separators) and some `ColorPicker`/`icons` tests that only time out under machine load.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved cluster authentication with service-account token awareness.
  * Added automatic retries for temporary connection failures.
  * Added clearer timeout and unreachable-cluster error reporting.

* **Bug Fixes**
  * Authentication failures are now distinguished more accurately from transient connection issues.
  * Improved cancellation and timeout handling for cluster requests.

* **Tests**
  * Added coverage for authentication retries, request failures, timeout handling, and token behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->