### PR TITLE
0032: frontend: reload after deleting a cluster

### DIFF
--- a/e2e-tests/tests/dynamicCluster.spec.ts
+++ b/e2e-tests/tests/dynamicCluster.spec.ts
@@ -178,6 +178,59 @@ test('adding another stateless cluster keeps previously added clusters available
   );
 });
 
+test('deleting a backend-managed cluster reloads the home page', async ({ page }, testInfo) => {
+  const clusterName = `delete-reload-${testInfo.workerIndex}-${Date.now()}`;
+  let clusterDeleted = false;
+
+  await page.route('**/config', async route => {
+    const response = await route.fetch();
+    const config = await response.json();
+    const clusters = clusterDeleted
+      ? config.clusters
+      : [
+          ...config.clusters,
+          {
+            name: clusterName,
+            auth_type: '',
+            meta_data: { source: 'dynamic_cluster' },
+          },
+        ];
+    await route.fulfill({ response, json: { ...config, clusters } });
+  });
+
+  await page.route(`**/cluster/${clusterName}`, async route => {
+    if (route.request().method() !== 'DELETE') {
+      await route.fallback();
+      return;
+    }
+
+    clusterDeleted = true;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ clusters: [] }),
+    });
+  });
+
+  await page.goto('/');
+  const clusterRow = page.locator('table tbody tr', { hasText: clusterName });
+  await expect(clusterRow).toBeVisible();
+
+  await page.evaluate(() => {
+    (window as any).__clusterDeletionPageMarker = true;
+  });
+
+  await clusterRow.getByRole('button', { name: 'Actions' }).click();
+  await page.getByRole('menuitem', { name: 'Delete' }).click();
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: 'load' }),
+    page.getByRole('button', { name: 'Delete' }).click(),
+  ]);
+
+  expect(await page.evaluate(() => (window as any).__clusterDeletionPageMarker)).toBeUndefined();
+  await expect(page.locator('table tbody tr', { hasText: clusterName })).toHaveCount(0);
+});
+
 test('valid kubeconfig is still parsed when an invalid one is also sent', async ({ page }) => {
   const validKubeconfig = await getBase64EncodedKubeconfig();
   // A clearly invalid kubeconfig that cannot be decoded

--- a/frontend/src/components/App/Home/ClusterContextMenu.tsx
+++ b/frontend/src/components/App/Home/ClusterContextMenu.tsx
@@ -39,12 +39,17 @@ import ErrorBoundary from '../../common/ErrorBoundary/ErrorBoundary';
 interface ClusterContextMenuProps {
   /** The cluster for the context menu to act on. */
   cluster: Cluster;
+  /** Called after the cluster is successfully removed. */
+  onClusterRemoved?: () => void;
 }
 
 /**
  * ClusterContextMenu component displays a context menu for a given cluster.
  */
-export default function ClusterContextMenu({ cluster }: ClusterContextMenuProps) {
+export default function ClusterContextMenu({
+  cluster,
+  onClusterRemoved = () => window.location.reload(),
+}: ClusterContextMenuProps) {
   const { t } = useTranslation(['translation']);
   const history = useHistory();
   const dispatch = useDispatch();
@@ -68,6 +73,7 @@ export default function ClusterContextMenu({ cluster }: ClusterContextMenuProps)
     deleteCluster(clusterName, deleteFromKubeconfig, clusterID, kubeconfigOrigin, originalName)
       .then(config => {
         dispatch(setConfig(config));
+        onClusterRemoved();
       })
       .catch((err: Error) => {
         enqueueSnackbar(
@@ -77,9 +83,6 @@ export default function ClusterContextMenu({ cluster }: ClusterContextMenuProps)
             preventDuplicate: true,
           }
         );
-      })
-      .finally(() => {
-        history.push('/');
       });
   }
 

--- a/frontend/src/components/App/Home/ClusterContextMenu.tsx
+++ b/frontend/src/components/App/Home/ClusterContextMenu.tsx
@@ -39,12 +39,16 @@ import ErrorBoundary from '../../common/ErrorBoundary/ErrorBoundary';
 interface ClusterContextMenuProps {
   /** The cluster for the context menu to act on. */
   cluster: Cluster;
+  onClusterRemoved?: () => void;
 }
 
 /**
  * ClusterContextMenu component displays a context menu for a given cluster.
  */
-export default function ClusterContextMenu({ cluster }: ClusterContextMenuProps) {
+export default function ClusterContextMenu({
+  cluster,
+  onClusterRemoved = () => window.location.reload(),
+}: ClusterContextMenuProps) {
   const { t } = useTranslation(['translation']);
   const history = useHistory();
   const dispatch = useDispatch();
@@ -68,6 +72,7 @@ export default function ClusterContextMenu({ cluster }: ClusterContextMenuProps)
     deleteCluster(clusterName, deleteFromKubeconfig, clusterID, kubeconfigOrigin, originalName)
       .then(config => {
         dispatch(setConfig(config));
+        onClusterRemoved();
       })
       .catch((err: Error) => {
         enqueueSnackbar(
@@ -77,9 +82,6 @@ export default function ClusterContextMenu({ cluster }: ClusterContextMenuProps)
             preventDuplicate: true,
           }
         );
-      })
-      .finally(() => {
-        history.push('/');
       });
   }
 

--- a/frontend/src/components/App/Home/ClusterTable.test.tsx
+++ b/frontend/src/components/App/Home/ClusterTable.test.tsx
@@ -27,6 +27,7 @@ import ClusterContextMenu from './ClusterContextMenu';
 import ClusterTable from './ClusterTable';
 
 const theme = createMuiTheme({ name: 'light', base: 'light' });
+const { dispatchMock } = vi.hoisted(() => ({ dispatchMock: vi.fn() }));
 
 function renderWithTheme(ui: ReactNode) {
   return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
@@ -47,7 +48,7 @@ vi.mock('react-i18next', async importOriginal => {
 });
 
 vi.mock('react-redux', () => ({
-  useDispatch: () => vi.fn(),
+  useDispatch: () => dispatchMock,
 }));
 
 vi.mock('../../../lib/k8s/api/v1/clusterApi', () => ({
@@ -372,7 +373,7 @@ describe('ClusterContextMenu', () => {
     vi.clearAllMocks();
   });
 
-  it('notifies the page after deleting a cluster', async () => {
+  it('updates the config before notifying the page after deleting a cluster', async () => {
     vi.mocked(deleteCluster).mockResolvedValue({} as Awaited<ReturnType<typeof deleteCluster>>);
     const onClusterRemoved = vi.fn();
 
@@ -400,6 +401,10 @@ describe('ClusterContextMenu', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
 
     await waitFor(() => expect(onClusterRemoved).toHaveBeenCalledOnce());
+    expect(dispatchMock).toHaveBeenCalledOnce();
+    expect(dispatchMock.mock.invocationCallOrder[0]).toBeLessThan(
+      onClusterRemoved.mock.invocationCallOrder[0]
+    );
   });
 
   it('keeps the page open when deleting a cluster fails', async () => {

--- a/frontend/src/components/App/Home/ClusterTable.test.tsx
+++ b/frontend/src/components/App/Home/ClusterTable.test.tsx
@@ -15,11 +15,12 @@
  */
 
 import { ThemeProvider } from '@mui/material/styles';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
 import { ReactNode } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { deleteCluster } from '../../../lib/k8s/api/v1/clusterApi';
 import { Cluster } from '../../../lib/k8s/cluster';
 import { createMuiTheme } from '../../../lib/themes';
 import ClusterContextMenu from './ClusterContextMenu';
@@ -29,6 +30,10 @@ const theme = createMuiTheme({ name: 'light', base: 'light' });
 
 function renderWithTheme(ui: ReactNode) {
   return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
+}
+
+function LocationDisplay() {
+  return <div data-testid="location">{useLocation().pathname}</div>;
 }
 
 vi.mock('react-i18next', async importOriginal => {
@@ -43,6 +48,10 @@ vi.mock('react-i18next', async importOriginal => {
 
 vi.mock('react-redux', () => ({
   useDispatch: () => vi.fn(),
+}));
+
+vi.mock('../../../lib/k8s/api/v1/clusterApi', () => ({
+  deleteCluster: vi.fn(),
 }));
 
 vi.mock('../../../helpers', () => ({
@@ -359,6 +368,73 @@ describe('ClusterTable', () => {
 });
 
 describe('ClusterContextMenu', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('notifies the page after deleting a cluster', async () => {
+    vi.mocked(deleteCluster).mockResolvedValue({} as Awaited<ReturnType<typeof deleteCluster>>);
+    const onClusterRemoved = vi.fn();
+
+    render(
+      <SnackbarProvider>
+        <MemoryRouter>
+          <ClusterContextMenu
+            onClusterRemoved={onClusterRemoved}
+            cluster={
+              {
+                name: 'spoke-a',
+                auth_type: '',
+                meta_data: {
+                  source: 'kubeconfig',
+                },
+              } as Cluster
+            }
+          />
+        </MemoryRouter>
+      </SnackbarProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    fireEvent.click(screen.getByText('Delete'));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(onClusterRemoved).toHaveBeenCalledOnce());
+  });
+
+  it('keeps the page open when deleting a cluster fails', async () => {
+    vi.mocked(deleteCluster).mockRejectedValue(new Error('request failed'));
+    const onClusterRemoved = vi.fn();
+
+    render(
+      <SnackbarProvider>
+        <MemoryRouter initialEntries={['/c/spoke-a']}>
+          <ClusterContextMenu
+            onClusterRemoved={onClusterRemoved}
+            cluster={
+              {
+                name: 'spoke-a',
+                auth_type: '',
+                meta_data: {
+                  source: 'dynamic_cluster',
+                },
+              } as Cluster
+            }
+          />
+          <LocationDisplay />
+        </MemoryRouter>
+      </SnackbarProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    fireEvent.click(screen.getByText('Delete'));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Failed to delete cluster');
+    expect(onClusterRemoved).not.toHaveBeenCalled();
+    expect(screen.getByTestId('location')).toHaveTextContent('/c/spoke-a');
+  });
+
   it('does not show delete actions for Cluster Inventory clusters', () => {
     render(
       <SnackbarProvider>

--- a/frontend/src/components/App/Home/ClusterTable.test.tsx
+++ b/frontend/src/components/App/Home/ClusterTable.test.tsx
@@ -15,11 +15,12 @@
  */
 
 import { ThemeProvider } from '@mui/material/styles';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
 import { ComponentType, ReactNode } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { deleteCluster } from '../../../lib/k8s/api/v1/clusterApi';
 import { Cluster } from '../../../lib/k8s/cluster';
 import { createMuiTheme } from '../../../lib/themes';
 import ClusterContextMenu from './ClusterContextMenu';
@@ -30,6 +31,10 @@ let ClusterEmptyState: ComponentType<{ defaultContent: ReactNode }> | null = nul
 
 function renderWithTheme(ui: ReactNode) {
   return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
+}
+
+function LocationDisplay() {
+  return <div data-testid="location">{useLocation().pathname}</div>;
 }
 
 vi.mock('react-i18next', async importOriginal => {
@@ -44,6 +49,10 @@ vi.mock('react-i18next', async importOriginal => {
 
 vi.mock('react-redux', () => ({
   useDispatch: () => vi.fn(),
+}));
+
+vi.mock('../../../lib/k8s/api/v1/clusterApi', () => ({
+  deleteCluster: vi.fn(),
 }));
 
 vi.mock('../../../helpers', () => ({
@@ -421,6 +430,73 @@ describe('ClusterTable', () => {
 });
 
 describe('ClusterContextMenu', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('notifies the page after deleting a cluster', async () => {
+    vi.mocked(deleteCluster).mockResolvedValue({} as Awaited<ReturnType<typeof deleteCluster>>);
+    const onClusterRemoved = vi.fn();
+
+    render(
+      <SnackbarProvider>
+        <MemoryRouter>
+          <ClusterContextMenu
+            onClusterRemoved={onClusterRemoved}
+            cluster={
+              {
+                name: 'spoke-a',
+                auth_type: '',
+                meta_data: {
+                  source: 'kubeconfig',
+                },
+              } as Cluster
+            }
+          />
+        </MemoryRouter>
+      </SnackbarProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    fireEvent.click(screen.getByText('Delete'));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(onClusterRemoved).toHaveBeenCalledOnce());
+  });
+
+  it('keeps the page open when deleting a cluster fails', async () => {
+    vi.mocked(deleteCluster).mockRejectedValue(new Error('request failed'));
+    const onClusterRemoved = vi.fn();
+
+    render(
+      <SnackbarProvider>
+        <MemoryRouter initialEntries={['/c/spoke-a']}>
+          <ClusterContextMenu
+            onClusterRemoved={onClusterRemoved}
+            cluster={
+              {
+                name: 'spoke-a',
+                auth_type: '',
+                meta_data: {
+                  source: 'dynamic_cluster',
+                },
+              } as Cluster
+            }
+          />
+          <LocationDisplay />
+        </MemoryRouter>
+      </SnackbarProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    fireEvent.click(screen.getByText('Delete'));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Failed to delete cluster');
+    expect(onClusterRemoved).not.toHaveBeenCalled();
+    expect(screen.getByTestId('location')).toHaveTextContent('/c/spoke-a');
+  });
+
   it('does not show delete actions for Cluster Inventory clusters', () => {
     render(
       <SnackbarProvider>

--- a/frontend/src/components/App/Home/ClusterTable.test.tsx
+++ b/frontend/src/components/App/Home/ClusterTable.test.tsx
@@ -28,6 +28,7 @@ import ClusterTable from './ClusterTable';
 
 const theme = createMuiTheme({ name: 'light', base: 'light' });
 let ClusterEmptyState: ComponentType<{ defaultContent: ReactNode }> | null = null;
+const { dispatchMock } = vi.hoisted(() => ({ dispatchMock: vi.fn() }));
 
 function renderWithTheme(ui: ReactNode) {
   return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
@@ -48,7 +49,7 @@ vi.mock('react-i18next', async importOriginal => {
 });
 
 vi.mock('react-redux', () => ({
-  useDispatch: () => vi.fn(),
+  useDispatch: () => dispatchMock,
 }));
 
 vi.mock('../../../lib/k8s/api/v1/clusterApi', () => ({
@@ -434,7 +435,7 @@ describe('ClusterContextMenu', () => {
     vi.clearAllMocks();
   });
 
-  it('notifies the page after deleting a cluster', async () => {
+  it('updates the config before notifying the page after deleting a cluster', async () => {
     vi.mocked(deleteCluster).mockResolvedValue({} as Awaited<ReturnType<typeof deleteCluster>>);
     const onClusterRemoved = vi.fn();
 
@@ -462,6 +463,10 @@ describe('ClusterContextMenu', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
 
     await waitFor(() => expect(onClusterRemoved).toHaveBeenCalledOnce());
+    expect(dispatchMock).toHaveBeenCalledOnce();
+    expect(dispatchMock.mock.invocationCallOrder[0]).toBeLessThan(
+      onClusterRemoved.mock.invocationCallOrder[0]
+    );
   });
 
   it('keeps the page open when deleting a cluster fails', async () => {


### PR DESCRIPTION
## Summary

- reload the page after a cluster is successfully deleted so stale cluster-scoped browser state is cleared
- keep the current page and error context when cluster deletion fails
- cover successful and failed deletion outcomes with unit tests
- add a Playwright regression for backend-managed cluster deletion and document reload

## Coverage

`ClusterContextMenu.tsx` branch coverage increased from 47.36% to 90%, exceeding the requested 80% threshold.

## Testing

- `npm test -- src/components/App/Home/ClusterTable.test.tsx --run --coverage --coverage.include=src/components/App/Home/ClusterContextMenu.tsx --coverage.reporter=text --coverage.thresholds.branches=80 --coverage.thresholds.statements=0 --coverage.thresholds.functions=0 --coverage.thresholds.lines=0` (12 tests passed; 90% branch coverage)
- `npm run tsc`
- changed-file ESLint check
- `playwright test tests/dynamicCluster.spec.ts --list` (9 tests discovered, including the new deletion reload regression)

The Playwright regression was registered locally; full execution requires the documented two-kind-cluster Headlamp e2e deployment.

## Provenance

This upstreams patch 0032 retained by [Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823). The retained patch records source SHA `aa1e398ebf1f0deb23faa1795ccc2a1f27ff5d65` by Oleksandr Dubenko. The surviving downstream history includes:

- [`bd39620b`](https://github.com/Azure/aks-desktop/commit/bd39620b16a75bad38ec0a881eaa9721b54e51aa), which introduced reloading after cluster deletion
- [`9696c57e`](https://github.com/Azure/aks-desktop/commit/9696c57e68930ccd1a2b214552b65e8104efa8ef), which added cluster-deletion error notification

Patch 0032 refines those behaviors by reloading only after successful deletion. The implementation commit preserves Oleksandr Dubenko as author and the retained patch author date, with René Dudfield as co-author.

Assisted by copilot