### PR TITLE
0028: List allowed namespaces without cluster-wide access

### DIFF
--- a/e2e-tests/tests/namespaces.spec.ts
+++ b/e2e-tests/tests/namespaces.spec.ts
@@ -14,9 +14,63 @@
  * limitations under the License.
  */
 
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { HeadlampPage } from './headlampPage';
 import { NamespacesPage } from './namespacesPage';
+
+test('lists allowed namespaces without cluster-wide namespace access', async ({ page }) => {
+  const allowedNamespaces = ['team-a', 'team-b'];
+  const namespaceRequests: string[] = [];
+  const namespaceWebSockets: string[] = [];
+
+  await page.addInitScript(namespaces => {
+    window.localStorage.setItem(
+      'cluster_settings.test',
+      JSON.stringify({ allowedNamespaces: namespaces })
+    );
+  }, allowedNamespaces);
+  page.on('websocket', socket => {
+    if (socket.url().includes('/api/v1/namespaces')) {
+      namespaceWebSockets.push(socket.url());
+    }
+  });
+  await page.route('**/clusters/test/api/v1/namespaces**', async route => {
+    const url = new URL(route.request().url());
+    namespaceRequests.push(`${url.pathname}${url.search}`);
+    const name = allowedNamespaces.find(namespace =>
+      url.pathname.endsWith(`/namespaces/${namespace}`)
+    );
+
+    if (!name) {
+      await route.fulfill({ status: 403, json: { message: 'namespace list is forbidden' } });
+      return;
+    }
+
+    await route.fulfill({
+      json: {
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        metadata: {
+          name,
+          resourceVersion: '1',
+          creationTimestamp: '2026-01-01T00:00:00Z',
+        },
+        status: { phase: 'Active' },
+      },
+    });
+  });
+
+  const headlampPage = new HeadlampPage(page);
+  await headlampPage.navigateToCluster('test', process.env.HEADLAMP_TEST_TOKEN);
+
+  for (const namespace of allowedNamespaces) {
+    await expect
+      .poll(() => namespaceRequests.some(request => request.endsWith(`/namespaces/${namespace}`)))
+      .toBe(true);
+  }
+  expect(namespaceRequests.some(request => /\/namespaces(?:\?|$)/.test(request))).toBe(false);
+  expect(namespaceWebSockets).toEqual([]);
+});
 
 test('create a namespace with the minimal editor then delete it', async ({ page }) => {
   const name = 'testing-e2e';

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
@@ -367,6 +367,161 @@ describe('useKubeObjectList', () => {
   beforeEach(() => {
     vi.stubEnv('REACT_APP_ENABLE_WEBSOCKET_MULTIPLEXER', 'false');
     vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('fetches allowed namespaces individually without starting a cluster-wide watch', async () => {
+    const namespaceClass = class {
+      static apiVersion = 'v1';
+      static apiName = 'namespaces';
+      static kind = 'Namespace';
+
+      constructor(public jsonData: any) {}
+    } as any;
+    localStorage.setItem(
+      'cluster_settings.restricted',
+      JSON.stringify({ allowedNamespaces: ['team-a', 'team-b'] })
+    );
+    mockClusterFetch
+      .mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve({
+            metadata: { name: 'team-a', managedFields: [{ manager: 'kubectl' }] },
+          }),
+      } as Response)
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve({ metadata: { name: 'team-b' } }),
+      } as Response);
+
+    const query = kubeObjectListQuery(
+      namespaceClass,
+      { version: 'v1', resource: 'namespaces' },
+      undefined,
+      'restricted',
+      {}
+    );
+    const response = await (query.queryFn as any)();
+    const items = response.list.items as Array<{
+      cluster: string;
+      jsonData: { metadata: { name: string; managedFields?: unknown[] } };
+    }>;
+
+    expect(mockClusterFetch).toHaveBeenNthCalledWith(1, 'api/v1/namespaces/team-a', {
+      cluster: 'restricted',
+    });
+    expect(mockClusterFetch).toHaveBeenNthCalledWith(2, 'api/v1/namespaces/team-b', {
+      cluster: 'restricted',
+    });
+    expect(items.map(item => item.jsonData.metadata.name)).toEqual(['team-a', 'team-b']);
+    expect(items[0].jsonData.metadata.managedFields).toBeUndefined();
+    expect(items.every(item => item.cluster === 'restricted')).toBe(true);
+    expect(response.skipWatch).toBe(true);
+  });
+
+  it('adds cluster and namespace context to allowed namespace errors', async () => {
+    localStorage.setItem(
+      'cluster_settings.restricted',
+      JSON.stringify({ allowedNamespaces: ['team-a'] })
+    );
+    const error = new ApiError('Forbidden', { status: 403 });
+    mockClusterFetch.mockRejectedValueOnce(error);
+
+    const query = kubeObjectListQuery(
+      class {
+        static apiVersion = 'v1';
+        static apiName = 'namespaces';
+        static kind = 'Namespace';
+      } as any,
+      { version: 'v1', resource: 'namespaces' },
+      undefined,
+      'restricted',
+      {}
+    );
+
+    await expect((query.queryFn as any)()).rejects.toBe(error);
+    expect(error).toMatchObject({ cluster: 'restricted', namespace: 'team-a', status: 403 });
+  });
+
+  it('preserves non-ApiError failures from allowed namespace requests', async () => {
+    localStorage.setItem(
+      'cluster_settings.restricted',
+      JSON.stringify({ allowedNamespaces: ['team-a'] })
+    );
+    const error = new TypeError('invalid namespace response');
+    mockClusterFetch.mockRejectedValueOnce(error);
+
+    const query = kubeObjectListQuery(
+      class {
+        static apiVersion = 'v1';
+        static apiName = 'namespaces';
+        static kind = 'Namespace';
+      } as any,
+      { version: 'v1', resource: 'namespaces' },
+      undefined,
+      'restricted',
+      {}
+    );
+
+    await expect((query.queryFn as any)()).rejects.toBe(error);
+  });
+
+  it('uses the cluster-wide namespace query when no allowed namespaces are configured', async () => {
+    const namespaceClass = class {
+      static apiVersion = 'v1';
+      static apiName = 'namespaces';
+      static kind = 'Namespace';
+
+      constructor(public jsonData: any) {}
+    } as any;
+    mockClusterFetch.mockResolvedValueOnce({
+      json: () => Promise.resolve(makeListResponse({ kind: 'NamespaceList' })),
+    } as Response);
+
+    const query = kubeObjectListQuery(
+      namespaceClass,
+      { version: 'v1', resource: 'namespaces' },
+      undefined,
+      'unrestricted',
+      {}
+    );
+    const response = await (query.queryFn as any)();
+
+    expect(mockClusterFetch).toHaveBeenCalledWith('api/v1/namespaces', {
+      cluster: 'unrestricted',
+    });
+    expect(response.skipWatch).toBeUndefined();
+  });
+
+  it('does not watch the synthesized allowed namespace list', async () => {
+    const namespaceClass = class {
+      static apiVersion = 'v1';
+      static apiName = 'namespaces';
+      static kind = 'Namespace';
+      static apiEndpoint = {
+        apiInfo: [{ group: '', resource: 'namespaces', version: 'v1' }],
+      };
+
+      constructor(public jsonData: any) {}
+    } as any;
+    localStorage.setItem(
+      'cluster_settings.restricted',
+      JSON.stringify({ allowedNamespaces: ['team-a'] })
+    );
+    mockClusterFetch.mockResolvedValueOnce({
+      json: () => Promise.resolve({ metadata: { name: 'team-a' } }),
+    } as Response);
+
+    const result = renderHook(
+      () =>
+        useKubeObjectList({
+          kubeObjectClass: namespaceClass,
+          requests: [{ cluster: 'restricted' }],
+        }),
+      { wrapper: queryClientWrapper(new QueryClient()) }
+    );
+
+    await waitFor(() => expect(result.result.current.items).toHaveLength(1));
+    expect(mockUseWebSockets.mock.calls.at(-1)?.[0].connections).toEqual([]);
   });
 
   it('should not add a list limit unless the caller opts in', async () => {
@@ -387,6 +542,43 @@ describe('useKubeObjectList', () => {
     expect(mockClusterFetch).toHaveBeenCalledWith('api/v1/pods', {
       cluster: 'default',
     });
+  });
+
+  it('should not fetch when no endpoint is available', async () => {
+    const query = kubeObjectListQuery(mockClass, undefined as any, undefined, 'default', {});
+
+    await expect((query.queryFn as any)()).resolves.toBeUndefined();
+    expect(mockClusterFetch).not.toHaveBeenCalled();
+  });
+
+  it('should remove managed fields from listed objects', async () => {
+    mockClusterFetch.mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve(
+          makeListResponse({
+            items: [
+              {
+                ...makePod('pod-with-managed-fields', '1'),
+                metadata: {
+                  ...makePod('pod-with-managed-fields', '1').metadata,
+                  managedFields: [{ manager: 'kubectl' }],
+                },
+              },
+            ],
+          })
+        ),
+    } as Response);
+
+    const query = kubeObjectListQuery(
+      mockClass,
+      { version: 'v1', resource: 'pods' },
+      undefined,
+      'default',
+      {}
+    );
+    const response = await (query.queryFn as any)();
+
+    expect(response.list.items[0].jsonData.metadata.managedFields).toBeUndefined();
   });
 
   it('should strip only the List suffix from item kind', async () => {

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -17,6 +17,7 @@
 import type { QueryObserverOptions } from '@tanstack/react-query';
 import { useQueries, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { loadClusterSettings } from '../../../../helpers/clusterSettings';
 import type { KubeObject, KubeObjectClass } from '../../KubeObject';
 import type { QueryParameters } from '../v1/queryParameters';
 import { ApiError } from './ApiError';
@@ -63,6 +64,65 @@ export interface ListResponse<K extends KubeObject> {
   cluster: string;
   /** If the list only has items from one namespace */
   namespace?: string;
+  /** Whether this synthesized list must not start a cluster-wide watch */
+  skipWatch?: boolean;
+}
+
+function allowedNamespaceListQuery<K extends KubeObject>(
+  kubeObjectClass: KubeObjectClass,
+  cluster: string,
+  refetchInterval?: number
+): QueryObserverOptions<ListResponse<K> | undefined | null, ApiError> {
+  const allowedNamespaces = loadClusterSettings(cluster).allowedNamespaces ?? [];
+
+  return {
+    placeholderData: null,
+    refetchInterval,
+    retry: kubeRequestRetry,
+    queryKey: [
+      'kubeObject',
+      'list',
+      kubeObjectClass.apiVersion,
+      kubeObjectClass.apiName,
+      cluster,
+      '',
+      { allowedNamespaces },
+    ],
+    queryFn: async () => {
+      const items = await Promise.all(
+        allowedNamespaces.map(async name => {
+          try {
+            const item = await clusterFetch(makeUrl(['api', 'v1', 'namespaces', name]), {
+              cluster,
+            }).then(response => response.json());
+            if (item.metadata?.managedFields) {
+              delete item.metadata.managedFields;
+            }
+            const kubeObject = new kubeObjectClass(item) as K;
+            kubeObject.cluster = cluster;
+            return kubeObject;
+          } catch (error) {
+            if (error instanceof ApiError) {
+              error.cluster = cluster;
+              error.namespace = name;
+            }
+            throw error;
+          }
+        })
+      );
+
+      return {
+        list: {
+          items,
+          kind: 'NamespaceList',
+          apiVersion: 'v1',
+          metadata: { resourceVersion: '0' },
+        } as KubeList<K>,
+        cluster,
+        skipWatch: true,
+      };
+    },
+  };
 }
 
 /**
@@ -83,6 +143,13 @@ export function kubeObjectListQuery<K extends KubeObject>(
   queryParams: QueryParameters,
   refetchInterval?: number
 ): QueryObserverOptions<ListResponse<K> | undefined | null, ApiError> {
+  if (
+    kubeObjectClass.kind === 'Namespace' &&
+    (loadClusterSettings(cluster).allowedNamespaces?.length ?? 0) > 0
+  ) {
+    return allowedNamespaceListQuery<K>(kubeObjectClass, cluster, refetchInterval);
+  }
+
   return {
     placeholderData: null,
     refetchInterval,
@@ -663,11 +730,13 @@ export function useKubeObjectList<K extends KubeObject>({
           : keptListsToWatch;
       }
 
-      const nextListsToWatch = query.data.filter(Boolean).map(data => ({
-        cluster: data!.cluster,
-        namespace: data!.namespace,
-        resourceVersion: data!.list.metadata.resourceVersion,
-      }));
+      const nextListsToWatch = query.data
+        .filter(data => data && !data.skipWatch)
+        .map(data => ({
+          cluster: data!.cluster,
+          namespace: data!.namespace,
+          resourceVersion: data!.list.metadata.resourceVersion,
+        }));
 
       if (
         nextListsToWatch.length === currentListsToWatch.length &&


### PR DESCRIPTION
## Summary

Allow the Namespace list to work when cluster settings contain `allowedNamespaces` but the user cannot list Namespace resources cluster-wide. Headlamp fetches each configured Namespace object, synthesizes the list response, and avoids opening an unauthorized cluster-wide watch.

## Changes

- add unit regressions before the implementation commit for restricted and unrestricted namespace queries, watch suppression, object trimming, error context, and nearby query branches
- add a Playwright regression before the implementation commit that verifies individual Namespace requests without a cluster-wide list or watch
- preserve Oleksandr Dubenko as the implementation author and the original 2025-11-21 author date, with Rene Dudfield as co-author
- read cluster settings from their owning helper to avoid a circular Kubernetes barrel import in the full frontend suite

## Provenance

- retained downstream patch: [Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823), patch 0028
- original implementation PR: [Azure/aks-desktop#8](https://github.com/Azure/aks-desktop/pull/8)
- original PR commit: [fdcd1ea](https://github.com/Azure/aks-desktop/commit/fdcd1ea5685f834f1e57d09fee1b7133e3adbac3)
- dependent project-import workflow: [Azure/aks-desktop#7](https://github.com/Azure/aks-desktop/pull/7)

## Testing

- full frontend suite: 182 files, 2,403 tests passed
- `vitest run src/lib/k8s/api/v2/useKubeObjectList.test.tsx` (38 tests passed)
- changed-file coverage for `useKubeObjectList.ts`: 89.09% statements, 80.36% branches, 91.11% functions, 90.55% lines
- Prettier check for all changed files
- ESLint for all changed files
- frontend TypeScript check with `tsgo --noEmit`
- Playwright discovery for `e2e-tests/tests/namespaces.spec.ts` (2 tests discovered)
- Build Container and test CI, including kind setup, Playwright e2e, and in-cluster TypeScript API tests

## Notes for the Reviewer

The test commits intentionally precede the implementation commit to make the restricted-access regression explicit. Open PRs #6150 and #6759 touch adjacent namespace configuration/discovery behavior but do not synthesize a NamespaceList from individual object requests or suppress that synthesized list's watch.

Assisted by copilot