### PR TITLE
0021: Storybook CRD mocks

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -234,6 +234,42 @@ jobs:
         run: |
           make frontend-build-storybook
 
+  test-storybook-mocks:
+    name: test storybook mocks
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node-version: [22.x]
+        os: [ubuntu-22.04]
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+          cache-dependency-path: |
+            frontend/package-lock.json
+            e2e-tests/package-lock.json
+
+      # The Playwright config starts `storybook dev` from the frontend workspace,
+      # so both the frontend and the e2e-tests dependencies are needed here.
+      - name: Install dependencies
+        run: |
+          make frontend-install-ci
+          cd e2e-tests && npm ci
+
+      - name: Install Playwright browsers
+        run: |
+          cd e2e-tests
+          npx playwright install --with-deps chromium
+
+      - name: Run storybook mock tests
+        run: |
+          make e2e-test-storybook
+
   test-a11y:
     name: test accessibility
     runs-on: ${{ matrix.os }}

--- a/Makefile
+++ b/Makefile
@@ -358,6 +358,13 @@ frontend-test:
 frontend-test-a11y:
 	cd frontend && npm run test:a11y
 
+# Runs the browser-level Playwright checks for the global Storybook MSW mocks.
+# The Playwright config boots `storybook dev` itself, so frontend deps must be
+# installed before this target runs.
+.PHONY: e2e-test-storybook
+e2e-test-storybook:
+	cd e2e-tests && npm run test:storybook
+
 .PHONY: lint
 lint: backend-lint frontend-lint
 

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
-  "scripts": {},
+  "scripts": {
+    "test:storybook": "playwright test --config playwright.storybook.config.ts"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/e2e-tests/playwright.storybook.config.ts
+++ b/e2e-tests/playwright.storybook.config.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 The Kubernetes Authors
+ * Copyright 2025 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'npm --prefix ../frontend run storybook -- --ci --host 127.0.0.1 --port 6007',
+    command: 'cd ../frontend && npm exec storybook dev -- --ci --host 127.0.0.1 --port 6007',
     url: 'http://127.0.0.1:6007',
     reuseExistingServer: !process.env.CI,
   },

--- a/e2e-tests/playwright.storybook.config.ts
+++ b/e2e-tests/playwright.storybook.config.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './storybook-tests',
+  use: {
+    baseURL: 'http://127.0.0.1:6007',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm --prefix ../frontend run storybook -- --ci --host 127.0.0.1 --port 6007',
+    url: 'http://127.0.0.1:6007',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/e2e-tests/playwright.storybook.config.ts
+++ b/e2e-tests/playwright.storybook.config.ts
@@ -32,5 +32,8 @@ export default defineConfig({
     command: 'cd ../frontend && npm exec storybook dev -- --ci --host 127.0.0.1 --port 6007',
     url: 'http://127.0.0.1:6007',
     reuseExistingServer: !process.env.CI,
+    // A cold Storybook dev start on a CI runner regularly exceeds Playwright's
+    // 60s default.
+    timeout: 180_000,
   },
 });

--- a/e2e-tests/storybook-tests/crdMocks.spec.ts
+++ b/e2e-tests/storybook-tests/crdMocks.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 The Kubernetes Authors
+ * Copyright 2025 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,18 +27,12 @@ test('Storybook mocks custom resource definition discovery', async ({ page }) =>
   const result = await page.evaluate(
     async ({ v1Url, v1beta1Url }) => {
       const response = await fetch(v1Url);
-      let v1beta1Failed = false;
-
-      try {
-        await fetch(v1beta1Url);
-      } catch {
-        v1beta1Failed = true;
-      }
+      const v1beta1Response = await fetch(v1beta1Url);
 
       return {
         status: response.status,
         body: await response.json(),
-        v1beta1Failed,
+        v1beta1Status: v1beta1Response.status,
       };
     },
     { v1Url: crdV1Url, v1beta1Url: crdV1beta1Url }
@@ -52,6 +46,6 @@ test('Storybook mocks custom resource definition discovery', async ({ page }) =>
       metadata: {},
       items: [],
     },
-    v1beta1Failed: true,
+    v1beta1Status: 404,
   });
 });

--- a/e2e-tests/storybook-tests/crdMocks.spec.ts
+++ b/e2e-tests/storybook-tests/crdMocks.spec.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+
+const crdV1Url = 'http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions';
+const crdV1beta1Url =
+  'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions';
+
+test('Storybook mocks custom resource definition discovery', async ({ page }) => {
+  await page.goto('/iframe.html?id=common-actionbutton--basic&viewMode=story');
+  await expect(page.getByRole('button', { name: 'Some label' })).toBeVisible();
+
+  const result = await page.evaluate(
+    async ({ v1Url, v1beta1Url }) => {
+      const response = await fetch(v1Url);
+      let v1beta1Failed = false;
+
+      try {
+        await fetch(v1beta1Url);
+      } catch {
+        v1beta1Failed = true;
+      }
+
+      return {
+        status: response.status,
+        body: await response.json(),
+        v1beta1Failed,
+      };
+    },
+    { v1Url: crdV1Url, v1beta1Url: crdV1beta1Url }
+  );
+
+  expect(result).toEqual({
+    status: 200,
+    body: {
+      kind: 'CustomResourceDefinitionList',
+      apiVersion: 'apiextensions.k8s.io/v1',
+      metadata: {},
+      items: [],
+    },
+    v1beta1Failed: true,
+  });
+});

--- a/frontend/.storybook/baseMocks.ts
+++ b/frontend/.storybook/baseMocks.ts
@@ -120,7 +120,7 @@ export const baseMocks = [
   ),
   http.get(
     'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
-    () => HttpResponse.error()
+    () => new HttpResponse(null, { status: 404 })
   ),
   http.get('http://localhost:4466/apis/metrics.k8s.io/v1beta1/nodes', () =>
     HttpResponse.json({

--- a/frontend/.storybook/baseMocks.ts
+++ b/frontend/.storybook/baseMocks.ts
@@ -110,6 +110,18 @@ export const baseMocks = [
       items: [],
     })
   ),
+  http.get('http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions', () =>
+    HttpResponse.json({
+      kind: 'CustomResourceDefinitionList',
+      apiVersion: 'apiextensions.k8s.io/v1',
+      metadata: {},
+      items: [],
+    })
+  ),
+  http.get(
+    'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
+    () => HttpResponse.error()
+  ),
   http.get('http://localhost:4466/apis/metrics.k8s.io/v1beta1/nodes', () =>
     HttpResponse.json({
       apiVersion: 'metrics.k8s.io/v1beta1',

--- a/frontend/src/components/crd/CustomResourceDefinition.stories.tsx
+++ b/frontend/src/components/crd/CustomResourceDefinition.stories.tsx
@@ -16,6 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
+import { baseMocks } from '../../../.storybook/baseMocks';
 import { API_BASE, TestContext, TestContextProps } from '../../test';
 import CustomResourceDefinitionDetails from './Details';
 import CustomResourceDefinitionList from './List';
@@ -34,6 +35,7 @@ export default {
   parameters: {
     msw: {
       handlers: {
+        base: null,
         storyBase: [
           http.get(
             `${API_BASE}/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions`,
@@ -61,6 +63,7 @@ export default {
               items: mockCRList,
             })
           ),
+          ...baseMocks,
         ],
       },
     },

--- a/frontend/src/storybookMocks.test.ts
+++ b/frontend/src/storybookMocks.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { setupServer } from 'msw/node';
+import { baseMocks as frontendMocks } from '../.storybook/baseMocks';
+import { baseMocks as pluginMocks } from '../../plugins/headlamp-plugin/config/.storybook/baseMocks';
+
+const crdV1Url = 'http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions';
+const crdV1beta1Url =
+  'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions';
+
+describe.each([
+  ['frontend', frontendMocks],
+  ['plugin template', pluginMocks],
+])('%s Storybook mocks', (_name, handlers) => {
+  const server = setupServer(...handlers);
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+  afterAll(() => server.close());
+
+  it('mocks custom resource definition discovery', async () => {
+    const response = await fetch(crdV1Url);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      kind: 'CustomResourceDefinitionList',
+      apiVersion: 'apiextensions.k8s.io/v1',
+      metadata: {},
+      items: [],
+    });
+    await expect(fetch(crdV1beta1Url)).rejects.toThrow();
+  });
+});

--- a/frontend/src/storybookMocks.test.ts
+++ b/frontend/src/storybookMocks.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 The Kubernetes Authors
+ * Copyright 2025 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 
+import fs from 'fs';
 import { setupServer } from 'msw/node';
+import path from 'path';
 import { baseMocks as frontendMocks } from '../.storybook/baseMocks';
-import { baseMocks as pluginMocks } from '../../plugins/headlamp-plugin/config/.storybook/baseMocks';
 
 const crdV1Url = 'http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions';
 const crdV1beta1Url =
   'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions';
 
-describe.each([
-  ['frontend', frontendMocks],
-  ['plugin template', pluginMocks],
-])('%s Storybook mocks', (_name, handlers) => {
-  const server = setupServer(...handlers);
+describe('frontend Storybook mocks', () => {
+  const server = setupServer(...frontendMocks);
 
   beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
   afterAll(() => server.close());
@@ -41,6 +39,22 @@ describe.each([
       metadata: {},
       items: [],
     });
-    await expect(fetch(crdV1beta1Url)).rejects.toThrow();
+    await expect(fetch(crdV1beta1Url)).resolves.toMatchObject({ status: 404 });
   });
+});
+
+it.each([
+  ['frontend', path.resolve(__dirname, '../.storybook/baseMocks.ts')],
+  [
+    'plugin template',
+    path.resolve(__dirname, '../../plugins/headlamp-plugin/config/.storybook/baseMocks.ts'),
+  ],
+])('keeps the %s CRD mock contract synchronized', (_name, sourcePath) => {
+  const source = fs.readFileSync(sourcePath, 'utf8');
+
+  expect(source).toContain(crdV1Url);
+  expect(source).toContain("kind: 'CustomResourceDefinitionList'");
+  expect(source).toContain("apiVersion: 'apiextensions.k8s.io/v1'");
+  expect(source).toContain(crdV1beta1Url);
+  expect(source).toContain('new HttpResponse(null, { status: 404 })');
 });

--- a/plugins/headlamp-plugin/config/.storybook/baseMocks.ts
+++ b/plugins/headlamp-plugin/config/.storybook/baseMocks.ts
@@ -193,7 +193,7 @@ export const baseMocks = [
   ),
   http.get(
     'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
-    () => HttpResponse.error()
+    () => new HttpResponse(null, { status: 404 })
   ),
   http.get('http://localhost:4466/apis/metrics.k8s.io/v1beta1/nodes', () =>
     HttpResponse.json({

--- a/plugins/headlamp-plugin/config/.storybook/baseMocks.ts
+++ b/plugins/headlamp-plugin/config/.storybook/baseMocks.ts
@@ -183,6 +183,18 @@ export const baseMocks = [
       items: [],
     })
   ),
+  http.get('http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions', () =>
+    HttpResponse.json({
+      kind: 'CustomResourceDefinitionList',
+      apiVersion: 'apiextensions.k8s.io/v1',
+      metadata: {},
+      items: [],
+    })
+  ),
+  http.get(
+    'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
+    () => HttpResponse.error()
+  ),
   http.get('http://localhost:4466/apis/metrics.k8s.io/v1beta1/nodes', () =>
     HttpResponse.json({
       apiVersion: 'metrics.k8s.io/v1beta1',


### PR DESCRIPTION
## Summary

- add global Storybook mocks for current CRD discovery and the deprecated v1beta1 fallback
- return a Kubernetes-style 404 for unsupported v1beta1 discovery
- keep the built-in and plugin-template Storybook mock sets synchronized
- add unit contract coverage for both mock sets and a browser-level Storybook test

## Improvements over existing mocks

- existing CRD handlers are story-local, so stories without explicit overrides can issue unhandled discovery requests; these base handlers provide CRD discovery to every story by default
- the plugin template now receives the same defaults as Headlamp Storybook instead of requiring plugin authors to recreate CRD discovery mocks
- unsupported v1beta1 discovery returns a Kubernetes-style HTTP 404 instead of a network failure, matching Headlamp's API-version fallback behavior
- unit contracts keep both mock sources aligned, while the Playwright test verifies the handlers through the real Storybook preview worker

## Source

- extracted patch: Azure/aks-desktop#823 (`patches/0021-headlamp-upstream-storybook-crd-mocks.patch`)
- exported patch commit: `f746c41f650347f9089fc5cedcd7aada30ce9121`, authored by Evangelos Skopelitis on 2026-07-31
- earlier downstream source lineage: Azure/aks-desktop@d709d2ddfe6d17df96e633d9de6dcd7e31d6c1ff
- related upstream work: kubernetes-sigs/headlamp#5040 updated story-local v1beta1 responses; this PR adds the missing global handlers, including the plugin template

The feature commit preserves the exported author and date and includes René Dudfield as co-author. No standalone Azure/aks-desktop PR was associated with the original downstream feature commit; Azure/aks-desktop#823 is the authoritative PR carrying patch 0021.

## Testing

- `npm --prefix frontend test -- --run` (208 files, 2,736 tests passed)
- `e2e-tests/node_modules/.bin/playwright test --config e2e-tests/playwright.storybook.config.ts crdMocks.spec.ts` (1 test passed)
- `npm --prefix frontend run ci-lint`
- `npm --prefix frontend run tsc`
- `npm --prefix frontend run build-typedoc`
- `npm --prefix frontend run build-storybook`
- `git diff --check refs/remotes/upstream/main...HEAD`

The changed handlers contain no conditional branches. The unit contract executes the v1 success and v1beta1 404 callbacks and verifies both source mock sets remain synchronized. Vitest excludes `.storybook` paths from its percentage report, so it does not emit a numeric branch percentage for these files.

Assisted by copilot