### PR TITLE
fix(api): fix WebSocket unmount race condition and connection leaks

### DIFF
--- a/frontend/src/lib/k8s/api/v2/multiplexer.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.ts
@@ -192,19 +192,41 @@ export const WebSocketManager = {
     }
 
     // Establish connection and send REQUEST
-    const socket = await this.connect();
-    const userId = getUserIdFromLocalStorage();
-    const requestMsg: WebSocketMessage = {
-      clusterId,
-      path,
-      query,
-      userId: userId || '',
-      type: 'REQUEST',
-    };
-    socket.send(JSON.stringify(requestMsg));
+    try {
+      const socket = await this.connect();
+      const userId = getUserIdFromLocalStorage();
+      const requestMsg: WebSocketMessage = {
+        clusterId,
+        path,
+        query,
+        userId: userId || '',
+        type: 'REQUEST',
+      };
+      socket.send(JSON.stringify(requestMsg));
 
-    // Return cleanup function
-    return () => this.unsubscribe(key, clusterId, path, query, onMessage, onError);
+      // Return cleanup function
+      return () => this.unsubscribe(key, clusterId, path, query, onMessage, onError);
+    } catch (err) {
+      // Clean up orphaned listeners if connection fails
+      this.activeSubscriptions.delete(key);
+      const msgListeners = this.listeners.get(key);
+      if (msgListeners) {
+        msgListeners.delete(onMessage);
+        if (msgListeners.size === 0) {
+          this.listeners.delete(key);
+        }
+      }
+      if (onError) {
+        const errListeners = this.errorListeners.get(key);
+        if (errListeners) {
+          errListeners.delete(onError);
+          if (errListeners.size === 0) {
+            this.errorListeners.delete(key);
+          }
+        }
+      }
+      throw err;
+    }
   },
 
   /**

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -305,6 +305,7 @@ function useWatchKubeObjectListsMultiplexed<K extends KubeObject>({
       return;
     }
 
+    let isCancelled = false;
     const cleanups: (() => void)[] = [];
 
     // Create subscriptions for each connection
@@ -319,7 +320,13 @@ function useWatchKubeObjectListsMultiplexed<K extends KubeObject>({
         update => handleUpdate(update, cluster, namespace),
         error => console.error(`WebSocket subscription error for cluster ${cluster}:`, error)
       ).then(
-        cleanup => cleanups.push(cleanup),
+        cleanup => {
+          if (isCancelled) {
+            cleanup();
+          } else {
+            cleanups.push(cleanup);
+          }
+        },
         error => {
           // Track retry count in the URL's searchParams
           const retryCount = parseInt(parsedUrl.searchParams.get('retryCount') || '0');
@@ -334,6 +341,7 @@ function useWatchKubeObjectListsMultiplexed<K extends KubeObject>({
 
     // Cleanup subscriptions when effect re-runs or unmounts
     return () => {
+      isCancelled = true;
       cleanups.forEach(cleanup => cleanup());
     };
   }, [connections, enabled, endpoint, handleUpdate]);


### PR DESCRIPTION
Fixes #6861. This PR resolves a complex race condition during component unmounts that resulted in orphaned WebSocket subscriptions, memory leaks, and excessive backend watch queries.

1. **useKubeObjectList.ts**: Added an `isCancelled` guard to the `useEffect` cleanup function so that if the component unmounts while `WebSocketManager.subscribe()` is pending, it correctly cleans up the subscription as soon as the promise resolves rather than dropping it into an orphaned closure.
2. **multiplexer.ts**: Wrapped `this.connect()` in a `try...catch` block to ensure that optimistically registered listeners and active subscriptions are properly purged if the connection fails or rejects.