### PR TITLE
fix(backend): add X-Frame-Options and Content-Security-Policy headers

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -569,6 +569,14 @@ func setupInClusterContext(config *HeadlampConfig) {
 	}
 }
 
+func securityHeadersMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("Content-Security-Policy", "frame-ancestors 'none'")
+		next.ServeHTTP(w, r)
+	})
+}
+
 //nolint:gocognit,funlen,gocyclo
 func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Handler {
 	kubeConfigPath := config.KubeConfigPath
@@ -645,6 +653,8 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		baseRoute := mux.NewRouter()
 		r = baseRoute.PathPrefix(config.BaseURL).Subrouter()
 	}
+
+	r.Use(securityHeadersMiddleware)
 
 	logger.Log(logger.LevelInfo, nil, nil, "*** Headlamp Server ***")
 	logger.Log(logger.LevelInfo, nil, nil, "  API Routers:")

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -4158,3 +4158,27 @@ func TestExternalProxyOversizeResponseGzip(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, int(maxProxyResponseSize), rr.Body.Len())
 }
+
+func TestSecurityHeadersMiddleware(t *testing.T) {
+	cache := cache.New[interface{}]()
+	kubeConfigStore := kubeconfig.NewContextStore()
+
+	handler := createHeadlampHandler(context.Background(), &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:    false,
+				KubeConfigStore: kubeConfigStore,
+			},
+			Cache: cache,
+		},
+	})
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/config", nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, "DENY", rr.Header().Get("X-Frame-Options"))
+	assert.Equal(t, "frame-ancestors 'none'", rr.Header().Get("Content-Security-Policy"))
+}


### PR DESCRIPTION
Fixes #6870. This PR adds a new `securityHeadersMiddleware` to the main backend router to protect the application (including the OIDC login flow) from clickjacking attacks.

1. **`backend/cmd/headlamp.go`**: Created `securityHeadersMiddleware` and applied it to the root `mux.Router`.
2. **`backend/cmd/headlamp_test.go`**: Added `TestSecurityHeadersMiddleware` to assert that the `X-Frame-Options: DENY` and `Content-Security-Policy: frame-ancestors 'none'` headers are correctly returned on all endpoints.