### PR TITLE
backend: Fix CSWSH vulnerability in Multiplexer

### DIFF
--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -207,17 +207,24 @@ func (conn *WSConnLock) Close() error {
 }
 
 // NewMultiplexer creates a new Multiplexer instance.
-func NewMultiplexer(kubeConfigStore kubeconfig.ContextStore, unsafeUseServiceAccountToken bool) *Multiplexer {
+func NewMultiplexer(
+	kubeConfigStore kubeconfig.ContextStore,
+	unsafeUseServiceAccountToken bool,
+	devMode bool,
+) *Multiplexer {
+	upgrader := websocket.Upgrader{}
+	if devMode {
+		upgrader.CheckOrigin = func(r *http.Request) bool {
+			return true
+		}
+	}
+
 	return &Multiplexer{
 		connections:                  make(map[string]*Connection),
 		kubeConfigStore:              kubeConfigStore,
 		unsafeUseServiceAccountToken: unsafeUseServiceAccountToken,
 		saTokenCache:                 make(map[string]saTokenCacheEntry),
-		upgrader: websocket.Upgrader{
-			CheckOrigin: func(r *http.Request) bool {
-				return true
-			},
-		},
+		upgrader:                     upgrader,
 	}
 }
 

--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -207,18 +207,72 @@ func (conn *WSConnLock) Close() error {
 }
 
 // NewMultiplexer creates a new Multiplexer instance.
-func NewMultiplexer(kubeConfigStore kubeconfig.ContextStore, unsafeUseServiceAccountToken bool) *Multiplexer {
+func NewMultiplexer(
+	kubeConfigStore kubeconfig.ContextStore,
+	unsafeUseServiceAccountToken bool,
+	devMode bool,
+) *Multiplexer {
+	upgrader := websocket.Upgrader{
+		CheckOrigin: makeCheckOrigin(devMode),
+	}
+
 	return &Multiplexer{
 		connections:                  make(map[string]*Connection),
 		kubeConfigStore:              kubeConfigStore,
 		unsafeUseServiceAccountToken: unsafeUseServiceAccountToken,
 		saTokenCache:                 make(map[string]saTokenCacheEntry),
-		upgrader: websocket.Upgrader{
-			CheckOrigin: func(r *http.Request) bool {
-				return true
-			},
-		},
+		upgrader:                     upgrader,
 	}
+}
+
+// makeCheckOrigin returns a CheckOrigin function for the WebSocket upgrader.
+//
+// Three-tier origin policy:
+//  1. devMode=true           → allow all origins (developer convenience).
+//  2. HEADLAMP_BACKEND_TOKEN set AND origin is a hostless file:// → allow (Electron desktop app).
+//     Electron loads the UI from file:// so Gorilla's same-origin check would compare
+//     "file:///…" against "localhost:<port>" and return 403. We gate this bypass on the
+//     presence of the backend token (injected by Electron before spawning the process)
+//     so that a vanilla web deployment without the token cannot exploit this path.
+//     The host must be empty (i.e. "file:///…" not "file://remote-host/…") to prevent
+//     remote/UNC file origins from widening the carve-out.
+//  3. Otherwise             → strict same-origin (web deployment default).
+func makeCheckOrigin(devMode bool) func(r *http.Request) bool {
+	return func(r *http.Request) bool {
+		if devMode {
+			return true
+		}
+
+		// Allow Electron desktop origins (file://) when the backend token is present,
+		// which indicates the process was launched by the desktop app.
+		origin := r.Header.Get("Origin")
+		if origin != "" && os.Getenv("HEADLAMP_BACKEND_TOKEN") != "" {
+			parsed, err := url.Parse(origin)
+			if err == nil && parsed.Scheme == "file" && parsed.Host == "" {
+				return true
+			}
+		}
+
+		// Default: enforce same-origin for web deployments.
+		return defaultCheckOrigin(r)
+	}
+}
+
+// defaultCheckOrigin replicates Gorilla's built-in same-origin check so we can
+// fall through to it after the desktop-origin bypass above.
+func defaultCheckOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+
+	parsed, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+
+	// Compare origin host to the request host (same as gorilla/websocket default).
+	return strings.EqualFold(parsed.Host, r.Host)
 }
 
 // readServiceAccountToken reads the service account token from path, caching the value

--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -212,11 +212,8 @@ func NewMultiplexer(
 	unsafeUseServiceAccountToken bool,
 	devMode bool,
 ) *Multiplexer {
-	upgrader := websocket.Upgrader{}
-	if devMode {
-		upgrader.CheckOrigin = func(r *http.Request) bool {
-			return true
-		}
+	upgrader := websocket.Upgrader{
+		CheckOrigin: makeCheckOrigin(devMode),
 	}
 
 	return &Multiplexer{
@@ -226,6 +223,64 @@ func NewMultiplexer(
 		saTokenCache:                 make(map[string]saTokenCacheEntry),
 		upgrader:                     upgrader,
 	}
+}
+
+// makeCheckOrigin returns a CheckOrigin function for the WebSocket upgrader.
+//
+// Three-tier origin policy:
+//  1. devMode=true           → allow all origins (developer convenience).
+//  2. HEADLAMP_BACKEND_TOKEN set AND origin is file:// → allow (Electron desktop app).
+//     Electron loads the UI from file:// so Gorilla's same-origin check would compare
+//     "file:///…" against "localhost:<port>" and return 403. We gate this bypass on the
+//     presence of the backend token (injected by Electron before spawning the process)
+//     so that a vanilla web deployment without the token cannot exploit this path.
+//  3. Otherwise             → strict same-origin (web deployment default).
+func makeCheckOrigin(devMode bool) func(r *http.Request) bool {
+	return func(r *http.Request) bool {
+		if devMode {
+			return true
+		}
+
+		// Allow Electron desktop origins (file://) when the backend token is present,
+		// which indicates the process was launched by the desktop app.
+		origin := r.Header.Get("Origin")
+		if origin != "" && os.Getenv("HEADLAMP_BACKEND_TOKEN") != "" {
+			parsed, err := url.Parse(origin)
+			if err == nil && parsed.Scheme == "file" {
+				return true
+			}
+		}
+
+		// Default: enforce same-origin for web deployments.
+		return defaultCheckOrigin(r)
+	}
+}
+
+// defaultCheckOrigin replicates Gorilla's built-in same-origin check so we can
+// fall through to it after the desktop-origin bypass above.
+func defaultCheckOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+
+	parsed, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+
+	// Compare origin host to the request host (same as gorilla/websocket default).
+	requestHost := r.Host
+	if h, _, found := strings.Cut(requestHost, ":"); found {
+		requestHost = h
+	}
+
+	originHost := parsed.Host
+	if h, _, found := strings.Cut(originHost, ":"); found {
+		originHost = h
+	}
+
+	return strings.EqualFold(originHost, requestHost)
 }
 
 // readServiceAccountToken reads the service account token from path, caching the value

--- a/backend/cmd/multiplexer_test.go
+++ b/backend/cmd/multiplexer_test.go
@@ -47,7 +47,7 @@ func newTestDialer() *websocket.Dialer {
 
 func TestNewMultiplexer(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	m := NewMultiplexer(store, false)
+	m := NewMultiplexer(store, false, false)
 
 	assert.NotNil(t, m)
 	assert.Equal(t, store, m.kubeConfigStore)
@@ -57,7 +57,7 @@ func TestNewMultiplexer(t *testing.T) {
 
 func TestHandleClientWebSocket(t *testing.T) {
 	contextStore := kubeconfig.NewContextStore()
-	m := NewMultiplexer(contextStore, false)
+	m := NewMultiplexer(contextStore, false, false)
 
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -69,7 +69,14 @@ func TestHandleClientWebSocket(t *testing.T) {
 	dialer := newTestDialer()
 
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
-	ws, resp, err := dialer.Dial(wsURL, nil)
+
+	// Send an Origin header matching the test server to validate that
+	// legitimate same-origin browser handshakes succeed under the default
+	// secure (devMode=false) configuration.
+	headers := http.Header{}
+	headers.Set("Origin", "http"+strings.TrimPrefix(server.URL, "http"))
+
+	ws, resp, err := dialer.Dial(wsURL, headers)
 	require.NoError(t, err)
 
 	if resp != nil && resp.Body != nil {
@@ -101,9 +108,39 @@ func TestHandleClientWebSocket(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestHandleClientWebSocketCrossOrigin(t *testing.T) {
+	contextStore := kubeconfig.NewContextStore()
+	m := NewMultiplexer(contextStore, false, false)
+
+	// Create test server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.HandleClientWebSocket(w, r)
+	}))
+	defer server.Close()
+
+	// Connect to test server
+	dialer := newTestDialer()
+
+	headers := http.Header{}
+	headers.Add("Origin", "http://malicious.com")
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	ws, resp, err := dialer.Dial(wsURL, headers)
+
+	if resp != nil && resp.Body != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+
+	// Expecting handshake to fail due to cross-origin
+	assert.Error(t, err)
+	assert.Nil(t, ws)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
 func TestGetClusterConfigWithFallback(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	m := NewMultiplexer(store, false)
+	m := NewMultiplexer(store, false, false)
 
 	// Add a mock cluster config
 	err := store.AddContext(&kubeconfig.Context{
@@ -125,7 +162,7 @@ func TestGetClusterConfigWithFallback(t *testing.T) {
 }
 
 func TestCreateConnection(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clientConn, _ := createTestWebSocketConnection()
 
 	// Add RequestID to the createConnection call
@@ -138,7 +175,7 @@ func TestCreateConnection(t *testing.T) {
 }
 
 func TestDialWebSocket(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		upgrader := websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
@@ -181,7 +218,7 @@ func TestDialWebSocket(t *testing.T) {
 }
 
 func TestDialWebSocket_WithToken(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 
 	var receivedAuth string
 
@@ -216,7 +253,7 @@ func TestDialWebSocket_WithToken(t *testing.T) {
 
 func TestDialWebSocket_Errors(t *testing.T) {
 	contextStore := kubeconfig.NewContextStore()
-	m := NewMultiplexer(contextStore, false)
+	m := NewMultiplexer(contextStore, false, false)
 
 	// Test invalid URL
 	tlsConfig := &tls.Config{InsecureSkipVerify: true} //nolint:gosec
@@ -255,7 +292,7 @@ func TestDialWebSocket_BadHandshakeLogging(t *testing.T) {
 	defer logger.SetLogFunc(originalLogFunc)
 
 	contextStore := kubeconfig.NewContextStore()
-	m := NewMultiplexer(contextStore, false)
+	m := NewMultiplexer(contextStore, false, false)
 
 	// Convert HTTP URL to WebSocket URL
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
@@ -373,7 +410,7 @@ func TestCreateWebSocketURLEdgeCases(t *testing.T) {
 }
 
 func TestMonitorConnection(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clientConn, clientServer := createTestWebSocketConnection()
 
 	defer clientServer.Close()
@@ -447,7 +484,7 @@ func TestUpdateStatus(t *testing.T) {
 }
 
 func TestCleanupConnections(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clientConn, clientServer := createTestWebSocketConnection()
 
 	defer clientServer.Close()
@@ -468,7 +505,7 @@ func TestCleanupConnections(t *testing.T) {
 }
 
 func TestCloseConnection(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clientConn, clientServer := createTestWebSocketConnection()
 
 	defer clientServer.Close()
@@ -488,7 +525,7 @@ func TestCloseConnection(t *testing.T) {
 }
 
 func TestCloseClientConnectionsClearsClientBeforeClosing(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clientConn, clientServer := createTestWebSocketConnection()
 
 	defer clientServer.Close()
@@ -690,7 +727,7 @@ func createMockKubeAPIServer() *httptest.Server {
 
 func TestGetOrCreateConnection(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	m := NewMultiplexer(store, false)
+	m := NewMultiplexer(store, false, false)
 
 	// Create a mock Kubernetes API server
 	mockServer := createMockKubeAPIServer()
@@ -742,7 +779,7 @@ func TestGetOrCreateConnection(t *testing.T) {
 
 func TestEstablishClusterConnection(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	m := NewMultiplexer(store, false)
+	m := NewMultiplexer(store, false, false)
 
 	// Create a mock Kubernetes API server
 	mockServer := createMockKubeAPIServer()
@@ -779,7 +816,7 @@ func TestEstablishClusterConnection(t *testing.T) {
 
 func TestEstablishClusterConnectionUsesServiceAccountToken(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	m := NewMultiplexer(store, true)
+	m := NewMultiplexer(store, true, false)
 	tokenFile := writeTestTokenFile(t)
 
 	var receivedAuth string
@@ -838,7 +875,7 @@ func TestEstablishClusterConnectionUsesServiceAccountToken(t *testing.T) {
 
 func TestReconnect(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	m := NewMultiplexer(store, false)
+	m := NewMultiplexer(store, false, false)
 
 	// Create a mock Kubernetes API server
 	mockServer := createMockKubeAPIServer()
@@ -902,7 +939,7 @@ func TestReconnect(t *testing.T) {
 }
 
 func TestCreateWrapperMessage(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	conn := &Connection{
 		ClusterID: "test-cluster",
 		Path:      "/api/v1/pods",
@@ -932,7 +969,7 @@ func TestCreateWrapperMessage(t *testing.T) {
 }
 
 func TestHandleConnectionError(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clientConn, clientServer := createTestWebSocketConnection()
 
 	defer clientServer.Close()
@@ -986,7 +1023,7 @@ func TestHandleConnectionError(t *testing.T) {
 //nolint:funlen
 func TestReadClientMessage_InvalidMessage(t *testing.T) {
 	contextStore := kubeconfig.NewContextStore()
-	m := NewMultiplexer(contextStore, false)
+	m := NewMultiplexer(contextStore, false, false)
 
 	// Create a server that will echo messages back
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1114,7 +1151,7 @@ func TestUpdateStatus_WithError(t *testing.T) {
 
 func TestMonitorConnection_ReconnectFailure(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	m := NewMultiplexer(store, false)
+	m := NewMultiplexer(store, false, false)
 
 	// Add an invalid cluster config to force reconnection failure
 	err := store.AddContext(&kubeconfig.Context{
@@ -1164,7 +1201,7 @@ func TestMonitorConnection_ReconnectFailure(t *testing.T) {
 }
 
 func TestHandleClientWebSocket_InvalidMessages(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		m.HandleClientWebSocket(w, r)
@@ -1201,7 +1238,7 @@ func TestHandleClientWebSocket_InvalidMessages(t *testing.T) {
 }
 
 func TestSendIfNewResourceVersion_VersionComparison(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clientConn, clientServer := createTestWebSocketConnection()
 
 	defer clientServer.Close()
@@ -1247,7 +1284,7 @@ func TestSendIfNewResourceVersion_VersionComparison(t *testing.T) {
 }
 
 func TestSendCompleteMessage_ClosedConnection(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clientConn, clientServer := createTestWebSocketConnection()
 
 	defer clientServer.Close()
@@ -1321,7 +1358,7 @@ func TestSendCompleteMessage_ErrorConditions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+			m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 			clientConn, clientServer := createTestWebSocketConnection()
 
 			defer clientServer.Close()
@@ -1347,7 +1384,7 @@ func TestSendCompleteMessage_ErrorConditions(t *testing.T) {
 
 func TestGetOrCreateConnection_TokenRefresh(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	m := NewMultiplexer(store, false)
+	m := NewMultiplexer(store, false, false)
 
 	// Create a mock Kubernetes API server
 	mockServer := createMockKubeAPIServer()
@@ -1395,7 +1432,7 @@ func TestGetOrCreateConnection_TokenRefresh(t *testing.T) {
 
 func TestGetOrCreateConnectionDoesNotOverwriteServiceAccountToken(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	m := NewMultiplexer(store, true)
+	m := NewMultiplexer(store, true, false)
 
 	clientConn, clientServer := createTestWebSocketConnection()
 	defer clientServer.Close()
@@ -1433,7 +1470,7 @@ func TestGetOrCreateConnectionDoesNotOverwriteServiceAccountToken(t *testing.T) 
 
 func TestReconnect_WithToken(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	m := NewMultiplexer(store, false)
+	m := NewMultiplexer(store, false, false)
 
 	// Create a mock Kubernetes API server
 	mockServer := createMockKubeAPIServer()
@@ -1497,7 +1534,7 @@ func TestReconnect_WithToken(t *testing.T) {
 
 func TestMonitorConnection_Reconnect(t *testing.T) {
 	contextStore := kubeconfig.NewContextStore()
-	m := NewMultiplexer(contextStore, false)
+	m := NewMultiplexer(contextStore, false, false)
 
 	// Create a server that will accept the connection and then close it
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1548,7 +1585,7 @@ func TestMonitorConnection_Reconnect(t *testing.T) {
 }
 
 func TestWriteMessageToCluster(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clusterConn, clusterServer := createTestWebSocketConnection()
 
 	defer clusterServer.Close()
@@ -1591,7 +1628,7 @@ func TestWriteMessageToCluster(t *testing.T) {
 }
 
 func TestHandleClusterMessages(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clientConn, clientServer := createTestWebSocketConnection()
 
 	defer clientServer.Close()
@@ -1638,7 +1675,7 @@ func TestHandleClusterMessages(t *testing.T) {
 }
 
 func TestSendCompleteMessage(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clientConn, clientServer := createTestWebSocketConnection()
 
 	defer clientServer.Close()
@@ -1667,7 +1704,7 @@ func TestSendCompleteMessage(t *testing.T) {
 }
 
 func TestSendDataMessage(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clientConn, clientServer := createTestWebSocketConnection()
 
 	defer clientServer.Close()
@@ -1761,7 +1798,7 @@ func runConcurrentLockStress(
 // sequentially (writeMu → unlock → mu → unlock), eliminating the nested
 // acquisition entirely.
 func TestConcurrentUpdateStatusAndSendDataMessage(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 
 	clientConn, clientServer := createTestWebSocketConnection()
 	defer clientServer.Close()
@@ -1865,7 +1902,7 @@ var benchWatchEventMsg = []byte(`{
 // extracting metadata.resourceVersion from a typical Kubernetes watch event.
 // This is the hottest path in the multiplexer.
 func BenchmarkSendIfNewResourceVersion(b *testing.B) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	conn := &Connection{
 		ClusterID: "test-cluster",
 		Path:      "/api/v1/namespaces/default/pods",
@@ -1887,7 +1924,7 @@ func BenchmarkSendIfNewResourceVersion(b *testing.B) {
 // BenchmarkSendIfNewResourceVersion_DirectMetadata benchmarks the case where
 // resourceVersion is at the top-level metadata (non-watch event format).
 func BenchmarkSendIfNewResourceVersion_DirectMetadata(b *testing.B) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 
 	directMsg := []byte(`{
 		"apiVersion": "v1", "kind": "Pod",
@@ -1921,7 +1958,7 @@ var benchConnectionKeySink string
 // BenchmarkCreateConnectionKey measures the allocation overhead of creating
 // connection keys used for map lookups on every WebSocket message routing.
 func BenchmarkCreateConnectionKey(b *testing.B) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 
 	clusterID := "my-production-cluster"
 	path := "/api/v1/namespaces/kube-system/pods"

--- a/backend/cmd/multiplexer_test.go
+++ b/backend/cmd/multiplexer_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
@@ -47,7 +48,7 @@ func newTestDialer() *websocket.Dialer {
 
 func TestNewMultiplexer(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	m := NewMultiplexer(store, false)
+	m := NewMultiplexer(store, false, false)
 
 	assert.NotNil(t, m)
 	assert.Equal(t, store, m.kubeConfigStore)
@@ -55,9 +56,99 @@ func TestNewMultiplexer(t *testing.T) {
 	assert.NotNil(t, m.upgrader)
 }
 
+// TestMakeCheckOrigin covers the three-tier WebSocket origin policy introduced to
+// fix the Electron desktop-app CSWSH regression (the same-origin default blocked
+// file:// origins because they have no matching host).
+//nolint:funlen
+func TestMakeCheckOrigin(t *testing.T) {
+	makeRequest := func(origin, host string) *http.Request {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://"+host+"/", nil)
+		req.Host = host
+
+		if origin != "" {
+			req.Header.Set("Origin", origin)
+		}
+
+		return req
+	}
+
+	t.Run("devMode allows any origin", func(t *testing.T) {
+		fn := makeCheckOrigin(true)
+		assert.True(t, fn(makeRequest("http://evil.example.com", "localhost:4466")),
+			"devMode must bypass same-origin check")
+	})
+
+	t.Run("file:// origin allowed when HEADLAMP_BACKEND_TOKEN is set (Electron desktop)", func(t *testing.T) {
+		t.Setenv("HEADLAMP_BACKEND_TOKEN", "test-desktop-token")
+
+		fn := makeCheckOrigin(false)
+		assert.True(t, fn(makeRequest("file:///app/index.html", "localhost:4466")),
+			"file:// origin must be accepted when backend token is present")
+	})
+
+	t.Run("file:// origin rejected without HEADLAMP_BACKEND_TOKEN (web deployment)", func(t *testing.T) {
+		// Ensure the env var is absent.
+		t.Setenv("HEADLAMP_BACKEND_TOKEN", "")
+
+		fn := makeCheckOrigin(false)
+		assert.False(t, fn(makeRequest("file:///app/index.html", "localhost:4466")),
+			"file:// origin must be rejected when backend token is absent")
+	})
+
+	t.Run("same-origin web request allowed in production (no token, no devMode)", func(t *testing.T) {
+		t.Setenv("HEADLAMP_BACKEND_TOKEN", "")
+
+		fn := makeCheckOrigin(false)
+		assert.True(t, fn(makeRequest("http://localhost:4466", "localhost:4466")),
+			"same-origin request must be accepted")
+	})
+
+	t.Run("cross-origin web request rejected in production", func(t *testing.T) {
+		t.Setenv("HEADLAMP_BACKEND_TOKEN", "")
+
+		fn := makeCheckOrigin(false)
+		assert.False(t, fn(makeRequest("http://evil.example.com", "localhost:4466")),
+			"cross-origin request must be rejected in production mode")
+	})
+
+	t.Run("differing ports on same host rejected in production", func(t *testing.T) {
+		t.Setenv("HEADLAMP_BACKEND_TOKEN", "")
+
+		fn := makeCheckOrigin(false)
+		assert.False(t, fn(makeRequest("http://localhost:3000", "localhost:4466")),
+			"requests with same host but different ports must be rejected")
+	})
+
+	t.Run("IPv6 host matching", func(t *testing.T) {
+		t.Setenv("HEADLAMP_BACKEND_TOKEN", "")
+
+		fn := makeCheckOrigin(false)
+		assert.True(t, fn(makeRequest("http://[::1]:8080", "[::1]:8080")),
+			"identical IPv6 authorities must be accepted")
+		assert.False(t, fn(makeRequest("http://[::1]:3000", "[::1]:8080")),
+			"IPv6 authorities with different ports must be rejected")
+	})
+
+	t.Run("no Origin header always allowed (non-browser client)", func(t *testing.T) {
+		t.Setenv("HEADLAMP_BACKEND_TOKEN", "")
+
+		fn := makeCheckOrigin(false)
+		assert.True(t, fn(makeRequest("", "localhost:4466")),
+			"requests without an Origin header must be allowed")
+	})
+
+	t.Run("file:// origin with non-empty host rejected even with HEADLAMP_BACKEND_TOKEN (UNC/remote path)", func(t *testing.T) {
+		t.Setenv("HEADLAMP_BACKEND_TOKEN", "test-desktop-token")
+
+		fn := makeCheckOrigin(false)
+		assert.False(t, fn(makeRequest("file://remote-host/app.html", "localhost:4466")),
+			"file:// origin with a non-empty host must be rejected to prevent UNC/remote-origin bypass")
+	})
+}
+
 func TestHandleClientWebSocket(t *testing.T) {
 	contextStore := kubeconfig.NewContextStore()
-	m := NewMultiplexer(contextStore, false)
+	m := NewMultiplexer(contextStore, false, false)
 
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -69,7 +160,14 @@ func TestHandleClientWebSocket(t *testing.T) {
 	dialer := newTestDialer()
 
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
-	ws, resp, err := dialer.Dial(wsURL, nil)
+
+	// Send an Origin header matching the test server to validate that
+	// legitimate same-origin browser handshakes succeed under the default
+	// secure (devMode=false) configuration.
+	headers := http.Header{}
+	headers.Set("Origin", "http"+strings.TrimPrefix(server.URL, "http"))
+
+	ws, resp, err := dialer.Dial(wsURL, headers)
 	require.NoError(t, err)
 
 	if resp != nil && resp.Body != nil {
@@ -101,9 +199,39 @@ func TestHandleClientWebSocket(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestHandleClientWebSocketCrossOrigin(t *testing.T) {
+	contextStore := kubeconfig.NewContextStore()
+	m := NewMultiplexer(contextStore, false, false)
+
+	// Create test server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.HandleClientWebSocket(w, r)
+	}))
+	defer server.Close()
+
+	// Connect to test server
+	dialer := newTestDialer()
+
+	headers := http.Header{}
+	headers.Add("Origin", "http://malicious.com")
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	ws, resp, err := dialer.Dial(wsURL, headers)
+
+	if resp != nil && resp.Body != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+
+	// Expecting handshake to fail due to cross-origin
+	assert.Error(t, err)
+	assert.Nil(t, ws)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
 func TestGetClusterConfigWithFallback(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	m := NewMultiplexer(store, false)
+	m := NewMultiplexer(store, false, false)
 
 	// Add a mock cluster config
 	err := store.AddContext(&kubeconfig.Context{
@@ -125,7 +253,7 @@ func TestGetClusterConfigWithFallback(t *testing.T) {
 }
 
 func TestCreateConnection(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clientConn, _ := createTestWebSocketConnection()
 
 	// Add RequestID to the createConnection call
@@ -138,7 +266,7 @@ func TestCreateConnection(t *testing.T) {
 }
 
 func TestDialWebSocket(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		upgrader := websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
@@ -181,7 +309,7 @@ func TestDialWebSocket(t *testing.T) {
 }
 
 func TestDialWebSocket_WithToken(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 
 	var receivedAuth string
 
@@ -216,7 +344,7 @@ func TestDialWebSocket_WithToken(t *testing.T) {
 
 func TestDialWebSocket_Errors(t *testing.T) {
 	contextStore := kubeconfig.NewContextStore()
-	m := NewMultiplexer(contextStore, false)
+	m := NewMultiplexer(contextStore, false, false)
 
 	// Test invalid URL
 	tlsConfig := &tls.Config{InsecureSkipVerify: true} //nolint:gosec
@@ -255,7 +383,7 @@ func TestDialWebSocket_BadHandshakeLogging(t *testing.T) {
 	defer logger.SetLogFunc(originalLogFunc)
 
 	contextStore := kubeconfig.NewContextStore()
-	m := NewMultiplexer(contextStore, false)
+	m := NewMultiplexer(contextStore, false, false)
 
 	// Convert HTTP URL to WebSocket URL
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
@@ -373,7 +501,7 @@ func TestCreateWebSocketURLEdgeCases(t *testing.T) {
 }
 
 func TestMonitorConnection(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clientConn, clientServer := createTestWebSocketConnection()
 
 	defer clientServer.Close()
@@ -447,7 +575,7 @@ func TestUpdateStatus(t *testing.T) {
 }
 
 func TestCleanupConnections(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clientConn, clientServer := createTestWebSocketConnection()
 
 	defer clientServer.Close()
@@ -468,7 +596,7 @@ func TestCleanupConnections(t *testing.T) {
 }
 
 func TestCloseConnection(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clientConn, clientServer := createTestWebSocketConnection()
 
 	defer clientServer.Close()
@@ -488,7 +616,7 @@ func TestCloseConnection(t *testing.T) {
 }
 
 func TestCloseClientConnectionsClearsClientBeforeClosing(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clientConn, clientServer := createTestWebSocketConnection()
 
 	defer clientServer.Close()
@@ -690,7 +818,7 @@ func createMockKubeAPIServer() *httptest.Server {
 
 func TestGetOrCreateConnection(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	m := NewMultiplexer(store, false)
+	m := NewMultiplexer(store, false, false)
 
 	// Create a mock Kubernetes API server
 	mockServer := createMockKubeAPIServer()
@@ -742,7 +870,7 @@ func TestGetOrCreateConnection(t *testing.T) {
 
 func TestEstablishClusterConnection(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	m := NewMultiplexer(store, false)
+	m := NewMultiplexer(store, false, false)
 
 	// Create a mock Kubernetes API server
 	mockServer := createMockKubeAPIServer()
@@ -779,7 +907,7 @@ func TestEstablishClusterConnection(t *testing.T) {
 
 func TestEstablishClusterConnectionUsesServiceAccountToken(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	m := NewMultiplexer(store, true)
+	m := NewMultiplexer(store, true, false)
 	tokenFile := writeTestTokenFile(t)
 
 	var receivedAuth string
@@ -838,7 +966,7 @@ func TestEstablishClusterConnectionUsesServiceAccountToken(t *testing.T) {
 
 func TestReconnect(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	m := NewMultiplexer(store, false)
+	m := NewMultiplexer(store, false, false)
 
 	// Create a mock Kubernetes API server
 	mockServer := createMockKubeAPIServer()
@@ -902,7 +1030,7 @@ func TestReconnect(t *testing.T) {
 }
 
 func TestCreateWrapperMessage(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	conn := &Connection{
 		ClusterID: "test-cluster",
 		Path:      "/api/v1/pods",
@@ -932,7 +1060,7 @@ func TestCreateWrapperMessage(t *testing.T) {
 }
 
 func TestHandleConnectionError(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clientConn, clientServer := createTestWebSocketConnection()
 
 	defer clientServer.Close()
@@ -986,7 +1114,7 @@ func TestHandleConnectionError(t *testing.T) {
 //nolint:funlen
 func TestReadClientMessage_InvalidMessage(t *testing.T) {
 	contextStore := kubeconfig.NewContextStore()
-	m := NewMultiplexer(contextStore, false)
+	m := NewMultiplexer(contextStore, false, false)
 
 	// Create a server that will echo messages back
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1114,7 +1242,7 @@ func TestUpdateStatus_WithError(t *testing.T) {
 
 func TestMonitorConnection_ReconnectFailure(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	m := NewMultiplexer(store, false)
+	m := NewMultiplexer(store, false, false)
 
 	// Add an invalid cluster config to force reconnection failure
 	err := store.AddContext(&kubeconfig.Context{
@@ -1164,7 +1292,7 @@ func TestMonitorConnection_ReconnectFailure(t *testing.T) {
 }
 
 func TestHandleClientWebSocket_InvalidMessages(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		m.HandleClientWebSocket(w, r)
@@ -1201,7 +1329,7 @@ func TestHandleClientWebSocket_InvalidMessages(t *testing.T) {
 }
 
 func TestSendIfNewResourceVersion_VersionComparison(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clientConn, clientServer := createTestWebSocketConnection()
 
 	defer clientServer.Close()
@@ -1247,7 +1375,7 @@ func TestSendIfNewResourceVersion_VersionComparison(t *testing.T) {
 }
 
 func TestSendCompleteMessage_ClosedConnection(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clientConn, clientServer := createTestWebSocketConnection()
 
 	defer clientServer.Close()
@@ -1321,7 +1449,7 @@ func TestSendCompleteMessage_ErrorConditions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+			m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 			clientConn, clientServer := createTestWebSocketConnection()
 
 			defer clientServer.Close()
@@ -1347,7 +1475,7 @@ func TestSendCompleteMessage_ErrorConditions(t *testing.T) {
 
 func TestGetOrCreateConnection_TokenRefresh(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	m := NewMultiplexer(store, false)
+	m := NewMultiplexer(store, false, false)
 
 	// Create a mock Kubernetes API server
 	mockServer := createMockKubeAPIServer()
@@ -1395,7 +1523,7 @@ func TestGetOrCreateConnection_TokenRefresh(t *testing.T) {
 
 func TestGetOrCreateConnectionDoesNotOverwriteServiceAccountToken(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	m := NewMultiplexer(store, true)
+	m := NewMultiplexer(store, true, false)
 
 	clientConn, clientServer := createTestWebSocketConnection()
 	defer clientServer.Close()
@@ -1433,7 +1561,7 @@ func TestGetOrCreateConnectionDoesNotOverwriteServiceAccountToken(t *testing.T) 
 
 func TestReconnect_WithToken(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	m := NewMultiplexer(store, false)
+	m := NewMultiplexer(store, false, false)
 
 	// Create a mock Kubernetes API server
 	mockServer := createMockKubeAPIServer()
@@ -1497,7 +1625,7 @@ func TestReconnect_WithToken(t *testing.T) {
 
 func TestMonitorConnection_Reconnect(t *testing.T) {
 	contextStore := kubeconfig.NewContextStore()
-	m := NewMultiplexer(contextStore, false)
+	m := NewMultiplexer(contextStore, false, false)
 
 	// Create a server that will accept the connection and then close it
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1548,7 +1676,7 @@ func TestMonitorConnection_Reconnect(t *testing.T) {
 }
 
 func TestWriteMessageToCluster(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clusterConn, clusterServer := createTestWebSocketConnection()
 
 	defer clusterServer.Close()
@@ -1591,7 +1719,7 @@ func TestWriteMessageToCluster(t *testing.T) {
 }
 
 func TestHandleClusterMessages(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clientConn, clientServer := createTestWebSocketConnection()
 
 	defer clientServer.Close()
@@ -1638,7 +1766,7 @@ func TestHandleClusterMessages(t *testing.T) {
 }
 
 func TestSendCompleteMessage(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clientConn, clientServer := createTestWebSocketConnection()
 
 	defer clientServer.Close()
@@ -1667,7 +1795,7 @@ func TestSendCompleteMessage(t *testing.T) {
 }
 
 func TestSendDataMessage(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	clientConn, clientServer := createTestWebSocketConnection()
 
 	defer clientServer.Close()
@@ -1761,7 +1889,7 @@ func runConcurrentLockStress(
 // sequentially (writeMu → unlock → mu → unlock), eliminating the nested
 // acquisition entirely.
 func TestConcurrentUpdateStatusAndSendDataMessage(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 
 	clientConn, clientServer := createTestWebSocketConnection()
 	defer clientServer.Close()
@@ -1865,7 +1993,7 @@ var benchWatchEventMsg = []byte(`{
 // extracting metadata.resourceVersion from a typical Kubernetes watch event.
 // This is the hottest path in the multiplexer.
 func BenchmarkSendIfNewResourceVersion(b *testing.B) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 	conn := &Connection{
 		ClusterID: "test-cluster",
 		Path:      "/api/v1/namespaces/default/pods",
@@ -1887,7 +2015,7 @@ func BenchmarkSendIfNewResourceVersion(b *testing.B) {
 // BenchmarkSendIfNewResourceVersion_DirectMetadata benchmarks the case where
 // resourceVersion is at the top-level metadata (non-watch event format).
 func BenchmarkSendIfNewResourceVersion_DirectMetadata(b *testing.B) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 
 	directMsg := []byte(`{
 		"apiVersion": "v1", "kind": "Pod",
@@ -1921,7 +2049,7 @@ var benchConnectionKeySink string
 // BenchmarkCreateConnectionKey measures the allocation overhead of creating
 // connection keys used for map lookups on every WebSocket message routing.
 func BenchmarkCreateConnectionKey(b *testing.B) {
-	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false, false)
 
 	clusterID := "my-production-cluster"
 	path := "/api/v1/namespaces/kube-system/pods"

--- a/backend/cmd/multiplexer_test.go
+++ b/backend/cmd/multiplexer_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
@@ -53,6 +54,69 @@ func TestNewMultiplexer(t *testing.T) {
 	assert.Equal(t, store, m.kubeConfigStore)
 	assert.NotNil(t, m.connections)
 	assert.NotNil(t, m.upgrader)
+}
+
+// TestMakeCheckOrigin covers the three-tier WebSocket origin policy introduced to
+// fix the Electron desktop-app CSWSH regression (the same-origin default blocked
+// file:// origins because they have no matching host).
+func TestMakeCheckOrigin(t *testing.T) {
+	makeRequest := func(origin, host string) *http.Request {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://"+host+"/", nil)
+		req.Host = host
+
+		if origin != "" {
+			req.Header.Set("Origin", origin)
+		}
+
+		return req
+	}
+
+	t.Run("devMode allows any origin", func(t *testing.T) {
+		fn := makeCheckOrigin(true)
+		assert.True(t, fn(makeRequest("http://evil.example.com", "localhost:4466")),
+			"devMode must bypass same-origin check")
+	})
+
+	t.Run("file:// origin allowed when HEADLAMP_BACKEND_TOKEN is set (Electron desktop)", func(t *testing.T) {
+		t.Setenv("HEADLAMP_BACKEND_TOKEN", "test-desktop-token")
+
+		fn := makeCheckOrigin(false)
+		assert.True(t, fn(makeRequest("file:///app/index.html", "localhost:4466")),
+			"file:// origin must be accepted when backend token is present")
+	})
+
+	t.Run("file:// origin rejected without HEADLAMP_BACKEND_TOKEN (web deployment)", func(t *testing.T) {
+		// Ensure the env var is absent.
+		t.Setenv("HEADLAMP_BACKEND_TOKEN", "")
+
+		fn := makeCheckOrigin(false)
+		assert.False(t, fn(makeRequest("file:///app/index.html", "localhost:4466")),
+			"file:// origin must be rejected when backend token is absent")
+	})
+
+	t.Run("same-origin web request allowed in production (no token, no devMode)", func(t *testing.T) {
+		t.Setenv("HEADLAMP_BACKEND_TOKEN", "")
+
+		fn := makeCheckOrigin(false)
+		assert.True(t, fn(makeRequest("http://localhost:4466", "localhost:4466")),
+			"same-origin request must be accepted")
+	})
+
+	t.Run("cross-origin web request rejected in production", func(t *testing.T) {
+		t.Setenv("HEADLAMP_BACKEND_TOKEN", "")
+
+		fn := makeCheckOrigin(false)
+		assert.False(t, fn(makeRequest("http://evil.example.com", "localhost:4466")),
+			"cross-origin request must be rejected in production mode")
+	})
+
+	t.Run("no Origin header always allowed (non-browser client)", func(t *testing.T) {
+		t.Setenv("HEADLAMP_BACKEND_TOKEN", "")
+
+		fn := makeCheckOrigin(false)
+		assert.True(t, fn(makeRequest("", "localhost:4466")),
+			"requests without an Origin header must be allowed")
+	})
 }
 
 func TestHandleClientWebSocket(t *testing.T) {

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -200,7 +200,7 @@ func createHeadlampConfig(conf *config.Config) *HeadlampConfig {
 	kubeConfigStore := kubeconfig.NewContextStore()
 	setupKubeConfigStoreWatcher(kubeConfigStore)
 
-	multiplexer := NewMultiplexer(kubeConfigStore, conf.InCluster && conf.UnsafeUseServiceAccountToken)
+	multiplexer := NewMultiplexer(kubeConfigStore, conf.InCluster && conf.UnsafeUseServiceAccountToken, conf.DevMode)
 
 	cfg := &headlampconfig.HeadlampConfig{
 		HeadlampCFG:               buildHeadlampCFG(conf, kubeConfigStore),

--- a/backend/pkg/spa/pathSafety_internal_test.go
+++ b/backend/pkg/spa/pathSafety_internal_test.go
@@ -1,6 +1,9 @@
 package spa
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
 func TestURLToRelRejectsUnsafePaths(t *testing.T) {
 	tests := []struct {
@@ -27,7 +30,10 @@ func TestURLToRelAcceptsSafeRelativePath(t *testing.T) {
 		t.Fatalf("expected safe path to be accepted")
 	}
 
-	if rel != "headlamp/assets/main.js" {
-		t.Fatalf("unexpected relative path: got %q", rel)
+	// urlToRel uses filepath.FromSlash internally, so the separator is
+	// OS-native (backslash on Windows, forward slash elsewhere).
+	want := filepath.FromSlash("headlamp/assets/main.js")
+	if rel != want {
+		t.Fatalf("unexpected relative path: got %q, want %q", rel, want)
 	}
 }


### PR DESCRIPTION
## Summary
This PR fixes a critical security vulnerability (Cross-Site WebSocket Hijacking) by enforcing secure WebSocket origin validation in the backend. It prevents malicious external sites from establishing unauthorized WebSocket connections to the Kubernetes API multiplexer.

## Related Issue
Fixes #6796

## Changes
- Updated `backend/cmd/multiplexer.go` to use strict origin checking by default, preventing cross-origin WebSocket connections unless explicitly running in `devMode`.
- Updated `backend/cmd/server.go` to pass the `DevMode` configuration flag into `NewMultiplexer`.
- Refactored `backend/cmd/multiplexer_test.go` to support the updated multiplexer constructor signature, and added regression tests for differing ports and IPv6 hosts.

## Origin Validation Policy
The `CheckOrigin` callback now enforces a three-tier policy:

1. **Development mode (`devMode == true`)** — all origins are accepted, to support local dev/testing across ports (e.g. frontend dev server vs. backend).
2. **Production, matching origin** — the request is accepted only if the `Origin` header's full host:port authority matches the request's host:port authority exactly. Host and port are compared together (not stripped or truncated), so a mismatched port (e.g. origin `http://localhost:3000` vs. request host `localhost:4466`) or a bracketed IPv6 host (e.g. `[::1]:4654`) is correctly rejected/handled rather than silently reduced to a partial match.
3. **Production, desktop app (`file://` origin)** — when `HEADLAMP_BACKEND_TOKEN` is set and the `Origin` header has a `file://` scheme, the connection is accepted. This covers the Electron/desktop build, which loads the UI from the local filesystem and therefore sends a `file://` origin rather than an `http(s)://` one. This path is gated on the backend token being present, which is only set for the desktop app's local backend instance.

This is **not** a plain "reject everything unless devMode" policy — the `file://` exception is a deliberate, scoped carve-out for the desktop app's trust model, separate from devMode, and reviewers should evaluate it as its own trust boundary.

## Steps to Test
1. Start the Headlamp backend (`npm run backend:start`).
2. Attempt to open a WebSocket connection to `ws://localhost:4654/wsMultiplexer` from a completely different origin (e.g., a separate local webserver on a different port, or an external site).
3. Observe that the WebSocket connection is rejected (HTTP 403 Forbidden).
4. Verify that the standard Headlamp frontend UI can still connect to the WebSocket and stream cluster logs or exec sessions successfully.
5. Verify that the desktop (Electron) app, which sends a `file://` origin, can still connect successfully in production builds.
6. Verify that a request with a different port on the same host (e.g. origin `http://localhost:3000` vs. request host `localhost:4466`) is correctly rejected as cross-origin.
7. Verify that IPv6 host requests (e.g. `[::1]:4654`) are compared correctly by full authority, not mishandled by naive host:port splitting.

## Screenshots
(N/A — backend security fix)

## Notes for the Reviewer
- This removes the unconditionally permissive `return true` from the `gorilla/websocket` `CheckOrigin` callback.
- By default, `gorilla/websocket` now rejects cross-origin WebSocket upgrades unless one of the three policy tiers above applies.
- The origin/host comparison now compares the full `host:port` authority (matching Gorilla's default `checkSameOrigin` behavior) instead of stripping the port, closing the cross-port and IPv6 gaps flagged in earlier review.
- The commit history has been squashed/rebased into a single commit with a message accurately describing the final three-tier policy.