### PR TITLE
fix(search): prevent eviction of oldest item if selected item is already in recent list

### DIFF
--- a/frontend/src/components/globalSearch/useRecent.tsx
+++ b/frontend/src/components/globalSearch/useRecent.tsx
@@ -33,30 +33,40 @@ export function useRecent(
 ): [Record<string, number>, (id: string) => void] {
   const [recent, setRecent] = useLocalStorageState<Record<string, number>>(key, {});
 
-  const bump = useCallback((id: string) => {
-    setRecent(recent => {
-      const entries = Object.entries(recent);
-      const newRecent: Record<string, number> = { ...recent };
+  const bump = useCallback(
+    (id: string) => {
+      setRecent(recent => {
+        if (maxItems <= 0) return {};
 
-      if (entries.length + 1 > maxItems) {
-        // Find oldest entry
-        let oldestEntry = entries[0];
-        entries.forEach(entry => {
-          if (entry[1] < oldestEntry[1]) {
-            oldestEntry = entry;
-          }
-        });
+        const entries = Object.entries(recent);
+        const newRecent: Record<string, number> = Object.assign(Object.create(null), recent);
 
-        // Remove it
-        delete newRecent[oldestEntry[0]];
-      }
+        const isNewItem = !Object.prototype.hasOwnProperty.call(recent, id);
 
-      newRecent[id] = +new Date();
+        if (isNewItem && entries.length >= maxItems) {
+          // Find oldest entry
+          let oldestEntry = entries[0];
+          entries.forEach(entry => {
+            if (entry[1] < oldestEntry[1]) {
+              oldestEntry = entry;
+            }
+          });
 
-      return newRecent;
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+          // Remove it
+          delete newRecent[oldestEntry[0]];
+        }
+
+        newRecent[id] = +new Date();
+
+        return newRecent;
+      });
+    },
+    [maxItems, setRecent]
+  );
+
+  if (maxItems <= 0) {
+    return [{}, () => {}] as const;
+  }
 
   return [recent, bump] as const;
 }


### PR DESCRIPTION
Fixes #6778. Currently, selecting an existing recent item in Global Search while the recent-item list is at capacity incorrectly removes the oldest entry. This PR updates the `useRecent` hook to ensure that we only evict the oldest entry if the selected item is actually new.