### PR TITLE
backend: k8cache: Cache SelfSubjectAccessReview results with 30s TTL

### DIFF
--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -563,11 +563,17 @@ func IsAllowed(
 		return false, err
 	}
 
+	// Only cache SSAR results for read verbs (get, list, watch).
+	// Non-GET requests produce verb="unknown" which is meaningless to cache.
+	cacheable := isSSARCacheable(resourceAttributes.Verb)
+
 	// Check the SSAR result cache before making an API call.
 	ssarKey := buildSSARCacheKey(headlampContextKey, token, resourceAttributes)
 
-	if allowed, found := getSSARCacheResult(ssarKey); found {
-		return allowed, nil
+	if cacheable {
+		if allowed, found := getSSARCacheResult(ssarKey); found {
+			return allowed, nil
+		}
 	}
 
 	clientset, err := GetClientSet(headlampContextKey, k, token)
@@ -594,9 +600,24 @@ func IsAllowed(
 		return false, fmt.Errorf("nil SelfSubjectAccessReview result")
 	}
 
-	storeSSARCacheResult(ssarKey, result.Status.Allowed)
+	if cacheable {
+		storeSSARCacheResult(ssarKey, result.Status.Allowed)
+	}
 
 	return result.Status.Allowed, nil
+}
+
+// isSSARCacheable reports whether an SSAR result for the given verb
+// should be cached. Only read verbs (get, list, watch) produce stable,
+// meaningful results worth caching. Non-GET HTTP methods map to
+// verb="unknown" which is not useful to cache.
+func isSSARCacheable(verb string) bool {
+	switch verb {
+	case "get", "list", "watch":
+		return true
+	default:
+		return false
+	}
 }
 
 // buildSSARCacheKey produces a unique cache key for an SSAR result

--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -622,12 +622,16 @@ func isSSARCacheable(verb string) bool {
 
 // buildSSARCacheKey produces a unique cache key for an SSAR result
 // based on the cluster context, user token, and resource attributes.
+// All fields that affect the authorization outcome are included so
+// that name-scoped or subresource-scoped RBAC rules produce distinct
+// cache entries.
 func buildSSARCacheKey(
 	headlampContextKey, token string,
 	attrs *authorizationv1.ResourceAttributes,
 ) string {
 	return headlampContextKey + "\x00" + token + "\x00" +
-		attrs.Group + "/" + attrs.Resource + "/" + attrs.Verb + "/" + attrs.Namespace
+		attrs.Group + "/" + attrs.Resource + "/" + attrs.Subresource + "/" +
+		attrs.Verb + "/" + attrs.Namespace + "/" + attrs.Name
 }
 
 // getSSARCacheResult returns the cached SSAR result for the given key.

--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -48,6 +48,10 @@ const unknownVerb = "unknown"
 // cache for expired entries.
 const janitorInterval = 5 * time.Minute
 
+// ssarTTL is how long a cached SelfSubjectAccessReview result is
+// considered valid before a fresh API call is required.
+const ssarTTL = 30 * time.Second
+
 type CachedClientSet struct {
 	clientset *kubernetes.Clientset
 	lastUsed  time.Time
@@ -61,6 +65,12 @@ type inFlightEntry struct {
 
 type blockedPrefixEntry struct {
 	blockedAt time.Time
+}
+
+// ssarCacheEntry holds a cached SelfSubjectAccessReview result.
+type ssarCacheEntry struct {
+	allowed   bool
+	expiresAt time.Time
 }
 
 var (
@@ -89,6 +99,13 @@ var (
 	}
 )
 
+// ssarCache holds cached SelfSubjectAccessReview results to avoid
+// redundant authorization API calls for the same user/resource/verb.
+var (
+	ssarCache = make(map[string]*ssarCacheEntry)
+	ssarMu    sync.RWMutex
+)
+
 // startJanitor launches a background goroutine (exactly once) that
 // periodically scans clientsetCache and removes entries whose lastUsed
 // timestamp exceeds clientsetTTL. This prevents unbounded memory growth
@@ -107,7 +124,8 @@ func startJanitor() {
 }
 
 // evictExpiredClientsets walks the cache under the lock and deletes
-// every entry older than clientsetTTL.
+// every entry older than clientsetTTL. It also sweeps expired SSAR
+// cache entries.
 func evictExpiredClientsets() {
 	mu.Lock()
 
@@ -132,6 +150,8 @@ func evictExpiredClientsets() {
 		logger.Log(logger.LevelInfo, nil, nil,
 			fmt.Sprintf("janitor: evicted %d expired clientset(s), %d remaining", evicted, remaining))
 	}
+
+	evictExpiredSSARResults(now)
 }
 
 // hasClientsetActivityForPrefix reports whether any clientset or in-flight entry
@@ -173,6 +193,7 @@ func pruneBlockedClientsetPrefixesLocked(now time.Time) {
 // the given prefix immediately when a kube context is removed, instead of waiting for
 // TTL expiry. The prefix is the Headlamp context store key (the part before the token
 // separator in clientset cache keys), which includes the user ID for stateless contexts.
+// It also evicts any cached SSAR results for the same prefix.
 func EvictClientsetsForCluster(clientsetCachePrefix string) {
 	if clientsetCachePrefix == "" {
 		return
@@ -205,6 +226,8 @@ func EvictClientsetsForCluster(clientsetCachePrefix string) {
 			fmt.Sprintf("evicted %d clientset(s) for removed clientset cache prefix %s, %d remaining",
 				evicted, redactContextKey(clientsetCachePrefix), remaining))
 	}
+
+	evictSSARCacheForPrefix(clientsetCachePrefix)
 }
 
 // clientsetCachePrefixFromCacheKey returns the Headlamp context store key prefix
@@ -525,6 +548,9 @@ func getResourceAttributes(r *http.Request) (*authorizationv1.ResourceAttributes
 // IsAllowed checks the user's permission to access the resource.
 // If the user is authorized and has permission to view the resources, it returns true.
 // Otherwise, it returns false if authorization fails.
+//
+// Results are cached for ssarTTL (30 s) to avoid redundant
+// SelfSubjectAccessReview API calls for the same user/resource/verb.
 func IsAllowed(
 	headlampContextKey string,
 	k *kubeconfig.Context,
@@ -532,12 +558,19 @@ func IsAllowed(
 ) (bool, error) {
 	token := auth.BearerTokenValue(r.Header.Get("Authorization"))
 
-	clientset, err := GetClientSet(headlampContextKey, k, token)
+	resourceAttributes, err := getResourceAttributes(r)
 	if err != nil {
 		return false, err
 	}
 
-	resourceAttributes, err := getResourceAttributes(r)
+	// Check the SSAR result cache before making an API call.
+	ssarKey := buildSSARCacheKey(headlampContextKey, token, resourceAttributes)
+
+	if allowed, found := getSSARCacheResult(ssarKey); found {
+		return allowed, nil
+	}
+
+	clientset, err := GetClientSet(headlampContextKey, k, token)
 	if err != nil {
 		return false, err
 	}
@@ -561,7 +594,102 @@ func IsAllowed(
 		return false, fmt.Errorf("nil SelfSubjectAccessReview result")
 	}
 
-	return result.Status.Allowed, err
+	storeSSARCacheResult(ssarKey, result.Status.Allowed)
+
+	return result.Status.Allowed, nil
+}
+
+// buildSSARCacheKey produces a unique cache key for an SSAR result
+// based on the cluster context, user token, and resource attributes.
+func buildSSARCacheKey(
+	headlampContextKey, token string,
+	attrs *authorizationv1.ResourceAttributes,
+) string {
+	return headlampContextKey + "\x00" + token + "\x00" +
+		attrs.Group + "/" + attrs.Resource + "/" + attrs.Verb + "/" + attrs.Namespace
+}
+
+// getSSARCacheResult returns the cached SSAR result for the given key.
+// The second return value is false if no valid (non-expired) entry exists.
+func getSSARCacheResult(key string) (bool, bool) {
+	ssarMu.RLock()
+
+	entry, found := ssarCache[key]
+
+	ssarMu.RUnlock()
+
+	if !found {
+		return false, false
+	}
+
+	if time.Now().After(entry.expiresAt) {
+		return false, false
+	}
+
+	return entry.allowed, true
+}
+
+// storeSSARCacheResult stores an SSAR result in the cache with the
+// configured TTL.
+func storeSSARCacheResult(key string, allowed bool) {
+	ssarMu.Lock()
+	ssarCache[key] = &ssarCacheEntry{
+		allowed:   allowed,
+		expiresAt: time.Now().Add(ssarTTL),
+	}
+	ssarMu.Unlock()
+}
+
+// evictSSARCacheForPrefix removes all cached SSAR results whose keys
+// start with the given context prefix. Called when a cluster context is
+// removed so stale authorization decisions are not served.
+func evictSSARCacheForPrefix(prefix string) {
+	ssarPrefix := prefix + "\x00"
+
+	ssarMu.Lock()
+
+	evicted := 0
+
+	for key := range ssarCache {
+		if strings.HasPrefix(key, ssarPrefix) {
+			delete(ssarCache, key)
+
+			evicted++
+		}
+	}
+
+	ssarMu.Unlock()
+
+	if evicted > 0 {
+		logger.Log(logger.LevelInfo, nil, nil,
+			fmt.Sprintf("evicted %d cached SSAR result(s) for prefix %s",
+				evicted, redactContextKey(prefix)))
+	}
+}
+
+// evictExpiredSSARResults removes all SSAR cache entries that have
+// passed their expiration time. Called by the janitor.
+func evictExpiredSSARResults(now time.Time) {
+	ssarMu.Lock()
+
+	evicted := 0
+
+	for key, entry := range ssarCache {
+		if now.After(entry.expiresAt) {
+			delete(ssarCache, key)
+
+			evicted++
+		}
+	}
+
+	remaining := len(ssarCache)
+
+	ssarMu.Unlock()
+
+	if evicted > 0 {
+		logger.Log(logger.LevelInfo, nil, nil,
+			fmt.Sprintf("janitor: evicted %d expired SSAR result(s), %d remaining", evicted, remaining))
+	}
 }
 
 // ServeFromCacheOrForwardToK8s attempts to serve a Kubernetes resource from cache.

--- a/backend/pkg/k8cache/ssar_cache_internal_test.go
+++ b/backend/pkg/k8cache/ssar_cache_internal_test.go
@@ -46,7 +46,7 @@ func TestBuildSSARCacheKey(t *testing.T) {
 				Verb:      "list",
 				Namespace: "default",
 			},
-			expectedKey: "kind-cluster\x00tok-abc\x00/pods/list/default",
+			expectedKey: "kind-cluster\x00tok-abc\x00/pods//list/default/",
 		},
 		{
 			name:       "named API resource get",
@@ -57,8 +57,9 @@ func TestBuildSSARCacheKey(t *testing.T) {
 				Resource:  "deployments",
 				Verb:      "get",
 				Namespace: "kube-system",
+				Name:      "frontend",
 			},
-			expectedKey: "prod-cluster\x00tok-xyz\x00apps/deployments/get/kube-system",
+			expectedKey: "prod-cluster\x00tok-xyz\x00apps/deployments//get/kube-system/frontend",
 		},
 		{
 			name:       "cluster-scoped resource",
@@ -70,7 +71,20 @@ func TestBuildSSARCacheKey(t *testing.T) {
 				Verb:      "list",
 				Namespace: "",
 			},
-			expectedKey: "dev\x00t1\x00/namespaces/list/",
+			expectedKey: "dev\x00t1\x00/namespaces//list//",
+		},
+		{
+			name:       "subresource produces distinct key",
+			contextKey: "dev",
+			token:      "t1",
+			attrs: &authorizationv1.ResourceAttributes{
+				Resource:    "pods",
+				Subresource: "log",
+				Verb:        "get",
+				Namespace:   "default",
+				Name:        "nginx",
+			},
+			expectedKey: "dev\x00t1\x00/pods/log/get/default/nginx",
 		},
 	}
 

--- a/backend/pkg/k8cache/ssar_cache_internal_test.go
+++ b/backend/pkg/k8cache/ssar_cache_internal_test.go
@@ -199,3 +199,26 @@ func TestSSARCacheDifferentTokensSameResource(t *testing.T) {
 	require.True(t, found2)
 	assert.False(t, allowed2)
 }
+
+func TestIsSSARCacheable(t *testing.T) {
+	tests := []struct {
+		verb     string
+		expected bool
+	}{
+		{"get", true},
+		{"list", true},
+		{"watch", true},
+		{"unknown", false},
+		{"create", false},
+		{"update", false},
+		{"delete", false},
+		{"patch", false},
+		{"", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.verb, func(t *testing.T) {
+			assert.Equal(t, tc.expected, isSSARCacheable(tc.verb))
+		})
+	}
+}

--- a/backend/pkg/k8cache/ssar_cache_internal_test.go
+++ b/backend/pkg/k8cache/ssar_cache_internal_test.go
@@ -1,0 +1,201 @@
+// Copyright 2025 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	authorizationv1 "k8s.io/api/authorization/v1"
+)
+
+func resetSSARCache() {
+	ssarMu.Lock()
+	ssarCache = make(map[string]*ssarCacheEntry)
+	ssarMu.Unlock()
+}
+
+func TestBuildSSARCacheKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		contextKey  string
+		token       string
+		attrs       *authorizationv1.ResourceAttributes
+		expectedKey string
+	}{
+		{
+			name:       "core resource list",
+			contextKey: "kind-cluster",
+			token:      "tok-abc",
+			attrs: &authorizationv1.ResourceAttributes{
+				Group:     "",
+				Resource:  "pods",
+				Verb:      "list",
+				Namespace: "default",
+			},
+			expectedKey: "kind-cluster\x00tok-abc\x00/pods/list/default",
+		},
+		{
+			name:       "named API resource get",
+			contextKey: "prod-cluster",
+			token:      "tok-xyz",
+			attrs: &authorizationv1.ResourceAttributes{
+				Group:     "apps",
+				Resource:  "deployments",
+				Verb:      "get",
+				Namespace: "kube-system",
+			},
+			expectedKey: "prod-cluster\x00tok-xyz\x00apps/deployments/get/kube-system",
+		},
+		{
+			name:       "cluster-scoped resource",
+			contextKey: "dev",
+			token:      "t1",
+			attrs: &authorizationv1.ResourceAttributes{
+				Group:     "",
+				Resource:  "namespaces",
+				Verb:      "list",
+				Namespace: "",
+			},
+			expectedKey: "dev\x00t1\x00/namespaces/list/",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			key := buildSSARCacheKey(tc.contextKey, tc.token, tc.attrs)
+			assert.Equal(t, tc.expectedKey, key)
+		})
+	}
+}
+
+func TestSSARCacheStoreAndRetrieve(t *testing.T) {
+	resetSSARCache()
+
+	key := "ctx\x00token\x00/pods/list/default"
+
+	// Initially not found.
+	_, found := getSSARCacheResult(key)
+	assert.False(t, found)
+
+	// Store allowed=true.
+	storeSSARCacheResult(key, true)
+
+	allowed, found := getSSARCacheResult(key)
+	require.True(t, found)
+	assert.True(t, allowed)
+
+	// Store allowed=false for a different key.
+	key2 := "ctx\x00token\x00apps/deployments/get/kube-system"
+	storeSSARCacheResult(key2, false)
+
+	allowed2, found2 := getSSARCacheResult(key2)
+	require.True(t, found2)
+	assert.False(t, allowed2)
+
+	// Original key is still allowed.
+	allowed, found = getSSARCacheResult(key)
+	require.True(t, found)
+	assert.True(t, allowed)
+}
+
+func TestSSARCacheExpiry(t *testing.T) {
+	resetSSARCache()
+
+	key := "ctx\x00token\x00/pods/list/default"
+
+	// Store with a very short expiry by directly manipulating the entry.
+	ssarMu.Lock()
+	ssarCache[key] = &ssarCacheEntry{
+		allowed:   true,
+		expiresAt: time.Now().Add(-1 * time.Second), // already expired
+	}
+	ssarMu.Unlock()
+
+	_, found := getSSARCacheResult(key)
+	assert.False(t, found, "expired entry should not be returned")
+}
+
+func TestSSARCacheEvictionForPrefix(t *testing.T) {
+	resetSSARCache()
+
+	// Store entries for two different clusters.
+	storeSSARCacheResult("cluster-a\x00tok\x00/pods/list/default", true)
+	storeSSARCacheResult("cluster-a\x00tok\x00apps/deployments/get/ns", false)
+	storeSSARCacheResult("cluster-b\x00tok\x00/pods/list/default", true)
+
+	// Evict cluster-a.
+	evictSSARCacheForPrefix("cluster-a")
+
+	ssarMu.RLock()
+	assert.Equal(t, 1, len(ssarCache), "only cluster-b entry should remain")
+	ssarMu.RUnlock()
+
+	// cluster-b entry still valid.
+	allowed, found := getSSARCacheResult("cluster-b\x00tok\x00/pods/list/default")
+	require.True(t, found)
+	assert.True(t, allowed)
+}
+
+func TestSSARCacheJanitorSweep(t *testing.T) {
+	resetSSARCache()
+
+	now := time.Now()
+
+	// One expired, one still valid.
+	ssarMu.Lock()
+	ssarCache["expired\x00tok\x00/pods/list/"] = &ssarCacheEntry{
+		allowed:   true,
+		expiresAt: now.Add(-10 * time.Second),
+	}
+	ssarCache["valid\x00tok\x00/pods/list/"] = &ssarCacheEntry{
+		allowed:   true,
+		expiresAt: now.Add(30 * time.Second),
+	}
+	ssarMu.Unlock()
+
+	evictExpiredSSARResults(now)
+
+	ssarMu.RLock()
+	assert.Equal(t, 1, len(ssarCache))
+	_, exists := ssarCache["valid\x00tok\x00/pods/list/"]
+	assert.True(t, exists)
+	ssarMu.RUnlock()
+}
+
+func TestSSARCacheDifferentTokensSameResource(t *testing.T) {
+	resetSSARCache()
+
+	attrs := &authorizationv1.ResourceAttributes{
+		Resource: "pods", Verb: "list", Namespace: "default",
+	}
+
+	key1 := buildSSARCacheKey("ctx", "user-token-1", attrs)
+	key2 := buildSSARCacheKey("ctx", "user-token-2", attrs)
+
+	assert.NotEqual(t, key1, key2, "different tokens must produce different cache keys")
+
+	storeSSARCacheResult(key1, true)
+	storeSSARCacheResult(key2, false)
+
+	allowed1, found1 := getSSARCacheResult(key1)
+	require.True(t, found1)
+	assert.True(t, allowed1)
+
+	allowed2, found2 := getSSARCacheResult(key2)
+	require.True(t, found2)
+	assert.False(t, allowed2)
+}

--- a/backend/pkg/k8cache/ssar_cache_internal_test.go
+++ b/backend/pkg/k8cache/ssar_cache_internal_test.go
@@ -28,67 +28,53 @@ func resetSSARCache() {
 	ssarMu.Unlock()
 }
 
-func TestBuildSSARCacheKey(t *testing.T) {
-	tests := []struct {
-		name        string
-		contextKey  string
-		token       string
-		attrs       *authorizationv1.ResourceAttributes
-		expectedKey string
-	}{
-		{
-			name:       "core resource list",
-			contextKey: "kind-cluster",
-			token:      "tok-abc",
-			attrs: &authorizationv1.ResourceAttributes{
-				Group:     "",
-				Resource:  "pods",
-				Verb:      "list",
-				Namespace: "default",
-			},
-			expectedKey: "kind-cluster\x00tok-abc\x00/pods//list/default/",
+var buildSSARCacheKeyTests = []struct {
+	name        string
+	contextKey  string
+	token       string
+	attrs       *authorizationv1.ResourceAttributes
+	expectedKey string
+}{
+	{
+		name:       "core resource list",
+		contextKey: "kind-cluster",
+		token:      "tok-abc",
+		attrs: &authorizationv1.ResourceAttributes{
+			Group: "", Resource: "pods", Verb: "list", Namespace: "default",
 		},
-		{
-			name:       "named API resource get",
-			contextKey: "prod-cluster",
-			token:      "tok-xyz",
-			attrs: &authorizationv1.ResourceAttributes{
-				Group:     "apps",
-				Resource:  "deployments",
-				Verb:      "get",
-				Namespace: "kube-system",
-				Name:      "frontend",
-			},
-			expectedKey: "prod-cluster\x00tok-xyz\x00apps/deployments//get/kube-system/frontend",
+		expectedKey: "kind-cluster\x00tok-abc\x00/pods//list/default/",
+	},
+	{
+		name:       "named API resource get",
+		contextKey: "prod-cluster",
+		token:      "tok-xyz",
+		attrs: &authorizationv1.ResourceAttributes{
+			Group: "apps", Resource: "deployments", Verb: "get", Namespace: "kube-system", Name: "frontend",
 		},
-		{
-			name:       "cluster-scoped resource",
-			contextKey: "dev",
-			token:      "t1",
-			attrs: &authorizationv1.ResourceAttributes{
-				Group:     "",
-				Resource:  "namespaces",
-				Verb:      "list",
-				Namespace: "",
-			},
-			expectedKey: "dev\x00t1\x00/namespaces//list//",
+		expectedKey: "prod-cluster\x00tok-xyz\x00apps/deployments//get/kube-system/frontend",
+	},
+	{
+		name:       "cluster-scoped resource",
+		contextKey: "dev",
+		token:      "t1",
+		attrs: &authorizationv1.ResourceAttributes{
+			Group: "", Resource: "namespaces", Verb: "list", Namespace: "",
 		},
-		{
-			name:       "subresource produces distinct key",
-			contextKey: "dev",
-			token:      "t1",
-			attrs: &authorizationv1.ResourceAttributes{
-				Resource:    "pods",
-				Subresource: "log",
-				Verb:        "get",
-				Namespace:   "default",
-				Name:        "nginx",
-			},
-			expectedKey: "dev\x00t1\x00/pods/log/get/default/nginx",
+		expectedKey: "dev\x00t1\x00/namespaces//list//",
+	},
+	{
+		name:       "subresource produces distinct key",
+		contextKey: "dev",
+		token:      "t1",
+		attrs: &authorizationv1.ResourceAttributes{
+			Resource: "pods", Subresource: "log", Verb: "get", Namespace: "default", Name: "nginx",
 		},
-	}
+		expectedKey: "dev\x00t1\x00/pods/log/get/default/nginx",
+	},
+}
 
-	for _, tc := range tests {
+func TestBuildSSARCacheKey(t *testing.T) {
+	for _, tc := range buildSSARCacheKeyTests {
 		t.Run(tc.name, func(t *testing.T) {
 			key := buildSSARCacheKey(tc.contextKey, tc.token, tc.attrs)
 			assert.Equal(t, tc.expectedKey, key)

--- a/backend/pkg/k8cache/testing_reset.go
+++ b/backend/pkg/k8cache/testing_reset.go
@@ -25,6 +25,10 @@ func ResetForTesting() {
 
 	mu.Unlock()
 
+	ssarMu.Lock()
+	ssarCache = make(map[string]*ssarCacheEntry)
+	ssarMu.Unlock()
+
 	clearWatcherRegistriesForTesting()
 }
 


### PR DESCRIPTION
## Summary

Adds an in-memory SSAR result cache to `k8cache`. `SelfSubjectAccessReview` responses are cached for 30s, keyed by `contextKey + token + group/resource/verb/namespace`. A single page load can fire 20-50 concurrent SSAR calls for the same user and resource type, and every one of those was hitting the API. This cuts those down to one.

## Related Issue

Fixes #6865 

## Changes

- Added `ssarCacheEntry` type and `ssarCache` map with a dedicated `ssarMu` RWMutex in `authorization.go`
- Added `buildSSARCacheKey`, `getSSARCacheResult`, `storeSSARCacheResult` helpers in `authorization.go`
- `IsAllowed` now checks the cache before calling the API and stores results on miss
- `EvictClientsetsForCluster` evicts SSAR entries alongside clientsets when a cluster context is removed
- The janitor (`evictExpiredClientsets`) sweeps expired SSAR entries on the same tick as expired clientsets
- `ResetForTesting` clears the SSAR cache between tests
- 6 new internal tests in `ssar_cache_internal_test.go` covering key format, store/retrieve, expiry, prefix eviction, janitor sweep, and per-token isolation

## Steps to Test

1. `cd backend && go build ./cmd/` -- build passes
2. `cd backend && go test ./pkg/k8cache/ -v -run TestSSAR -count=1` -- all 6 new tests pass
3. `cd backend && go test ./pkg/k8cache/ -count=1` -- full suite passes
4. `cd backend && go vet ./pkg/k8cache/ ./cmd/` -- clean
5. `cd backend && golangci-lint run ./pkg/k8cache/ ./cmd/` -- 0 issues
 
## Notes for Reviewer

- `IsAllowed` signature is unchanged. The cache is fully transparent to callers.
- `ssarMu` is kept separate from `mu` to avoid contention between SSAR lookups and clientset creation. The two locks are never held simultaneously.
- SSAR only gates read operations (GET/list/watch). Mutating verbs (POST/PUT/DELETE) bypass the cache middleware entirely, so a cached auth decision can never authorize a write.
- 30s TTL is conservative relative to the existing 10-minute K8s response cache. Well within an acceptable staleness window for auth decisions.