### PR TITLE
0027: Make the column selector keyboard accessible

### DIFF
--- a/e2e-tests/tests/podsPage.spec.ts
+++ b/e2e-tests/tests/podsPage.spec.ts
@@ -114,6 +114,37 @@ test('loads the next page of pods', async ({ page }) => {
   expect(listRequests[1].searchParams.get('continue')).toBe('next-page');
 });
 
+test('changes column visibility with the keyboard', async ({ page }) => {
+  const headlampPage = new HeadlampPage(page);
+  await headlampPage.navigateToCluster('test', process.env.HEADLAMP_TEST_TOKEN);
+  await headlampPage.navigateTopage('/c/test/pods', /Pods/);
+
+  const columnSelector = page.getByRole('button', { name: 'Show/Hide columns' });
+  await columnSelector.focus();
+  await page.keyboard.press('Enter');
+
+  await expect(page.getByRole('menuitem', { name: 'Hide all' })).toBeFocused();
+
+  const columnItem = page.locator('[role="menuitemcheckbox"]:not([aria-disabled="true"])').first();
+  const initialChecked = await columnItem.getAttribute('aria-checked');
+  expect(initialChecked).toMatch(/^(true|false)$/);
+
+  const menuItemCount = await page.locator('[role="menuitem"], [role="menuitemcheckbox"]').count();
+  for (let index = 0; index < menuItemCount; index++) {
+    await page.keyboard.press('ArrowDown');
+    if (await columnItem.evaluate(element => element === document.activeElement)) {
+      break;
+    }
+  }
+  await expect(columnItem).toBeFocused();
+
+  await page.keyboard.press('Space');
+  await expect(columnItem).toHaveAttribute(
+    'aria-checked',
+    initialChecked === 'true' ? 'false' : 'true'
+  );
+});
+
 test('multi tab create delete pod', async ({ browser }) => {
   // This test may be slow to create and delete a pod
   test.setTimeout(60000);

--- a/e2e-tests/tests/podsPage.spec.ts
+++ b/e2e-tests/tests/podsPage.spec.ts
@@ -123,16 +123,18 @@ test('changes column visibility with the keyboard', async ({ page }) => {
   await columnSelector.focus();
   await page.keyboard.press('Enter');
 
-  await expect(page.getByRole('menuitem', { name: 'Hide all' })).toBeFocused();
-  await page.keyboard.press('ArrowDown');
-  await page.keyboard.press('ArrowDown');
-
   const columnItem = page.getByRole('menuitemcheckbox').first();
+  const initialChecked = await columnItem.getAttribute('aria-checked');
+  expect(initialChecked).toMatch(/^(true|false)$/);
+
+  await columnItem.focus();
   await expect(columnItem).toBeFocused();
-  await expect(columnItem).toHaveAttribute('aria-checked', 'true');
 
   await page.keyboard.press('Space');
-  await expect(columnItem).toHaveAttribute('aria-checked', 'false');
+  await expect(columnItem).toHaveAttribute(
+    'aria-checked',
+    initialChecked === 'true' ? 'false' : 'true'
+  );
 });
 
 test('multi tab create delete pod', async ({ browser }) => {

--- a/e2e-tests/tests/podsPage.spec.ts
+++ b/e2e-tests/tests/podsPage.spec.ts
@@ -114,6 +114,27 @@ test('loads the next page of pods', async ({ page }) => {
   expect(listRequests[1].searchParams.get('continue')).toBe('next-page');
 });
 
+test('changes column visibility with the keyboard', async ({ page }) => {
+  const headlampPage = new HeadlampPage(page);
+  await headlampPage.navigateToCluster('test', process.env.HEADLAMP_TEST_TOKEN);
+  await headlampPage.navigateTopage('/c/test/pods', /Pods/);
+
+  const columnSelector = page.getByRole('button', { name: 'Show/Hide columns' });
+  await columnSelector.focus();
+  await page.keyboard.press('Enter');
+
+  await expect(page.getByRole('menuitem', { name: 'Hide all' })).toBeFocused();
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('ArrowDown');
+
+  const columnItem = page.getByRole('menuitemcheckbox').first();
+  await expect(columnItem).toBeFocused();
+  await expect(columnItem).toHaveAttribute('aria-checked', 'true');
+
+  await page.keyboard.press('Space');
+  await expect(columnItem).toHaveAttribute('aria-checked', 'false');
+});
+
 test('multi tab create delete pod', async ({ browser }) => {
   // This test may be slow to create and delete a pod
   test.setTimeout(60000);

--- a/frontend/src/components/App/Home/__snapshots__/ClusterTable.Connecting.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/ClusterTable.Connecting.stories.storyshot
@@ -109,6 +109,7 @@
                 />
               </button>
               <button
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/App/Home/__snapshots__/ClusterTable.Default.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/ClusterTable.Default.stories.storyshot
@@ -109,6 +109,7 @@
                 />
               </button>
               <button
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/App/Home/__snapshots__/ClusterTable.NotConnected.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/ClusterTable.NotConnected.stories.storyshot
@@ -109,6 +109,7 @@
                 />
               </button>
               <button
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/App/Home/__snapshots__/ClusterTable.UnhealthyControlPlane.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/ClusterTable.UnhealthyControlPlane.stories.storyshot
@@ -109,6 +109,7 @@
                 />
               </button>
               <button
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/App/Home/__snapshots__/ClusterTable.WithErrors.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/ClusterTable.WithErrors.stories.storyshot
@@ -109,6 +109,7 @@
                 />
               </button>
               <button
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/App/Home/__snapshots__/index.Base.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/index.Base.stories.storyshot
@@ -198,6 +198,7 @@
                           />
                         </button>
                         <button
+                          aria-haspopup="menu"
                           aria-label="Show/Hide columns"
                           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                           data-mui-internal-clone-element="true"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.DefaultSaveEnable.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.DefaultSaveEnable.stories.storyshot
@@ -137,6 +137,7 @@
                       />
                     </button>
                     <button
+                      aria-haspopup="menu"
                       aria-label="Show/Hide columns"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.EmptyHomepageItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.EmptyHomepageItems.stories.storyshot
@@ -137,6 +137,7 @@
                       />
                     </button>
                     <button
+                      aria-haspopup="menu"
                       aria-label="Show/Hide columns"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.FewItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.FewItems.stories.storyshot
@@ -137,6 +137,7 @@
                       />
                     </button>
                     <button
+                      aria-haspopup="menu"
                       aria-label="Show/Hide columns"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.ManyItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.ManyItems.stories.storyshot
@@ -137,6 +137,7 @@
                       />
                     </button>
                     <button
+                      aria-haspopup="menu"
                       aria-label="Show/Hide columns"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MigrationScenario.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MigrationScenario.stories.storyshot
@@ -137,6 +137,7 @@
                       />
                     </button>
                     <button
+                      aria-haspopup="menu"
                       aria-label="Show/Hide columns"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MoreItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MoreItems.stories.storyshot
@@ -137,6 +137,7 @@
                       />
                     </button>
                     <button
+                      aria-haspopup="menu"
                       aria-label="Show/Hide columns"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MultipleLocations.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MultipleLocations.stories.storyshot
@@ -137,6 +137,7 @@
                       />
                     </button>
                     <button
+                      aria-haspopup="menu"
                       aria-label="Show/Hide columns"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"

--- a/frontend/src/components/advancedSearch/__snapshots__/ResourceSearch.Default.stories.storyshot
+++ b/frontend/src/components/advancedSearch/__snapshots__/ResourceSearch.Default.stories.storyshot
@@ -142,6 +142,7 @@
                   />
                 </button>
                 <button
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceListView.OneHiddenColumn.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceListView.OneHiddenColumn.stories.storyshot
@@ -134,6 +134,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NameSearch.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NameSearch.stories.storyshot
@@ -173,6 +173,7 @@
                 />
               </button>
               <button
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NoFilter.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NoFilter.stories.storyshot
@@ -108,6 +108,7 @@
                 />
               </button>
               <button
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.WithHiddenCols.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.WithHiddenCols.stories.storyshot
@@ -108,6 +108,7 @@
                 />
               </button>
               <button
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/ColumnVisibilityButton.test.tsx
+++ b/frontend/src/components/common/Table/ColumnVisibilityButton.test.tsx
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MRT_Column, MRT_TableInstance } from 'material-react-table';
+import { expect, test, vi } from 'vitest';
+import { ColumnVisibilityButton } from './ColumnVisibilityButton';
+
+type Row = Record<string, unknown>;
+
+function makeColumn(
+  id: string,
+  options: {
+    canHide?: boolean;
+    columnDef?: Partial<MRT_Column<Row>['columnDef']>;
+    isVisible?: boolean;
+  } = {}
+) {
+  return {
+    id,
+    columnDef: { header: id, ...options.columnDef },
+    getCanHide: () => options.canHide ?? true,
+    getIsVisible: () => options.isVisible ?? true,
+    toggleVisibility: vi.fn(),
+  } as unknown as MRT_Column<Row>;
+}
+
+function makeTable(columns: MRT_Column<Row>[]) {
+  return {
+    options: {
+      icons: { ViewColumnIcon: () => <span /> },
+      localization: {
+        hideAll: 'Hide all',
+        showAll: 'Show all',
+        showHideColumns: 'Show or hide columns',
+      },
+    },
+    getAllLeafColumns: () => columns,
+  } as unknown as MRT_TableInstance<Row>;
+}
+
+test('exposes the menu state and closes it with Escape', async () => {
+  render(<ColumnVisibilityButton table={makeTable([makeColumn('Name')])} />);
+
+  const button = screen.getByRole('button', { name: 'Show or hide columns' });
+  expect(button).not.toHaveAttribute('aria-expanded');
+  expect(button).not.toHaveAttribute('aria-controls');
+
+  fireEvent.click(button);
+
+  expect(button).toHaveAttribute('aria-expanded', 'true');
+  const controlledMenu = document.getElementById(button.getAttribute('aria-controls')!);
+  expect(controlledMenu).toContainElement(screen.getByRole('menu'));
+
+  fireEvent.keyDown(screen.getByRole('menu'), { key: 'Escape' });
+  await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
+  expect(button).not.toHaveAttribute('aria-expanded');
+});
+
+test('only lists eligible columns as keyboard-accessible menu items', () => {
+  const name = makeColumn('Name');
+  const locked = makeColumn('Locked', { canHide: false, isVisible: false });
+  const hidingDisabled = makeColumn('Hiding disabled', {
+    columnDef: { enableHiding: false },
+  });
+  const omitted = makeColumn('Omitted', {
+    columnDef: { visibleInShowHideMenu: false },
+  });
+  const display = makeColumn('Display', {
+    columnDef: { columnDefType: 'display' },
+  });
+
+  render(
+    <ColumnVisibilityButton table={makeTable([name, locked, hidingDisabled, omitted, display])} />
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'Show or hide columns' }));
+
+  const nameItem = screen.getByRole('menuitemcheckbox', { name: 'Name', checked: true });
+  expect(nameItem).toHaveAttribute('tabindex', '-1');
+  expect(screen.getByRole('menuitemcheckbox', { name: 'Locked', checked: false })).toHaveAttribute(
+    'aria-disabled',
+    'true'
+  );
+  expect(screen.getAllByRole('menuitemcheckbox')).toHaveLength(2);
+  expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  expect(nameItem.querySelector('input')).toHaveAttribute('tabindex', '-1');
+  expect(nameItem.querySelector('input')).toHaveAttribute('readonly');
+
+  fireEvent.click(nameItem);
+  expect(name.toggleVisibility).toHaveBeenCalledOnce();
+});
+
+test('hides and shows every hideable column', () => {
+  const name = makeColumn('Name');
+  const age = makeColumn('Age', { isVisible: false });
+  const locked = makeColumn('Locked', { canHide: false });
+
+  render(<ColumnVisibilityButton table={makeTable([name, age, locked])} />);
+  fireEvent.click(screen.getByRole('button', { name: 'Show or hide columns' }));
+
+  fireEvent.click(screen.getByRole('menuitem', { name: 'Hide all' }));
+  expect(name.toggleVisibility).toHaveBeenCalledWith(false);
+  expect(age.toggleVisibility).toHaveBeenCalledWith(false);
+  expect(locked.toggleVisibility).not.toHaveBeenCalled();
+
+  fireEvent.click(screen.getByRole('menuitem', { name: 'Show all' }));
+  expect(name.toggleVisibility).toHaveBeenLastCalledWith(true);
+  expect(age.toggleVisibility).toHaveBeenLastCalledWith(true);
+});
+
+test('disables bulk actions when they cannot change visibility', () => {
+  render(<ColumnVisibilityButton table={makeTable([makeColumn('Locked', { canHide: false })])} />);
+  fireEvent.click(screen.getByRole('button', { name: 'Show or hide columns' }));
+
+  expect(screen.getByRole('menuitem', { name: 'Hide all' })).toHaveAttribute(
+    'aria-disabled',
+    'true'
+  );
+  expect(screen.getByRole('menuitem', { name: 'Show all' })).toHaveAttribute(
+    'aria-disabled',
+    'true'
+  );
+});
+
+test('derives bulk action availability from hideable columns', () => {
+  render(
+    <ColumnVisibilityButton
+      table={makeTable([
+        makeColumn('Locked', { canHide: false, isVisible: true }),
+        makeColumn('Hidden', { isVisible: false }),
+      ])}
+    />
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'Show or hide columns' }));
+
+  expect(screen.getByRole('menuitem', { name: 'Hide all' })).toHaveAttribute(
+    'aria-disabled',
+    'true'
+  );
+  expect(screen.getByRole('menuitem', { name: 'Show all' })).not.toHaveAttribute(
+    'aria-disabled',
+    'true'
+  );
+});

--- a/frontend/src/components/common/Table/ColumnVisibilityButton.test.tsx
+++ b/frontend/src/components/common/Table/ColumnVisibilityButton.test.tsx
@@ -38,10 +38,7 @@ function makeColumn(
   } as unknown as MRT_Column<Row>;
 }
 
-function makeTable(
-  columns: MRT_Column<Row>[],
-  options: { allVisible?: boolean; someVisible?: boolean } = {}
-) {
+function makeTable(columns: MRT_Column<Row>[]) {
   return {
     options: {
       icons: { ViewColumnIcon: () => <span /> },
@@ -52,8 +49,6 @@ function makeTable(
       },
     },
     getAllLeafColumns: () => columns,
-    getIsSomeColumnsVisible: () => options.someVisible ?? true,
-    getIsAllColumnsVisible: () => options.allVisible ?? false,
   } as unknown as MRT_TableInstance<Row>;
 }
 
@@ -101,6 +96,8 @@ test('only lists eligible columns as keyboard-accessible menu items', () => {
   );
   expect(screen.getAllByRole('menuitemcheckbox')).toHaveLength(2);
   expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  expect(nameItem.querySelector('input')).toHaveAttribute('tabindex', '-1');
+  expect(nameItem.querySelector('input')).toHaveAttribute('readonly');
 
   fireEvent.click(nameItem);
   expect(name.toggleVisibility).toHaveBeenCalledOnce();
@@ -108,7 +105,7 @@ test('only lists eligible columns as keyboard-accessible menu items', () => {
 
 test('hides and shows every hideable column', () => {
   const name = makeColumn('Name');
-  const age = makeColumn('Age');
+  const age = makeColumn('Age', { isVisible: false });
   const locked = makeColumn('Locked', { canHide: false });
 
   render(<ColumnVisibilityButton table={makeTable([name, age, locked])} />);
@@ -125,9 +122,26 @@ test('hides and shows every hideable column', () => {
 });
 
 test('disables bulk actions when they cannot change visibility', () => {
+  render(<ColumnVisibilityButton table={makeTable([makeColumn('Locked', { canHide: false })])} />);
+  fireEvent.click(screen.getByRole('button', { name: 'Show or hide columns' }));
+
+  expect(screen.getByRole('menuitem', { name: 'Hide all' })).toHaveAttribute(
+    'aria-disabled',
+    'true'
+  );
+  expect(screen.getByRole('menuitem', { name: 'Show all' })).toHaveAttribute(
+    'aria-disabled',
+    'true'
+  );
+});
+
+test('derives bulk action availability from hideable columns', () => {
   render(
     <ColumnVisibilityButton
-      table={makeTable([makeColumn('Name')], { allVisible: true, someVisible: false })}
+      table={makeTable([
+        makeColumn('Locked', { canHide: false, isVisible: true }),
+        makeColumn('Hidden', { isVisible: false }),
+      ])}
     />
   );
   fireEvent.click(screen.getByRole('button', { name: 'Show or hide columns' }));
@@ -136,7 +150,7 @@ test('disables bulk actions when they cannot change visibility', () => {
     'aria-disabled',
     'true'
   );
-  expect(screen.getByRole('menuitem', { name: 'Show all' })).toHaveAttribute(
+  expect(screen.getByRole('menuitem', { name: 'Show all' })).not.toHaveAttribute(
     'aria-disabled',
     'true'
   );

--- a/frontend/src/components/common/Table/ColumnVisibilityButton.test.tsx
+++ b/frontend/src/components/common/Table/ColumnVisibilityButton.test.tsx
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MRT_Column, MRT_TableInstance } from 'material-react-table';
+import { expect, test, vi } from 'vitest';
+import { ColumnVisibilityButton } from './ColumnVisibilityButton';
+
+type Row = Record<string, unknown>;
+
+function makeColumn(
+  id: string,
+  options: {
+    canHide?: boolean;
+    columnDef?: Partial<MRT_Column<Row>['columnDef']>;
+    isVisible?: boolean;
+  } = {}
+) {
+  return {
+    id,
+    columnDef: { header: id, ...options.columnDef },
+    getCanHide: () => options.canHide ?? true,
+    getIsVisible: () => options.isVisible ?? true,
+    toggleVisibility: vi.fn(),
+  } as unknown as MRT_Column<Row>;
+}
+
+function makeTable(
+  columns: MRT_Column<Row>[],
+  options: { allVisible?: boolean; someVisible?: boolean } = {}
+) {
+  return {
+    options: {
+      icons: { ViewColumnIcon: () => <span /> },
+      localization: {
+        hideAll: 'Hide all',
+        showAll: 'Show all',
+        showHideColumns: 'Show or hide columns',
+      },
+    },
+    getAllLeafColumns: () => columns,
+    getIsSomeColumnsVisible: () => options.someVisible ?? true,
+    getIsAllColumnsVisible: () => options.allVisible ?? false,
+  } as unknown as MRT_TableInstance<Row>;
+}
+
+test('exposes the menu state and closes it with Escape', async () => {
+  render(<ColumnVisibilityButton table={makeTable([makeColumn('Name')])} />);
+
+  const button = screen.getByRole('button', { name: 'Show or hide columns' });
+  expect(button).not.toHaveAttribute('aria-expanded');
+  expect(button).not.toHaveAttribute('aria-controls');
+
+  fireEvent.click(button);
+
+  expect(button).toHaveAttribute('aria-expanded', 'true');
+  const controlledMenu = document.getElementById(button.getAttribute('aria-controls')!);
+  expect(controlledMenu).toContainElement(screen.getByRole('menu'));
+
+  fireEvent.keyDown(screen.getByRole('menu'), { key: 'Escape' });
+  await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
+  expect(button).not.toHaveAttribute('aria-expanded');
+});
+
+test('only lists eligible columns as keyboard-accessible menu items', () => {
+  const name = makeColumn('Name');
+  const locked = makeColumn('Locked', { canHide: false, isVisible: false });
+  const hidingDisabled = makeColumn('Hiding disabled', {
+    columnDef: { enableHiding: false },
+  });
+  const omitted = makeColumn('Omitted', {
+    columnDef: { visibleInShowHideMenu: false },
+  });
+  const display = makeColumn('Display', {
+    columnDef: { columnDefType: 'display' },
+  });
+
+  render(
+    <ColumnVisibilityButton table={makeTable([name, locked, hidingDisabled, omitted, display])} />
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'Show or hide columns' }));
+
+  const nameItem = screen.getByRole('menuitemcheckbox', { name: 'Name', checked: true });
+  expect(nameItem).toHaveAttribute('tabindex', '-1');
+  expect(screen.getByRole('menuitemcheckbox', { name: 'Locked', checked: false })).toHaveAttribute(
+    'aria-disabled',
+    'true'
+  );
+  expect(screen.getAllByRole('menuitemcheckbox')).toHaveLength(2);
+  expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+
+  fireEvent.click(nameItem);
+  expect(name.toggleVisibility).toHaveBeenCalledOnce();
+});
+
+test('hides and shows every hideable column', () => {
+  const name = makeColumn('Name');
+  const age = makeColumn('Age');
+  const locked = makeColumn('Locked', { canHide: false });
+
+  render(<ColumnVisibilityButton table={makeTable([name, age, locked])} />);
+  fireEvent.click(screen.getByRole('button', { name: 'Show or hide columns' }));
+
+  fireEvent.click(screen.getByRole('menuitem', { name: 'Hide all' }));
+  expect(name.toggleVisibility).toHaveBeenCalledWith(false);
+  expect(age.toggleVisibility).toHaveBeenCalledWith(false);
+  expect(locked.toggleVisibility).not.toHaveBeenCalled();
+
+  fireEvent.click(screen.getByRole('menuitem', { name: 'Show all' }));
+  expect(name.toggleVisibility).toHaveBeenLastCalledWith(true);
+  expect(age.toggleVisibility).toHaveBeenLastCalledWith(true);
+});
+
+test('disables bulk actions when they cannot change visibility', () => {
+  render(
+    <ColumnVisibilityButton
+      table={makeTable([makeColumn('Name')], { allVisible: true, someVisible: false })}
+    />
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'Show or hide columns' }));
+
+  expect(screen.getByRole('menuitem', { name: 'Hide all' })).toHaveAttribute(
+    'aria-disabled',
+    'true'
+  );
+  expect(screen.getByRole('menuitem', { name: 'Show all' })).toHaveAttribute(
+    'aria-disabled',
+    'true'
+  );
+});

--- a/frontend/src/components/common/Table/ColumnVisibilityButton.tsx
+++ b/frontend/src/components/common/Table/ColumnVisibilityButton.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Divider from '@mui/material/Divider';
+import IconButton from '@mui/material/IconButton';
+import ListItemText from '@mui/material/ListItemText';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Switch from '@mui/material/Switch';
+import Tooltip from '@mui/material/Tooltip';
+import { MRT_TableInstance } from 'material-react-table';
+import { useId, useState } from 'react';
+
+export function ColumnVisibilityButton<T extends Record<string, any>>({
+  table,
+}: {
+  table: MRT_TableInstance<T>;
+}) {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const menuId = useId();
+  const isOpen = !!anchorEl;
+  const {
+    icons: { ViewColumnIcon },
+    localization,
+  } = table.options;
+
+  const columns = table
+    .getAllLeafColumns()
+    .filter(
+      col =>
+        col.columnDef.enableHiding !== false &&
+        col.columnDef.visibleInShowHideMenu !== false &&
+        col.columnDef.columnDefType !== 'display'
+    );
+  const hideableColumns = columns.filter(col => col.getCanHide());
+  const hasVisibleHideableColumns = hideableColumns.some(col => col.getIsVisible());
+  const hasHiddenHideableColumns = hideableColumns.some(col => !col.getIsVisible());
+
+  const handleToggleAll = (visible: boolean) => {
+    hideableColumns.forEach(col => col.toggleVisibility(visible));
+  };
+
+  return (
+    <>
+      <Tooltip title={localization.showHideColumns}>
+        <IconButton
+          aria-label={localization.showHideColumns}
+          aria-haspopup="menu"
+          aria-expanded={isOpen || undefined}
+          aria-controls={isOpen ? menuId : undefined}
+          onClick={event => setAnchorEl(event.currentTarget)}
+        >
+          <ViewColumnIcon />
+        </IconButton>
+      </Tooltip>
+      <Menu
+        id={menuId}
+        anchorEl={anchorEl}
+        open={isOpen}
+        onClose={() => setAnchorEl(null)}
+        disableScrollLock
+      >
+        <MenuItem disabled={!hasVisibleHideableColumns} onClick={() => handleToggleAll(false)}>
+          {localization.hideAll}
+        </MenuItem>
+        <MenuItem disabled={!hasHiddenHideableColumns} onClick={() => handleToggleAll(true)}>
+          {localization.showAll}
+        </MenuItem>
+        <Divider />
+        {columns.map(column => (
+          <MenuItem
+            key={column.id}
+            role="menuitemcheckbox"
+            aria-checked={column.getIsVisible()}
+            disabled={!column.getCanHide()}
+            onClick={() => column.toggleVisibility()}
+          >
+            <Switch
+              size="small"
+              checked={column.getIsVisible()}
+              readOnly
+              tabIndex={-1}
+              inputProps={{ 'aria-hidden': true, tabIndex: -1 }}
+              edge="start"
+              sx={{ mr: 1, pointerEvents: 'none' }}
+            />
+            <ListItemText>{column.columnDef.header}</ListItemText>
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+}

--- a/frontend/src/components/common/Table/ColumnVisibilityButton.tsx
+++ b/frontend/src/components/common/Table/ColumnVisibilityButton.tsx
@@ -45,9 +45,12 @@ export function ColumnVisibilityButton<T extends Record<string, any>>({
         col.columnDef.visibleInShowHideMenu !== false &&
         col.columnDef.columnDefType !== 'display'
     );
+  const hideableColumns = columns.filter(col => col.getCanHide());
+  const hasVisibleHideableColumns = hideableColumns.some(col => col.getIsVisible());
+  const hasHiddenHideableColumns = hideableColumns.some(col => !col.getIsVisible());
 
   const handleToggleAll = (visible: boolean) => {
-    columns.filter(col => col.getCanHide()).forEach(col => col.toggleVisibility(visible));
+    hideableColumns.forEach(col => col.toggleVisibility(visible));
   };
 
   return (
@@ -70,13 +73,10 @@ export function ColumnVisibilityButton<T extends Record<string, any>>({
         onClose={() => setAnchorEl(null)}
         disableScrollLock
       >
-        <MenuItem
-          disabled={!table.getIsSomeColumnsVisible()}
-          onClick={() => handleToggleAll(false)}
-        >
+        <MenuItem disabled={!hasVisibleHideableColumns} onClick={() => handleToggleAll(false)}>
           {localization.hideAll}
         </MenuItem>
-        <MenuItem disabled={table.getIsAllColumnsVisible()} onClick={() => handleToggleAll(true)}>
+        <MenuItem disabled={!hasHiddenHideableColumns} onClick={() => handleToggleAll(true)}>
           {localization.showAll}
         </MenuItem>
         <Divider />
@@ -91,9 +91,9 @@ export function ColumnVisibilityButton<T extends Record<string, any>>({
             <Switch
               size="small"
               checked={column.getIsVisible()}
-              onChange={() => {}}
+              readOnly
               tabIndex={-1}
-              inputProps={{ 'aria-hidden': true }}
+              inputProps={{ 'aria-hidden': true, tabIndex: -1 }}
               edge="start"
               sx={{ mr: 1, pointerEvents: 'none' }}
             />

--- a/frontend/src/components/common/Table/ColumnVisibilityButton.tsx
+++ b/frontend/src/components/common/Table/ColumnVisibilityButton.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Divider from '@mui/material/Divider';
+import IconButton from '@mui/material/IconButton';
+import ListItemText from '@mui/material/ListItemText';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Switch from '@mui/material/Switch';
+import Tooltip from '@mui/material/Tooltip';
+import { MRT_TableInstance } from 'material-react-table';
+import { useId, useState } from 'react';
+
+export function ColumnVisibilityButton<T extends Record<string, any>>({
+  table,
+}: {
+  table: MRT_TableInstance<T>;
+}) {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const menuId = useId();
+  const isOpen = !!anchorEl;
+  const {
+    icons: { ViewColumnIcon },
+    localization,
+  } = table.options;
+
+  const columns = table
+    .getAllLeafColumns()
+    .filter(
+      col =>
+        col.columnDef.enableHiding !== false &&
+        col.columnDef.visibleInShowHideMenu !== false &&
+        col.columnDef.columnDefType !== 'display'
+    );
+
+  const handleToggleAll = (visible: boolean) => {
+    columns.filter(col => col.getCanHide()).forEach(col => col.toggleVisibility(visible));
+  };
+
+  return (
+    <>
+      <Tooltip title={localization.showHideColumns}>
+        <IconButton
+          aria-label={localization.showHideColumns}
+          aria-haspopup="menu"
+          aria-expanded={isOpen || undefined}
+          aria-controls={isOpen ? menuId : undefined}
+          onClick={event => setAnchorEl(event.currentTarget)}
+        >
+          <ViewColumnIcon />
+        </IconButton>
+      </Tooltip>
+      <Menu
+        id={menuId}
+        anchorEl={anchorEl}
+        open={isOpen}
+        onClose={() => setAnchorEl(null)}
+        disableScrollLock
+      >
+        <MenuItem
+          disabled={!table.getIsSomeColumnsVisible()}
+          onClick={() => handleToggleAll(false)}
+        >
+          {localization.hideAll}
+        </MenuItem>
+        <MenuItem disabled={table.getIsAllColumnsVisible()} onClick={() => handleToggleAll(true)}>
+          {localization.showAll}
+        </MenuItem>
+        <Divider />
+        {columns.map(column => (
+          <MenuItem
+            key={column.id}
+            role="menuitemcheckbox"
+            aria-checked={column.getIsVisible()}
+            disabled={!column.getCanHide()}
+            onClick={() => column.toggleVisibility()}
+          >
+            <Switch
+              size="small"
+              checked={column.getIsVisible()}
+              onChange={() => {}}
+              tabIndex={-1}
+              inputProps={{ 'aria-hidden': true }}
+              edge="start"
+              sx={{ mr: 1, pointerEvents: 'none' }}
+            />
+            <ListItemText>{column.columnDef.header}</ListItemText>
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+}

--- a/frontend/src/components/common/Table/Table.test.tsx
+++ b/frontend/src/components/common/Table/Table.test.tsx
@@ -52,6 +52,9 @@ vi.mock('../../App/Settings/hook', () => ({ useSettings: () => [10] }));
 vi.mock('../../resourceMap/useQueryParamsState', () => ({
   useQueryParamsState: (_key: string, initialValue: unknown) => [initialValue, vi.fn()],
 }));
+vi.mock('./ColumnVisibilityButton', () => ({
+  ColumnVisibilityButton: () => <button data-testid="column-visibility" />,
+}));
 vi.mock('./useScrollPreservation', () => ({
   useScrollPreservationOnDataChange: () => ({ ref: { current: null }, onScroll: vi.fn() }),
 }));
@@ -73,6 +76,10 @@ vi.mock('material-react-table', () => ({
     );
   },
   MRT_TableHeadCell: () => <th>Selection</th>,
+  MRT_ToggleDensePaddingButton: () => <button data-testid="density-toggle" />,
+  MRT_ToggleFiltersButton: () => <button data-testid="filters-toggle" />,
+  MRT_ToggleFullScreenButton: () => <button data-testid="fullscreen-toggle" />,
+  MRT_ToggleGlobalFilterButton: () => <button data-testid="search-toggle" />,
   MRT_TopToolbar: () => <div data-testid="top-toolbar" />,
   useMaterialReactTable: (options: any) => {
     tableMocks.options = options;
@@ -149,6 +156,13 @@ function renderTable(props: Partial<TableProps<TestRow>> = {}) {
       />
     </ThemeProvider>
   );
+}
+
+function toolbarTable(selectedRows: object[] = []) {
+  return {
+    getSelectedRowModel: () => ({ rows: selectedRows }),
+    options: tableMocks.options,
+  };
 }
 
 describe('Table toolbar and selection props', () => {
@@ -298,25 +312,44 @@ describe('Table states and options', () => {
     renderTable({ enableRowSelection: true, renderRowSelectionToolbar });
 
     const noSelection = tableMocks.options.renderToolbarInternalActions({
-      table: { getSelectedRowModel: () => ({ rows: [] }) },
+      table: toolbarTable(),
     });
     const withSelection = tableMocks.options.renderToolbarInternalActions({
-      table: { getSelectedRowModel: () => ({ rows: [{}] }) },
+      table: toolbarTable([{}]),
     });
 
-    expect(noSelection).toBeNull();
+    expect(noSelection).not.toBeNull();
     expect(withSelection).toEqual(<span>Selected actions</span>);
     expect(renderRowSelectionToolbar).toHaveBeenCalledOnce();
   });
 
-  it('returns no selection toolbar when no renderer is provided', () => {
+  it('renders internal controls when selected rows have no custom toolbar', () => {
     renderTable({ enableRowSelection: true });
 
     const toolbar = tableMocks.options.renderToolbarInternalActions({
-      table: { getSelectedRowModel: () => ({ rows: [{}] }) },
+      table: toolbarTable([{}]),
     });
 
-    expect(toolbar).toBeNull();
+    render(<ThemeProvider theme={theme}>{toolbar}</ThemeProvider>);
+
+    expect(screen.getByTestId('search-toggle')).toBeVisible();
+    expect(screen.getByTestId('filters-toggle')).toBeVisible();
+    expect(screen.getByTestId('column-visibility')).toBeVisible();
+  });
+
+  it('renders every enabled internal toolbar control', () => {
+    renderTable({ enableDensityToggle: true, enableFullScreenToggle: true });
+
+    const toolbar = tableMocks.options.renderToolbarInternalActions({
+      table: toolbarTable(),
+    });
+    render(<ThemeProvider theme={theme}>{toolbar}</ThemeProvider>);
+
+    expect(screen.getByTestId('search-toggle')).toBeVisible();
+    expect(screen.getByTestId('filters-toggle')).toBeVisible();
+    expect(screen.getByTestId('column-visibility')).toBeVisible();
+    expect(screen.getByTestId('density-toggle')).toBeVisible();
+    expect(screen.getByTestId('fullscreen-toggle')).toBeVisible();
   });
 
   it('provides an empty-results fallback to Material React Table', () => {

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -32,6 +32,10 @@ import {
   MRT_TableHeadCell,
   MRT_TableInstance,
   MRT_TableOptions as MaterialTableOptions,
+  MRT_ToggleDensePaddingButton,
+  MRT_ToggleFiltersButton,
+  MRT_ToggleFullScreenButton,
+  MRT_ToggleGlobalFilterButton,
   MRT_TopToolbar,
   useMaterialReactTable,
   useMRT_Rows,
@@ -45,6 +49,7 @@ import { useSettings } from '../../App/Settings/hook';
 import { useQueryParamsState } from '../../resourceMap/useQueryParamsState';
 import Empty from '../EmptyContent';
 import Loader from '../Loader';
+import { ColumnVisibilityButton } from './ColumnVisibilityButton';
 import { getTableLocalization } from './tableLocalization';
 
 /**
@@ -377,16 +382,41 @@ export default function Table<RowItem extends Record<string, any>>({
     },
     onGlobalFilterChange: setGlobalFilter,
     onColumnVisibilityChange: setColumnVisibility,
-    renderToolbarInternalActions: props => {
+    renderToolbarInternalActions: ({ table: tbl }) => {
       const isSomeRowsSelected =
-        tableProps.enableRowSelection && props.table.getSelectedRowModel().rows.length !== 0;
-      if (isSomeRowsSelected) {
-        const renderRowSelectionToolbar = tableProps.renderRowSelectionToolbar;
-        if (renderRowSelectionToolbar !== undefined) {
-          return renderRowSelectionToolbar(props);
-        }
+        tableProps.enableRowSelection && tbl.getSelectedRowModel().rows.length !== 0;
+      if (isSomeRowsSelected && tableProps.renderRowSelectionToolbar) {
+        return tableProps.renderRowSelectionToolbar({ table: tbl });
       }
-      return null;
+
+      const {
+        enableFilters = true,
+        enableGlobalFilter = true,
+        enableColumnFilters = true,
+        enableHiding = true,
+        enableColumnOrdering,
+        enableColumnPinning,
+        enableDensityToggle,
+        enableFullScreenToggle,
+        columnFilterDisplayMode,
+        initialState: initState,
+      } = tbl.options;
+
+      return (
+        <>
+          {enableFilters && enableGlobalFilter && !initState?.showGlobalFilter && (
+            <MRT_ToggleGlobalFilterButton table={tbl} />
+          )}
+          {enableFilters && enableColumnFilters && columnFilterDisplayMode !== 'popover' && (
+            <MRT_ToggleFiltersButton table={tbl} />
+          )}
+          {(enableHiding || enableColumnOrdering || enableColumnPinning) && (
+            <ColumnVisibilityButton table={tbl} />
+          )}
+          {enableDensityToggle && <MRT_ToggleDensePaddingButton table={tbl} />}
+          {enableFullScreenToggle && <MRT_ToggleFullScreenButton table={tbl} />}
+        </>
+      );
     },
     initialState: useMemo(
       () => ({

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -33,6 +33,8 @@ import {
   MRT_TableHeadCell,
   MRT_TableInstance,
   MRT_TableOptions as MaterialTableOptions,
+  MRT_ToggleFiltersButton,
+  MRT_ToggleGlobalFilterButton,
   MRT_TopToolbar,
   useMaterialReactTable,
   useMRT_Rows,
@@ -59,6 +61,7 @@ import { useSettings } from '../../App/Settings/hook';
 import { useQueryParamsState } from '../../resourceMap/useQueryParamsState';
 import Empty from '../EmptyContent';
 import Loader from '../Loader';
+import { ColumnVisibilityButton } from './ColumnVisibilityButton';
 
 /**
  * Column definition
@@ -406,16 +409,37 @@ export default function Table<RowItem extends Record<string, any>>({
     },
     onGlobalFilterChange: setGlobalFilter,
     onColumnVisibilityChange: setColumnVisibility,
-    renderToolbarInternalActions: props => {
+    renderToolbarInternalActions: ({ table: tbl }) => {
       const isSomeRowsSelected =
-        tableProps.enableRowSelection && props.table.getSelectedRowModel().rows.length !== 0;
-      if (isSomeRowsSelected) {
-        const renderRowSelectionToolbar = tableProps.renderRowSelectionToolbar;
-        if (renderRowSelectionToolbar !== undefined) {
-          return renderRowSelectionToolbar(props);
-        }
+        tableProps.enableRowSelection && tbl.getSelectedRowModel().rows.length !== 0;
+      if (isSomeRowsSelected && tableProps.renderRowSelectionToolbar) {
+        return tableProps.renderRowSelectionToolbar({ table: tbl });
       }
-      return null;
+
+      const {
+        enableFilters = true,
+        enableGlobalFilter = true,
+        enableColumnFilters = true,
+        enableHiding = true,
+        enableColumnOrdering,
+        enableColumnPinning,
+        columnFilterDisplayMode,
+        initialState: initState,
+      } = tbl.options;
+
+      return (
+        <>
+          {enableFilters && enableGlobalFilter && !initState?.showGlobalFilter && (
+            <MRT_ToggleGlobalFilterButton table={tbl} />
+          )}
+          {enableFilters && enableColumnFilters && columnFilterDisplayMode !== 'popover' && (
+            <MRT_ToggleFiltersButton table={tbl} />
+          )}
+          {(enableHiding || enableColumnOrdering || enableColumnPinning) && (
+            <ColumnVisibilityButton table={tbl} />
+          )}
+        </>
+      );
     },
     initialState: useMemo(
       () => ({

--- a/frontend/src/components/common/Table/__snapshots__/Table.Datum.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.Datum.stories.storyshot
@@ -108,6 +108,7 @@
                 />
               </button>
               <button
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.Getter.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.Getter.stories.storyshot
@@ -108,6 +108,7 @@
                 />
               </button>
               <button
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.LabelSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.LabelSearch.stories.storyshot
@@ -217,6 +217,7 @@
                 />
               </button>
               <button
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NameSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NameSearch.stories.storyshot
@@ -217,6 +217,7 @@
                 />
               </button>
               <button
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSearch.stories.storyshot
@@ -217,6 +217,7 @@
                 />
               </button>
               <button
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSelect.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSelect.stories.storyshot
@@ -255,6 +255,7 @@
                 />
               </button>
               <button
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NotFoundMessage.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NotFoundMessage.stories.storyshot
@@ -217,6 +217,7 @@
                 />
               </button>
               <button
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NumberSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NumberSearch.stories.storyshot
@@ -217,6 +217,7 @@
                 />
               </button>
               <button
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURL.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURL.stories.storyshot
@@ -125,6 +125,7 @@
                   />
                 </button>
                 <button
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURLWithPrefix.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURLWithPrefix.stories.storyshot
@@ -125,6 +125,7 @@
                   />
                 </button>
                 <button
+                  aria-haspopup="menu"
                   aria-label="Show/Hide columns"
                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                   data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.UIDSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.UIDSearch.stories.storyshot
@@ -217,6 +217,7 @@
                 />
               </button>
               <button
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.WithFilterMultiSelect.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.WithFilterMultiSelect.stories.storyshot
@@ -108,6 +108,7 @@
                 />
               </button>
               <button
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.WithGlobalFilter.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.WithGlobalFilter.stories.storyshot
@@ -175,6 +175,7 @@
                 />
               </button>
               <button
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/common/Table/__snapshots__/Table.WithSorting.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.WithSorting.stories.storyshot
@@ -108,6 +108,7 @@
                 />
               </button>
               <button
+                aria-haspopup="menu"
                 aria-label="Show/Hide columns"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"

--- a/frontend/src/components/configmap/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/List.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
@@ -728,6 +728,7 @@
                           />
                         </button>
                         <button
+                          aria-haspopup="menu"
                           aria-label="Show/Hide columns"
                           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                           data-mui-internal-clone-element="true"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
@@ -734,6 +734,7 @@
                           />
                         </button>
                         <button
+                          aria-haspopup="menu"
                           aria-label="Show/Hide columns"
                           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                           data-mui-internal-clone-element="true"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.List.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.List.stories.storyshot
@@ -134,6 +134,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
@@ -245,6 +245,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/cronjob/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/List.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/daemonset/__snapshots__/List.DaemonSets.stories.storyshot
+++ b/frontend/src/components/daemonset/__snapshots__/List.DaemonSets.stories.storyshot
@@ -238,6 +238,7 @@
                       />
                     </button>
                     <button
+                      aria-haspopup="menu"
                       aria-label="Show/Hide columns"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"

--- a/frontend/src/components/daemonset/__snapshots__/List.LongName.stories.storyshot
+++ b/frontend/src/components/daemonset/__snapshots__/List.LongName.stories.storyshot
@@ -238,6 +238,7 @@
                       />
                     </button>
                     <button
+                      aria-haspopup="menu"
                       aria-label="Show/Hide columns"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"

--- a/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
+++ b/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
@@ -238,6 +238,7 @@
                       />
                     </button>
                     <button
+                      aria-haspopup="menu"
                       aria-label="Show/Hide columns"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"

--- a/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
+++ b/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/gateway/__snapshots__/BackendTLSPolicyList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/BackendTLSPolicyList.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/gateway/__snapshots__/BackendTrafficPolicyList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/BackendTrafficPolicyList.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/gateway/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ClassList.Items.stories.storyshot
@@ -146,6 +146,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/gateway/__snapshots__/GRPCRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GRPCRouteList.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/gateway/__snapshots__/GatewayList.BrokenSpec.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GatewayList.BrokenSpec.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/gateway/__snapshots__/GatewayList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GatewayList.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/gateway/__snapshots__/HTTPRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/HTTPRouteList.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/gateway/__snapshots__/ReferenceGrantList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ReferenceGrantList.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/gateway/__snapshots__/TCPRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/TCPRouteList.Items.stories.storyshot
@@ -223,6 +223,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/gateway/__snapshots__/UDPRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/UDPRouteList.Items.stories.storyshot
@@ -223,6 +223,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.Items.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/ingress/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/ClassList.Items.stories.storyshot
@@ -146,6 +146,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/job/__snapshots__/JobList.Items.stories.storyshot
+++ b/frontend/src/components/job/__snapshots__/JobList.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/jobset/__snapshots__/JobSetList.Items.stories.storyshot
+++ b/frontend/src/components/jobset/__snapshots__/JobSetList.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/leaderworkerset/__snapshots__/LeaderWorkerSetList.Items.stories.storyshot
+++ b/frontend/src/components/leaderworkerset/__snapshots__/LeaderWorkerSetList.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/lease/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/lease/__snapshots__/List.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/limitRange/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/limitRange/__snapshots__/List.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/namespace/__snapshots__/NamespaceList.Regular.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceList.Regular.stories.storyshot
@@ -146,6 +146,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/networkpolicy/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/networkpolicy/__snapshots__/List.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/node/__snapshots__/List.NoNodePools.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/List.NoNodePools.stories.storyshot
@@ -149,6 +149,7 @@
                       />
                     </button>
                     <button
+                      aria-haspopup="menu"
                       aria-label="Show/Hide columns"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"

--- a/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
@@ -149,6 +149,7 @@
                       />
                     </button>
                     <button
+                      aria-haspopup="menu"
                       aria-label="Show/Hide columns"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"

--- a/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.Items.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/podGroup/__snapshots__/List.PodGroups.stories.storyshot
+++ b/frontend/src/components/podGroup/__snapshots__/List.PodGroups.stories.storyshot
@@ -226,6 +226,7 @@
                       />
                     </button>
                     <button
+                      aria-haspopup="menu"
                       aria-label="Show/Hide columns"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassList.Items.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassList.Items.stories.storyshot
@@ -146,6 +146,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/replicaset/__snapshots__/List.ReplicaSets.stories.storyshot
+++ b/frontend/src/components/replicaset/__snapshots__/List.ReplicaSets.stories.storyshot
@@ -238,6 +238,7 @@
                       />
                     </button>
                     <button
+                      aria-haspopup="menu"
                       aria-label="Show/Hide columns"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.Items.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/role/__snapshots__/BindingList.RoleBindings.stories.storyshot
+++ b/frontend/src/components/role/__snapshots__/BindingList.RoleBindings.stories.storyshot
@@ -137,6 +137,7 @@
                       />
                     </button>
                     <button
+                      aria-haspopup="menu"
                       aria-label="Show/Hide columns"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"

--- a/frontend/src/components/role/__snapshots__/List.Roles.stories.storyshot
+++ b/frontend/src/components/role/__snapshots__/List.Roles.stories.storyshot
@@ -137,6 +137,7 @@
                       />
                     </button>
                     <button
+                      aria-haspopup="menu"
                       aria-label="Show/Hide columns"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"

--- a/frontend/src/components/runtimeClass/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/runtimeClass/__snapshots__/List.Items.stories.storyshot
@@ -146,6 +146,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/schedulingWorkload/__snapshots__/List.Workloads.stories.storyshot
+++ b/frontend/src/components/schedulingWorkload/__snapshots__/List.Workloads.stories.storyshot
@@ -226,6 +226,7 @@
                       />
                     </button>
                     <button
+                      aria-haspopup="menu"
                       aria-label="Show/Hide columns"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"

--- a/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
@@ -266,6 +266,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/service/__snapshots__/ServiceList.Items.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceList.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/service/__snapshots__/ServiceList.WithOwnerAnnotation.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceList.WithOwnerAnnotation.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/serviceaccount/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/serviceaccount/__snapshots__/List.Items.stories.storyshot
@@ -238,6 +238,7 @@
                       />
                     </button>
                     <button
+                      aria-haspopup="menu"
                       aria-label="Show/Hide columns"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"

--- a/frontend/src/components/statefulset/__snapshots__/List.Default.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.Default.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/statefulset/__snapshots__/List.SingleItem.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.SingleItem.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/statefulset/__snapshots__/List.WithNotReadyReplicas.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.WithNotReadyReplicas.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/storage/__snapshots__/ClaimList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClaimList.Items.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
@@ -146,6 +146,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/storage/__snapshots__/VolumeAttributesClassList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeAttributesClassList.Items.stories.storyshot
@@ -146,6 +146,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
@@ -146,6 +146,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPAList.List.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPAList.List.stories.storyshot
@@ -235,6 +235,7 @@
                     />
                   </button>
                   <button
+                    aria-haspopup="menu"
                     aria-label="Show/Hide columns"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigList.Items.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigList.Items.stories.storyshot
@@ -149,6 +149,7 @@
                       />
                     </button>
                     <button
+                      aria-haspopup="menu"
                       aria-label="Show/Hide columns"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigList.Items.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigList.Items.stories.storyshot
@@ -149,6 +149,7 @@
                       />
                     </button>
                     <button
+                      aria-haspopup="menu"
                       aria-label="Show/Hide columns"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"

--- a/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
@@ -1425,6 +1425,7 @@
                             />
                           </button>
                           <button
+                            aria-haspopup="menu"
                             aria-label="Show/Hide columns"
                             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                             data-mui-internal-clone-element="true"

--- a/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
@@ -1307,6 +1307,7 @@
                             />
                           </button>
                           <button
+                            aria-haspopup="menu"
                             aria-label="Show/Hide columns"
                             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                             data-mui-internal-clone-element="true"


### PR DESCRIPTION
## Summary

- replace MRT's nested column controls with semantic `menuitemcheckbox` items
- preserve table search, filter, and row-selection toolbar behavior
- align bulk actions with the columns they can actually change
- add focused unit coverage, current storyshots, and a deployed keyboard e2e test

## Compared with Azure/aks-desktop PR #316

This keeps the original custom column menu and toolbar integration, with these
changes for upstream Headlamp:

- individual columns expose `menuitemcheckbox` and `aria-checked` semantics
- the decorative switch is read-only, hidden from accessibility APIs, and
  removed from the input tab order
- Hide all and Show all derive their disabled state from hideable columns rather
  than table-wide visibility that can include locked or display columns
- the trigger only exposes `aria-expanded` and `aria-controls` while its menu is
  open
- caller-enabled density and fullscreen controls remain in MRT's default toolbar
  order alongside search, filters, and column visibility
- five unit tests cover menu state, filtering, disabled columns, bulk actions,
  and keyboard semantics with 100% branch coverage for the new component
- the Playwright scenario uses arrow-key navigation from MUI's initial menu focus
  and toggles from the item's observed state
- storyshots are refreshed against current upstream `main`

The development history is organized into two reviewable commits. The selector
implementation includes its unit tests and storyshots, so the first commit passes
frontend checks independently. The second commit contains only the e2e scenario.

## Provenance

This upstreams `0027-headlamp-upstream-accessible-column-selector.patch` from
Azure/aks-desktop PR [#823](https://github.com/Azure/aks-desktop/pull/823), where
it is retained as embedded patch commit
`26eee3137cde616dc089f035acb73a86208b9982`.

The original implementation came from Azure/aks-desktop PR
[#316](https://github.com/Azure/aks-desktop/pull/316), commit
[`08f52c0f5ef6344122bbd3f8670cfbdc3e470b4c`](https://github.com/Azure/aks-desktop/commit/08f52c0f5ef6344122bbd3f8670cfbdc3e470b4c),
by Oleksandr Dubenko. The frontend commit preserves Oleksandr's author date and
adds René Dudfield as co-author.

## Testing

Selector commit and final tree:

- `make frontend-test`
- `make frontend-i18n-check`
- `make frontend-lint`
- `npm --prefix frontend run tsc`
- `make frontend-build`
- focused selector coverage: 100% statements, branches, functions, and lines

E2e commit:

- `playwright test tests/podsPage.spec.ts --list` (9 tests discovered)
- `make frontend-lint`
- `git diff --check`
- `git range-diff` confirms the selector and e2e patches are unchanged by the
  current-main rebase

The cluster-backed Playwright scenario was not executed locally because it
requires the documented two-kind-cluster Headlamp deployment.

Assisted by copilot
