### PR TITLE
0030: app: Use package name in artifact filenames

### DIFF
--- a/app/electron/package.test.ts
+++ b/app/electron/package.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import { describe, expect, it } from 'vitest';
+
+const packageJson = JSON.parse(
+  fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8')
+) as {
+  build: {
+    artifactName: string;
+  };
+};
+
+describe('desktop package configuration', () => {
+  it('uses the package name for artifact filenames', () => {
+    expect(packageJson.build.artifactName).toBe('${name}-${version}-${os}-${arch}.${ext}');
+  });
+});

--- a/app/electron/package.test.ts
+++ b/app/electron/package.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+const packageJson = JSON.parse(
+  fs.readFileSync(new URL('../package.json', import.meta.url), 'utf-8')
+) as {
+  name: string;
+  productName: string;
+  version: string;
+  build: {
+    artifactName: string;
+  };
+};
+const require = createRequire(import.meta.url);
+const { expandMsiArtifactName } = require('../windows/msi/artifact-name.js') as {
+  expandMsiArtifactName: (pattern: string, options: Record<string, string>) => string;
+};
+
+describe('desktop package configuration', () => {
+  it('uses the package name for artifact filenames', () => {
+    expect(packageJson.build.artifactName).toBe('${name}-${version}-${os}-${arch}.${ext}');
+  });
+
+  it('expands the package name in Windows MSI filenames', () => {
+    expect(
+      expandMsiArtifactName(packageJson.build.artifactName, {
+        name: packageJson.name,
+        productName: packageJson.productName,
+        version: packageJson.version,
+        os: 'win',
+        arch: 'x64',
+      })
+    ).toBe(`${packageJson.name}-${packageJson.version}-win-x64.msi`);
+  });
+});

--- a/app/package.json
+++ b/app/package.json
@@ -38,7 +38,7 @@
     "beforeBuild": "./scripts/build-backend.js",
     "afterPack": "./scripts/after-pack.js",
     "asar": false,
-    "artifactName": "${productName}-${version}-${os}-${arch}.${ext}",
+    "artifactName": "${name}-${version}-${os}-${arch}.${ext}",
     "protocols": {
       "name": "headlamp-protocol",
       "schemes": [

--- a/app/scripts/verify-build-mac.sh
+++ b/app/scripts/verify-build-mac.sh
@@ -92,10 +92,11 @@ echo ""
 echo "Checking for built artifacts..."
 ls -lh "$DIST_DIR/" || true
 
-if ls "$DIST_DIR"/*.dmg 1> /dev/null 2>&1; then
-  echo "✓ Mac DMG found"
+PACKAGE_NAME=$(node -p "require(process.argv[1]).name" "$APP_DIR/package.json")
+if ls "$DIST_DIR/${PACKAGE_NAME}-"*.dmg 1> /dev/null 2>&1; then
+  echo "✓ Mac DMG found with package name"
 else
-  echo "✗ No Mac DMG found"
+  echo "✗ No Mac DMG found with package name: $PACKAGE_NAME"
   exit 1
 fi
 echo ""

--- a/app/scripts/verify-build-mac.sh
+++ b/app/scripts/verify-build-mac.sh
@@ -92,10 +92,11 @@ echo ""
 echo "Checking for built artifacts..."
 ls -lh "$DIST_DIR/" || true
 
-if ls "$DIST_DIR"/*.dmg 1> /dev/null 2>&1; then
-  echo "✓ Mac DMG found"
+PACKAGE_NAME=$(node -p "require('$APP_DIR/package.json').name")
+if ls "$DIST_DIR/${PACKAGE_NAME}-"*.dmg 1> /dev/null 2>&1; then
+  echo "✓ Mac DMG found with package name"
 else
-  echo "✗ No Mac DMG found"
+  echo "✗ No Mac DMG found with package name: $PACKAGE_NAME"
   exit 1
 fi
 echo ""

--- a/app/windows/msi/artifact-name.js
+++ b/app/windows/msi/artifact-name.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Expands Electron Builder macros for an MSI artifact filename.
+ *
+ * @param {string} pattern Electron Builder artifact name pattern.
+ * @param {Record<string, string>} options Macro values to substitute.
+ * @returns {string} Expanded MSI artifact filename.
+ */
+function expandMsiArtifactName(pattern, options) {
+  let installerName = pattern.split('.')[0];
+  Object.entries(options).forEach(([key, value]) => {
+    installerName = installerName.replace(`\${${key}}`, value);
+  });
+  return `${installerName}.msi`;
+}
+
+module.exports = { expandMsiArtifactName };

--- a/app/windows/msi/build.js
+++ b/app/windows/msi/build.js
@@ -3,6 +3,7 @@ const { MSICreator } = require('electron-wix-msi');
 const fs = require('fs');
 const path = require('path');
 const info = require('../../package.json');
+const { expandMsiArtifactName } = require('./artifact-name');
 
 // Detect the architecture from the dist directory
 // electron-builder creates win-unpacked for x64 and win-arm64-unpacked for arm64
@@ -93,6 +94,7 @@ const APP_UUIDS = {
 const APP_UUID = APP_UUIDS[ARCH];
 
 const nameOptions = {
+  name: info.name,
   productName: info.productName,
   version: info.version,
   os: 'win',
@@ -100,11 +102,7 @@ const nameOptions = {
 };
 
 // Generate the exe name from electron-builder's artifactName
-let installerName = info.build.artifactName.split('.')[0];
-Object.entries(nameOptions).forEach(([key, value]) => {
-  installerName = installerName.replace(`\${${key}}`, value);
-});
-installerName += '.msi';
+const installerName = expandMsiArtifactName(info.build.artifactName, nameOptions);
 
 // For reference: https://github.com/felixrieseberg/electron-wix-msi#configuration
 const msiOptions = {


### PR DESCRIPTION
## Summary

This allows downstream distributions to customize their package identity without changing the user-facing product name.

- name Electron Builder artifacts from the package `name` instead of the display `productName`
- expand the package-name macro in the custom Windows MSI builder
- add focused unit regressions in the implementation commit
- verify the observable macOS DMG basename in packaged-app CI

The original downstream change only switched the one-line Electron Builder artifact template. This upstream version improves it with direct unit coverage, Windows MSI compatibility, and packaged-artifact verification.

## Provenance

Ported from Azure/aks-desktop patch 0030 in https://github.com/Azure/aks-desktop/pull/823. The original downstream change is Azure/aks-desktop commit `c4b0bb4536ab0c40a426accc40a5a53df855968a`, authored by Joaquim Rocha. GitHub does not associate an originating Azure PR with that commit; PR 823 extracted it into the numbered patch series. The implementation commit preserves Joaquim Rocha as author and the original author date, and adds René Dudfield as co-author.

## Coverage / Proof it works?

The implementation commit directly tests the shared Electron Builder template and the custom Windows MSI expansion, including an assertion that `${name}` resolves in the MSI filename. The existing macOS packaged-app verifier checks the observable DMG basename.

No screenshot is included because this changes generated package filenames rather than visible UI.

## Testing

- focused package and Windows MSI artifact-name regressions
- `npm run tsc` in `app`
- `npm run frontend:lint`
- JavaScript and shell syntax checks
- Prettier and `git diff --check`

CI restarted after rebasing onto current `main`.

Assisted by copilot