### PR TITLE
0033: Support conditional project overview sections

### DIFF
--- a/docs/development/plugins/functionality/index.md
+++ b/docs/development/plugins/functionality/index.md
@@ -282,7 +282,24 @@ Each tab needs a unique ID, a label, and a React component that receives the pro
 
 Add custom sections to the project overview page with
 [registerProjectOverviewSection](../../api/plugin/registry/functions/registerProjectOverviewSection).
-These sections appear in the project's main overview area.
+Each section needs a unique `id` and a component. The component receives the current
+`project` and its loaded `projectResources`.
+
+Use the optional asynchronous `isEnabled` callback to display a section only for
+matching projects. The callback receives `{ project }` and returns a `Promise<boolean>`.
+Sections without the callback are displayed by default. A section is hidden when the
+callback resolves to `false`, rejects, or throws, and eligibility is checked again when
+the project changes.
+
+```tsx
+registerProjectOverviewSection({
+  id: 'multi-cluster-summary',
+  component: ({ project, projectResources }) => (
+    <MultiClusterSummary project={project} resources={projectResources} />
+  ),
+  isEnabled: async ({ project }) => project.clusters.length > 1,
+});
+```
 
 Register custom API resources (e.g. CRDs) for project resource tracking with
 [registerProjectApiResource](../../api/plugin/registry/functions/registerProjectApiResource).
@@ -290,7 +307,8 @@ Once registered, the CRD resources will appear in the project's resource count,
 health status, and Resources tab. Only namespaced resources can be registered,
 since Projects are scoped to namespaces.
 
-Example plugin: [How to customize projects](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/projects)
+Example plugin: [How to customize projects](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/projects),
+including conditionally displayed overview sections.
 
 ### Activities
 

--- a/e2e-tests/tests/projectOverview.spec.ts
+++ b/e2e-tests/tests/projectOverview.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import { HeadlampPage } from './headlampPage';
+
+test('project overview displays only enabled plugin sections', async ({ page }) => {
+  const token = process.env.HEADLAMP_TEST_TOKEN;
+  test.skip(!token, 'HEADLAMP_TEST_TOKEN is required to create the project fixture.');
+
+  const projectName = `conditional-overview-${Date.now()}`;
+  const namespacePath = `/clusters/test/api/v1/namespaces/${projectName}`;
+  const headers = { Authorization: `Bearer ${token}` };
+  const headlampPage = new HeadlampPage(page);
+
+  await page.route(
+    `**/clusters/test/apis/argoproj.io/v1alpha1/namespaces/${projectName}/applications*`,
+    async route => {
+      await route.fulfill({
+        json: {
+          apiVersion: 'argoproj.io/v1alpha1',
+          kind: 'ApplicationList',
+          metadata: { resourceVersion: '1' },
+          items: [],
+        },
+      });
+    }
+  );
+
+  await headlampPage.navigateToCluster('test', token);
+
+  const createResponse = await page.request.post('/clusters/test/api/v1/namespaces', {
+    headers,
+    data: {
+      apiVersion: 'v1',
+      kind: 'Namespace',
+      metadata: {
+        name: projectName,
+        labels: { 'headlamp.dev/project-id': projectName },
+      },
+    },
+  });
+  expect(createResponse.status()).toBe(201);
+
+  try {
+    await headlampPage.navigateTopage(`/project/${projectName}`, /Project Details/);
+
+    await expect(page.getByRole('progressbar', { name: 'Loading' })).toBeHidden({
+      timeout: 15_000,
+    });
+    await expect(page.getByText(`Custom resource usage for project ${projectName}`)).toBeVisible();
+    await expect(page.getByText(`Multi-cluster project: ${projectName}`)).toHaveCount(0);
+  } finally {
+    const deleteResponse = await page.request.delete(namespacePath, { headers });
+    expect(deleteResponse.ok()).toBe(true);
+  }
+});

--- a/frontend/src/components/project/ProjectDetails.test.tsx
+++ b/frontend/src/components/project/ProjectDetails.test.tsx
@@ -138,6 +138,31 @@ describe('ProjectDetails overview sections', () => {
     }
   });
 
+  it('continues evaluating sections when an isEnabled predicate throws', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const isEnabled = vi.fn(() => {
+        throw new Error('predicate threw');
+      });
+      renderProjectOverview([
+        {
+          id: 'failed',
+          component: () => <div>Failed section</div>,
+          isEnabled,
+        },
+        {
+          id: 'visible',
+          component: () => <div>Visible section</div>,
+        },
+      ]);
+
+      expect(await screen.findByText('Visible section')).toBeInTheDocument();
+      expect(screen.queryByText('Failed section')).not.toBeInTheDocument();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it('rechecks conditional sections when the project changes', async () => {
     const isEnabled = vi.fn().mockResolvedValue(true);
     const store = configureStore({
@@ -168,6 +193,45 @@ describe('ProjectDetails overview sections', () => {
 
     await waitFor(() => expect(isEnabled).toHaveBeenCalledWith({ project: nextProject }));
     expect(isEnabled).toHaveBeenCalledTimes(2);
+  });
+
+  it('hides sections from the previous project while predicates are rechecked', async () => {
+    let resolveNextProject: (enabled: boolean) => void = () => {};
+    const isEnabled = vi.fn(({ project: currentProject }: { project: ProjectDefinition }) =>
+      currentProject.id === project.id
+        ? Promise.resolve(true)
+        : new Promise<boolean>(resolve => {
+            resolveNextProject = resolve;
+          })
+    );
+    const store = configureStore({
+      reducer: reducers,
+      middleware: getDefaultMiddleware => getDefaultMiddleware({ serializableCheck: false }),
+    });
+    store.dispatch(
+      addOverviewSection({
+        id: 'project-specific',
+        component: ({ project }) => <div>Section for {project.id}</div>,
+        isEnabled,
+      })
+    );
+
+    const { rerender } = render(
+      <TestContext store={store}>
+        <ProjectDetailsContent project={project} />
+      </TestContext>
+    );
+    await screen.findByText('Section for project-a');
+
+    const nextProject = { ...project, id: 'project-b' };
+    rerender(
+      <TestContext store={store}>
+        <ProjectDetailsContent project={nextProject} />
+      </TestContext>
+    );
+
+    expect(screen.queryByText('Section for project-b')).not.toBeInTheDocument();
+    await act(async () => resolveNextProject(false));
   });
 
   it('ignores a predicate result from the previously rendered project', async () => {

--- a/frontend/src/components/project/ProjectDetails.test.tsx
+++ b/frontend/src/components/project/ProjectDetails.test.tsx
@@ -14,40 +14,95 @@
  * limitations under the License.
  */
 
+import { configureStore } from '@reduxjs/toolkit';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ReactNode } from 'react';
 import { vi } from 'vitest';
 
-const project = {
+const { MockKubeObject } = vi.hoisted(() => {
+  class MockKubeObject {
+    static kind = '';
+    jsonData: any;
+
+    constructor(data: any) {
+      this.jsonData = data;
+    }
+
+    get kind() {
+      return this.jsonData?.kind;
+    }
+  }
+
+  return { MockKubeObject };
+});
+
+vi.mock('../../lib/k8s/KubeObject', () => ({ KubeObject: MockKubeObject }));
+vi.mock('./ProjectDeleteButton', () => ({ ProjectDeleteButton: () => null }));
+
+const eventProject = {
   id: 'project-1',
   namespaces: ['ns1'],
   clusters: ['cluster-1'],
 };
 
 vi.mock('./ProjectList', () => ({
-  useProject: () => ({ project, isLoading: false }),
-}));
-
-vi.mock('./useProjectResources', () => ({
-  useProjectItems: () => ({ items: [], isLoading: false }),
+  useProject: () => ({ project: eventProject, isLoading: false }),
 }));
 
 import App from '../../App';
 import { HeadlampEventType } from '../../redux/headlampEventSlice';
+import { addOverviewSection, ProjectDefinition } from '../../redux/projectsSlice';
+import reducers from '../../redux/reducers/reducers';
 import { recordHeadlampEvents, TestContext } from '../../test';
-import ProjectDetails from './ProjectDetails';
+import ProjectDetails, { ProjectDetailsContent } from './ProjectDetails';
+import { useProjectItems } from './useProjectResources';
+
+vi.mock('./useProjectResources', () => ({
+  useProjectItems: vi.fn(),
+}));
 
 // cyclic imports fix
 // eslint-disable-next-line no-unused-vars
 const _dont_delete_me = App;
 
+const overviewProject: ProjectDefinition = {
+  id: 'project-a',
+  namespaces: ['namespace-a'],
+  clusters: ['cluster-a'],
+};
+
+function renderProjectOverview(
+  sections: Array<{
+    id: string;
+    component: () => ReactNode;
+    isEnabled?: ({ project }: { project: ProjectDefinition }) => Promise<boolean>;
+  }>
+) {
+  const store = configureStore({
+    reducer: reducers,
+    middleware: getDefaultMiddleware => getDefaultMiddleware({ serializableCheck: false }),
+  });
+  sections.forEach(section => store.dispatch(addOverviewSection(section)));
+
+  return render(
+    <TestContext store={store}>
+      <ProjectDetailsContent project={overviewProject} />
+    </TestContext>
+  );
+}
+
 describe('ProjectDetails events', () => {
+  beforeEach(() => {
+    vi.mocked(useProjectItems).mockReturnValue({ items: [], errors: [], isLoading: false });
+  });
+
   function renderDetails() {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
     return render(
-      <TestContext routerMap={{ name: project.id }}>
+      <TestContext routerMap={{ name: eventProject.id }}>
         <QueryClientProvider client={queryClient}>
           <ProjectDetails />
         </QueryClientProvider>
@@ -61,12 +116,14 @@ describe('ProjectDetails events', () => {
     renderDetails();
 
     await waitFor(() => {
-      expect(events.filter(e => e.type === HeadlampEventType.PROJECT_DETAILS_VIEW)).toEqual([
-        {
-          type: HeadlampEventType.PROJECT_DETAILS_VIEW,
-          data: { project, resources: [] },
-        },
-      ]);
+      expect(events.filter(event => event.type === HeadlampEventType.PROJECT_DETAILS_VIEW)).toEqual(
+        [
+          {
+            type: HeadlampEventType.PROJECT_DETAILS_VIEW,
+            data: { project: eventProject, resources: [] },
+          },
+        ]
+      );
     });
   });
 
@@ -77,7 +134,9 @@ describe('ProjectDetails events', () => {
 
     await screen.findByRole('tab', { name: /Overview/ });
 
-    expect(events.filter(e => e.type === HeadlampEventType.PROJECT_DETAILS_TAB_CHANGE)).toEqual([]);
+    expect(
+      events.filter(event => event.type === HeadlampEventType.PROJECT_DETAILS_TAB_CHANGE)
+    ).toEqual([]);
   });
 
   it('dispatches PROJECT_DETAILS_TAB_CHANGE when the user switches tab', async () => {
@@ -88,14 +147,153 @@ describe('ProjectDetails events', () => {
     fireEvent.click(await screen.findByRole('tab', { name: /Resources/ }));
 
     await waitFor(() => {
-      const tabEvents = events.filter(e => e.type === HeadlampEventType.PROJECT_DETAILS_TAB_CHANGE);
+      const tabEvents = events.filter(
+        event => event.type === HeadlampEventType.PROJECT_DETAILS_TAB_CHANGE
+      );
       expect(tabEvents).toHaveLength(1);
       expect(tabEvents[0].data).toMatchObject({
-        project,
+        project: eventProject,
         resources: [],
         tab: { id: 'headlamp-projects.tabs.resources' },
         previousTab: { id: 'headlamp-projects.tabs.overview' },
       });
     });
+  });
+});
+
+describe('ProjectDetails overview sections', () => {
+  beforeEach(() => {
+    vi.mocked(useProjectItems).mockReturnValue({ items: [], errors: [], isLoading: false });
+  });
+
+  it('renders a section without an isEnabled predicate', async () => {
+    renderProjectOverview([
+      {
+        id: 'always-visible',
+        component: () => <div>Always visible</div>,
+      },
+    ]);
+
+    expect(await screen.findByText('Always visible')).toBeInTheDocument();
+  });
+
+  it('renders a section when its isEnabled predicate resolves true', async () => {
+    const isEnabled = vi.fn().mockResolvedValue(true);
+    renderProjectOverview([
+      {
+        id: 'enabled',
+        component: () => <div>Enabled section</div>,
+        isEnabled,
+      },
+    ]);
+
+    expect(await screen.findByText('Enabled section')).toBeInTheDocument();
+    expect(isEnabled).toHaveBeenCalledWith({ project: overviewProject });
+  });
+
+  it('does not render a section when its isEnabled predicate resolves false', async () => {
+    const isEnabled = vi.fn().mockResolvedValue(false);
+    renderProjectOverview([
+      {
+        id: 'disabled',
+        component: () => <div>Disabled section</div>,
+        isEnabled,
+      },
+    ]);
+
+    await waitFor(() => expect(isEnabled).toHaveBeenCalledWith({ project: overviewProject }));
+    expect(screen.queryByText('Disabled section')).not.toBeInTheDocument();
+  });
+
+  it('does not render a section when its isEnabled predicate rejects', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const isEnabled = vi.fn().mockRejectedValue(new Error('predicate failed'));
+      renderProjectOverview([
+        {
+          id: 'failed',
+          component: () => <div>Failed section</div>,
+          isEnabled,
+        },
+      ]);
+
+      await waitFor(() => expect(isEnabled).toHaveBeenCalledWith({ project: overviewProject }));
+      expect(screen.queryByText('Failed section')).not.toBeInTheDocument();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('rechecks conditional sections when the project changes', async () => {
+    const isEnabled = vi.fn().mockResolvedValue(true);
+    const store = configureStore({
+      reducer: reducers,
+      middleware: getDefaultMiddleware => getDefaultMiddleware({ serializableCheck: false }),
+    });
+    store.dispatch(
+      addOverviewSection({
+        id: 'project-specific',
+        component: () => <div>Project-specific section</div>,
+        isEnabled,
+      })
+    );
+
+    const { rerender } = render(
+      <TestContext store={store}>
+        <ProjectDetailsContent project={overviewProject} />
+      </TestContext>
+    );
+    await screen.findByText('Project-specific section');
+
+    const nextProject = { ...overviewProject, id: 'project-b' };
+    rerender(
+      <TestContext store={store}>
+        <ProjectDetailsContent project={nextProject} />
+      </TestContext>
+    );
+
+    await waitFor(() => expect(isEnabled).toHaveBeenCalledWith({ project: nextProject }));
+    expect(isEnabled).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores a predicate result from the previously rendered project', async () => {
+    let resolveFirstPredicate: (enabled: boolean) => void = () => {};
+    const isEnabled = vi.fn(({ project: currentProject }: { project: ProjectDefinition }) =>
+      currentProject.id === overviewProject.id
+        ? new Promise<boolean>(resolve => {
+            resolveFirstPredicate = resolve;
+          })
+        : Promise.resolve(false)
+    );
+    const store = configureStore({
+      reducer: reducers,
+      middleware: getDefaultMiddleware => getDefaultMiddleware({ serializableCheck: false }),
+    });
+    store.dispatch(
+      addOverviewSection({
+        id: 'project-specific',
+        component: () => <div>Stale project section</div>,
+        isEnabled,
+      })
+    );
+
+    const { rerender } = render(
+      <TestContext store={store}>
+        <ProjectDetailsContent project={overviewProject} />
+      </TestContext>
+    );
+    await waitFor(() => expect(isEnabled).toHaveBeenCalledWith({ project: overviewProject }));
+
+    const nextProject = { ...overviewProject, id: 'project-b' };
+    rerender(
+      <TestContext store={store}>
+        <ProjectDetailsContent project={nextProject} />
+      </TestContext>
+    );
+    await waitFor(() => expect(isEnabled).toHaveBeenCalledWith({ project: nextProject }));
+
+    await act(async () => resolveFirstPredicate(true));
+
+    expect(screen.queryByText('Stale project section')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/project/ProjectDetails.test.tsx
+++ b/frontend/src/components/project/ProjectDetails.test.tsx
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { vi } from 'vitest';
+
+const { MockKubeObject } = vi.hoisted(() => {
+  class MockKubeObject {
+    static kind = '';
+    jsonData: any;
+
+    constructor(data: any) {
+      this.jsonData = data;
+    }
+
+    get kind() {
+      return this.jsonData?.kind;
+    }
+  }
+
+  return { MockKubeObject };
+});
+
+vi.mock('../../lib/k8s/KubeObject', () => ({ KubeObject: MockKubeObject }));
+vi.mock('./ProjectDeleteButton', () => ({ ProjectDeleteButton: () => null }));
+
+import { addOverviewSection, ProjectDefinition } from '../../redux/projectsSlice';
+import reducers from '../../redux/reducers/reducers';
+import { TestContext } from '../../test';
+import { ProjectDetailsContent } from './ProjectDetails';
+import { useProjectItems } from './useProjectResources';
+
+vi.mock('./useProjectResources', () => ({
+  useProjectItems: vi.fn(),
+}));
+
+const project: ProjectDefinition = {
+  id: 'project-a',
+  namespaces: ['namespace-a'],
+  clusters: ['cluster-a'],
+};
+
+function renderProjectOverview(
+  sections: Array<{
+    id: string;
+    component: () => ReactNode;
+    isEnabled?: ({ project }: { project: ProjectDefinition }) => Promise<boolean>;
+  }>
+) {
+  const store = configureStore({
+    reducer: reducers,
+    middleware: getDefaultMiddleware => getDefaultMiddleware({ serializableCheck: false }),
+  });
+  sections.forEach(section => store.dispatch(addOverviewSection(section)));
+
+  return render(
+    <TestContext store={store}>
+      <ProjectDetailsContent project={project} />
+    </TestContext>
+  );
+}
+
+describe('ProjectDetails overview sections', () => {
+  beforeEach(() => {
+    vi.mocked(useProjectItems).mockReturnValue({ items: [], errors: [], isLoading: false });
+  });
+
+  it('renders a section without an isEnabled predicate', async () => {
+    renderProjectOverview([
+      {
+        id: 'always-visible',
+        component: () => <div>Always visible</div>,
+      },
+    ]);
+
+    expect(await screen.findByText('Always visible')).toBeInTheDocument();
+  });
+
+  it('renders a section when its isEnabled predicate resolves true', async () => {
+    const isEnabled = vi.fn().mockResolvedValue(true);
+    renderProjectOverview([
+      {
+        id: 'enabled',
+        component: () => <div>Enabled section</div>,
+        isEnabled,
+      },
+    ]);
+
+    expect(await screen.findByText('Enabled section')).toBeInTheDocument();
+    expect(isEnabled).toHaveBeenCalledWith({ project });
+  });
+
+  it('does not render a section when its isEnabled predicate resolves false', async () => {
+    const isEnabled = vi.fn().mockResolvedValue(false);
+    renderProjectOverview([
+      {
+        id: 'disabled',
+        component: () => <div>Disabled section</div>,
+        isEnabled,
+      },
+    ]);
+
+    await waitFor(() => expect(isEnabled).toHaveBeenCalledWith({ project }));
+    expect(screen.queryByText('Disabled section')).not.toBeInTheDocument();
+  });
+
+  it('does not render a section when its isEnabled predicate rejects', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const isEnabled = vi.fn().mockRejectedValue(new Error('predicate failed'));
+      renderProjectOverview([
+        {
+          id: 'failed',
+          component: () => <div>Failed section</div>,
+          isEnabled,
+        },
+      ]);
+
+      await waitFor(() => expect(isEnabled).toHaveBeenCalledWith({ project }));
+      expect(screen.queryByText('Failed section')).not.toBeInTheDocument();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('rechecks conditional sections when the project changes', async () => {
+    const isEnabled = vi.fn().mockResolvedValue(true);
+    const store = configureStore({
+      reducer: reducers,
+      middleware: getDefaultMiddleware => getDefaultMiddleware({ serializableCheck: false }),
+    });
+    store.dispatch(
+      addOverviewSection({
+        id: 'project-specific',
+        component: () => <div>Project-specific section</div>,
+        isEnabled,
+      })
+    );
+
+    const { rerender } = render(
+      <TestContext store={store}>
+        <ProjectDetailsContent project={project} />
+      </TestContext>
+    );
+    await screen.findByText('Project-specific section');
+
+    const nextProject = { ...project, id: 'project-b' };
+    rerender(
+      <TestContext store={store}>
+        <ProjectDetailsContent project={nextProject} />
+      </TestContext>
+    );
+
+    await waitFor(() => expect(isEnabled).toHaveBeenCalledWith({ project: nextProject }));
+    expect(isEnabled).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores a predicate result from the previously rendered project', async () => {
+    let resolveFirstPredicate: (enabled: boolean) => void = () => {};
+    const isEnabled = vi.fn(({ project: currentProject }: { project: ProjectDefinition }) =>
+      currentProject.id === project.id
+        ? new Promise<boolean>(resolve => {
+            resolveFirstPredicate = resolve;
+          })
+        : Promise.resolve(false)
+    );
+    const store = configureStore({
+      reducer: reducers,
+      middleware: getDefaultMiddleware => getDefaultMiddleware({ serializableCheck: false }),
+    });
+    store.dispatch(
+      addOverviewSection({
+        id: 'project-specific',
+        component: () => <div>Stale project section</div>,
+        isEnabled,
+      })
+    );
+
+    const { rerender } = render(
+      <TestContext store={store}>
+        <ProjectDetailsContent project={project} />
+      </TestContext>
+    );
+    await waitFor(() => expect(isEnabled).toHaveBeenCalledWith({ project }));
+
+    const nextProject = { ...project, id: 'project-b' };
+    rerender(
+      <TestContext store={store}>
+        <ProjectDetailsContent project={nextProject} />
+      </TestContext>
+    );
+    await waitFor(() => expect(isEnabled).toHaveBeenCalledWith({ project: nextProject }));
+
+    await act(async () => resolveFirstPredicate(true));
+
+    expect(screen.queryByText('Stale project section')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/project/ProjectDetails.test.tsx
+++ b/frontend/src/components/project/ProjectDetails.test.tsx
@@ -224,6 +224,31 @@ describe('ProjectDetails overview sections', () => {
     }
   });
 
+  it('continues evaluating sections when an isEnabled predicate throws', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const isEnabled = vi.fn(() => {
+        throw new Error('predicate threw');
+      });
+      renderProjectOverview([
+        {
+          id: 'failed',
+          component: () => <div>Failed section</div>,
+          isEnabled,
+        },
+        {
+          id: 'visible',
+          component: () => <div>Visible section</div>,
+        },
+      ]);
+
+      expect(await screen.findByText('Visible section')).toBeInTheDocument();
+      expect(screen.queryByText('Failed section')).not.toBeInTheDocument();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it('rechecks conditional sections when the project changes', async () => {
     const isEnabled = vi.fn().mockResolvedValue(true);
     const store = configureStore({
@@ -254,6 +279,45 @@ describe('ProjectDetails overview sections', () => {
 
     await waitFor(() => expect(isEnabled).toHaveBeenCalledWith({ project: nextProject }));
     expect(isEnabled).toHaveBeenCalledTimes(2);
+  });
+
+  it('hides sections from the previous project while predicates are rechecked', async () => {
+    let resolveNextProject: (enabled: boolean) => void = () => {};
+    const isEnabled = vi.fn(({ project: currentProject }: { project: ProjectDefinition }) =>
+      currentProject.id === overviewProject.id
+        ? Promise.resolve(true)
+        : new Promise<boolean>(resolve => {
+            resolveNextProject = resolve;
+          })
+    );
+    const store = configureStore({
+      reducer: reducers,
+      middleware: getDefaultMiddleware => getDefaultMiddleware({ serializableCheck: false }),
+    });
+    store.dispatch(
+      addOverviewSection({
+        id: 'project-specific',
+        component: ({ project }) => <div>Section for {project.id}</div>,
+        isEnabled,
+      })
+    );
+
+    const { rerender } = render(
+      <TestContext store={store}>
+        <ProjectDetailsContent project={overviewProject} />
+      </TestContext>
+    );
+    await screen.findByText('Section for project-a');
+
+    const nextProject = { ...overviewProject, id: 'project-b' };
+    rerender(
+      <TestContext store={store}>
+        <ProjectDetailsContent project={nextProject} />
+      </TestContext>
+    );
+
+    expect(screen.queryByText('Section for project-b')).not.toBeInTheDocument();
+    await act(async () => resolveNextProject(false));
   });
 
   it('ignores a predicate result from the previously rendered project', async () => {

--- a/frontend/src/components/project/ProjectDetails.tsx
+++ b/frontend/src/components/project/ProjectDetails.tsx
@@ -25,7 +25,11 @@ import Role from '../../lib/k8s/role';
 import RoleBinding from '../../lib/k8s/roleBinding';
 import { SelectedClustersContext } from '../../lib/k8s/SelectedClustersContext';
 import { useTypedSelector } from '../../redux/hooks';
-import { ProjectDefinition, ProjectDetailsTab } from '../../redux/projectsSlice';
+import {
+  ProjectDefinition,
+  ProjectDetailsTab,
+  ProjectOverviewSection,
+} from '../../redux/projectsSlice';
 import { Activity } from '../activity/Activity';
 import { ButtonStyle, EditButton, EditorDialog, Loader, StatusLabel } from '../common';
 import Link from '../common/Link';
@@ -36,6 +40,7 @@ import { GraphView } from '../resourceMap/GraphView';
 import { ResourceQuotaTable } from '../resourceQuota/Details';
 import { ProjectDeleteButton } from './ProjectDeleteButton';
 import { useProject } from './ProjectList';
+import { getEnabledProjectOverviewSections } from './projectOverviewSections';
 import { ProjectResourcesTab, useResourceCategoriesList } from './ProjectResourcesTab';
 import { getHealthIcon, getResourcesHealth } from './projectUtils';
 import { ResourceCategoriesList } from './ResourceCategoriesList';
@@ -110,9 +115,33 @@ function ProjectOverview({
     throw new Error('Missing ProjectDetailsContext');
   }
   const { setSelectedCategoryName, setSelectedTab } = detailsContext;
-  const additionalOverviewSections = Object.values(
-    useTypedSelector(state => state.projects.overviewSections)
-  );
+  const additionalOverviewSections = useTypedSelector(state => state.projects.overviewSections);
+  const [evaluatedSections, setEvaluatedSections] = useState<{
+    project: ProjectDefinition;
+    sections: ProjectOverviewSection[];
+  }>();
+
+  useEffect(() => {
+    let isCurrent = true;
+
+    async function loadSections() {
+      const enabledSections = await getEnabledProjectOverviewSections(
+        Object.values(additionalOverviewSections),
+        project
+      );
+
+      if (isCurrent) {
+        setEvaluatedSections({ project, sections: enabledSections });
+      }
+    }
+
+    loadSections();
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [additionalOverviewSections, project]);
+
   const resourceQuotas = useMemo(
     () => (projectResources?.filter(it => it.kind === 'ResourceQuota') as ResourceQuota[]) ?? [],
     [projectResources]
@@ -121,6 +150,7 @@ function ProjectOverview({
   const categoryList = useResourceCategoriesList(projectResources);
 
   const projectHealth = useMemo(() => getResourcesHealth(projectResources), [projectResources]);
+  const projectSections = evaluatedSections?.project === project ? evaluatedSections.sections : [];
 
   return (
     <Grid container spacing={3} sx={{ pt: 2 }}>
@@ -292,15 +322,11 @@ function ProjectOverview({
         </Card>
       </Grid>
 
-      {additionalOverviewSections.map(section => (
-        <Grid item xs={12} md={4}>
+      {projectSections.map(section => (
+        <Grid key={section.id} item xs={12} md={4}>
           <Card sx={{ height: '100%' }}>
             <CardContent>
-              <section.component
-                key={section.id}
-                project={project}
-                projectResources={projectResources}
-              />
+              <section.component project={project} projectResources={projectResources} />
             </CardContent>
           </Card>
         </Grid>

--- a/frontend/src/components/project/ProjectDetails.tsx
+++ b/frontend/src/components/project/ProjectDetails.tsx
@@ -380,7 +380,7 @@ const ProjectDetailsContext = createContext<
 /**
  * Project Details page
  */
-function ProjectDetailsContent({ project }: { project: ProjectDefinition }) {
+export function ProjectDetailsContent({ project }: { project: ProjectDefinition }) {
   const { t } = useTranslation();
   const registeredTabs = useTypedSelector(state => state.projects.detailsTabs);
   const customDeleteButton = useTypedSelector(state => state.projects.projectDeleteButton);

--- a/frontend/src/components/project/ProjectDetails.tsx
+++ b/frontend/src/components/project/ProjectDetails.tsx
@@ -371,7 +371,7 @@ const ProjectDetailsContext = createContext<
 /**
  * Project Details page
  */
-function ProjectDetailsContent({ project }: { project: ProjectDefinition }) {
+export function ProjectDetailsContent({ project }: { project: ProjectDefinition }) {
   const { t } = useTranslation();
   const registeredTabs = useTypedSelector(state => state.projects.detailsTabs);
   const customDeleteButton = useTypedSelector(state => state.projects.projectDeleteButton);

--- a/frontend/src/components/project/ProjectDetails.tsx
+++ b/frontend/src/components/project/ProjectDetails.tsx
@@ -34,7 +34,11 @@ import RoleBinding from '../../lib/k8s/roleBinding';
 import { SelectedClustersContext } from '../../lib/k8s/SelectedClustersContext';
 import { HeadlampEventType, useEventCallback } from '../../redux/headlampEventSlice';
 import { useTypedSelector } from '../../redux/hooks';
-import { ProjectDefinition, ProjectDetailsTab } from '../../redux/projectsSlice';
+import {
+  ProjectDefinition,
+  ProjectDetailsTab,
+  ProjectOverviewSection,
+} from '../../redux/projectsSlice';
 import { Activity } from '../activity/Activity';
 import { ButtonStyle, EditButton, EditorDialog, Loader, StatusLabel } from '../common';
 import Link from '../common/Link';
@@ -45,6 +49,7 @@ import { GraphView } from '../resourceMap/GraphView';
 import { ResourceQuotaTable } from '../resourceQuota/Details';
 import { ProjectDeleteButton } from './ProjectDeleteButton';
 import { useProject } from './ProjectList';
+import { getEnabledProjectOverviewSections } from './projectOverviewSections';
 import { ProjectResourcesTab, useResourceCategoriesList } from './ProjectResourcesTab';
 import { getHealthIcon, getResourcesHealth } from './projectUtils';
 import { ResourceCategoriesList } from './ResourceCategoriesList';
@@ -119,9 +124,33 @@ function ProjectOverview({
     throw new Error('Missing ProjectDetailsContext');
   }
   const { setSelectedCategoryName, setSelectedTab } = detailsContext;
-  const additionalOverviewSections = Object.values(
-    useTypedSelector(state => state.projects.overviewSections)
-  );
+  const additionalOverviewSections = useTypedSelector(state => state.projects.overviewSections);
+  const [evaluatedSections, setEvaluatedSections] = useState<{
+    project: ProjectDefinition;
+    sections: ProjectOverviewSection[];
+  }>();
+
+  useEffect(() => {
+    let isCurrent = true;
+
+    async function loadSections() {
+      const enabledSections = await getEnabledProjectOverviewSections(
+        Object.values(additionalOverviewSections),
+        project
+      );
+
+      if (isCurrent) {
+        setEvaluatedSections({ project, sections: enabledSections });
+      }
+    }
+
+    loadSections();
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [additionalOverviewSections, project]);
+
   const resourceQuotas = useMemo(
     () => (projectResources?.filter(it => it.kind === 'ResourceQuota') as ResourceQuota[]) ?? [],
     [projectResources]
@@ -130,6 +159,7 @@ function ProjectOverview({
   const categoryList = useResourceCategoriesList(projectResources);
 
   const projectHealth = useMemo(() => getResourcesHealth(projectResources), [projectResources]);
+  const projectSections = evaluatedSections?.project === project ? evaluatedSections.sections : [];
 
   return (
     <Grid container spacing={3} sx={{ pt: 2 }}>
@@ -301,15 +331,11 @@ function ProjectOverview({
         </Card>
       </Grid>
 
-      {additionalOverviewSections.map(section => (
-        <Grid item xs={12} md={4}>
+      {projectSections.map(section => (
+        <Grid key={section.id} item xs={12} md={4}>
           <Card sx={{ height: '100%' }}>
             <CardContent>
-              <section.component
-                key={section.id}
-                project={project}
-                projectResources={projectResources}
-              />
+              <section.component project={project} projectResources={projectResources} />
             </CardContent>
           </Card>
         </Grid>

--- a/frontend/src/components/project/projectOverviewSections.ts
+++ b/frontend/src/components/project/projectOverviewSections.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ProjectDefinition, ProjectOverviewSection } from '../../redux/projectsSlice';
+
+/**
+ * Resolve the project overview sections that are enabled for a project.
+ *
+ * Sections without an `isEnabled` predicate are enabled by default. A section is omitted when its
+ * predicate returns `false`, rejects, or throws. Predicate failures are logged without preventing
+ * the remaining sections from being evaluated.
+ *
+ * @param sections - Project overview section registrations to evaluate.
+ * @param project - Project passed to each section's `isEnabled` predicate.
+ * @returns The sections enabled for the project, in registration order.
+ */
+export async function getEnabledProjectOverviewSections(
+  sections: ProjectOverviewSection[],
+  project: ProjectDefinition
+): Promise<ProjectOverviewSection[]> {
+  const enabledSections = await Promise.all(
+    sections.map(section =>
+      section.isEnabled
+        ? Promise.resolve()
+            .then(() => section.isEnabled!({ project }))
+            .then(isEnabled => (isEnabled ? section : undefined))
+            .catch(error => {
+              console.error('Failed to check if section is enabled', section, error);
+              return undefined;
+            })
+        : Promise.resolve(section)
+    )
+  );
+
+  return enabledSections.filter(
+    (section): section is ProjectOverviewSection => section !== undefined
+  );
+}

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -1148,13 +1148,16 @@ export function registerProjectDetailsTab(projectDetailsTab: ProjectDetailsTab) 
  *
  * @param projectOverviewSection - The section configuration to register
  * @param projectOverviewSection.id - Unique identifier for the section
- * @param projectOverviewSection.component - React component to render in the section
+ * @param projectOverviewSection.component - React component receiving the current project and its loaded resources
+ * @param projectOverviewSection.isEnabled - Optional asynchronous predicate receiving the project being evaluated
+ * @returns void
  *
  * @example
  * ```tsx
  * registerProjectOverviewSection({
  *   id: 'resource-usage',
- *   component: ({ project }) => <ResourceUsageChart project={project} />
+ *   component: ({ project }) => <ResourceUsageChart project={project} />,
+ *   isEnabled: async ({ project }) => project.clusters.length > 1,
  * });
  * ```
  */

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -1166,13 +1166,16 @@ export function registerProjectDetailsTab(projectDetailsTab: ProjectDetailsTab) 
  *
  * @param projectOverviewSection - The section configuration to register
  * @param projectOverviewSection.id - Unique identifier for the section
- * @param projectOverviewSection.component - React component to render in the section
+ * @param projectOverviewSection.component - React component receiving the current project and its loaded resources
+ * @param projectOverviewSection.isEnabled - Optional asynchronous predicate receiving the project being evaluated
+ * @returns void
  *
  * @example
  * ```tsx
  * registerProjectOverviewSection({
  *   id: 'resource-usage',
- *   component: ({ project }) => <ResourceUsageChart project={project} />
+ *   component: ({ project }) => <ResourceUsageChart project={project} />,
+ *   isEnabled: async ({ project }) => project.clusters.length > 1,
  * });
  * ```
  */

--- a/frontend/src/redux/projectsSlice.ts
+++ b/frontend/src/redux/projectsSlice.ts
@@ -46,8 +46,28 @@ export interface CustomCreateProject {
  * Custom section for the project overview tab
  */
 export interface ProjectOverviewSection {
+  /** Unique identifier for the section registration. */
   id: string;
+  /**
+   * Component rendered in the project overview.
+   *
+   * @param props - Properties supplied to the section component.
+   * @param props.project - Project currently displayed.
+   * @param props.projectResources - Kubernetes resources loaded for the project.
+   * @returns Content to render in the section.
+   */
   component: (props: { project: ProjectDefinition; projectResources: KubeObject[] }) => ReactNode;
+  /**
+   * Determines whether the section is displayed for a project.
+   *
+   * The section is displayed by default when this function is omitted. Rejected promises and
+   * synchronous errors are treated as `false`.
+   *
+   * @param params - Section enablement context.
+   * @param params.project - Project being evaluated.
+   * @returns A promise resolving to `true` when the section should be displayed.
+   */
+  isEnabled?: ({ project }: { project: ProjectDefinition }) => Promise<boolean>;
 }
 
 export interface ProjectDetailsTab {

--- a/plugins/examples/projects/src/index.tsx
+++ b/plugins/examples/projects/src/index.tsx
@@ -172,6 +172,15 @@ registerProjectDetailsTab({
 registerProjectOverviewSection({
   id: 'resource-usage',
   component: ({ project }) => <div>Custom resource usage for project {project.id}</div>,
+  // Display this section for projects that have at least one cluster.
+  isEnabled: async ({ project }) => project.clusters.length > 0,
+});
+
+registerProjectOverviewSection({
+  id: 'multi-cluster-summary',
+  component: ({ project }) => <div>Multi-cluster project: {project.id}</div>,
+  // Display this section only for projects spanning multiple clusters.
+  isEnabled: async ({ project }) => project.clusters.length > 1,
 });
 
 registerProjectDeleteButton({


### PR DESCRIPTION
## Summary

- let project overview section registrations asynchronously decide whether they apply to the current project
- omit sections whose checks resolve false or fail
- reevaluate section eligibility whenever the project changes

### Improvements over the original patch

- catch both synchronous predicate throws and asynchronous rejections without preventing other sections from being evaluated
- ignore stale asynchronous results and prevent sections evaluated for one project from briefly rendering with another project's props
- isolate enablement policy in a typed helper with 100% branch coverage
- add focused unit coverage before the implementation commit and regression tests alongside the final safeguards
- add a full browser test that verifies enabled and disabled plugin sections in the two-cluster environment
- document callback inputs, return behavior, defaults, and failure handling in the plugin API and Projects functionality guide
- demonstrate real single-cluster and multi-cluster predicates in the Projects example plugin

## Provenance

- Retained patch: [0033 from Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823)
- Original Azure commit: [5e79994e5ca7a502e2317d31fd9aa301b972cacb](https://github.com/Azure/aks-desktop/commit/5e79994e5ca7a502e2317d31fd9aa301b972cacb)
- Related Azure ProjectDetails stale-state work: [Azure/aks-desktop#639](https://github.com/Azure/aks-desktop/pull/639)

The implementation commit preserves Oleksandr Dubenko as author and the original November 3, 2025 author date, with René Dudfield as co-author.

## Testing

- `npm --prefix frontend test -- --run src/components/project/ProjectDetails.test.tsx` (11 tests passed: 3 upstream event tests and 8 conditional-section tests)
- focused Istanbul coverage for `projectOverviewSections.ts`: 100% branches, statements, functions, and lines
- stable TypeScript 5.6 `tsc --noEmit`
- focused ESLint and Prettier checks for changed files
- `npm --prefix e2e-tests exec playwright test tests/projectOverview.spec.ts --list` (1 test discovered)
- GitHub Actions `Build Container and test` full two-cluster workflow, including Playwright e2e tests

## Screenshots

Not applicable. This changes plugin-controlled section visibility without changing the appearance of visible sections.

Assisted by copilot
