### PR TITLE
0035: Improve debug image field narration

### DIFF
--- a/e2e-tests/tests/podDebugSettings.spec.ts
+++ b/e2e-tests/tests/podDebugSettings.spec.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import { HeadlampPage } from './headlampPage';
+
+test('pod debug image field has an accessible name', async ({ page }) => {
+  const headlampPage = new HeadlampPage(page);
+
+  await headlampPage.navigateToCluster('test', process.env.HEADLAMP_TEST_TOKEN);
+  await headlampPage.navigateTopage('/settings/cluster?c=test', /Cluster Settings/);
+
+  const debugImageInput = page.locator('input[aria-labelledby="debug-image-label"]');
+  await expect(debugImageInput).toBeVisible();
+  await expect(debugImageInput).toHaveAccessibleName(/.+/);
+});

--- a/frontend/src/components/App/Settings/PodDebugSettings.test.tsx
+++ b/frontend/src/components/App/Settings/PodDebugSettings.test.tsx
@@ -85,6 +85,12 @@ describe('PodDebugSettings', () => {
     expect(screen.getByRole('checkbox')).toBeChecked();
   });
 
+  it('labels the debug image textbox', () => {
+    renderSettings();
+
+    expect(screen.getByRole('textbox', { name: /Debug Image$/ })).toBeInTheDocument();
+  });
+
   it('removes whitespace when updating the debug image', () => {
     const setClusterSettings = renderSettings();
 

--- a/frontend/src/components/App/Settings/PodDebugSettings.test.tsx
+++ b/frontend/src/components/App/Settings/PodDebugSettings.test.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DEFAULT_POD_DEBUG_IMAGE } from '../../../helpers/clusterSettings';
+import { createMuiTheme } from '../../../lib/themes';
+import { TestContext } from '../../../test';
+import PodDebugSettings from './PodDebugSettings';
+
+const { mockUseTypedSelector } = vi.hoisted(() => ({ mockUseTypedSelector: vi.fn() }));
+const theme = createMuiTheme({ name: 'Light', base: 'light' });
+
+vi.mock('../../../redux/hooks', () => ({
+  useTypedSelector: mockUseTypedSelector,
+}));
+
+vi.mock('../../common/SectionBox', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+function renderSettings(
+  clusterSettings: React.ComponentProps<typeof PodDebugSettings>['clusterSettings'] = {},
+  defaultPodDebugImage?: string
+) {
+  const setClusterSettings = vi.fn();
+  mockUseTypedSelector.mockImplementation(selector =>
+    selector({ config: { defaultPodDebugImage } })
+  );
+
+  render(
+    <TestContext>
+      <ThemeProvider theme={theme}>
+        <PodDebugSettings
+          cluster="test"
+          clusterSettings={clusterSettings}
+          setClusterSettings={setClusterSettings}
+        />
+      </ThemeProvider>
+    </TestContext>
+  );
+
+  return setClusterSettings;
+}
+
+describe('PodDebugSettings', () => {
+  it('uses configured pod debug values', () => {
+    renderSettings(
+      {
+        podDebugTerminal: {
+          debugImage: 'registry.example/debug:latest',
+          isEnabled: false,
+        },
+      },
+      'registry.example/default:latest'
+    );
+
+    expect(screen.getByRole('textbox')).toHaveValue('registry.example/debug:latest');
+    expect(screen.getByRole('textbox')).toHaveAttribute(
+      'placeholder',
+      'registry.example/default:latest'
+    );
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+  });
+
+  it('uses fallback pod debug values', () => {
+    renderSettings();
+
+    expect(screen.getByRole('textbox')).toHaveValue('');
+    expect(screen.getByRole('textbox')).toHaveAttribute('placeholder', DEFAULT_POD_DEBUG_IMAGE);
+    expect(screen.getByRole('checkbox')).toBeChecked();
+  });
+
+  it('removes whitespace when updating the debug image', () => {
+    const setClusterSettings = renderSettings();
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'registry.example/ debug\timage:\nlatest' },
+    });
+
+    const update = setClusterSettings.mock.calls[0][0];
+    expect(update({ podDebugTerminal: { isEnabled: true } })).toEqual({
+      podDebugTerminal: {
+        debugImage: 'registry.example/debugimage:latest',
+        isEnabled: true,
+      },
+    });
+  });
+
+  it('updates whether pod debugging is enabled', () => {
+    const setClusterSettings = renderSettings();
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    const update = setClusterSettings.mock.calls[0][0];
+    expect(update({ podDebugTerminal: { debugImage: 'busybox' } })).toEqual({
+      podDebugTerminal: {
+        debugImage: 'busybox',
+        isEnabled: false,
+      },
+    });
+  });
+});

--- a/frontend/src/components/App/Settings/PodDebugSettings.tsx
+++ b/frontend/src/components/App/Settings/PodDebugSettings.tsx
@@ -49,6 +49,7 @@ export default function PodDebugSettings(props: SettingsProps) {
     useTypedSelector(state => state.config?.defaultPodDebugImage) || DEFAULT_POD_DEBUG_IMAGE;
 
   const podDebugLabelID = 'pod-debug-enabled-label';
+  const debugImageLabelID = 'debug-image-label';
 
   const image = clusterSettings.podDebugTerminal?.debugImage ?? '';
   const isEnabled = clusterSettings.podDebugTerminal?.isEnabled ?? true;
@@ -82,15 +83,18 @@ export default function PodDebugSettings(props: SettingsProps) {
             ),
           },
           {
-            name: 'Debug Image',
+            name: <span id={debugImageLabelID}>{t('translation|Debug Image')}</span>,
             value: (
               <TextField
                 onChange={event => {
-                  const value = event.target.value.replace(' ', '');
+                  const value = event.target.value.replace(/\s/g, '');
                   updatePodDebug({ debugImage: value });
                 }}
                 value={image}
                 placeholder={defaultPodDebugImage}
+                inputProps={{
+                  'aria-labelledby': debugImageLabelID,
+                }}
                 helperText={t(
                   'translation|The default image is used for creating ephemeral debug containers.'
                 )}

--- a/frontend/src/components/App/Settings/__snapshots__/PodDebugSettings.Default.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/PodDebugSettings.Default.stories.storyshot
@@ -74,7 +74,11 @@
           <dt
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
           >
-            Debug Image
+            <span
+              id="debug-image-label"
+            >
+              Debug Image
+            </span>
           </dt>
           <dd
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
@@ -88,6 +92,7 @@
                 <input
                   aria-describedby=":mock-test-id:"
                   aria-invalid="false"
+                  aria-labelledby="debug-image-label"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
                   id=":mock-test-id:"
                   placeholder="docker.io/library/busybox:latest"

--- a/frontend/src/components/App/Settings/__snapshots__/PodDebugSettings.Disabled.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/PodDebugSettings.Disabled.stories.storyshot
@@ -73,7 +73,11 @@
           <dt
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
           >
-            Debug Image
+            <span
+              id="debug-image-label"
+            >
+              Debug Image
+            </span>
           </dt>
           <dd
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
@@ -87,6 +91,7 @@
                 <input
                   aria-describedby=":mock-test-id:"
                   aria-invalid="false"
+                  aria-labelledby="debug-image-label"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
                   id=":mock-test-id:"
                   placeholder="docker.io/library/busybox:latest"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.Default.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.Default.stories.storyshot
@@ -557,7 +557,11 @@
           <dt
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
           >
-            Debug Image
+            <span
+              id="debug-image-label"
+            >
+              Debug Image
+            </span>
           </dt>
           <dd
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
@@ -571,6 +575,7 @@
                 <input
                   aria-describedby=":mock-test-id:"
                   aria-invalid="false"
+                  aria-labelledby="debug-image-label"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
                   id=":mock-test-id:"
                   placeholder="docker.io/library/busybox:latest"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.DynamicCluster.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.DynamicCluster.stories.storyshot
@@ -602,7 +602,11 @@
           <dt
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
           >
-            Debug Image
+            <span
+              id="debug-image-label"
+            >
+              Debug Image
+            </span>
           </dt>
           <dd
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
@@ -616,6 +620,7 @@
                 <input
                   aria-describedby=":mock-test-id:"
                   aria-invalid="false"
+                  aria-labelledby="debug-image-label"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
                   id=":mock-test-id:"
                   placeholder="docker.io/library/busybox:latest"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.MultipleAllowedNamespaces.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.MultipleAllowedNamespaces.stories.storyshot
@@ -690,7 +690,11 @@
           <dt
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
           >
-            Debug Image
+            <span
+              id="debug-image-label"
+            >
+              Debug Image
+            </span>
           </dt>
           <dd
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
@@ -704,6 +708,7 @@
                 <input
                   aria-describedby=":mock-test-id:"
                   aria-invalid="false"
+                  aria-labelledby="debug-image-label"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
                   id=":mock-test-id:"
                   placeholder="docker.io/library/busybox:latest"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.NamespaceValidation.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.NamespaceValidation.stories.storyshot
@@ -602,7 +602,11 @@
           <dt
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
           >
-            Debug Image
+            <span
+              id="debug-image-label"
+            >
+              Debug Image
+            </span>
           </dt>
           <dd
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
@@ -616,6 +620,7 @@
                 <input
                   aria-describedby=":mock-test-id:"
                   aria-invalid="false"
+                  aria-labelledby="debug-image-label"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
                   id=":mock-test-id:"
                   placeholder="docker.io/library/busybox:latest"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.WithAppearance.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.WithAppearance.stories.storyshot
@@ -580,7 +580,11 @@
           <dt
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
           >
-            Debug Image
+            <span
+              id="debug-image-label"
+            >
+              Debug Image
+            </span>
           </dt>
           <dd
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
@@ -594,6 +598,7 @@
                 <input
                   aria-describedby=":mock-test-id:"
                   aria-invalid="false"
+                  aria-labelledby="debug-image-label"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
                   id=":mock-test-id:"
                   placeholder="docker.io/library/busybox:latest"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.WithSavedSettings.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.WithSavedSettings.stories.storyshot
@@ -647,7 +647,11 @@
           <dt
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
           >
-            Debug Image
+            <span
+              id="debug-image-label"
+            >
+              Debug Image
+            </span>
           </dt>
           <dd
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
@@ -661,6 +665,7 @@
                 <input
                   aria-describedby=":mock-test-id:"
                   aria-invalid="false"
+                  aria-labelledby="debug-image-label"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
                   id=":mock-test-id:"
                   placeholder="docker.io/library/busybox:latest"

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -163,6 +163,7 @@
   "Custom value": "قيمة مخصصة",
   "Pod Debug Settings": "إعدادات تصحيح Pod",
   "Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated.": "لا يمكن إزالة حاويات التصحيح المؤقتة عبر Kubernetes API. ستبقى في مواصفات الـ pod حتى بعد إغلاق الطرفية. لإزالتها، يجب إعادة إنشاء الـ pod",
+  "Debug Image": "",
   "The default image is used for creating ephemeral debug containers.": "تُستخدم الصورة الافتراضية لإنشاء حاويات تصحيح مؤقتة.",
   "General Settings": "الإعدادات العامة",
   "Version": "الإصدار",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -163,6 +163,7 @@
   "Custom value": "Custom মান",
   "Pod Debug Settings": "Pod ডিবাগ সেটিংস",
   "Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated.": "অস্থায়ী ডিবাগ কনটেইনার Kubernetes API এর মাধ্যমে সরানো যায় না। Terminal বন্ধ হওয়ার পরেও এগুলো Pod-এর স্পেসিফিকেশনে থাকবে। সরাতে হলে Pod পুনরায় তৈরি করতে হবে।",
+  "Debug Image": "",
   "The default image is used for creating ephemeral debug containers.": "অস্থায়ী ডিবাগ কনটেইনার তৈরির জন্য ডিফল্ট ইমেজ ব্যবহৃত হয়।",
   "General Settings": "সাধারণ সেটিংস",
   "Version": "Version",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -163,6 +163,7 @@
   "Custom value": "",
   "Pod Debug Settings": "",
   "Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated.": "",
+  "Debug Image": "",
   "The default image is used for creating ephemeral debug containers.": "",
   "General Settings": "",
   "Version": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -163,6 +163,7 @@
   "Custom value": "Custom value",
   "Pod Debug Settings": "Pod Debug Settings",
   "Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated.": "Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated.",
+  "Debug Image": "Debug Image",
   "The default image is used for creating ephemeral debug containers.": "The default image is used for creating ephemeral debug containers.",
   "General Settings": "General Settings",
   "Version": "Version",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -163,6 +163,7 @@
   "Custom value": "",
   "Pod Debug Settings": "",
   "Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated.": "",
+  "Debug Image": "",
   "The default image is used for creating ephemeral debug containers.": "",
   "General Settings": "",
   "Version": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -163,6 +163,7 @@
   "Custom value": "",
   "Pod Debug Settings": "",
   "Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated.": "",
+  "Debug Image": "",
   "The default image is used for creating ephemeral debug containers.": "",
   "General Settings": "",
   "Version": "",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -163,6 +163,7 @@
   "Custom value": "Custom value",
   "Pod Debug Settings": "Pod Debug Settings",
   "Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated.": "Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated.",
+  "Debug Image": "",
   "The default image is used for creating ephemeral debug containers.": "The default image is used for creating ephemeral debug containers.",
   "General Settings": "General Settings",
   "Version": "Version",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -163,6 +163,7 @@
   "Custom value": "",
   "Pod Debug Settings": "",
   "Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated.": "",
+  "Debug Image": "",
   "The default image is used for creating ephemeral debug containers.": "",
   "General Settings": "",
   "Version": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -163,6 +163,7 @@
   "Custom value": "",
   "Pod Debug Settings": "",
   "Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated.": "",
+  "Debug Image": "",
   "The default image is used for creating ephemeral debug containers.": "",
   "General Settings": "",
   "Version": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -163,6 +163,7 @@
   "Custom value": "",
   "Pod Debug Settings": "",
   "Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated.": "",
+  "Debug Image": "",
   "The default image is used for creating ephemeral debug containers.": "",
   "General Settings": "",
   "Version": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -163,6 +163,7 @@
   "Custom value": "",
   "Pod Debug Settings": "",
   "Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated.": "",
+  "Debug Image": "",
   "The default image is used for creating ephemeral debug containers.": "",
   "General Settings": "",
   "Version": "",

--- a/frontend/src/i18n/locales/pt-br/translation.json
+++ b/frontend/src/i18n/locales/pt-br/translation.json
@@ -163,6 +163,7 @@
   "Custom value": "",
   "Pod Debug Settings": "",
   "Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated.": "",
+  "Debug Image": "",
   "The default image is used for creating ephemeral debug containers.": "",
   "General Settings": "",
   "Version": "",

--- a/frontend/src/i18n/locales/pt-pt/translation.json
+++ b/frontend/src/i18n/locales/pt-pt/translation.json
@@ -163,6 +163,7 @@
   "Custom value": "",
   "Pod Debug Settings": "",
   "Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated.": "",
+  "Debug Image": "",
   "The default image is used for creating ephemeral debug containers.": "",
   "General Settings": "",
   "Version": "",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -163,6 +163,7 @@
   "Custom value": "",
   "Pod Debug Settings": "",
   "Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated.": "",
+  "Debug Image": "",
   "The default image is used for creating ephemeral debug containers.": "",
   "General Settings": "",
   "Version": "",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -163,6 +163,7 @@
   "Custom value": "Пользовательское значение",
   "Pod Debug Settings": "Настройки отладки Pod",
   "Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated.": "Эфемерные отладочные контейнеры невозможно удалить через Kubernetes API. Они останутся в спецификации Pod даже после закрытия терминала. Чтобы удалить их, Pod необходимо пересоздать.",
+  "Debug Image": "",
   "The default image is used for creating ephemeral debug containers.": "Образ по умолчанию используется для создания временных контейнеров отладки.",
   "General Settings": "Общие настройки",
   "Version": "Версия",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -163,6 +163,7 @@
   "Custom value": "",
   "Pod Debug Settings": "",
   "Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated.": "",
+  "Debug Image": "",
   "The default image is used for creating ephemeral debug containers.": "",
   "General Settings": "",
   "Version": "",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -163,6 +163,7 @@
   "Custom value": "حسب ضرورت قدر",
   "Pod Debug Settings": "پوڈ ڈیبگ ترتیبات",
   "Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated.": "عارضی ڈیبگ کنٹینرز کو Kubernetes API کے ذریعے حذف نہیں کیا جا سکتا، ٹرمینل بند ہونے کے بعد بھی یہ پوڈ کی تفصیلات میں موجود رہیں گے، انہیں ہٹانے کے لیے پوڈ کو دوبارہ بنانا ہوگا",
+  "Debug Image": "",
   "The default image is used for creating ephemeral debug containers.": "ڈیفالٹ امیج عارضی ڈیبگ کنٹینرز بنانے کے لیے استعمال ہوتی ہے",
   "General Settings": "عمومی ترتیبات",
   "Version": "ورژن",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -163,6 +163,7 @@
   "Custom value": "",
   "Pod Debug Settings": "",
   "Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated.": "",
+  "Debug Image": "",
   "The default image is used for creating ephemeral debug containers.": "",
   "General Settings": "",
   "Version": "",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -163,6 +163,7 @@
   "Custom value": "",
   "Pod Debug Settings": "",
   "Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated.": "",
+  "Debug Image": "",
   "The default image is used for creating ephemeral debug containers.": "",
   "General Settings": "",
   "Version": "",


### PR DESCRIPTION
## Summary

- associate the translated Debug Image label with its textbox so assistive technology narrates the field
- remove spaces, tabs, newlines, and other whitespace from debug image references
- update generated storyshots and translation catalogs for current Headlamp locales

### Improvements over the original PR

Compared with Azure/aks-desktop#450, this focused upstream port:

- adds five unit tests covering configured and fallback values, accessible labeling, whitespace sanitization, and enable-state updates
- reaches 100% branch coverage for `PodDebugSettings.tsx`
- adds a Playwright regression test that verifies a non-empty accessible name without assuming a specific locale
- strengthens image sanitization from removing one literal space to removing all whitespace
- separates baseline unit coverage, browser coverage, and the production change into atomic commits

## Provenance

- Upstreams the debug-image portion of Azure/aks-desktop#450, especially commit [`4f543d9df9088f93291f13f7915e2afbda2039da`](https://github.com/Azure/aks-desktop/commit/4f543d9df9088f93291f13f7915e2afbda2039da).
- Ported from patch 0035 retained by Azure/aks-desktop#823.
- The production commit preserves Vincent T as author and the original source commit date, with René Dudfield as co-author.

## Testing

- `npm --prefix frontend test -- --run src/components/App/Settings/PodDebugSettings.test.tsx --coverage --coverage.include=src/components/App/Settings/PodDebugSettings.tsx` (5 passed; 100% branches)
- `npm --prefix frontend test -- --run src/storybook.test.tsx` (651 passed)
- `npm --prefix frontend run tsc`
- changed-file ESLint check
- `npm run i18n:check`
- Playwright discovery: 1 test in `podDebugSettings.spec.ts`

The live Playwright test was not run locally because the required two-cluster environment and Headlamp test credentials were unavailable. There is no visual change.

Assisted by copilot