### PR TITLE
0025: Project tabs high-zoom usability

### DIFF
--- a/e2e-tests/tests/projectDetailsZoom.spec.ts
+++ b/e2e-tests/tests/projectDetailsZoom.spec.ts
@@ -93,7 +93,9 @@ test("project tabs and resources remain usable at 200% text zoom", async ({
 
     await defaultTabs.nth(1).click();
     await page.getByRole("button", { name: /Configuration/ }).click();
-    await expect(page.getByRole("cell", { name: configMapName })).toBeVisible();
+    const configMapCell = page.getByRole("cell", { name: configMapName });
+    await configMapCell.scrollIntoViewIfNeeded();
+    await expect(configMapCell).toBeInViewport();
   } finally {
     const deleteNamespace = await page.request.delete(namespaceURL, {
       headers,

--- a/e2e-tests/tests/projectDetailsZoom.spec.ts
+++ b/e2e-tests/tests/projectDetailsZoom.spec.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from "@playwright/test";
+import { HeadlampPage } from "./headlampPage";
+
+test("project tabs and resources remain usable at 200% text zoom", async ({
+  page,
+}, testInfo) => {
+  const token = process.env.HEADLAMP_TEST_TOKEN;
+  if (!token) {
+    test.skip(
+      true,
+      "HEADLAMP_TEST_TOKEN is not set; cannot create the project fixture."
+    );
+  }
+
+  const fixtureId = `${testInfo.workerIndex}-${
+    testInfo.retry
+  }-${Date.now().toString(36)}`;
+  const namespaceName = `project-zoom-${fixtureId}`;
+  const projectName = namespaceName;
+  const configMapName = `zoom-config-${fixtureId}`;
+  const headers = { Authorization: `Bearer ${token}` };
+  const namespaceURL = `/clusters/test/api/v1/namespaces/${namespaceName}`;
+  const createNamespace = await page.request.post(
+    "/clusters/test/api/v1/namespaces",
+    {
+      headers,
+      data: {
+        apiVersion: "v1",
+        kind: "Namespace",
+        metadata: {
+          name: namespaceName,
+          labels: { "headlamp.dev/project-id": projectName },
+        },
+      },
+    }
+  );
+  expect(createNamespace.status(), await createNamespace.text()).toBe(201);
+
+  try {
+    const createConfigMap = await page.request.post(
+      `/clusters/test/api/v1/namespaces/${namespaceName}/configmaps`,
+      {
+        headers,
+        data: {
+          apiVersion: "v1",
+          kind: "ConfigMap",
+          metadata: { name: configMapName, namespace: namespaceName },
+          data: { purpose: "project zoom e2e coverage" },
+        },
+      }
+    );
+    expect(createConfigMap.status(), await createConfigMap.text()).toBe(201);
+
+    const headlampPage = new HeadlampPage(page);
+    await headlampPage.navigateToCluster("test", token);
+    await headlampPage.navigateTopage(`/project/${projectName}`);
+
+    const tabs = page.getByRole("tablist");
+    await expect(tabs).toBeVisible({ timeout: 30_000 });
+
+    await page.setViewportSize({ width: 640, height: 384 });
+    await page.addStyleTag({ content: ":root { font-size: 200%; }" });
+
+    const tabScroller = tabs.locator("..");
+    await expect(tabScroller).toHaveClass(/MuiTabs-scrollableX/);
+    await expect
+      .poll(() =>
+        tabScroller.evaluate(
+          (element) => element.scrollWidth > element.clientWidth
+        )
+      )
+      .toBe(true);
+    const defaultTabs = tabs.getByRole("tab");
+    for (let index = 0; index < 4; index += 1) {
+      await expect(defaultTabs.nth(index)).toBeAttached();
+    }
+
+    await defaultTabs.nth(1).click();
+    await page.getByRole("button", { name: /Configuration/ }).click();
+    await expect(page.getByRole("cell", { name: configMapName })).toBeVisible();
+  } finally {
+    const deleteNamespace = await page.request.delete(namespaceURL, {
+      headers,
+    });
+    expect([200, 202]).toContain(deleteNamespace.status());
+  }
+});

--- a/frontend/src/components/project/ProjectDetails.tsx
+++ b/frontend/src/components/project/ProjectDetails.tsx
@@ -547,7 +547,12 @@ function ProjectDetailsContent({ project }: { project: ProjectDefinition }) {
           }
         >
           <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-            <Tabs value={selectedTab} onChange={handleTabChange}>
+            <Tabs
+              value={selectedTab}
+              onChange={handleTabChange}
+              variant="scrollable"
+              scrollButtons="auto"
+            >
               {Object.values(allTabs)
                 .filter(tab => tab.component)
                 .map(tab => (
@@ -607,6 +612,7 @@ function ProjectGraph({ project: { namespaces, clusters } }: { project: ProjectD
         flexGrow: 1,
         display: 'flex',
         flexDirection: 'column',
+        minHeight: '600px',
       }}
     >
       <SelectedClustersContext.Provider value={clusters}>

--- a/frontend/src/components/project/ProjectResourcesTab.test.tsx
+++ b/frontend/src/components/project/ProjectResourcesTab.test.tsx
@@ -14,10 +14,15 @@
  * limitations under the License.
  */
 
+import { createTheme } from '@mui/material/styles';
 import { fireEvent, render, renderHook, screen } from '@testing-library/react';
 import type React from 'react';
 import { KubeObject } from '../../lib/k8s/KubeObject';
-import { ProjectResourcesTab, useResourceCategoriesList } from './ProjectResourcesTab';
+import {
+  ProjectResourcesTab,
+  resourcePaneStyles,
+  useResourceCategoriesList,
+} from './ProjectResourcesTab';
 
 const { mockActivityLaunch } = vi.hoisted(() => ({ mockActivityLaunch: vi.fn() }));
 const categories = new Map<string, { label: string; description: string; icon: string }>();
@@ -173,6 +178,17 @@ describe('useResourceCategoriesList', () => {
 });
 
 describe('ProjectResourcesTab', () => {
+  it('keeps the resource pane from shrinking in the stacked layout', () => {
+    const theme = createTheme();
+    const styles = resourcePaneStyles(theme);
+
+    expect(styles[theme.breakpoints.down('md')]).toEqual({
+      borderLeft: 0,
+      borderTop: '1px solid',
+      flexShrink: 0,
+    });
+  });
+
   it('asks the parent to select a resource category', () => {
     const setSelectedCategoryName = vi.fn();
 

--- a/frontend/src/components/project/ProjectResourcesTab.test.tsx
+++ b/frontend/src/components/project/ProjectResourcesTab.test.tsx
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, renderHook, screen } from '@testing-library/react';
+import type React from 'react';
+import { KubeObject } from '../../lib/k8s/KubeObject';
+import { ProjectResourcesTab, useResourceCategoriesList } from './ProjectResourcesTab';
+
+const { mockActivityLaunch } = vi.hoisted(() => ({ mockActivityLaunch: vi.fn() }));
+const categories = new Map<string, { label: string; description: string; icon: string }>();
+const mockGetKubeObjectCategory = vi.fn((resource: KubeObject) => {
+  const categoryName = (resource as KubeObject & { category?: string }).category ?? resource.kind;
+  if (!categories.has(categoryName)) {
+    categories.set(categoryName, {
+      label: categoryName,
+      description: `${categoryName} resources`,
+      icon: 'mdi:format-list-bulleted',
+    });
+  }
+  return categories.get(categoryName)!;
+});
+const mockGetResourcesHealth = vi.fn((resources: KubeObject[]) => {
+  void resources;
+  return { success: 1, warning: 0, error: 0 };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (text: string) => text }),
+}));
+
+vi.mock('../../lib/k8s/ResourceCategory', () => ({
+  getKubeObjectCategory: (resource: KubeObject) => mockGetKubeObjectCategory(resource),
+}));
+
+vi.mock('./projectUtils', () => ({
+  getResourcesHealth: (resources: KubeObject[]) => mockGetResourcesHealth(resources),
+}));
+
+vi.mock('../common', () => ({
+  StatusLabel: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('../resourceMap/nodes/KubeObjectStatus', () => ({
+  getStatus: (resource: KubeObject & { healthStatus?: string }) =>
+    resource.healthStatus ?? 'success',
+}));
+
+vi.mock('../activity/Activity', () => ({
+  Activity: { launch: mockActivityLaunch, close: vi.fn() },
+}));
+
+vi.mock('./ResourceCategoriesList', () => ({
+  ResourceCategoriesList: ({
+    categoryList,
+    onCategoryClick,
+  }: {
+    categoryList: Array<{ category: { label: string }; items: KubeObject[] }>;
+    onCategoryClick: (name: string) => void;
+  }) => (
+    <div>
+      {categoryList.map(({ category, items }) => (
+        <button key={category.label} onClick={() => onCategoryClick(category.label)}>
+          {category.label} ({items.length})
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('../common/Table', () => ({
+  default: ({
+    columns,
+    data,
+    state,
+  }: {
+    columns: Array<{
+      id: string;
+      accessorFn?: (resource: KubeObject) => unknown;
+      Cell?: React.ComponentType<{ row: { original: KubeObject } }>;
+    }>;
+    data: KubeObject[];
+    state: { columnVisibility: { cluster: boolean } };
+  }) => (
+    <div>
+      <div>Cluster column: {String(state.columnVisibility.cluster)}</div>
+      {data.flatMap((resource, resourceIndex) =>
+        columns.map(column => {
+          const value = column.accessorFn?.(resource);
+          const Cell = column.Cell;
+          return (
+            <div key={`${resourceIndex}-${column.id}`}>
+              {Cell ? <Cell row={{ original: resource }} /> : String(value ?? '')}
+            </div>
+          );
+        })
+      )}
+    </div>
+  ),
+}));
+
+vi.mock('../common/Link', () => ({
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock('../common/Resource/AuthVisible', () => ({
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock('../common/Resource/DeleteButton', () => ({ default: () => null }));
+vi.mock('../common/Resource/ScaleButton', () => ({ default: () => null }));
+vi.mock('../common/ActionButton/ActionButton', () => ({
+  default: ({ description, onClick }: { description: string; onClick: () => void }) => (
+    <button onClick={onClick}>{description}</button>
+  ),
+}));
+vi.mock('../common/Terminal', () => ({ default: () => null }));
+vi.mock('../pod/Details', () => ({ PodLogViewer: () => null }));
+
+function resource(kind: string, name: string, overrides: Record<string, unknown> = {}): KubeObject {
+  const metadata = {
+    name,
+    uid: `${kind}-${name}`,
+    namespace: 'default',
+    creationTimestamp: '2026-01-01T00:00:00Z',
+    ...((overrides.metadata as Record<string, unknown> | undefined) ?? {}),
+  };
+
+  return {
+    kind,
+    cluster: 'test',
+    spec: {},
+    status: {},
+    ...overrides,
+    metadata,
+  } as unknown as KubeObject;
+}
+
+describe('useResourceCategoriesList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    categories.clear();
+  });
+
+  it('groups resources by category and calculates health once per category', () => {
+    const resources = [resource('Pod', 'one'), resource('Pod', 'two'), resource('Service', 'api')];
+
+    const { result } = renderHook(() => useResourceCategoriesList(resources));
+
+    expect(result.current.map(({ category, items }) => [category.label, items.length])).toEqual([
+      ['Pod', 2],
+      ['Service', 1],
+    ]);
+    expect(mockGetResourcesHealth).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns no categories when the project has no resources', () => {
+    const { result } = renderHook(() => useResourceCategoriesList([]));
+
+    expect(result.current).toEqual([]);
+    expect(mockGetResourcesHealth).not.toHaveBeenCalled();
+  });
+});
+
+describe('ProjectResourcesTab', () => {
+  it('asks the parent to select a resource category', () => {
+    const setSelectedCategoryName = vi.fn();
+
+    render(
+      <ProjectResourcesTab
+        projectResources={[resource('Pod', 'one')]}
+        setSelectedCategoryName={setSelectedCategoryName}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pod (1)' }));
+    expect(setSelectedCategoryName).toHaveBeenCalledWith('Pod');
+    expect(screen.queryByText(/Cluster column:/)).not.toBeInTheDocument();
+  });
+
+  it('shows selected resources and honors cluster-column visibility', () => {
+    render(
+      <ProjectResourcesTab
+        projectResources={[resource('Pod', 'one')]}
+        selectedCategoryName="Pod"
+        setSelectedCategoryName={() => {}}
+        showClusterColumn
+      />
+    );
+
+    expect(screen.getByText('Cluster column: true')).toBeInTheDocument();
+  });
+
+  it('renders health, details, age, and actions for supported resource states', () => {
+    const projectResources = [
+      resource('Deployment', 'deployment-unhealthy', {
+        category: 'Workloads',
+        isScalable: true,
+        spec: { replicas: 3 },
+        status: { readyReplicas: 0 },
+        healthStatus: 'error',
+      }),
+      resource('Deployment', 'deployment-degraded', {
+        category: 'Workloads',
+        isScalable: true,
+        spec: { replicas: 3 },
+        status: { readyReplicas: 1 },
+        healthStatus: 'warning',
+      }),
+      resource('Deployment', 'deployment-healthy', {
+        category: 'Workloads',
+        isScalable: true,
+        spec: { replicas: 3 },
+        status: { readyReplicas: 3 },
+      }),
+      resource('StatefulSet', 'stateful-unhealthy', {
+        category: 'Workloads',
+        isScalable: true,
+        spec: { replicas: 2 },
+        status: { readyReplicas: 0 },
+      }),
+      resource('StatefulSet', 'stateful-degraded', {
+        category: 'Workloads',
+        isScalable: true,
+        spec: { replicas: 2 },
+        status: { readyReplicas: 1 },
+      }),
+      resource('DaemonSet', 'daemon-unhealthy', {
+        category: 'Workloads',
+        status: { numberReady: 0, desiredNumberScheduled: 2 },
+      }),
+      resource('DaemonSet', 'daemon-degraded', {
+        category: 'Workloads',
+        status: { numberReady: 1, desiredNumberScheduled: 2 },
+      }),
+      resource('DaemonSet', 'daemon-healthy', {
+        category: 'Workloads',
+        status: { numberReady: 2, desiredNumberScheduled: 2 },
+      }),
+      resource('Pod', 'pod-failed', {
+        category: 'Workloads',
+        status: { phase: 'Failed', conditions: [] },
+      }),
+      resource('Pod', 'pod-crash-loop', {
+        category: 'Workloads',
+        status: { phase: 'CrashLoopBackOff', conditions: [] },
+      }),
+      resource('Pod', 'pod-pending', {
+        category: 'Workloads',
+        status: { phase: 'Pending', conditions: [] },
+      }),
+      resource('Pod', 'pod-not-ready', {
+        category: 'Workloads',
+        status: { phase: 'Running', conditions: [{ type: 'Ready', status: 'False' }] },
+      }),
+      resource('Pod', 'pod-ready', {
+        category: 'Workloads',
+        status: { phase: 'Running', conditions: [{ type: 'Ready', status: 'True' }] },
+      }),
+      resource('Pod', 'pod-unknown', {
+        category: 'Workloads',
+        metadata: { name: 'pod-unknown', uid: 'Pod-pod-unknown' },
+        status: { conditions: [] },
+      }),
+      resource('Service', 'service', { category: 'Workloads' }),
+    ];
+
+    render(
+      <ProjectResourcesTab
+        projectResources={projectResources}
+        selectedCategoryName="Workloads"
+        setSelectedCategoryName={() => {}}
+      />
+    );
+
+    expect(screen.getByText('Cluster column: false')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Show Logs' })).toHaveLength(6);
+    expect(screen.getAllByRole('button', { name: 'Terminal / Exec' })).toHaveLength(6);
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Show Logs' })[0]);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Terminal / Exec' })[0]);
+    expect(mockActivityLaunch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/components/project/ProjectResourcesTab.tsx
+++ b/frontend/src/components/project/ProjectResourcesTab.tsx
@@ -397,6 +397,9 @@ export function ProjectResourcesTab({
           flexGrow: 1,
           minHeight: 0,
           flexBasis: 0,
+          [theme.breakpoints.down('md')]: {
+            flexDirection: 'column',
+          },
         })}
       >
         <ResourceCategoriesList
@@ -411,10 +414,14 @@ export function ProjectResourcesTab({
             overflowY: 'auto',
             borderLeft: '1px solid',
             borderColor: theme.palette.divider,
+            [theme.breakpoints.down('md')]: {
+              borderLeft: 0,
+              borderTop: '1px solid',
+            },
           })}
         >
           {selectedCategory && (
-            <Box>
+            <Box sx={{ minHeight: '400px' }}>
               {selectedResources.length === 0 ? (
                 <Typography variant="body2" color="text.secondary">
                   {t('No {{category}} resources found for this project.', {

--- a/frontend/src/components/project/ProjectResourcesTab.tsx
+++ b/frontend/src/components/project/ProjectResourcesTab.tsx
@@ -16,6 +16,7 @@
 
 import { Icon } from '@iconify/react';
 import { Box, Typography } from '@mui/material';
+import { Theme } from '@mui/material/styles';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import DaemonSet from '../../lib/k8s/daemonSet';
@@ -79,6 +80,19 @@ interface ProjectResourcesTabProps {
   selectedCategoryName?: string;
   setSelectedCategoryName: (name: string) => void;
 }
+
+export const resourcePaneStyles = (theme: Theme) => ({
+  flexGrow: 1,
+  padding: theme.spacing(1),
+  overflowY: 'auto',
+  borderLeft: '1px solid',
+  borderColor: theme.palette.divider,
+  [theme.breakpoints.down('md')]: {
+    borderLeft: 0,
+    borderTop: '1px solid',
+    flexShrink: 0,
+  },
+});
 
 export function ProjectResourcesTab({
   projectResources,
@@ -397,6 +411,9 @@ export function ProjectResourcesTab({
           flexGrow: 1,
           minHeight: 0,
           flexBasis: 0,
+          [theme.breakpoints.down('md')]: {
+            flexDirection: 'column',
+          },
         })}
       >
         <ResourceCategoriesList
@@ -404,17 +421,9 @@ export function ProjectResourcesTab({
           selectedCategoryName={selectedCategoryName}
           onCategoryClick={setSelectedCategoryName}
         />
-        <Box
-          sx={theme => ({
-            flexGrow: 1,
-            p: 1,
-            overflowY: 'auto',
-            borderLeft: '1px solid',
-            borderColor: theme.palette.divider,
-          })}
-        >
+        <Box sx={resourcePaneStyles}>
           {selectedCategory && (
-            <Box>
+            <Box sx={{ minHeight: '400px' }}>
               {selectedResources.length === 0 ? (
                 <Typography variant="body2" color="text.secondary">
                   {t('No {{category}} resources found for this project.', {

--- a/frontend/src/components/project/__snapshots__/ProjectResourcesTab.Empty.stories.storyshot
+++ b/frontend/src/components/project/__snapshots__/ProjectResourcesTab.Empty.stories.storyshot
@@ -4,7 +4,7 @@
       style="height: 500px;"
     >
       <div
-        class="MuiBox-root css-1xxsrwd"
+        class="MuiBox-root css-gul9zg"
       >
         <div
           class="MuiBox-root css-6su6fj"
@@ -14,7 +14,7 @@
           />
         </div>
         <div
-          class="MuiBox-root css-mndmei"
+          class="MuiBox-root css-3t24g2"
         />
       </div>
     </div>

--- a/frontend/src/components/project/__snapshots__/ProjectResourcesTab.Empty.stories.storyshot
+++ b/frontend/src/components/project/__snapshots__/ProjectResourcesTab.Empty.stories.storyshot
@@ -4,7 +4,7 @@
       style="height: 500px;"
     >
       <div
-        class="MuiBox-root css-1xxsrwd"
+        class="MuiBox-root css-gul9zg"
       >
         <div
           class="MuiBox-root css-6su6fj"
@@ -14,7 +14,7 @@
           />
         </div>
         <div
-          class="MuiBox-root css-mndmei"
+          class="MuiBox-root css-m4hr2q"
         />
       </div>
     </div>

--- a/frontend/src/components/project/__snapshots__/ProjectResourcesTab.WithWorkloads.stories.storyshot
+++ b/frontend/src/components/project/__snapshots__/ProjectResourcesTab.WithWorkloads.stories.storyshot
@@ -4,7 +4,7 @@
       style="height: 500px;"
     >
       <div
-        class="MuiBox-root css-1xxsrwd"
+        class="MuiBox-root css-gul9zg"
       >
         <div
           class="MuiBox-root css-6su6fj"
@@ -58,7 +58,7 @@
           </ul>
         </div>
         <div
-          class="MuiBox-root css-mndmei"
+          class="MuiBox-root css-3t24g2"
         />
       </div>
     </div>

--- a/frontend/src/components/project/__snapshots__/ProjectResourcesTab.WithWorkloads.stories.storyshot
+++ b/frontend/src/components/project/__snapshots__/ProjectResourcesTab.WithWorkloads.stories.storyshot
@@ -4,7 +4,7 @@
       style="height: 500px;"
     >
       <div
-        class="MuiBox-root css-1xxsrwd"
+        class="MuiBox-root css-gul9zg"
       >
         <div
           class="MuiBox-root css-6su6fj"
@@ -58,7 +58,7 @@
           </ul>
         </div>
         <div
-          class="MuiBox-root css-mndmei"
+          class="MuiBox-root css-m4hr2q"
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary

- make Project Details tabs horizontally scrollable when text zoom leaves insufficient width
- stack resource categories above the resource table at narrower breakpoints
- prevent the stacked resource pane from shrinking below its content
- preserve minimum heights for project map and resource content at high zoom
- add focused unit coverage and a 200% text-zoom Playwright regression

## Coverage

`ProjectResourcesTab.tsx`: 98.63% statements, 84.5% branches, 93.33% functions, and 98.51% lines.

## Testing

- `vitest --run src/components/project/ProjectResourcesTab.test.tsx --coverage --coverage.include=src/components/project/ProjectResourcesTab.tsx` (6 tests; 84.5% branches)
- focused ProjectResourcesTab Storybook snapshots (2 passed)
- `npm --prefix frontend run tsc`
- changed-file ESLint and Prettier checks
- `npm --prefix frontend run build`
- `playwright test --list tests/projectDetailsZoom.spec.ts` (1 test collected)

The Playwright regression now scrolls the selected resource into view and requires it to intersect the viewport, covering the stacked-pane collapse reported at 200% zoom. A live local run requires the documented two-cluster Headlamp e2e environment and `HEADLAMP_TEST_TOKEN`.

## Source provenance

This ports patch 0025 retained by Azure/aks-desktop PR [#823](https://github.com/Azure/aks-desktop/pull/823). The implementation commit preserves Oleksandr Dubenko as author at `2026-07-31T14:15:26Z`, with gambtho, Tejhan Diallo, and René Dudfield as co-authors.

Related Azure/aks-desktop work:

- [#364](https://github.com/Azure/aks-desktop/pull/364), commit [`d8a935f5`](https://github.com/Azure/aks-desktop/commit/d8a935f5ed8edf671ecd1203a3d137a8f081889f): scrollable tabs and responsive project resource content
- [#473](https://github.com/Azure/aks-desktop/pull/473), commits [`379b4e4d`](https://github.com/Azure/aks-desktop/commit/379b4e4dfd724ded219173b486bba0c8130ca707) and [`ece2dd20`](https://github.com/Azure/aks-desktop/commit/ece2dd20b51778dbd12a27131938283a0f3ae3cf): high-zoom map and resource content visibility
- [#823](https://github.com/Azure/aks-desktop/pull/823): numbered downstream patch-series migration containing `0025-headlamp-upstream-project-tabs-zoom.patch`

Assisted by copilot
