### PR TITLE
0005: app: build manifest: Configure platform metadata

### DIFF
--- a/app/e2e-tests/tests/buildManifest.spec.ts
+++ b/app/e2e-tests/tests/buildManifest.spec.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const appPath = path.resolve(__dirname, '../..');
+
+test('custom platform metadata reaches the Electron Builder configuration', () => {
+  const manifestDir = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-build-manifest-'));
+  const manifestFile = path.join(manifestDir, 'app-build-manifest.json');
+  fs.writeFileSync(
+    manifestFile,
+    JSON.stringify({
+      platforms: {
+        linux: { executableName: 'branded-headlamp' },
+        mac: { appId: 'io.example.branded-headlamp' },
+        win: { artifactName: 'branded-${version}.${ext}' },
+      },
+    })
+  );
+
+  try {
+    const output = execFileSync(
+      process.execPath,
+      [
+        '-e',
+        "const { getConfig } = require('app-builder-lib/out/util/config/config'); getConfig(process.cwd(), 'electron-builder.config.ts', {}).then(config => process.stdout.write('HEADLAMP_CONFIG_JSON=' + JSON.stringify({ linux: config.linux, mac: config.mac, win: config.win })));",
+      ],
+      {
+        cwd: appPath,
+        encoding: 'utf8',
+        env: { ...process.env, HEADLAMP_BUILD_MANIFEST: manifestFile },
+      }
+    );
+    const config = JSON.parse(output.split('HEADLAMP_CONFIG_JSON=')[1]);
+
+    expect(config.linux.executableName).toBe('branded-headlamp');
+    expect(config.linux.category).toBe('Network');
+    expect(config.mac.appId).toBe('io.example.branded-headlamp');
+    expect(config.mac.hardenedRuntime).toBe(true);
+    expect(config.win.artifactName).toBe('branded-${version}.${ext}');
+    expect(config.win.target).toEqual(['nsis']);
+  } finally {
+    fs.rmSync(manifestDir, { recursive: true, force: true });
+  }
+});

--- a/app/electron-builder.config.ts
+++ b/app/electron-builder.config.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Configuration } from 'electron-builder';
+
+const packageJson = require('./package.json');
+const {
+  applyPlatformMetadata,
+  loadBuildManifest,
+  resolveBuildManifestPath,
+} = require('./scripts/build-manifest');
+
+const config: Configuration = applyPlatformMetadata(
+  packageJson.build,
+  loadBuildManifest(resolveBuildManifestPath())
+);
+
+export default config;

--- a/app/electron/build-manifest.test.ts
+++ b/app/electron/build-manifest.test.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { applyPlatformMetadata } = require('../scripts/build-manifest');
+const { getConfig } = require('app-builder-lib/out/util/config/config');
+const appPath = path.resolve(__dirname, '..');
+
+describe('platform metadata', () => {
+  afterEach(() => {
+    delete process.env.HEADLAMP_BUILD_MANIFEST;
+  });
+
+  it.each([null, [], 'manifest'])('rejects an invalid manifest value: %j', manifest => {
+    expect(() => applyPlatformMetadata({}, manifest)).toThrow('Build manifest must be an object');
+  });
+
+  it('preserves the configuration when platform metadata is absent', () => {
+    const defaults = { linux: { category: 'Network' } };
+
+    expect(applyPlatformMetadata(defaults, {})).toBe(defaults);
+  });
+
+  it.each([null, [], 'linux'])('rejects an invalid platforms value: %j', platforms => {
+    expect(() => applyPlatformMetadata({}, { platforms })).toThrow(
+      'Build manifest platforms must be an object'
+    );
+  });
+
+  it('overrides allowed fields for every supported platform', () => {
+    const defaults = {
+      linux: { category: 'Network', executableName: 'headlamp' },
+      mac: { hardenedRuntime: true },
+      win: { target: ['nsis'] },
+    };
+
+    expect(
+      applyPlatformMetadata(defaults, {
+        platforms: {
+          linux: { executableName: 'example', icon: '/product/linux.png' },
+          mac: { appId: 'io.example.app', bundleShortVersion: '1.2.3', bundleVersion: '123' },
+          win: { artifactName: 'example-${version}.${ext}', icon: '/product/windows.ico' },
+        },
+      })
+    ).toEqual({
+      linux: {
+        category: 'Network',
+        executableName: 'example',
+        icon: '/product/linux.png',
+      },
+      mac: {
+        hardenedRuntime: true,
+        appId: 'io.example.app',
+        bundleShortVersion: '1.2.3',
+        bundleVersion: '123',
+      },
+      win: {
+        target: ['nsis'],
+        artifactName: 'example-${version}.${ext}',
+        icon: '/product/windows.ico',
+      },
+    });
+    expect(defaults.linux).toEqual({ category: 'Network', executableName: 'headlamp' });
+  });
+
+  it.each([null, [], 'linux'])('rejects invalid platform metadata: %j', metadata => {
+    expect(() => applyPlatformMetadata({}, { platforms: { linux: metadata } })).toThrow(
+      'Build manifest platforms.linux must be an object'
+    );
+  });
+
+  it('rejects arbitrary electron-builder platform settings', () => {
+    expect(() =>
+      applyPlatformMetadata({}, { platforms: { mac: { hardenedRuntime: false } } })
+    ).toThrow('Unsupported build manifest platforms.mac.hardenedRuntime');
+  });
+
+  it('rejects non-string allowed settings', () => {
+    expect(() =>
+      applyPlatformMetadata({}, { platforms: { win: { artifactName: false } } })
+    ).toThrow('Build manifest platforms.win.artifactName must be a string');
+  });
+
+  it('applies a selected manifest to the Electron Builder configuration', async () => {
+    process.env.HEADLAMP_BUILD_MANIFEST = require.resolve(
+      './fixtures/platform-build-manifest.json'
+    );
+
+    const config = await getConfig(appPath, 'electron-builder.config.ts', {});
+
+    expect(config.linux.executableName).toBe('example-headlamp');
+    expect(config.linux.category).toBe('Network');
+    expect(config.mac.appId).toBe('io.example.headlamp');
+    expect(config.win.icon).toBe('build/icons/example.ico');
+  });
+});

--- a/app/electron/fixtures/platform-build-manifest.json
+++ b/app/electron/fixtures/platform-build-manifest.json
@@ -1,0 +1,13 @@
+{
+  "platforms": {
+    "linux": {
+      "executableName": "example-headlamp"
+    },
+    "mac": {
+      "appId": "io.example.headlamp"
+    },
+    "win": {
+      "icon": "build/icons/example.ico"
+    }
+  }
+}

--- a/app/package.json
+++ b/app/package.json
@@ -10,7 +10,7 @@
     "node": ">=22.0.0"
   },
   "scripts": {
-    "build": "npm run copy-icons && npm run copy-plugins && npm run compile-electron && electron-builder --dir --publish never",
+    "build": "npm run copy-icons && npm run copy-plugins && npm run compile-electron && electron-builder --config electron-builder.config.ts --dir --publish never",
     "compile-electron": "node scripts/build-electron.js",
     "copy-icons": "mkdirp build/icons && copyfiles -f ../frontend/build/*.png ../frontend/build/*.ico ../frontend/build/*.icns ../frontend/build/*.svg build/icons",
     "copy-plugins": "npx --no-install shx rm -rf build/.plugins && mkdirp build/.plugins && copyfiles ../.plugins build/.plugins",
@@ -23,7 +23,7 @@
     "i18n-check": "npm run i18n -- --fail-on-update",
     "lint": "cd .. && npm run frontend:lint",
     "lint-fix": "cd .. && npm run frontend:lint:fix",
-    "package": "npm run build && electron-builder build --publish never",
+    "package": "npm run build && electron-builder build --config electron-builder.config.ts --publish never",
     "package-msi": "npm run build && node windows/msi/build.js",
     "start": "node scripts/start.js",
     "star": "node scripts/start.js --star",

--- a/app/scripts/build-manifest.js
+++ b/app/scripts/build-manifest.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DEFAULT_MANIFEST_FILE = path.resolve(__dirname, '../app-build-manifest.json');
+
+function resolveBuildManifestPath() {
+  return process.env.HEADLAMP_BUILD_MANIFEST || DEFAULT_MANIFEST_FILE;
+}
+
+function loadBuildManifest(manifestFile = resolveBuildManifestPath()) {
+  return JSON.parse(fs.readFileSync(manifestFile, 'utf8'));
+}
+
+function applyPlatformMetadata(config, manifest) {
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+    throw new Error('Build manifest must be an object');
+  }
+
+  const platforms = manifest.platforms;
+  if (platforms === undefined) {
+    return config;
+  }
+  if (!platforms || typeof platforms !== 'object' || Array.isArray(platforms)) {
+    throw new Error('Build manifest platforms must be an object');
+  }
+
+  const allowedFields = new Set([
+    'appId',
+    'bundleShortVersion',
+    'bundleVersion',
+    'executableName',
+    'icon',
+    'artifactName',
+  ]);
+  const result = { ...config };
+  for (const platform of ['linux', 'mac', 'win']) {
+    const metadata = platforms[platform];
+    if (metadata === undefined) {
+      continue;
+    }
+    if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+      throw new Error(`Build manifest platforms.${platform} must be an object`);
+    }
+    for (const [field, value] of Object.entries(metadata)) {
+      if (!allowedFields.has(field)) {
+        throw new Error(`Unsupported build manifest platforms.${platform}.${field}`);
+      }
+      if (typeof value !== 'string') {
+        throw new Error(`Build manifest platforms.${platform}.${field} must be a string`);
+      }
+    }
+    result[platform] = { ...config[platform], ...metadata };
+  }
+  return result;
+}
+
+module.exports = {
+  applyPlatformMetadata,
+  DEFAULT_MANIFEST_FILE,
+  loadBuildManifest,
+  resolveBuildManifestPath,
+};

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -14,6 +14,10 @@
     "outDir": "electron/",
     "noEmit": true
   },
-  "include": ["electron/**/*", "scripts/package-verification-name.ts"],
+  "include": [
+    "electron/**/*",
+    "electron-builder.config.ts",
+    "scripts/package-verification-name.ts"
+  ],
   "exclude": []
 }

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -14,6 +14,6 @@
     "outDir": "electron/",
     "noEmit": true
   },
-  "include": ["electron/**/*"],
+  "include": ["electron/**/*", "electron-builder.config.ts"],
   "exclude": []
 }


### PR DESCRIPTION
## Summary

- allow app build manifests to override an allowlisted set of Linux, macOS, and Windows product metadata
- reject invalid root manifests, arbitrary Electron Builder settings, and non-string platform metadata values with clear validation errors
- preserve existing platform defaults and wire packaging through the manifest-aware configuration
- add unit and process-level Playwright coverage before the behavior commit

## Provenance

This upstreams `patches/0005-headlamp-upstream-build-manifest-platform-metadata.patch` from [Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823).

- Original patch commit recorded by the patch header: `5d24cb166edd4893b17367af577e58b106ef20ba`, authored by ashu8912 on 2026-08-01 (the generated SHA is not present on a published Azure ref)
- Published Azure commit retaining the patch: [68e024dca932107a6a5a65b606edc1fdf2fae52d](https://github.com/Azure/aks-desktop/commit/68e024dca932107a6a5a65b606edc1fdf2fae52d)
- Published Azure commit consuming the retained patch series: [c3f501ec9d147e010c84deb18ce4f85d7063db39](https://github.com/Azure/aks-desktop/commit/c3f501ec9d147e010c84deb18ce4f85d7063db39)
- Related Azure PR: [Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823)

The behavior commit preserves ashu8912 as author and the original author date, with René Dudfield added as co-author.

## Testing

- `npm --prefix app test` (14 files, 189 tests)
- `npm --prefix app run tsc`
- `npm run frontend:lint`
- `npm --prefix app test -- --run electron/build-manifest.test.ts --coverage --coverage.include=scripts/build-manifest.js --coverage.reporter=text` (95.65% branches; 100% statements, functions, and lines before the additional fully exercised validation branches)
- `PLAYWRIGHT_TEST_MODE=web node node_modules/@playwright/test/cli.js test tests/buildManifest.spec.ts` from `app/e2e-tests` (1 passed)
- `git diff --check upstream/main...HEAD`