### PR TITLE
0029: Improve appearance control narration

### DIFF
--- a/e2e-tests/tests/clusterAppearance.spec.ts
+++ b/e2e-tests/tests/clusterAppearance.spec.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import { HeadlampPage } from './headlampPage';
+
+let headlampPage: HeadlampPage;
+
+test.beforeEach(async ({ page }) => {
+  headlampPage = new HeadlampPage(page);
+  await headlampPage.navigateToCluster('test', process.env.HEADLAMP_TEST_TOKEN);
+  await page.evaluate(() => localStorage.removeItem('cluster_settings.test'));
+  await headlampPage.navigateTopage('/settings/cluster?c=test');
+});
+
+test('cluster appearance controls update color and icon', async ({ page }) => {
+  await page.locator('#color-picker-button').click();
+  await page.locator('button[value="#f44336"]').click();
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => JSON.parse(localStorage.getItem('cluster_settings.test') || '{}'))
+    )
+    .toMatchObject({ appearance: { accentColor: '#f44336' } });
+
+  await page.locator('#icon-picker-button').click();
+  await page.locator('button[value="mdi:kubernetes"]').click();
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => JSON.parse(localStorage.getItem('cluster_settings.test') || '{}'))
+    )
+    .toMatchObject({ appearance: { accentColor: '#f44336', icon: 'mdi:kubernetes' } });
+});

--- a/frontend/src/components/App/Settings/SettingsCluster.test.tsx
+++ b/frontend/src/components/App/Settings/SettingsCluster.test.tsx
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMuiTheme } from '../../../lib/themes';
+import { TestContext } from '../../../test';
+import SettingsCluster from './SettingsCluster';
+
+const clusterName = 'my-cluster';
+const theme = createMuiTheme({ base: 'light', name: 'light' });
+const darkTheme = createMuiTheme({ base: 'dark', name: 'dark' });
+
+const { mockDeleteCluster, mockState } = vi.hoisted(() => ({
+  mockDeleteCluster: vi.fn(),
+  mockState: {
+    activeCluster: 'my-cluster' as string | null,
+    electron: false,
+    clustersConf: {} as Record<string, any>,
+  },
+}));
+
+vi.mock('../../../helpers/isElectron', () => ({ isElectron: () => mockState.electron }));
+
+vi.mock('../../../lib/k8s', () => ({
+  useCluster: () => mockState.activeCluster,
+  useClustersConf: () => mockState.clustersConf,
+}));
+
+vi.mock('../../../lib/k8s/api/v1/clusterApi', () => ({ deleteCluster: mockDeleteCluster }));
+vi.mock('../../common/ConfirmButton', () => ({
+  default: ({ children, onConfirm }: { children: React.ReactNode; onConfirm: () => void }) => (
+    <button onClick={onConfirm}>{children}</button>
+  ),
+}));
+vi.mock('./ClusterNameEditor', () => ({ ClusterNameEditor: () => <div>Cluster name editor</div> }));
+vi.mock('./ColorPicker', () => ({
+  default: ({
+    open,
+    onClose,
+    onSelectColor,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    onSelectColor: (color: string) => void;
+  }) =>
+    open ? (
+      <div>
+        <button onClick={() => onSelectColor('#123456')}>Select test color</button>
+        <button onClick={onClose}>Close color picker</button>
+      </div>
+    ) : null,
+}));
+vi.mock('./IconPicker', () => ({
+  default: ({
+    open,
+    onClose,
+    onSelectIcon,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    onSelectIcon: (icon: string) => void;
+  }) =>
+    open ? (
+      <div>
+        <button onClick={() => onSelectIcon('mdi:test-tube')}>Select test icon</button>
+        <button onClick={onClose}>Close icon picker</button>
+      </div>
+    ) : null,
+}));
+vi.mock('./NodeShellSettings', () => ({ default: () => null }));
+vi.mock('./PodDebugSettings', () => ({ default: () => null }));
+
+function renderSettings(
+  settings: Record<string, unknown> = {},
+  options: { queryCluster?: string | null; dark?: boolean } = {}
+) {
+  const { queryCluster = clusterName, dark = false } = options;
+  localStorage.setItem(`cluster_settings.${clusterName}`, JSON.stringify(settings));
+  return render(
+    <TestContext urlSearchParams={queryCluster === null ? undefined : { c: queryCluster }}>
+      <ThemeProvider theme={dark ? darkTheme : theme}>
+        <SettingsCluster />
+      </ThemeProvider>
+    </TestContext>
+  );
+}
+
+describe('SettingsCluster appearance controls', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockDeleteCluster.mockReset();
+    mockState.activeCluster = clusterName;
+    mockState.electron = false;
+    mockState.clustersConf = {
+      [clusterName]: {
+        name: clusterName,
+        meta_data: { namespace: 'default', source: 'kubeconfig' },
+      },
+    };
+  });
+
+  it('labels controls with their appearance subsection', () => {
+    renderSettings();
+
+    expect(screen.getByRole('button', { name: 'Appearance Choose Color' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Appearance Choose Icon' })).toBeInTheDocument();
+  });
+
+  it('updates configured appearance values', async () => {
+    renderSettings({ appearance: { accentColor: '#e91e63', icon: 'mdi:cloud-outline' } });
+
+    expect(screen.getByRole('button', { name: 'Appearance Change Color' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Appearance Change Icon' })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Clear accent color' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Clear cluster icon' }));
+    expect(screen.getByRole('button', { name: 'Appearance Choose Color' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Appearance Choose Icon' })).toBeInTheDocument();
+  });
+
+  it('selects values from the appearance pickers', async () => {
+    renderSettings();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Appearance Choose Color' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Select test color' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Appearance Choose Icon' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Select test icon' }));
+
+    expect(screen.getByRole('button', { name: 'Appearance Change Color' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Appearance Change Icon' })).toBeInTheDocument();
+  });
+
+  it('closes appearance pickers without changing values', async () => {
+    renderSettings();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Appearance Choose Color' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Close color picker' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Appearance Choose Icon' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Close icon picker' }));
+
+    expect(screen.queryByRole('button', { name: 'Close color picker' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Close icon picker' })).not.toBeInTheDocument();
+  });
+});
+
+describe('SettingsCluster states and namespaces', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockDeleteCluster.mockReset();
+    mockState.activeCluster = clusterName;
+    mockState.electron = false;
+    mockState.clustersConf = {
+      [clusterName]: {
+        name: clusterName,
+        meta_data: { namespace: 'default', source: 'kubeconfig' },
+      },
+    };
+  });
+
+  it('selects the first cluster when the query is missing', () => {
+    renderSettings({}, { queryCluster: null });
+    expect(screen.getByRole('button', { name: 'Appearance Choose Color' })).toBeInTheDocument();
+  });
+
+  it('shows the empty state when no clusters exist', () => {
+    mockState.activeCluster = null;
+    mockState.clustersConf = {};
+    renderSettings({}, { dark: true });
+    expect(screen.getByText(/no clusters configured/i)).toBeInTheDocument();
+  });
+
+  it('shows an invalid-cluster message', () => {
+    mockState.activeCluster = null;
+    renderSettings({}, { queryCluster: 'missing-cluster', dark: true });
+    expect(screen.getByText(/Cluster missing-cluster does not exist/i)).toBeInTheDocument();
+  });
+
+  it('validates and stores the default namespace', async () => {
+    renderSettings();
+    const input = screen.getByRole('textbox', { name: 'Default namespace' });
+
+    await userEvent.type(input, 'Invalid Namespace');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'team-a');
+
+    expect(
+      JSON.parse(localStorage.getItem(`cluster_settings.${clusterName}`) || '{}')
+    ).toMatchObject({ defaultNamespace: 'team-a' });
+  });
+
+  it('adds, deduplicates, and removes allowed namespaces', async () => {
+    renderSettings({ allowedNamespaces: ['zeta'] });
+    const input = screen.getByRole('textbox', { name: 'Allowed namespaces' });
+
+    await userEvent.type(input, 'alpha');
+    await userEvent.keyboard('{Enter}');
+    await userEvent.type(input, 'alpha');
+    await userEvent.click(screen.getByRole('button', { name: 'Add namespace' }));
+    const alphaChip = screen.getByText('alpha').closest('.MuiChip-root');
+    await userEvent.click(alphaChip?.querySelector('svg') as SVGElement);
+
+    expect(screen.queryByText('alpha')).not.toBeInTheDocument();
+    expect(screen.getByText('zeta')).toBeInTheDocument();
+  });
+
+  it('renders Electron controls and removes a dynamic cluster', async () => {
+    mockState.electron = true;
+    mockState.clustersConf[clusterName].meta_data.source = 'dynamic_cluster';
+    mockDeleteCluster.mockResolvedValue({ clusters: {} });
+    renderSettings();
+
+    expect(screen.getByText('Cluster name editor')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Remove Cluster' }));
+    await waitFor(() => expect(mockDeleteCluster).toHaveBeenCalledWith(clusterName));
+  });
+
+  it('handles a dynamic cluster removal failure', async () => {
+    mockState.electron = true;
+    mockState.clustersConf[clusterName].meta_data.source = 'dynamic_cluster';
+    mockDeleteCluster.mockRejectedValue(new Error('remove failed'));
+    renderSettings();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove Cluster' }));
+    await waitFor(() => expect(mockDeleteCluster).toHaveBeenCalledWith(clusterName));
+  });
+});

--- a/frontend/src/components/App/Settings/SettingsCluster.test.tsx
+++ b/frontend/src/components/App/Settings/SettingsCluster.test.tsx
@@ -118,39 +118,63 @@ describe('SettingsCluster appearance controls', () => {
   it('labels controls with their appearance subsection', () => {
     renderSettings();
 
-    expect(screen.getByRole('button', { name: 'Appearance Choose Color' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Appearance Choose Icon' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Appearance Accent color Choose Color' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Appearance Cluster icon Choose Icon' })
+    ).toBeInTheDocument();
   });
 
   it('updates configured appearance values', async () => {
     renderSettings({ appearance: { accentColor: '#e91e63', icon: 'mdi:cloud-outline' } });
 
-    expect(screen.getByRole('button', { name: 'Appearance Change Color' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Appearance Change Icon' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Appearance Accent color Change Color' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Appearance Cluster icon Change Icon' })
+    ).toBeInTheDocument();
     await userEvent.click(screen.getByRole('button', { name: 'Clear accent color' }));
     await userEvent.click(screen.getByRole('button', { name: 'Clear cluster icon' }));
-    expect(screen.getByRole('button', { name: 'Appearance Choose Color' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Appearance Choose Icon' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Appearance Accent color Choose Color' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Appearance Cluster icon Choose Icon' })
+    ).toBeInTheDocument();
   });
 
   it('selects values from the appearance pickers', async () => {
     renderSettings();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Appearance Choose Color' }));
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Appearance Accent color Choose Color' })
+    );
     await userEvent.click(screen.getByRole('button', { name: 'Select test color' }));
-    await userEvent.click(screen.getByRole('button', { name: 'Appearance Choose Icon' }));
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Appearance Cluster icon Choose Icon' })
+    );
     await userEvent.click(screen.getByRole('button', { name: 'Select test icon' }));
 
-    expect(screen.getByRole('button', { name: 'Appearance Change Color' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Appearance Change Icon' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Appearance Accent color Change Color' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Appearance Cluster icon Change Icon' })
+    ).toBeInTheDocument();
   });
 
   it('closes appearance pickers without changing values', async () => {
     renderSettings();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Appearance Choose Color' }));
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Appearance Accent color Choose Color' })
+    );
     await userEvent.click(screen.getByRole('button', { name: 'Close color picker' }));
-    await userEvent.click(screen.getByRole('button', { name: 'Appearance Choose Icon' }));
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Appearance Cluster icon Choose Icon' })
+    );
     await userEvent.click(screen.getByRole('button', { name: 'Close icon picker' }));
 
     expect(screen.queryByRole('button', { name: 'Close color picker' })).not.toBeInTheDocument();
@@ -174,7 +198,9 @@ describe('SettingsCluster states and namespaces', () => {
 
   it('selects the first cluster when the query is missing', () => {
     renderSettings({}, { queryCluster: null });
-    expect(screen.getByRole('button', { name: 'Appearance Choose Color' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Appearance Accent color Choose Color' })
+    ).toBeInTheDocument();
   });
 
   it('shows the empty state when no clusters exist', () => {

--- a/frontend/src/components/App/Settings/SettingsCluster.tsx
+++ b/frontend/src/components/App/Settings/SettingsCluster.tsx
@@ -256,7 +256,7 @@ export default function SettingsCluster() {
                         size="small"
                         onClick={() => setColorPickerOpen(true)}
                         startIcon={<Icon icon="mdi:palette" />}
-                        aria-labelledby={`${appearanceLabelID} ${colorButtonID}`}
+                        aria-labelledby={`${appearanceLabelID} ${accentColorLabelID} ${colorButtonID}`}
                       >
                         {appearanceAccentColor
                           ? t('translation|Change Color')
@@ -292,7 +292,7 @@ export default function SettingsCluster() {
                         size="small"
                         onClick={() => setIconPickerOpen(true)}
                         startIcon={<Icon icon="mdi:emoticon-outline" />}
-                        aria-labelledby={`${appearanceLabelID} ${iconButtonID}`}
+                        aria-labelledby={`${appearanceLabelID} ${clusterIconLabelID} ${iconButtonID}`}
                       >
                         {appearanceIcon
                           ? t('translation|Change Icon')

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.Default.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.Default.stories.storyshot
@@ -154,7 +154,7 @@
                   class="MuiBox-root css-axw7ok"
                 >
                   <button
-                    aria-labelledby="cluster-appearance-label color-picker-button"
+                    aria-labelledby="cluster-appearance-label accent-color-label color-picker-button"
                     class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-irzb5y-MuiButtonBase-root-MuiButton-root"
                     id="color-picker-button"
                     tabindex="0"
@@ -183,7 +183,7 @@
                   class="MuiBox-root css-axw7ok"
                 >
                   <button
-                    aria-labelledby="cluster-appearance-label icon-picker-button"
+                    aria-labelledby="cluster-appearance-label cluster-icon-label icon-picker-button"
                     class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-irzb5y-MuiButtonBase-root-MuiButton-root"
                     id="icon-picker-button"
                     tabindex="0"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.DynamicCluster.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.DynamicCluster.stories.storyshot
@@ -154,7 +154,7 @@
                   class="MuiBox-root css-axw7ok"
                 >
                   <button
-                    aria-labelledby="cluster-appearance-label color-picker-button"
+                    aria-labelledby="cluster-appearance-label accent-color-label color-picker-button"
                     class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-irzb5y-MuiButtonBase-root-MuiButton-root"
                     id="color-picker-button"
                     tabindex="0"
@@ -183,7 +183,7 @@
                   class="MuiBox-root css-axw7ok"
                 >
                   <button
-                    aria-labelledby="cluster-appearance-label icon-picker-button"
+                    aria-labelledby="cluster-appearance-label cluster-icon-label icon-picker-button"
                     class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-irzb5y-MuiButtonBase-root-MuiButton-root"
                     id="icon-picker-button"
                     tabindex="0"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.MultipleAllowedNamespaces.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.MultipleAllowedNamespaces.stories.storyshot
@@ -154,7 +154,7 @@
                   class="MuiBox-root css-axw7ok"
                 >
                   <button
-                    aria-labelledby="cluster-appearance-label color-picker-button"
+                    aria-labelledby="cluster-appearance-label accent-color-label color-picker-button"
                     class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-irzb5y-MuiButtonBase-root-MuiButton-root"
                     id="color-picker-button"
                     tabindex="0"
@@ -183,7 +183,7 @@
                   class="MuiBox-root css-axw7ok"
                 >
                   <button
-                    aria-labelledby="cluster-appearance-label icon-picker-button"
+                    aria-labelledby="cluster-appearance-label cluster-icon-label icon-picker-button"
                     class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-irzb5y-MuiButtonBase-root-MuiButton-root"
                     id="icon-picker-button"
                     tabindex="0"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.NamespaceValidation.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.NamespaceValidation.stories.storyshot
@@ -154,7 +154,7 @@
                   class="MuiBox-root css-axw7ok"
                 >
                   <button
-                    aria-labelledby="cluster-appearance-label color-picker-button"
+                    aria-labelledby="cluster-appearance-label accent-color-label color-picker-button"
                     class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-irzb5y-MuiButtonBase-root-MuiButton-root"
                     id="color-picker-button"
                     tabindex="0"
@@ -183,7 +183,7 @@
                   class="MuiBox-root css-axw7ok"
                 >
                   <button
-                    aria-labelledby="cluster-appearance-label icon-picker-button"
+                    aria-labelledby="cluster-appearance-label cluster-icon-label icon-picker-button"
                     class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-irzb5y-MuiButtonBase-root-MuiButton-root"
                     id="icon-picker-button"
                     tabindex="0"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.WithAppearance.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.WithAppearance.stories.storyshot
@@ -157,7 +157,7 @@
                     class="MuiBox-root css-1nkprdw"
                   />
                   <button
-                    aria-labelledby="cluster-appearance-label color-picker-button"
+                    aria-labelledby="cluster-appearance-label accent-color-label color-picker-button"
                     class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-irzb5y-MuiButtonBase-root-MuiButton-root"
                     id="color-picker-button"
                     tabindex="0"
@@ -196,7 +196,7 @@
                   class="MuiBox-root css-axw7ok"
                 >
                   <button
-                    aria-labelledby="cluster-appearance-label icon-picker-button"
+                    aria-labelledby="cluster-appearance-label cluster-icon-label icon-picker-button"
                     class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-irzb5y-MuiButtonBase-root-MuiButton-root"
                     id="icon-picker-button"
                     tabindex="0"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.WithSavedSettings.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.WithSavedSettings.stories.storyshot
@@ -157,7 +157,7 @@
                     class="MuiBox-root css-7mxbmx"
                   />
                   <button
-                    aria-labelledby="cluster-appearance-label color-picker-button"
+                    aria-labelledby="cluster-appearance-label accent-color-label color-picker-button"
                     class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-irzb5y-MuiButtonBase-root-MuiButton-root"
                     id="color-picker-button"
                     tabindex="0"
@@ -196,7 +196,7 @@
                   class="MuiBox-root css-axw7ok"
                 >
                   <button
-                    aria-labelledby="cluster-appearance-label icon-picker-button"
+                    aria-labelledby="cluster-appearance-label cluster-icon-label icon-picker-button"
                     class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-irzb5y-MuiButtonBase-root-MuiButton-root"
                     id="icon-picker-button"
                     tabindex="0"


### PR DESCRIPTION
## Summary

- preserve the original fix that includes the Accent color and Cluster icon subsection labels in the appearance control accessible names
- improve on the original snapshot-only coverage with 11 focused SettingsCluster behavior tests covering appearance, namespace, cluster-state, and removal paths
- raise scoped SettingsCluster branch coverage to 90.41%, above the requested 80% threshold
- add a locale-independent deployed e2e workflow that selects color and icon presets through stable selectors and verifies their persisted localStorage values

## Provenance

This upstreams patch 0029 retained by Azure/aks-desktop PR [#823](https://github.com/Azure/aks-desktop/pull/823) in commit [68e024d](https://github.com/Azure/aks-desktop/commit/68e024dca932107a6a5a65b606edc1fdf2fae52d).

The implementation originated in Azure/aks-desktop commit [e0d711e](https://github.com/Azure/aks-desktop/commit/e0d711e071a74b4d02b9fab71471c628b60a23be), authored by Vincent T and merged through Azure/aks-desktop PR [#450](https://github.com/Azure/aks-desktop/pull/450). The implementation commit preserves Vincent T's original author date and adds Rene Dudfield as co-author.

## Testing

- `npm --prefix frontend test -- --run src/components/App/Settings/SettingsCluster.test.tsx` (11 tests passed)
- scoped `SettingsCluster.tsx` coverage: 90.41% branches
- `vitest --run src/storybook.test.tsx -t 'Settings/SettingsCluster' --reporter=dot` (15 passed)
- `npm run tsc`
- ESLint and Prettier checks for changed TypeScript and e2e files
- `playwright test tests/clusterAppearance.spec.ts --list` (1 test discovered)
- `Build Container and test / build discover and deploy` (deployed Playwright workflow passed in CI)

Assisted by copilot
