### PR TITLE
frontend: backstageMessageReceiver: Validate message payloads

### DIFF
--- a/frontend/src/helpers/backstageMessageReceiver.test.ts
+++ b/frontend/src/helpers/backstageMessageReceiver.test.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import jsyaml from 'js-yaml';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as statelessFunctions from '../stateless';
+import { getBackstageToken, setupBackstageMessageReceiver } from './backstageMessageReceiver';
+import { encodeBase64 } from './base64';
+
+vi.mock('./isBackstage', () => ({
+  isBackstage: () => true,
+}));
+
+function dispatchMessage(data: unknown) {
+  window.dispatchEvent(
+    new MessageEvent('message', { data, origin: 'https://backstage.example.com' })
+  );
+}
+
+describe('setupBackstageMessageReceiver', () => {
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(window.parent, 'postMessage').mockImplementation(() => {});
+    cleanup = setupBackstageMessageReceiver();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('accepts a valid BACKSTAGE_AUTH_TOKEN message', async () => {
+    dispatchMessage({ type: 'BACKSTAGE_AUTH_TOKEN', payload: { token: 'trusted-token' } });
+    await vi.runAllTimersAsync();
+
+    expect(getBackstageToken()).toBe('trusted-token');
+    expect(window.parent.postMessage).toHaveBeenCalledWith(
+      { type: 'BACKSTAGE_AUTH_TOKEN_ACK' },
+      '*'
+    );
+  });
+
+  it('accepts a valid BACKSTAGE_KUBECONFIG message', async () => {
+    const findAndReplaceKubeconfig = vi
+      .spyOn(statelessFunctions, 'findAndReplaceKubeconfig')
+      .mockResolvedValue(undefined as any);
+
+    const kubeconfig = {
+      apiVersion: 'v1',
+      kind: 'Config',
+      'current-context': 'test-context',
+      contexts: [{ name: 'test-context', context: { cluster: 'test-cluster', user: 'test-user' } }],
+      clusters: [{ name: 'test-cluster', cluster: {} }],
+      users: [{ name: 'test-user', user: {} }],
+    };
+    const kubeconfigBase64 = encodeBase64(jsyaml.dump(kubeconfig));
+
+    dispatchMessage({ type: 'BACKSTAGE_KUBECONFIG', payload: { kubeconfig: kubeconfigBase64 } });
+    await vi.runAllTimersAsync();
+
+    expect(findAndReplaceKubeconfig).toHaveBeenCalledWith('test-context', expect.any(String), true);
+    expect(window.parent.postMessage).toHaveBeenCalledWith(
+      { type: 'BACKSTAGE_KUBECONFIG_ACK' },
+      '*'
+    );
+  });
+
+  it('ignores a null event.data', async () => {
+    dispatchMessage(null);
+    await vi.runAllTimersAsync();
+
+    expect(getBackstageToken()).toBeNull();
+    expect(window.parent.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('ignores a primitive event.data', async () => {
+    dispatchMessage('not-an-object');
+    await vi.runAllTimersAsync();
+
+    expect(getBackstageToken()).toBeNull();
+    expect(window.parent.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('ignores a message with a null payload', async () => {
+    dispatchMessage({ type: 'BACKSTAGE_AUTH_TOKEN', payload: null });
+    await vi.runAllTimersAsync();
+
+    expect(getBackstageToken()).toBeNull();
+    expect(window.parent.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('ignores a message with a primitive payload', async () => {
+    dispatchMessage({ type: 'BACKSTAGE_AUTH_TOKEN', payload: 'trusted-token' });
+    await vi.runAllTimersAsync();
+
+    expect(getBackstageToken()).toBeNull();
+    expect(window.parent.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('ignores a message with an unknown type', async () => {
+    dispatchMessage({ type: 'BACKSTAGE_UNKNOWN_TYPE', payload: { token: 'trusted-token' } });
+    await vi.runAllTimersAsync();
+
+    expect(getBackstageToken()).toBeNull();
+    expect(window.parent.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('ignores a BACKSTAGE_AUTH_TOKEN message with no token', async () => {
+    dispatchMessage({ type: 'BACKSTAGE_AUTH_TOKEN', payload: {} });
+    await vi.runAllTimersAsync();
+
+    expect(getBackstageToken()).toBeNull();
+    expect(window.parent.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('ignores a BACKSTAGE_AUTH_TOKEN message with a non-string token', async () => {
+    dispatchMessage({ type: 'BACKSTAGE_AUTH_TOKEN', payload: { token: 12345 } });
+    await vi.runAllTimersAsync();
+
+    expect(getBackstageToken()).toBeNull();
+    expect(window.parent.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('ignores a BACKSTAGE_KUBECONFIG message with a non-string kubeconfig', async () => {
+    const findAndReplaceKubeconfig = vi
+      .spyOn(statelessFunctions, 'findAndReplaceKubeconfig')
+      .mockResolvedValue(undefined as any);
+
+    dispatchMessage({ type: 'BACKSTAGE_KUBECONFIG', payload: { kubeconfig: 12345 } });
+    await vi.runAllTimersAsync();
+
+    expect(findAndReplaceKubeconfig).not.toHaveBeenCalled();
+    expect(window.parent.postMessage).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/helpers/backstageMessageReceiver.ts
+++ b/frontend/src/helpers/backstageMessageReceiver.ts
@@ -110,6 +110,49 @@ interface BackstageMessage {
 
 const BACKSTAGE_ACK_TIMEOUT_MS = 1000;
 
+const BACKSTAGE_MESSAGE_TYPES: Array<BackstageMessage['type']> = [
+  'BACKSTAGE_AUTH_TOKEN',
+  'BACKSTAGE_KUBECONFIG',
+];
+
+/**
+ * isBackstageMessage is a runtime type guard for BackstageMessage.
+ *
+ * event.data comes from outside the application, so its shape cannot be
+ * relied upon to match the BackstageMessage type just because it is cast to
+ * it. This checks the shape at runtime before the message is processed,
+ * rejecting anything that doesn't match rather than letting mistyped fields
+ * (e.g. a non-string token) flow into token/kubeconfig storage.
+ *
+ * @param data - the raw `event.data` from a postMessage event
+ * @returns true if data is a well-formed BackstageMessage
+ */
+function isBackstageMessage(data: unknown): data is BackstageMessage {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+
+  const { type, payload } = data as Record<string, unknown>;
+
+  if (!BACKSTAGE_MESSAGE_TYPES.includes(type as BackstageMessage['type'])) {
+    return false;
+  }
+
+  if (payload === undefined) {
+    return true;
+  }
+
+  if (typeof payload !== 'object' || payload === null) {
+    return false;
+  }
+
+  const { token, kubeconfig } = payload as Record<string, unknown>;
+  return (
+    (token === undefined || typeof token === 'string') &&
+    (kubeconfig === undefined || typeof kubeconfig === 'string')
+  );
+}
+
 /**
  * Sets up a listener for messages from the Backstage app.
  * Handles Backstage auth token messages by storing the Backstage token,
@@ -120,8 +163,12 @@ const BACKSTAGE_ACK_TIMEOUT_MS = 1000;
 export function setupBackstageMessageReceiver(): () => void {
   if (isBackstage()) {
     const handleMessage = async (event: MessageEvent) => {
+      if (!isBackstageMessage(event.data)) {
+        return;
+      }
+
       try {
-        const { type, payload } = event.data as BackstageMessage;
+        const { type, payload } = event.data;
         if (type === 'BACKSTAGE_AUTH_TOKEN') {
           const { token } = payload || {};
           if (token) {


### PR DESCRIPTION
## Summary

The Backstage message receiver currently relies on a compile-time type
assertion (`as BackstageMessage`) when processing incoming `window.postMessage`
events. Because the message shape is not verified at runtime, malformed payloads
with incorrect field types (for example, a numeric `token`) can still be
processed and implicitly coerced before being stored.

This PR introduces lightweight runtime type guards to validate incoming
Backstage messages before processing them, ensuring that only well-formed
messages update application state while preserving existing behavior for valid
messages.

## Related Issue

Fixes #6757

## Changes

- Added runtime validation for incoming Backstage messages.
- Validated supported message types.
- Validated payload structure and expected field types.
- Ignored malformed messages before any state updates.
- Added unit tests covering valid and invalid payload scenarios.

## Steps to Test

1. Run `npm run frontend:test`.
2. Send a valid `BACKSTAGE_AUTH_TOKEN` message and verify existing behavior.
3. Send malformed messages, including:
   - non-object `event.data`
   - non-object `payload`
   - unknown message types
   - non-string `token`
   - non-string `kubeconfig`
4. Verify malformed messages are ignored and no application state is updated.

## Notes for the Reviewer

- Introduces lightweight runtime type guards only.
- Adds no new dependencies.
- Preserves existing behavior for valid Backstage messages.
- Enforces the runtime contract instead of relying solely on the compile-time
  `BackstageMessage` type assertion.