### PR TITLE
frontend: portforward/index: Fix react-hooks/exhaustive-deps

### DIFF
--- a/frontend/src/components/portforward/index.tsx
+++ b/frontend/src/components/portforward/index.tsx
@@ -58,15 +58,14 @@ export default function PortForwardingList() {
   const portForwardInActionRef = React.useRef(portForwardInAction);
   const { enqueueSnackbar } = useSnackbar();
   const cluster = getCluster();
-  const { t, i18n } = useTranslation(['translation', 'glossary']);
+  const { t } = useTranslation(['translation', 'glossary']);
   const optionsTranslated = React.useMemo(
     () => ({
       [PortForwardAction.Start]: t('translation|Start'),
       [PortForwardAction.Stop]: t('translation|Stop'),
       [PortForwardAction.Delete]: t('translation|Delete'),
     }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [i18n.language]
+    [t]
   );
   const options = Object.keys(optionsTranslated) as (keyof typeof optionsTranslated)[];
 


### PR DESCRIPTION
Satisfies the exhaustive-deps lint rule for optionsTranslated by depending on t directly instead of i18n.language. Drops the now-unused i18n destructure. Part of the react-hooks cleanup tracked in #5183.

## Summary

This PR fixes a `react-hooks/exhaustive-deps` lint suppression in `frontend/src/components/portforward/index.tsx` by changing the `optionsTranslated` `useMemo` dependency array from `[i18n.language]` to `[t]`, and removing the `eslint-disable-next-line` comment that was masking the missing dependency.

## Related Issue

Fixes #6805

## Changes

- Changed `optionsTranslated` `useMemo` dependency array: `[i18n.language]` → `[t]`
- Removed the `eslint-disable-next-line react-hooks/exhaustive-deps` suppression
- Removed the now-unused `i18n` from the `useTranslation()` destructure

## Steps to Test

1. Run `cd frontend && npx eslint src/components/portforward/index.tsx` and confirm no `exhaustive-deps` warning is reported
2. Run `cd frontend && npx vitest run src/components/portforward/index.test.tsx` and confirm all 14 existing tests still pass
3. Open the Port Forwarding list in Headlamp and confirm the Start/Stop/Delete action menu still renders correctly with no visual change

## Screenshots (if applicable)

N/A — no UI or behavior change; this is a dependency-array correctness fix to satisfy the linter.

## Notes for the Reviewer

- This is a lint-hygiene cleanup as part of the broader `react-hooks` suppression cleanup tracked in #5183, not a fix for an observed user-facing bug — no behavior change is claimed.
- `t`'s reference is stable here since this component's translation namespaces (`['translation', 'glossary']`) are fixed at mount, so `[t]` and `[i18n.language]` are functionally equivalent in practice — `t` is simply the technically-correct dependency per the lint rule.
