### PR TITLE
plugins: fix race condition while copying plugin

### DIFF
--- a/backend/pkg/plugins/plugins.go
+++ b/backend/pkg/plugins/plugins.go
@@ -492,6 +492,11 @@ func HandlePluginEvents(staticPluginDir, userPluginDir, pluginDir string,
 			continue
 		}
 
+		sep := strings.LastIndexByte(event, ':')
+		if filepath.Base(event[:sep]) != "package.json" {
+			continue
+		}
+
 		// Set the refresh signal only if we cannot send it. We prevent it here
 		// because we only want to send refresh signals that *happen after* we are
 		// allowed to send them.

--- a/backend/pkg/plugins/plugins.go
+++ b/backend/pkg/plugins/plugins.go
@@ -493,6 +493,10 @@ func HandlePluginEvents(staticPluginDir, userPluginDir, pluginDir string,
 		}
 
 		sep := strings.LastIndexByte(event, ':')
+		if sep == -1 {
+			continue
+		}
+
 		if filepath.Base(event[:sep]) != "package.json" {
 			continue
 		}

--- a/backend/pkg/plugins/plugins_test.go
+++ b/backend/pkg/plugins/plugins_test.go
@@ -482,17 +482,23 @@ func TestHandlePluginEventsIgnoresIntermediateCopyEvents(t *testing.T) {
 
 	mainJSPath := filepath.Join(pluginDir, "main.js")
 	packageJSONPath := filepath.Join(pluginDir, "package.json")
+
 	require.NoError(t, os.WriteFile(mainJSPath, nil, 0o600))
 
 	events := make(chan string)
 	pluginCache := cache.New[interface{}]()
+
 	go plugins.HandlePluginEvents("", "", tempDir, events, pluginCache)
 
+	events <- "test"
+
 	events <- mainJSPath + ":CREATE"
+
 	_, err := pluginCache.Get(context.Background(), plugins.PluginListKey)
 	require.EqualError(t, err, cache.ErrNotFound.Error())
 
 	require.NoError(t, os.WriteFile(packageJSONPath, nil, 0o600))
+
 	events <- packageJSONPath + ":CREATE"
 
 	require.Eventually(t, func() bool {

--- a/backend/pkg/plugins/plugins_test.go
+++ b/backend/pkg/plugins/plugins_test.go
@@ -411,8 +411,7 @@ func TestHandlePluginEvents(t *testing.T) { //nolint:funlen
 	require.EqualError(t, err, cache.ErrNotFound.Error())
 	require.Nil(t, pluginRefresh)
 
-	// send event
-	events <- "test"
+	events <- packageJSONPath + ":CREATE"
 
 	// wait for the plugin list and refresh keys to be set
 	for {
@@ -442,8 +441,7 @@ func TestHandlePluginEvents(t *testing.T) { //nolint:funlen
 
 	go plugins.HandlePluginEvents("", "", testDirPath, events, ch)
 
-	// send event
-	events <- "test"
+	events <- packageJSONPath + ":WRITE"
 
 	// wait for the plugin list and refresh keys to be set
 	for {
@@ -475,6 +473,32 @@ func TestHandlePluginEvents(t *testing.T) { //nolint:funlen
 	// clean up
 	err = os.RemoveAll(testDirPath)
 	require.NoError(t, err)
+}
+
+func TestHandlePluginEventsIgnoresIntermediateCopyEvents(t *testing.T) {
+	tempDir := t.TempDir()
+	pluginDir := filepath.Join(tempDir, "plugin")
+	require.NoError(t, os.Mkdir(pluginDir, 0o750))
+
+	mainJSPath := filepath.Join(pluginDir, "main.js")
+	packageJSONPath := filepath.Join(pluginDir, "package.json")
+	require.NoError(t, os.WriteFile(mainJSPath, nil, 0o600))
+
+	events := make(chan string)
+	pluginCache := cache.New[interface{}]()
+	go plugins.HandlePluginEvents("", "", tempDir, events, pluginCache)
+
+	events <- mainJSPath + ":CREATE"
+	_, err := pluginCache.Get(context.Background(), plugins.PluginListKey)
+	require.EqualError(t, err, cache.ErrNotFound.Error())
+
+	require.NoError(t, os.WriteFile(packageJSONPath, nil, 0o600))
+	events <- packageJSONPath + ":CREATE"
+
+	require.Eventually(t, func() bool {
+		_, err := pluginCache.Get(context.Background(), plugins.PluginListKey)
+		return err == nil
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestHandlePluginReload(t *testing.T) {

--- a/plugins/headlamp-plugin/bin/headlamp-plugin.js
+++ b/plugins/headlamp-plugin/bin/headlamp-plugin.js
@@ -34,7 +34,6 @@ const { table } = require('table');
 const tar = require('tar');
 
 // ES imports
-const viteCopyPluginPromise = import('vite-plugin-static-copy');
 const viteConfigPromise = import('../config/vite.config.mjs');
 const vitePromise = import('vite');
 
@@ -537,46 +536,27 @@ async function start() {
     const paths = envPaths('Headlamp', { suffix: '' });
     const configDir = fs.existsSync(paths.data) ? paths.data : paths.config;
 
-    const { viteStaticCopy } = await viteCopyPluginPromise;
-
-    viteConfig.plugins.push(
-      viteStaticCopy({
-        targets: [
-          {
-            src: './dist/*',
-            dest: path.join(configDir, 'plugins', packageName),
-          },
-          {
-            src: './package.json',
-            dest: path.join(configDir, 'plugins', packageName),
-          },
-        ],
-      })
-    );
-
     viteConfig.plugins.push({
-      name: 'headlamp-log-files-copied-to-plugin-folder',
-      buildEnd: async () => {
+      name: 'headlamp-copy-plugin-files-via-temp',
+      writeBundle: () => {
         const destDir = path.join(configDir, 'plugins', packageName);
-        if (!fs.existsSync(destDir)) {
-          console.log(`No files copied to "${destDir}" (directory does not exist).`);
-          return;
-        }
-        try {
-          const files = fs.readdirSync(destDir);
-          if (files.length === 0) {
-            console.log(`No files found in "${destDir}".`);
-            return;
+        const distDir = path.resolve('dist');
+        const packageJsonPath = path.resolve('package.json');
+        const destPackageJsonPath = path.join(destDir, 'package.json');
+
+        fs.ensureDirSync(destDir);
+        fs.cpSync(distDir, destDir, { recursive: true, force: true });
+        fs.copyFileSync(packageJsonPath, destPackageJsonPath);
+
+        const files = fs.readdirSync(destDir);
+        files.forEach(file => {
+          const destPath = path.join(destDir, file);
+          let srcPath = path.join(distDir, file);
+          if (file === 'package.json') {
+            srcPath = packageJsonPath;
           }
-          files.forEach(file => {
-            const destPath = path.join(destDir, file);
-            const srcPath =
-              file === 'package.json' ? path.resolve('package.json') : path.resolve('dist', file);
-            console.log(`Copied "${srcPath}" -> "${destPath}"`);
-          });
-        } catch (err) {
-          console.error('Error logging copied files:', err);
-        }
+          console.log(`Copied "${srcPath}" -> "${destPath}"`);
+        });
       },
     });
   }
@@ -645,7 +625,6 @@ async function start() {
     });
   }
 
-  // Then add the plugins from copyToPluginsFolder which includes ViteStaticCopy
   await copyToPluginsFolder(config);
 
   try {

--- a/plugins/headlamp-plugin/bin/headlamp-plugin.js
+++ b/plugins/headlamp-plugin/bin/headlamp-plugin.js
@@ -37,7 +37,6 @@ const tar = require('tar');
 const binExt = process.platform === 'win32' ? '.cmd' : '';
 
 // ES imports
-const viteCopyPluginPromise = import('vite-plugin-static-copy');
 const viteConfigPromise = import('../config/vite.config.mjs');
 const vitePromise = import('vite');
 
@@ -510,46 +509,27 @@ async function start() {
     const paths = envPaths('Headlamp', { suffix: '' });
     const configDir = fs.existsSync(paths.data) ? paths.data : paths.config;
 
-    const { viteStaticCopy } = await viteCopyPluginPromise;
-
-    viteConfig.plugins.push(
-      viteStaticCopy({
-        targets: [
-          {
-            src: './dist/*',
-            dest: path.join(configDir, 'plugins', packageName),
-          },
-          {
-            src: './package.json',
-            dest: path.join(configDir, 'plugins', packageName),
-          },
-        ],
-      })
-    );
-
     viteConfig.plugins.push({
-      name: 'headlamp-log-files-copied-to-plugin-folder',
-      buildEnd: async () => {
+      name: 'headlamp-copy-plugin-files-via-temp',
+      writeBundle: () => {
         const destDir = path.join(configDir, 'plugins', packageName);
-        if (!fs.existsSync(destDir)) {
-          console.log(`No files copied to "${destDir}" (directory does not exist).`);
-          return;
-        }
-        try {
-          const files = fs.readdirSync(destDir);
-          if (files.length === 0) {
-            console.log(`No files found in "${destDir}".`);
-            return;
+        const distDir = path.resolve('dist');
+        const packageJsonPath = path.resolve('package.json');
+        const destPackageJsonPath = path.join(destDir, 'package.json');
+
+        fs.ensureDirSync(destDir);
+        fs.cpSync(distDir, destDir, { recursive: true, force: true });
+        fs.copyFileSync(packageJsonPath, destPackageJsonPath);
+
+        const files = fs.readdirSync(destDir);
+        files.forEach(file => {
+          const destPath = path.join(destDir, file);
+          let srcPath = path.join(distDir, file);
+          if (file === 'package.json') {
+            srcPath = packageJsonPath;
           }
-          files.forEach(file => {
-            const destPath = path.join(destDir, file);
-            const srcPath =
-              file === 'package.json' ? path.resolve('package.json') : path.resolve('dist', file);
-            console.log(`Copied "${srcPath}" -> "${destPath}"`);
-          });
-        } catch (err) {
-          console.error('Error logging copied files:', err);
-        }
+          console.log(`Copied "${srcPath}" -> "${destPath}"`);
+        });
       },
     });
   }
@@ -618,7 +598,6 @@ async function start() {
     });
   }
 
-  // Then add the plugins from copyToPluginsFolder which includes ViteStaticCopy
   await copyToPluginsFolder(config);
 
   try {

--- a/plugins/pluginctl/src/plugin-management.js
+++ b/plugins/pluginctl/src/plugin-management.js
@@ -49,7 +49,22 @@ const envPaths = require('env-paths');
  */
 function moveDirs(currentPath, newPath) {
   try {
-    fs.cpSync(currentPath, newPath, { recursive: true, force: true });
+    fs.mkdirSync(newPath, { recursive: true });
+
+    const entries = fs.readdirSync(currentPath, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === 'package.json') {
+        continue;
+      }
+
+      const srcPath = path.join(currentPath, entry.name);
+      const destPath = path.join(newPath, entry.name);
+      fs.cpSync(srcPath, destPath, { recursive: true, force: true });
+    }
+
+    const packageJsonPath = path.join(currentPath, 'package.json');
+    const destPackageJsonPath = path.join(newPath, 'package.json');
+    fs.copyFileSync(packageJsonPath, destPackageJsonPath);
     fs.rmSync(currentPath, { recursive: true });
     console.log(`Moved directory from ${currentPath} to ${newPath}`);
   } catch (err) {
@@ -157,12 +172,6 @@ class PluginManager {
       if (!fs.existsSync(destinationFolder)) {
         fs.mkdirSync(destinationFolder, { recursive: true });
       }
-
-      // remove the existing plugin folder
-      fs.rmSync(pluginDir, { recursive: true, force: true });
-
-      // create the plugin folder
-      fs.mkdirSync(pluginDir, { recursive: true });
 
       // move the plugin to the destination folder
       moveDirs(tempFolder, pluginDir);

--- a/plugins/pluginctl/src/plugin-management.js
+++ b/plugins/pluginctl/src/plugin-management.js
@@ -51,6 +51,12 @@ function moveDirs(currentPath, newPath) {
   try {
     fs.mkdirSync(newPath, { recursive: true });
 
+    for (const entry of fs.readdirSync(newPath, { withFileTypes: true })) {
+      if (entry.name !== 'package.json') {
+        fs.rmSync(path.join(newPath, entry.name), { recursive: true, force: true });
+      }
+    }
+
     const entries = fs.readdirSync(currentPath, { withFileTypes: true });
     for (const entry of entries) {
       if (entry.name === 'package.json') {


### PR DESCRIPTION
## Summary

This PR fixes race condition by refreshing list only after the whole plugin has been copied instead of watching for each file.
The package,json is copied at the last.

## Related Issue

Fixes #1772

## Changes

- Pignore intermediate file changes
- copy the package.json at the last
- after package.json only then refresh the list

## Steps to Test

1. go test -race -run '^TestHandlePluginEvents' ./pkg/plugins

## Notes for the Reviewer
This a kind of an workaround fix. Please suggest a better method if you can think of any. A atomic move could also be implemented as point out here https://github.com/kubernetes-sigs/headlamp/issues/1772#issuecomment-1999849022 But the question is it required here? 