### PR TITLE
frontend: Fix unmount race condition in multiplexer list watching

### DIFF
--- a/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
@@ -299,14 +299,50 @@ describe('WebSocket Multiplexer', () => {
       // Close the server to simulate connection failure
       await mockServer.close();
 
-      // Attempt to subscribe should fail
-      await expect(
-        WebSocketManager.subscribe(clusterName, '/api/v1/pods', 'watch=true', onMessage)
-      ).rejects.toThrow('WebSocket connection failed');
+      const path = '/api/v1/pods';
+      const query = 'watch=true';
 
-      // Verify error was handled
+      // Attempt to subscribe should fail
+      await expect(WebSocketManager.subscribe(clusterName, path, query, onMessage)).rejects.toThrow(
+        'WebSocket connection failed'
+      );
+
+      // Verify error was handled and listeners/subscriptions were cleaned up
       expect(WebSocketManager.socketMultiplexer).toBeNull();
       expect(WebSocketManager.connecting).toBe(false);
+      const key = WebSocketManager.createKey(clusterName, path, query);
+      expect(WebSocketManager.activeSubscriptions.has(key)).toBe(false);
+      expect(WebSocketManager.listeners.has(key)).toBe(false);
+
+      // No CLOSE should ever be sent for a subscription whose REQUEST was
+      // never delivered, so the debounced unsubscribe scheduled internally
+      // must have been cancelled rather than left pending.
+      expect(WebSocketManager.pendingUnsubscribes.has(key)).toBe(false);
+    });
+
+    it('should not send a spurious CLOSE after a failed subscribe once the socket reconnects', async () => {
+      // Close the server to simulate connection failure
+      await mockServer.close();
+
+      const path = '/api/v1/pods';
+      const query = 'watch=true';
+
+      // Attempt to subscribe should fail
+      await expect(WebSocketManager.subscribe(clusterName, path, query, onMessage)).rejects.toThrow(
+        'WebSocket connection failed'
+      );
+
+      // Reconnect with a fresh mock server, simulating a later, unrelated
+      // subscription opening the shared socket.
+      mockServer = new WS(`${BASE_WS_URL}${MULTIPLEXER_ENDPOINT}`);
+      await WebSocketManager.subscribe(clusterName, '/api/v1/services', 'watch=true', onMessage);
+      await mockServer.connected;
+
+      // The only message the server should see is the REQUEST for the new
+      // subscription -- never a CLOSE for the one that failed to connect.
+      const msg = JSON.parse((await mockServer.nextMessage) as string);
+      expect(msg.type).toBe('REQUEST');
+      expect(msg.path).toBe('/api/v1/services');
     });
 
     it('should handle duplicate subscriptions', async () => {

--- a/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
@@ -236,14 +236,50 @@ describe('WebSocket Multiplexer', () => {
       // Close the server to simulate connection failure
       await mockServer.close();
 
-      // Attempt to subscribe should fail
-      await expect(
-        WebSocketManager.subscribe(clusterName, '/api/v1/pods', 'watch=true', onMessage)
-      ).rejects.toThrow('WebSocket connection failed');
+      const path = '/api/v1/pods';
+      const query = 'watch=true';
 
-      // Verify error was handled
+      // Attempt to subscribe should fail
+      await expect(WebSocketManager.subscribe(clusterName, path, query, onMessage)).rejects.toThrow(
+        'WebSocket connection failed'
+      );
+
+      // Verify error was handled and listeners/subscriptions were cleaned up
       expect(WebSocketManager.socketMultiplexer).toBeNull();
       expect(WebSocketManager.connecting).toBe(false);
+      const key = WebSocketManager.createKey(clusterName, path, query);
+      expect(WebSocketManager.activeSubscriptions.has(key)).toBe(false);
+      expect(WebSocketManager.listeners.has(key)).toBe(false);
+
+      // No CLOSE should ever be sent for a subscription whose REQUEST was
+      // never delivered, so the debounced unsubscribe scheduled internally
+      // must have been cancelled rather than left pending.
+      expect(WebSocketManager.pendingUnsubscribes.has(key)).toBe(false);
+    });
+
+    it('should not send a spurious CLOSE after a failed subscribe once the socket reconnects', async () => {
+      // Close the server to simulate connection failure
+      await mockServer.close();
+
+      const path = '/api/v1/pods';
+      const query = 'watch=true';
+
+      // Attempt to subscribe should fail
+      await expect(WebSocketManager.subscribe(clusterName, path, query, onMessage)).rejects.toThrow(
+        'WebSocket connection failed'
+      );
+
+      // Reconnect with a fresh mock server, simulating a later, unrelated
+      // subscription opening the shared socket.
+      mockServer = new WS(`${BASE_WS_URL}${MULTIPLEXER_ENDPOINT}`);
+      await WebSocketManager.subscribe(clusterName, '/api/v1/services', 'watch=true', onMessage);
+      await mockServer.connected;
+
+      // The only message the server should see is the REQUEST for the new
+      // subscription -- never a CLOSE for the one that failed to connect.
+      const msg = JSON.parse((await mockServer.nextMessage) as string);
+      expect(msg.type).toBe('REQUEST');
+      expect(msg.path).toBe('/api/v1/services');
     });
 
     it('should handle duplicate subscriptions', async () => {

--- a/frontend/src/lib/k8s/api/v2/multiplexer.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.ts
@@ -191,17 +191,38 @@ export const WebSocketManager = {
       this.errorListeners.set(key, errListeners);
     }
 
-    // Establish connection and send REQUEST
-    const socket = await this.connect();
-    const userId = getUserIdFromLocalStorage();
-    const requestMsg: WebSocketMessage = {
-      clusterId,
-      path,
-      query,
-      userId: userId || '',
-      type: 'REQUEST',
-    };
-    socket.send(JSON.stringify(requestMsg));
+    try {
+      // Establish connection and send REQUEST
+      const socket = await this.connect();
+      const userId = getUserIdFromLocalStorage();
+      const requestMsg: WebSocketMessage = {
+        clusterId,
+        path,
+        query,
+        userId: userId || '',
+        type: 'REQUEST',
+      };
+      socket.send(JSON.stringify(requestMsg));
+    } catch (err) {
+      this.unsubscribe(key, clusterId, path, query, onMessage, onError);
+
+      // The REQUEST for this subscription was never sent, so there's nothing
+      // for the server to CLOSE. Cancel the debounced CLOSE that unsubscribe()
+      // just scheduled so a socket that opens later (e.g. for a different
+      // subscription) doesn't emit a spurious CLOSE for a watch that never opened.
+      const pendingTimeout = this.pendingUnsubscribes.get(key);
+      if (pendingTimeout) {
+        clearTimeout(pendingTimeout);
+        this.pendingUnsubscribes.delete(key);
+      }
+
+      if (!this.listeners.has(key)) {
+        this.activeSubscriptions.delete(key);
+        this.completedPaths.delete(key);
+      }
+
+      throw err;
+    }
 
     // Return cleanup function
     return () => this.unsubscribe(key, clusterId, path, query, onMessage, onError);

--- a/frontend/src/lib/k8s/api/v2/multiplexer.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.ts
@@ -197,17 +197,38 @@ export const WebSocketManager = {
       this.errorListeners.set(key, errListeners);
     }
 
-    // Establish connection and send REQUEST
-    const socket = await this.connect();
-    const userId = getUserIdFromLocalStorage();
-    const requestMsg: WebSocketMessage = {
-      clusterId,
-      path,
-      query,
-      userId: userId || '',
-      type: 'REQUEST',
-    };
-    socket.send(JSON.stringify(requestMsg));
+    try {
+      // Establish connection and send REQUEST
+      const socket = await this.connect();
+      const userId = getUserIdFromLocalStorage();
+      const requestMsg: WebSocketMessage = {
+        clusterId,
+        path,
+        query,
+        userId: userId || '',
+        type: 'REQUEST',
+      };
+      socket.send(JSON.stringify(requestMsg));
+    } catch (err) {
+      this.unsubscribe(key, clusterId, path, query, onMessage, onError);
+
+      // The REQUEST for this subscription was never sent, so there's nothing
+      // for the server to CLOSE. Cancel the debounced CLOSE that unsubscribe()
+      // just scheduled so a socket that opens later (e.g. for a different
+      // subscription) doesn't emit a spurious CLOSE for a watch that never opened.
+      const pendingTimeout = this.pendingUnsubscribes.get(key);
+      if (pendingTimeout) {
+        clearTimeout(pendingTimeout);
+        this.pendingUnsubscribes.delete(key);
+      }
+
+      if (!this.listeners.has(key)) {
+        this.activeSubscriptions.delete(key);
+        this.completedPaths.delete(key);
+      }
+
+      throw err;
+    }
 
     // Return cleanup function
     return () => this.unsubscribe(key, clusterId, path, query, onMessage, onError);

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
@@ -1535,4 +1535,42 @@ describe('useWatchKubeObjectLists (Multiplexer)', () => {
       ).toBe(true)
     );
   });
+
+  it('should clean up subscription immediately if unmounted before subscribe promise resolves', async () => {
+    const mockCleanup = vi.fn();
+    let resolveSubscribe: (cleanup: () => void) => void;
+    const pendingPromise = new Promise<() => void>(resolve => {
+      resolveSubscribe = resolve;
+    });
+
+    mockSubscribe.mockReturnValueOnce(pendingPromise);
+
+    const lists = [{ cluster: 'cluster-a', namespace: 'namespace-a', resourceVersion: '1' }];
+
+    const { unmount } = renderHook(
+      () =>
+        useWatchKubeObjectLists({
+          kubeObjectClass: mockClass,
+          endpoint: { version: 'v1', resource: 'pods' },
+          lists,
+        }),
+      {
+        wrapper: ({ children }) => (
+          <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+        ),
+      }
+    );
+
+    // Unmount before subscribe resolves
+    unmount();
+
+    // Now resolve subscribe
+    await act(async () => {
+      resolveSubscribe!(mockCleanup);
+      await pendingPromise;
+    });
+
+    // Verify cleanup was invoked immediately upon resolution because component was unmounted
+    expect(mockCleanup).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
@@ -1094,4 +1094,42 @@ describe('useWatchKubeObjectLists (Multiplexer)', () => {
       ).toBe(true)
     );
   });
+
+  it('should clean up subscription immediately if unmounted before subscribe promise resolves', async () => {
+    const mockCleanup = vi.fn();
+    let resolveSubscribe: (cleanup: () => void) => void;
+    const pendingPromise = new Promise<() => void>(resolve => {
+      resolveSubscribe = resolve;
+    });
+
+    mockSubscribe.mockReturnValueOnce(pendingPromise);
+
+    const lists = [{ cluster: 'cluster-a', namespace: 'namespace-a', resourceVersion: '1' }];
+
+    const { unmount } = renderHook(
+      () =>
+        useWatchKubeObjectLists({
+          kubeObjectClass: mockClass,
+          endpoint: { version: 'v1', resource: 'pods' },
+          lists,
+        }),
+      {
+        wrapper: ({ children }) => (
+          <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+        ),
+      }
+    );
+
+    // Unmount before subscribe resolves
+    unmount();
+
+    // Now resolve subscribe
+    await act(async () => {
+      resolveSubscribe!(mockCleanup);
+      await pendingPromise;
+    });
+
+    // Verify cleanup was invoked immediately upon resolution because component was unmounted
+    expect(mockCleanup).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -428,6 +428,7 @@ function useWatchKubeObjectListsMultiplexed<K extends KubeObject>({
       return;
     }
 
+    let isCancelled = false;
     const cleanups: (() => void)[] = [];
 
     // Create subscriptions for each connection
@@ -442,7 +443,13 @@ function useWatchKubeObjectListsMultiplexed<K extends KubeObject>({
         update => handleUpdate(update, cluster, namespace),
         error => console.error(`WebSocket subscription error for cluster ${cluster}:`, error)
       ).then(
-        cleanup => cleanups.push(cleanup),
+        cleanup => {
+          if (isCancelled) {
+            cleanup();
+          } else {
+            cleanups.push(cleanup);
+          }
+        },
         error => {
           // Track retry count in the URL's searchParams
           const retryCount = parseInt(parsedUrl.searchParams.get('retryCount') || '0');
@@ -457,6 +464,7 @@ function useWatchKubeObjectListsMultiplexed<K extends KubeObject>({
 
     // Cleanup subscriptions when effect re-runs or unmounts
     return () => {
+      isCancelled = true;
       cleanups.forEach(cleanup => cleanup());
     };
   }, [connections, enabled, endpoint, handleUpdate]);

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -305,6 +305,7 @@ function useWatchKubeObjectListsMultiplexed<K extends KubeObject>({
       return;
     }
 
+    let isCancelled = false;
     const cleanups: (() => void)[] = [];
 
     // Create subscriptions for each connection
@@ -319,7 +320,13 @@ function useWatchKubeObjectListsMultiplexed<K extends KubeObject>({
         update => handleUpdate(update, cluster, namespace),
         error => console.error(`WebSocket subscription error for cluster ${cluster}:`, error)
       ).then(
-        cleanup => cleanups.push(cleanup),
+        cleanup => {
+          if (isCancelled) {
+            cleanup();
+          } else {
+            cleanups.push(cleanup);
+          }
+        },
         error => {
           // Track retry count in the URL's searchParams
           const retryCount = parseInt(parsedUrl.searchParams.get('retryCount') || '0');
@@ -334,6 +341,7 @@ function useWatchKubeObjectListsMultiplexed<K extends KubeObject>({
 
     // Cleanup subscriptions when effect re-runs or unmounts
     return () => {
+      isCancelled = true;
       cleanups.forEach(cleanup => cleanup());
     };
   }, [connections, enabled, endpoint, handleUpdate]);


### PR DESCRIPTION
## Summary

This PR fixes an unmount race condition and memory leak in `useWatchKubeObjectListsMultiplexed` (`frontend/src/lib/k8s/api/v2/useKubeObjectList.ts`).

`WebSocketManager.subscribe()` is asynchronous (`async subscribe(...): Promise<() => void>`). Inside `useWatchKubeObjectListsMultiplexed`, subscriptions are registered via `.then(cleanup => cleanups.push(cleanup))` within `useEffect`. If a component unmounts or its watch parameters change before `subscribe()` finishes resolving, React synchronously runs `useEffect`'s cleanup function (`cleanups.forEach(...)`) while `cleanups` is empty `[]`. When `subscribe()` later resolves, the returned `cleanup()` function is added to the already-executed effect closure and is never called, leaving orphan subscriptions and listener callbacks in `WebSocketManager.activeSubscriptions` and `listeners` indefinitely.

## Related Issue

Fixes #6861

## Changes

- Added an `isCancelled` flag to `useEffect` in `useWatchKubeObjectListsMultiplexed`. If the component unmounts or effect dependencies change before `subscribe()` resolves, the returned `cleanup()` function is called immediately upon resolution.
- Updated `WebSocketManager.subscribe` in `frontend/src/lib/k8s/api/v2/multiplexer.ts` to clean up pre-registered listeners and active subscriptions if `connect()` fails or throws an exception.
- Added unit tests in `frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx` and `multiplexer.test.ts` covering unmount-during-pending-subscription and connection rejection cleanup.

## Steps to Test

1. Run vitest suite: `npm test -- src/lib/k8s/api/v2/useKubeObjectList.test.tsx src/lib/k8s/api/v2/multiplexer.test.ts` (verify all 56 tests pass).
2. Run linter: `npm run lint` (verify 0 lint errors).
3. Open Headlamp, navigate to a resource list view (e.g. Pods or Events), and rapidly switch namespaces or sidebar sections before the WebSocket multiplexer connection finishes opening.
4. Verify in browser devtools that `WebSocketManager.activeSubscriptions` and `listeners` are properly cleared with zero orphan entries.

## Screenshots (if applicable)

N/A (Backend / State management & hook lifecycle fix).

## Notes for the Reviewer

- All unit tests and linter checks pass with zero warnings/errors.
- The git commit message follows Kubernetes Linux kernel standards (< 72 char line wrapping, signed-off).

Signed-off-by: bhuvan-somisetty <somisettybhuvan5@gmail.com>
