### PR TITLE
frontend: ClusterChooserPopup: Sort recent clusters by recency

### DIFF
--- a/frontend/src/components/cluster/ClusterChooserPopup.stories.tsx
+++ b/frontend/src/components/cluster/ClusterChooserPopup.stories.tsx
@@ -108,6 +108,14 @@ NoClustersButRecent.args = {
   clusters: ourState().config.clusters.slice(0, 3),
 };
 
+// Recent clusters should be ordered by recency (most recent first), not by
+// the order they happen to appear in the clusters list.
+export const RecencyOrder = Template.bind({});
+RecencyOrder.args = {
+  cluster: 'cluster4',
+  recentClusters: ['cluster2', 'cluster0', 'cluster1'],
+};
+
 export const Scrollbar = Template.bind({});
 Scrollbar.args = {
   cluster: 'cluster2',

--- a/frontend/src/components/cluster/ClusterChooserPopup.tsx
+++ b/frontend/src/components/cluster/ClusterChooserPopup.tsx
@@ -139,7 +139,7 @@ function ClusterChooserPopup(props: ChooserPopupPros) {
         return 1;
       }
 
-      return 0;
+      return recentClustersNames.indexOf(a.name) - recentClustersNames.indexOf(b.name);
     });
 
     clustersToShow.sort((a, b) => {

--- a/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.RecencyOrder.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.RecencyOrder.stories.storyshot
@@ -1,0 +1,201 @@
+<body>
+  <div
+    aria-hidden="true"
+  >
+    <span />
+  </div>
+  <div
+    aria-busy="false"
+    aria-labelledby="chooser-dialog-title"
+    class="MuiPopover-root MuiModal-root css-1ha3vqg-MuiModal-root-MuiPopover-root"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop css-g3hgs1-MuiBackdrop-root-MuiModal-backdrop"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-testid="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiPopover-paper css-qmfbpu-MuiPaper-root-MuiPopover-paper"
+      style="opacity: 1; transform: none; transition: opacity 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; top: 16px; left: 16px; transform-origin: -16px -16px;"
+      tabindex="-1"
+    >
+      <div
+        class="MuiBox-root css-17xfcuj"
+      >
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1f7ywh2-MuiFormLabel-root-MuiInputLabel-root"
+            data-shrink="true"
+            for="filled-size-small"
+            id="filled-size-small-label"
+          >
+            Choose cluster
+          </label>
+          <div
+            aria-haspopup="listbox"
+            aria-owns="cluster-chooser-list"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused MuiInputBase-formControl MuiInputBase-sizeSmall css-u775sc-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
+              id="filled-size-small"
+              placeholder="Name"
+              type="text"
+              value=""
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-sl37lx-MuiNotchedOutlined-root"
+              >
+                <span>
+                  Choose cluster
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+        <ul
+          class="MuiList-root MuiList-padding MuiList-dense css-1k1lw4j-MuiList-root"
+          id="cluster-chooser-list"
+          role="listbox"
+          tabindex="0"
+        >
+          <li
+            class="MuiListSubheader-root MuiListSubheader-gutters css-1ac4l9u-MuiListSubheader-root"
+            role="presentation"
+          >
+            Recent clusters
+          </li>
+          <li
+            aria-selected="false"
+            class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
+            id="cluster2"
+            role="option"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-172hjuw"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+              >
+                cluster2
+              </span>
+            </div>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </li>
+          <li
+            aria-selected="false"
+            class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
+            id="cluster0"
+            role="option"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-172hjuw"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+              >
+                cluster0
+              </span>
+            </div>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </li>
+          <li
+            aria-selected="false"
+            class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
+            id="cluster1"
+            role="option"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-172hjuw"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+              >
+                cluster1
+              </span>
+            </div>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </li>
+          <hr
+            class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"
+            role="separator"
+          />
+          <li
+            aria-selected="true"
+            class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
+            id="cluster4"
+            role="option"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-172hjuw"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+              >
+                cluster4
+              </span>
+            </div>
+            <div
+              class="MuiListItemText-root MuiListItemText-dense css-krqs19-MuiListItemText-root"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+              >
+                Current
+              </p>
+            </div>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </li>
+          <li
+            aria-selected="false"
+            class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
+            id="cluster3"
+            role="option"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-172hjuw"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+              >
+                cluster3
+              </span>
+            </div>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div
+      data-testid="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>


### PR DESCRIPTION
### Fixes
Fixes #6841 

## Summary
- The "Recent clusters" section in the cluster switcher only checked membership in the recent-clusters list, not the actual recency order, so entries could appear in an arbitrary order instead of most-recently-used first.
- Sorts non-current recent clusters by their index in the recency list returned by `getRecentClusters()`.

## Test plan
- [x] Added a `RecencyOrder` story where the clusters list order differs from recency order, with a storyshot snapshot verifying correct ordering.
- [x] Manually tested: created 3 local clusters, switched between them in order, confirmed the switcher lists them most-recent-first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cluster chooser sorting so recently used clusters consistently appear in recency order, including when entries have matching timestamps.

* **Tests**
  * Added coverage and visual snapshot validation for the recent-cluster ordering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Screen Recordings


https://github.com/user-attachments/assets/aee5b6a2-997d-43cc-afbd-957b057390cb


As on main

https://github.com/user-attachments/assets/19363804-f8a5-494e-b53a-30126aae8242

On the feature branch. 

We can see from the picker the order in which clusters were opened is not correctly depicted on main, while the feature branch has tackled this. 



