### PR TITLE
fix: parse milli-quantities in parseUnitsOfBytes

### DIFF
--- a/frontend/src/lib/units.test.ts
+++ b/frontend/src/lib/units.test.ts
@@ -53,6 +53,12 @@ describe('parseRam', () => {
     expect(parseRam('0.5G')).toBe(500000000);
   });
 
+  it('should parse milli quantities (e.g. from prometheus-adapter)', () => {
+    expect(parseRam('1000m')).toBe(1);
+    expect(parseRam('2687146666666m')).toBeCloseTo(2687146666.666, 1);
+    expect(parseRam('1.5m')).toBe(0.0015);
+  });
+
   it('should scale binary units by powers of 1024', () => {
     fc.assert(
       fc.property(fc.integer({ min: 1, max: 100 }), num => {

--- a/frontend/src/lib/units.ts
+++ b/frontend/src/lib/units.ts
@@ -38,6 +38,13 @@ export function parseRam(value: string) {
 function parseUnitsOfBytes(value: string): number {
   if (!value) return 0;
 
+  // Milli-quantity ex. "2687146666666m". Valid Kubernetes quantity syntax
+  // (e.g. emitted by prometheus-adapter for memory usage), but no unit is
+  // matched by the regex below, which would misread it as raw bytes.
+  if (value.endsWith('m')) {
+    return parseFloat(value) / 1000;
+  }
+
   const groups = value.match(/(\d+(?:\.\d+)?)([BKMGTPEe])?(i)?(\d+)?/) || [];
   const number = parseFloat(groups[1]);
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where memory usage percentages are displayed approximately **1000× larger than expected** when the Metrics API returns memory quantities in **milli-units** (for example, `2687146666666m`).

This occurs with **prometheus-adapter**, which commonly serves the `metrics.k8s.io` API in Prometheus-backed Kubernetes clusters that do not use `metrics-server`.

## Related Issue

Fixes #6816

## Changes

- Added support for the Kubernetes **`m` (milli)** suffix in `parseUnitsOfBytes()` (`frontend/src/lib/units.ts`).
- Parsed milli-byte values as `parseFloat(value) / 1000`, matching the existing handling in `parseCpu()`.
- Added unit tests covering milli-byte quantities, including:
  - `1000m` → `1`
  - `2687146666666m` → `2687146666.666`
  - `1.5m` → `0.0015`

## Steps to Test

1. Set up a cluster where the Metrics API is provided by **prometheus-adapter** (with `resourceRules` enabled) instead of `metrics-server`.
2. Open **Cluster Overview**.
   - Verify memory usage displays approximately **32.8%** (about **2.5 GiB / 7.63 GiB**) instead of **32800%**.
3. Open **Workloads → Pods**.
   - Verify the CPU/Memory columns and the **"Request: X%"** tooltips display correct values.
4. Observe the UI for a few metrics refresh cycles.
   - Memory usage should remain stable even when the metrics provider alternates between `Ki` and `m` quantity formats.

## Screenshots

**Before**
Images are present in issue 
**After**
<img width="184" height="102" alt="image" src="https://github.com/user-attachments/assets/4315d895-e334-41ac-9a62-49464f36bf16" />

## Notes for Reviewers

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory quantity parsing for Kubernetes milli-unit values.
  * Correctly handles whole, large, and fractional milli-quantities by converting them to base units.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->