### PR TITLE
fix(ui): show service account namespace in rolebindings list if different

### DIFF
--- a/frontend/src/components/role/BindingList.tsx
+++ b/frontend/src/components/role/BindingList.tsx
@@ -165,14 +165,22 @@ export default function RoleBindingList() {
           getValue: item =>
             item?.subjects
               ?.filter(subject => subject.kind === 'ServiceAccount')
-              ?.map(subject => subject.name)
+              ?.map(subject =>
+                subject.namespace && subject.namespace !== item.getNamespace()
+                  ? `${subject.namespace}/${subject.name}`
+                  : subject.name
+              )
               ?.join(' '),
           render: item => (
             <LabelListItem
               labels={
                 item?.subjects
                   ?.filter(subject => subject.kind === 'ServiceAccount')
-                  .map(subject => subject.name) || []
+                  .map(subject =>
+                    subject.namespace && subject.namespace !== item.getNamespace()
+                      ? `${subject.namespace}/${subject.name}`
+                      : subject.name
+                  ) || []
               }
             />
           ),


### PR DESCRIPTION
Fixes #6794. The RoleBindings list view currently omits the namespace of service accounts when they differ from the RoleBinding's namespace. This PR updates the React rendering logic in BindingList to conditionally display the subject namespace when it differs from the RoleBinding's namespace to prevent confusion.