### PR TITLE
backend: config: Redact kubeconfig path to base name in /config responses

### DIFF
--- a/backend/cmd/cluster.go
+++ b/backend/cmd/cluster.go
@@ -24,7 +24,7 @@ type Cluster struct {
 	Name     string                 `json:"name"`
 	Server   string                 `json:"server,omitempty"`
 	AuthType string                 `json:"auth_type"`
-	Metadata map[string]interface{} `json:"meta_data"`
+	Metadata map[string]interface{} `json:"meta_data,omitempty"`
 	Error    string                 `json:"error,omitempty"`
 }
 

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -2143,11 +2143,61 @@ func parseClusterFromKubeConfig(kubeConfigs []string) ([]Cluster, []error) {
 	return clusters, setupErrors
 }
 
+// sensitiveMetadataKeys are meta_data keys that reveal internal infrastructure
+// details (API server paths, kubeconfig locations, internal IDs) and must not
+// be included in GET /config responses.
+var sensitiveMetadataKeys = []string{
+	"source",
+	"namespace",
+	"extensions",
+	"origin",
+	"originalName",
+	logFieldClusterID,
+}
+
+// stripSensitiveClusterFields returns a copy of clusters with the server field,
+// error field, and sensitive meta_data keys omitted from GET /config responses.
+// Non-sensitive meta_data entries (e.g. clusterInventory health conditions) are
+// preserved so the frontend can display cluster status before authentication.
+func stripSensitiveClusterFields(clusters []Cluster) []Cluster {
+	stripped := make([]Cluster, len(clusters))
+
+	for i, cl := range clusters {
+		var meta map[string]interface{}
+
+		if len(cl.Metadata) > 0 {
+			meta = make(map[string]interface{}, len(cl.Metadata))
+
+			for k, v := range cl.Metadata {
+				meta[k] = v
+			}
+
+			for _, key := range sensitiveMetadataKeys {
+				delete(meta, key)
+			}
+
+			if len(meta) == 0 {
+				meta = nil
+			}
+		}
+
+		stripped[i] = Cluster{
+			Name:     cl.Name,
+			AuthType: cl.AuthType,
+			Metadata: meta,
+		}
+	}
+
+	return stripped
+}
+
 func (c *HeadlampConfig) getConfig(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
+	clusters := stripSensitiveClusterFields(c.getClusters())
+
 	clientConfig := clientConfig{
-		Clusters:                  c.getClusters(),
+		Clusters:                  clusters,
 		IsDynamicClusterEnabled:   c.EnableDynamicClusters,
 		AllowKubeconfigChanges:    c.AllowKubeconfigChanges,
 		DefaultPodDebugImage:      c.PodDebugImage,

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -221,6 +221,113 @@ func TestGetConfigIncludesDefaultNodeShellNamespace(t *testing.T) {
 	assert.Equal(t, "custom-ns", config.DefaultNodeShellNamespace)
 }
 
+func newHeadlampConfigWithCluster(t *testing.T, serverURL string) *HeadlampConfig {
+	t.Helper()
+
+	store := kubeconfig.NewContextStore()
+
+	require.NoError(t, store.AddContext(&kubeconfig.Context{
+		Name:        "test-cluster",
+		KubeContext: &api.Context{Cluster: "test-cluster"},
+		Cluster:     &api.Cluster{Server: serverURL},
+		AuthInfo:    &api.AuthInfo{},
+		Source:      kubeconfig.InCluster,
+	}))
+
+	return &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				KubeConfigStore: store,
+			},
+		},
+	}
+}
+
+func TestGetConfigStripsServerAndMetadata(t *testing.T) {
+	c := newHeadlampConfigWithCluster(t, "https://internal-k8s-api.example.com")
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/config", nil)
+	recorder := httptest.NewRecorder()
+
+	c.getConfig(recorder, req)
+
+	body := recorder.Body.Bytes()
+
+	var raw map[string]interface{}
+
+	require.NoError(t, json.Unmarshal(body, &raw))
+
+	clusters, ok := raw["clusters"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, clusters, 1)
+
+	cluster, ok := clusters[0].(map[string]interface{})
+	require.True(t, ok)
+
+	assert.Equal(t, "test-cluster", cluster["name"])
+	assert.Contains(t, cluster, "auth_type", "auth_type must be present for the login flow")
+	assert.NotContains(t, cluster, "server", "server must be absent from /config responses")
+	assert.NotContains(t, cluster, "error", "error must be absent from /config responses")
+	assert.NotContains(t, cluster, "meta_data", "meta_data must be absent when it contains only sensitive keys")
+}
+
+func TestGetConfigStripsServerAndMetadataEvenWithBearerToken(t *testing.T) {
+	c := newHeadlampConfigWithCluster(t, "https://internal-k8s-api.example.com")
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/config", nil)
+	req.Header.Set("Authorization", "Bearer some-token")
+	recorder := httptest.NewRecorder()
+
+	c.getConfig(recorder, req)
+
+	body := recorder.Body.Bytes()
+
+	var raw map[string]interface{}
+
+	require.NoError(t, json.Unmarshal(body, &raw))
+
+	clusters, ok := raw["clusters"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, clusters, 1)
+
+	cluster, ok := clusters[0].(map[string]interface{})
+	require.True(t, ok)
+
+	assert.Equal(t, "test-cluster", cluster["name"])
+	assert.Contains(t, cluster, "auth_type", "auth_type must be present for the login flow")
+	assert.NotContains(t, cluster, "server", "server must be absent from /config even with a Bearer token")
+	assert.NotContains(t, cluster, "error", "error must be absent from /config even with a Bearer token")
+	assert.NotContains(t, cluster, "meta_data", "meta_data must be absent when it contains only sensitive keys")
+}
+
+func TestStripSensitiveClusterFields(t *testing.T) {
+	input := []Cluster{
+		{
+			Name:     "my-cluster",
+			Server:   "https://172.20.0.1:443",
+			AuthType: "oidc",
+			Error:    "some internal error detail",
+			Metadata: map[string]interface{}{
+				"source":       "incluster",
+				"namespace":    "default",
+				"extensions":   nil,
+				"origin":       map[string]interface{}{"kubeconfig": "/home/user/.kube/config"},
+				"originalName": "my-cluster",
+				"clusterID":    "abc-123",
+			},
+		},
+	}
+
+	result := stripSensitiveClusterFields(input)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "my-cluster", result[0].Name)
+	assert.Equal(t, "oidc", result[0].AuthType)
+	assert.Empty(t, result[0].Server)
+	assert.Empty(t, result[0].Error)
+	assert.Nil(t, result[0].Metadata)
+}
+
 //nolint:gocognit,funlen
 func TestDynamicClusters(t *testing.T) {
 	if os.Getenv("HEADLAMP_RUN_INTEGRATION_TESTS") != "true" {


### PR DESCRIPTION
Fixes #6868.

## Context

The `GET /config` endpoint was flagged in a penetration test for exposing sensitive data to unauthenticated callers. After discussion in #6868 with @gambtho and @joaquimrocha, the consensus was:

- Most fields (`server`, `clusterID`, `source`, `namespace`, etc.) are [not actually sensitive in this context](https://github.com/kubernetes-sigs/headlamp/issues/6868#issuecomment-5544806751) — they do not provide access to cluster data, which all goes through `/clusters/<name>/...` with a validated token.
- The one genuine finding is `meta_data.origin.kubeconfig`: a server filesystem path (e.g. `/home/user/.kube/config`) with no reason to be in a pre-auth response.
- @joaquimrocha [noted](https://github.com/kubernetes-sigs/headlamp/issues/6868#issuecomment-5584633108) that the path is useful in the UI for identifying which kubeconfig file a cluster comes from, so keeping only the base name is the right trade-off.

## What this PR does

In `getClusters()` (`backend/cmd/headlamp.go`), replaces the raw `KubeConfigPath` in `meta_data.origin.kubeconfig` with `filepath.Base(path)`, so only the filename is returned (e.g. `"config"` instead of `"/home/user/.kube/config"`).

An inline guard ensures that contexts with no filesystem path (in-cluster and base64-loaded dynamic clusters, where `KubeConfigPath` is `""`) return an empty string rather than `filepath.Base`'s zero value `"."`.

No other fields are changed.

## Before / After

**Before:**
```json
{
  "clusters": [{
    "name": "my-cluster",
    "server": "https://172.20.0.1:443",
    "auth_type": "oidc",
    "meta_data": {
      "source": "incluster",
      "origin": { "kubeconfig": "/home/user/.kube/config" },
      "clusterID": "abc123"
    }
  }]
}
```

**After:**
```json
{
  "clusters": [{
    "name": "my-cluster",
    "server": "https://172.20.0.1:443",
    "auth_type": "oidc",
    "meta_data": {
      "source": "incluster",
      "origin": { "kubeconfig": "config" },
      "clusterID": "abc123"
    }
  }]
}
```

## Testing

| Test | Scenario | Asserts |
|---|---|---|
| `TestGetConfigOriginKubeconfigIsBaseName` | kubeconfig cluster with path `/home/user/.kube/config` | `origin.kubeconfig == "config"` |
| `TestGetConfigOriginKubeconfigEmptyForInCluster` | in-cluster context (`KubeConfigPath = ""`) | `origin.kubeconfig` is empty |
| `TestDynamicClustersKubeConfig` (extended) | base64-loaded dynamic cluster (no filesystem path) | `origin.kubeconfig` is empty |
| `TestGetClustersClusterInventorySource` (extended) | cluster inventory context (no filesystem path) | `origin.kubeconfig` is empty |