### PR TITLE
frontend: prevent partial project deletion with mixed RBAC

### DIFF
--- a/frontend/src/components/project/ProjectDeleteButton.test.tsx
+++ b/frontend/src/components/project/ProjectDeleteButton.test.tsx
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockUseList } = vi.hoisted(() => ({
+  mockUseList: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/namespace', () => ({
+  __esModule: true,
+  default: {
+    useList: mockUseList,
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('../common/ActionButton', () => ({
+  __esModule: true,
+  default: ({ description, onClick }: { description: string; onClick: () => void }) => (
+    <button onClick={onClick}>{description}</button>
+  ),
+}));
+
+vi.mock('./ProjectDeleteDialog', () => ({
+  ProjectDeleteDialog: ({
+    open,
+    canDeleteNamespaces,
+  }: {
+    open: boolean;
+    canDeleteNamespaces: boolean;
+  }) =>
+    open ? (
+      <div data-testid="delete-dialog" data-can-delete-namespaces={canDeleteNamespaces} />
+    ) : null,
+}));
+
+import { ProjectDeleteButton } from './ProjectDeleteButton';
+
+type NamespacePermissions = {
+  update: boolean;
+  delete: boolean;
+};
+
+function makeNamespace(name: string, permissions: NamespacePermissions, cluster = 'cluster-a') {
+  return {
+    cluster,
+    metadata: { name },
+    getAuthorization: vi.fn((verb: keyof NamespacePermissions) =>
+      Promise.resolve({
+        status: {
+          allowed: permissions[verb],
+        },
+      })
+    ),
+  };
+}
+
+function renderButton(
+  namespaces: ReturnType<typeof makeNamespace>[],
+  queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+) {
+  mockUseList.mockReturnValue([namespaces]);
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ProjectDeleteButton
+        project={{
+          id: 'test-project',
+          namespaces: namespaces.map(namespace => namespace.metadata.name),
+          clusters: ['cluster-a'],
+        }}
+      />
+    </QueryClientProvider>
+  );
+}
+
+describe('ProjectDeleteButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the action when every namespace can be updated', async () => {
+    const namespaces = [
+      makeNamespace('ns1', { update: true, delete: true }),
+      makeNamespace('ns2', { update: true, delete: true }),
+    ];
+
+    renderButton(namespaces);
+
+    expect(await screen.findByRole('button', { name: 'Delete project' })).toBeInTheDocument();
+    expect(namespaces[0].getAuthorization).toHaveBeenCalledWith('update');
+    expect(namespaces[1].getAuthorization).toHaveBeenCalledWith('update');
+  });
+
+  it('hides the action when any namespace cannot be updated', async () => {
+    const namespaces = [
+      makeNamespace('ns1', { update: true, delete: true }),
+      makeNamespace('ns2', { update: false, delete: true }),
+    ];
+
+    renderButton(namespaces);
+
+    await waitFor(() => {
+      expect(namespaces[0].getAuthorization).toHaveBeenCalledWith('update');
+      expect(namespaces[1].getAuthorization).toHaveBeenCalledWith('update');
+    });
+
+    expect(namespaces[0].getAuthorization).not.toHaveBeenCalledWith('delete');
+    expect(namespaces[1].getAuthorization).not.toHaveBeenCalledWith('delete');
+    expect(screen.queryByRole('button', { name: 'Delete project' })).not.toBeInTheDocument();
+  });
+
+  it('hides the action while update authorization is loading', async () => {
+    let resolveAuthorization: (value: { status: { allowed: boolean } }) => void = () => {};
+    const pendingAuthorization = new Promise<{ status: { allowed: boolean } }>(resolve => {
+      resolveAuthorization = resolve;
+    });
+    const namespace = makeNamespace('ns1', { update: true, delete: true });
+    namespace.getAuthorization.mockImplementation(verb =>
+      verb === 'update'
+        ? pendingAuthorization
+        : Promise.resolve({
+            status: {
+              allowed: true,
+            },
+          })
+    );
+
+    renderButton([namespace]);
+
+    await waitFor(() => {
+      expect(namespace.getAuthorization).toHaveBeenCalledWith('update');
+    });
+    expect(screen.queryByRole('button', { name: 'Delete project' })).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolveAuthorization({ status: { allowed: true } });
+    });
+    expect(await screen.findByRole('button', { name: 'Delete project' })).toBeInTheDocument();
+  });
+
+  it('hides the action when an update authorization check fails', async () => {
+    const namespace = makeNamespace('ns1', { update: true, delete: true });
+    namespace.getAuthorization.mockImplementation(verb =>
+      verb === 'update'
+        ? Promise.reject(new Error('Authorization check failed'))
+        : Promise.resolve({
+            status: {
+              allowed: true,
+            },
+          })
+    );
+
+    renderButton([namespace]);
+
+    await waitFor(() => {
+      expect(namespace.getAuthorization).toHaveBeenCalledWith('update');
+    });
+    expect(screen.queryByRole('button', { name: 'Delete project' })).not.toBeInTheDocument();
+  });
+
+  it('only enables namespace deletion when every namespace can be deleted', async () => {
+    const namespaces = [
+      makeNamespace('ns1', { update: true, delete: true }),
+      makeNamespace('ns2', { update: true, delete: false }),
+    ];
+
+    renderButton(namespaces);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete project' }));
+
+    await waitFor(() => {
+      expect(namespaces[0].getAuthorization).toHaveBeenCalledWith('delete');
+      expect(namespaces[1].getAuthorization).toHaveBeenCalledWith('delete');
+    });
+
+    expect(screen.getByTestId('delete-dialog')).toHaveAttribute(
+      'data-can-delete-namespaces',
+      'false'
+    );
+  });
+
+  it('checks delete authorization after the dialog is opened', async () => {
+    const namespaces = [
+      makeNamespace('ns1', { update: true, delete: true }),
+      makeNamespace('ns2', { update: true, delete: true }),
+    ];
+
+    renderButton(namespaces);
+
+    const deleteButton = await screen.findByRole('button', { name: 'Delete project' });
+
+    expect(namespaces[0].getAuthorization).not.toHaveBeenCalledWith('delete');
+    expect(namespaces[1].getAuthorization).not.toHaveBeenCalledWith('delete');
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(namespaces[0].getAuthorization).toHaveBeenCalledWith('delete');
+      expect(namespaces[1].getAuthorization).toHaveBeenCalledWith('delete');
+      expect(screen.getByTestId('delete-dialog')).toHaveAttribute(
+        'data-can-delete-namespaces',
+        'true'
+      );
+    });
+  });
+
+  it('keeps namespace deletion disabled while a fresh delete authorization check is pending', async () => {
+    const namespaces = [
+      makeNamespace('ns1', { update: true, delete: true }),
+      makeNamespace('ns2', { update: true, delete: true }),
+    ];
+
+    let resolveDelete: (value: { status: { allowed: boolean } }) => void = () => {};
+    const pendingDelete = new Promise<{ status: { allowed: boolean } }>(resolve => {
+      resolveDelete = resolve;
+    });
+
+    namespaces.forEach(namespace => {
+      namespace.getAuthorization.mockImplementation(verb =>
+        verb === 'delete' ? pendingDelete : Promise.resolve({ status: { allowed: true } })
+      );
+    });
+
+    renderButton(namespaces);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete project' }));
+
+    await waitFor(() => {
+      expect(namespaces[0].getAuthorization).toHaveBeenCalledWith('delete');
+      expect(namespaces[1].getAuthorization).toHaveBeenCalledWith('delete');
+    });
+
+    expect(screen.getByTestId('delete-dialog')).toHaveAttribute(
+      'data-can-delete-namespaces',
+      'false'
+    );
+
+    await act(async () => {
+      resolveDelete({ status: { allowed: true } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('delete-dialog')).toHaveAttribute(
+        'data-can-delete-namespaces',
+        'true'
+      );
+    });
+  });
+
+  it('keeps namespace deletion disabled when a delete authorization check fails', async () => {
+    const namespace = makeNamespace('ns1', { update: true, delete: true });
+    namespace.getAuthorization.mockImplementation(verb =>
+      verb === 'delete'
+        ? Promise.reject(new Error('Authorization check failed'))
+        : Promise.resolve({
+            status: {
+              allowed: true,
+            },
+          })
+    );
+
+    renderButton([namespace]);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete project' }));
+
+    await waitFor(() => {
+      expect(namespace.getAuthorization).toHaveBeenCalledWith('delete');
+    });
+    expect(screen.getByTestId('delete-dialog')).toHaveAttribute(
+      'data-can-delete-namespaces',
+      'false'
+    );
+  });
+});

--- a/frontend/src/components/project/ProjectDeleteButton.test.tsx
+++ b/frontend/src/components/project/ProjectDeleteButton.test.tsx
@@ -131,6 +131,9 @@ describe('ProjectDeleteButton', () => {
       expect(namespaces[0].getAuthorization).toHaveBeenCalledWith('update');
       expect(namespaces[1].getAuthorization).toHaveBeenCalledWith('update');
     });
+
+    expect(namespaces[0].getAuthorization).not.toHaveBeenCalledWith('delete');
+    expect(namespaces[1].getAuthorization).not.toHaveBeenCalledWith('delete');
     expect(screen.queryByRole('button', { name: 'Delete project' })).not.toBeInTheDocument();
   });
 
@@ -199,7 +202,7 @@ describe('ProjectDeleteButton', () => {
     );
   });
 
-  it('enables namespace deletion when every namespace can be deleted', async () => {
+  it('checks delete authorization after the dialog is opened', async () => {
     const namespaces = [
       makeNamespace('ns1', { update: true, delete: true }),
       makeNamespace('ns2', { update: true, delete: true }),
@@ -207,9 +210,16 @@ describe('ProjectDeleteButton', () => {
 
     renderButton(namespaces);
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Delete project' }));
+    const deleteButton = await screen.findByRole('button', { name: 'Delete project' });
+
+    expect(namespaces[0].getAuthorization).not.toHaveBeenCalledWith('delete');
+    expect(namespaces[1].getAuthorization).not.toHaveBeenCalledWith('delete');
+
+    fireEvent.click(deleteButton);
 
     await waitFor(() => {
+      expect(namespaces[0].getAuthorization).toHaveBeenCalledWith('delete');
+      expect(namespaces[1].getAuthorization).toHaveBeenCalledWith('delete');
       expect(screen.getByTestId('delete-dialog')).toHaveAttribute(
         'data-can-delete-namespaces',
         'true'

--- a/frontend/src/components/project/ProjectDeleteButton.test.tsx
+++ b/frontend/src/components/project/ProjectDeleteButton.test.tsx
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockUseList } = vi.hoisted(() => ({
+  mockUseList: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/namespace', () => ({
+  __esModule: true,
+  default: {
+    useList: mockUseList,
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('../common/ActionButton', () => ({
+  __esModule: true,
+  default: ({ description, onClick }: { description: string; onClick: () => void }) => (
+    <button onClick={onClick}>{description}</button>
+  ),
+}));
+
+vi.mock('./ProjectDeleteDialog', () => ({
+  ProjectDeleteDialog: ({
+    open,
+    canDeleteNamespaces,
+  }: {
+    open: boolean;
+    canDeleteNamespaces: boolean;
+  }) =>
+    open ? (
+      <div data-testid="delete-dialog" data-can-delete-namespaces={canDeleteNamespaces} />
+    ) : null,
+}));
+
+import { ProjectDeleteButton } from './ProjectDeleteButton';
+
+type NamespacePermissions = {
+  update: boolean;
+  delete: boolean;
+};
+
+function makeNamespace(name: string, permissions: NamespacePermissions, cluster = 'cluster-a') {
+  return {
+    cluster,
+    metadata: { name },
+    getAuthorization: vi.fn((verb: keyof NamespacePermissions) =>
+      Promise.resolve({
+        status: {
+          allowed: permissions[verb],
+        },
+      })
+    ),
+  };
+}
+
+function renderButton(namespaces: ReturnType<typeof makeNamespace>[]) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  mockUseList.mockReturnValue([namespaces]);
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ProjectDeleteButton
+        project={{
+          id: 'test-project',
+          namespaces: namespaces.map(namespace => namespace.metadata.name),
+          clusters: ['cluster-a'],
+        }}
+      />
+    </QueryClientProvider>
+  );
+}
+
+describe('ProjectDeleteButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the action when every namespace can be updated', async () => {
+    const namespaces = [
+      makeNamespace('ns1', { update: true, delete: true }),
+      makeNamespace('ns2', { update: true, delete: true }),
+    ];
+
+    renderButton(namespaces);
+
+    expect(await screen.findByRole('button', { name: 'Delete project' })).toBeInTheDocument();
+    expect(namespaces[0].getAuthorization).toHaveBeenCalledWith('update');
+    expect(namespaces[1].getAuthorization).toHaveBeenCalledWith('update');
+  });
+
+  it('hides the action when any namespace cannot be updated', async () => {
+    const namespaces = [
+      makeNamespace('ns1', { update: true, delete: true }),
+      makeNamespace('ns2', { update: false, delete: true }),
+    ];
+
+    renderButton(namespaces);
+
+    await waitFor(() => {
+      expect(namespaces[0].getAuthorization).toHaveBeenCalledWith('update');
+      expect(namespaces[1].getAuthorization).toHaveBeenCalledWith('update');
+    });
+    expect(screen.queryByRole('button', { name: 'Delete project' })).not.toBeInTheDocument();
+  });
+
+  it('hides the action while update authorization is loading', async () => {
+    let resolveAuthorization: (value: { status: { allowed: boolean } }) => void = () => {};
+    const pendingAuthorization = new Promise<{ status: { allowed: boolean } }>(resolve => {
+      resolveAuthorization = resolve;
+    });
+    const namespace = makeNamespace('ns1', { update: true, delete: true });
+    namespace.getAuthorization.mockImplementation(verb =>
+      verb === 'update'
+        ? pendingAuthorization
+        : Promise.resolve({
+            status: {
+              allowed: true,
+            },
+          })
+    );
+
+    renderButton([namespace]);
+
+    await waitFor(() => {
+      expect(namespace.getAuthorization).toHaveBeenCalledWith('update');
+    });
+    expect(screen.queryByRole('button', { name: 'Delete project' })).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolveAuthorization({ status: { allowed: true } });
+    });
+    expect(await screen.findByRole('button', { name: 'Delete project' })).toBeInTheDocument();
+  });
+
+  it('hides the action when an update authorization check fails', async () => {
+    const namespace = makeNamespace('ns1', { update: true, delete: true });
+    namespace.getAuthorization.mockImplementation(verb =>
+      verb === 'update'
+        ? Promise.reject(new Error('Authorization check failed'))
+        : Promise.resolve({
+            status: {
+              allowed: true,
+            },
+          })
+    );
+
+    renderButton([namespace]);
+
+    await waitFor(() => {
+      expect(namespace.getAuthorization).toHaveBeenCalledWith('update');
+    });
+    expect(screen.queryByRole('button', { name: 'Delete project' })).not.toBeInTheDocument();
+  });
+
+  it('only enables namespace deletion when every namespace can be deleted', async () => {
+    const namespaces = [
+      makeNamespace('ns1', { update: true, delete: true }),
+      makeNamespace('ns2', { update: true, delete: false }),
+    ];
+
+    renderButton(namespaces);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete project' }));
+
+    expect(screen.getByTestId('delete-dialog')).toHaveAttribute(
+      'data-can-delete-namespaces',
+      'false'
+    );
+  });
+
+  it('enables namespace deletion when every namespace can be deleted', async () => {
+    const namespaces = [
+      makeNamespace('ns1', { update: true, delete: true }),
+      makeNamespace('ns2', { update: true, delete: true }),
+    ];
+
+    renderButton(namespaces);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete project' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('delete-dialog')).toHaveAttribute(
+        'data-can-delete-namespaces',
+        'true'
+      );
+    });
+  });
+
+  it('keeps namespace deletion disabled when a delete authorization check fails', async () => {
+    const namespace = makeNamespace('ns1', { update: true, delete: true });
+    namespace.getAuthorization.mockImplementation(verb =>
+      verb === 'delete'
+        ? Promise.reject(new Error('Authorization check failed'))
+        : Promise.resolve({
+            status: {
+              allowed: true,
+            },
+          })
+    );
+
+    renderButton([namespace]);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete project' }));
+
+    await waitFor(() => {
+      expect(namespace.getAuthorization).toHaveBeenCalledWith('delete');
+    });
+    expect(screen.getByTestId('delete-dialog')).toHaveAttribute(
+      'data-can-delete-namespaces',
+      'false'
+    );
+  });
+});

--- a/frontend/src/components/project/ProjectDeleteButton.tsx
+++ b/frontend/src/components/project/ProjectDeleteButton.tsx
@@ -27,18 +27,25 @@ interface ProjectDeleteButtonProps {
   buttonStyle?: ButtonStyle;
 }
 
-function useAllNamespacesAuthorized(namespaces: Namespace[], authVerb: 'update' | 'delete') {
+function useAllNamespacesAuthorized(
+  namespaces: Namespace[],
+  authVerb: 'update' | 'delete',
+  enabled = true
+) {
   const authQueries = useQueries({
     queries: namespaces.map(namespace => ({
       queryKey: ['projectDelete:auth', authVerb, namespace.cluster, namespace.metadata.name],
       queryFn: () => namespace.getAuthorization(authVerb),
+      enabled,
     })),
   });
 
   return {
     allAuthorized:
-      namespaces.length > 0 && authQueries.every(query => query.data?.status?.allowed === true),
-    isLoading: authQueries.some(query => query.isLoading),
+      enabled &&
+      namespaces.length > 0 &&
+      authQueries.every(query => query.data?.status?.allowed === true),
+    isLoading: enabled && authQueries.some(query => query.isLoading),
   };
 }
 
@@ -50,7 +57,11 @@ export function ProjectDeleteButton({ project, buttonStyle }: ProjectDeleteButto
   const projectNamespaces =
     namespaces?.filter(ns => project.namespaces.includes(ns.metadata.name)) ?? [];
   const updateAuthorization = useAllNamespacesAuthorized(projectNamespaces, 'update');
-  const deleteAuthorization = useAllNamespacesAuthorized(projectNamespaces, 'delete');
+  const deleteAuthorization = useAllNamespacesAuthorized(
+    projectNamespaces,
+    'delete',
+    openDialog && updateAuthorization.allAuthorized
+  );
 
   // Project deletion affects every namespace, so only expose the action after
   // update authorization has been confirmed for every target namespace.

--- a/frontend/src/components/project/ProjectDeleteButton.tsx
+++ b/frontend/src/components/project/ProjectDeleteButton.tsx
@@ -14,17 +14,48 @@
  * limitations under the License.
  */
 
+import { useQueries } from '@tanstack/react-query';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Namespace from '../../lib/k8s/namespace';
 import { ProjectDefinition } from '../../redux/projectsSlice';
 import ActionButton, { ButtonStyle } from '../common/ActionButton';
-import AuthVisible from '../common/Resource/AuthVisible';
 import { ProjectDeleteDialog } from './ProjectDeleteDialog';
 
 interface ProjectDeleteButtonProps {
   project: ProjectDefinition;
   buttonStyle?: ButtonStyle;
+}
+
+function useAllNamespacesAuthorized(
+  namespaces: Namespace[],
+  authVerb: 'update' | 'delete',
+  enabled = true
+) {
+  const authQueries = useQueries({
+    queries: namespaces.map(namespace => ({
+      queryKey: ['projectDelete:auth', authVerb, namespace.cluster, namespace.metadata.name],
+      queryFn: () => namespace.getAuthorization(authVerb),
+      enabled,
+      staleTime: 0,
+      refetchOnMount: 'always' as const,
+    })),
+  });
+
+  const hasPendingChecks = authQueries.some(
+    query => query.isLoading || query.isFetching || query.status === 'pending'
+  );
+  const hasFailedChecks = authQueries.some(query => query.isError);
+
+  return {
+    allAuthorized:
+      enabled &&
+      namespaces.length > 0 &&
+      !hasPendingChecks &&
+      !hasFailedChecks &&
+      authQueries.every(query => query.data?.status?.allowed === true),
+    isLoading: enabled && hasPendingChecks,
+  };
 }
 
 export function ProjectDeleteButton({ project, buttonStyle }: ProjectDeleteButtonProps) {
@@ -34,14 +65,25 @@ export function ProjectDeleteButton({ project, buttonStyle }: ProjectDeleteButto
 
   const projectNamespaces =
     namespaces?.filter(ns => project.namespaces.includes(ns.metadata.name)) ?? [];
+  const updateAuthorization = useAllNamespacesAuthorized(projectNamespaces, 'update');
+  const deleteAuthorization = useAllNamespacesAuthorized(
+    projectNamespaces,
+    'delete',
+    openDialog && !updateAuthorization.isLoading && updateAuthorization.allAuthorized
+  );
 
-  // Don't show the button if there are no namespaces for this project
-  if (projectNamespaces.length === 0) {
+  // Project deletion affects every namespace, so only expose the action after
+  // update authorization has been confirmed for every target namespace.
+  if (
+    projectNamespaces.length === 0 ||
+    updateAuthorization.isLoading ||
+    !updateAuthorization.allAuthorized
+  ) {
     return null;
   }
 
   return (
-    <AuthVisible item={projectNamespaces[0]} authVerb="update">
+    <>
       <ActionButton
         description={t('Delete project')}
         buttonStyle={buttonStyle}
@@ -53,7 +95,8 @@ export function ProjectDeleteButton({ project, buttonStyle }: ProjectDeleteButto
         project={project}
         onClose={() => setOpenDialog(false)}
         namespaces={projectNamespaces}
+        canDeleteNamespaces={deleteAuthorization.allAuthorized}
       />
-    </AuthVisible>
+    </>
   );
 }

--- a/frontend/src/components/project/ProjectDeleteButton.tsx
+++ b/frontend/src/components/project/ProjectDeleteButton.tsx
@@ -14,17 +14,32 @@
  * limitations under the License.
  */
 
+import { useQueries } from '@tanstack/react-query';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Namespace from '../../lib/k8s/namespace';
 import { ProjectDefinition } from '../../redux/projectsSlice';
 import ActionButton, { ButtonStyle } from '../common/ActionButton';
-import AuthVisible from '../common/Resource/AuthVisible';
 import { ProjectDeleteDialog } from './ProjectDeleteDialog';
 
 interface ProjectDeleteButtonProps {
   project: ProjectDefinition;
   buttonStyle?: ButtonStyle;
+}
+
+function useAllNamespacesAuthorized(namespaces: Namespace[], authVerb: 'update' | 'delete') {
+  const authQueries = useQueries({
+    queries: namespaces.map(namespace => ({
+      queryKey: ['projectDelete:auth', authVerb, namespace.cluster, namespace.metadata.name],
+      queryFn: () => namespace.getAuthorization(authVerb),
+    })),
+  });
+
+  return {
+    allAuthorized:
+      namespaces.length > 0 && authQueries.every(query => query.data?.status?.allowed === true),
+    isLoading: authQueries.some(query => query.isLoading),
+  };
 }
 
 export function ProjectDeleteButton({ project, buttonStyle }: ProjectDeleteButtonProps) {
@@ -34,14 +49,21 @@ export function ProjectDeleteButton({ project, buttonStyle }: ProjectDeleteButto
 
   const projectNamespaces =
     namespaces?.filter(ns => project.namespaces.includes(ns.metadata.name)) ?? [];
+  const updateAuthorization = useAllNamespacesAuthorized(projectNamespaces, 'update');
+  const deleteAuthorization = useAllNamespacesAuthorized(projectNamespaces, 'delete');
 
-  // Don't show the button if there are no namespaces for this project
-  if (projectNamespaces.length === 0) {
+  // Project deletion affects every namespace, so only expose the action after
+  // update authorization has been confirmed for every target namespace.
+  if (
+    projectNamespaces.length === 0 ||
+    updateAuthorization.isLoading ||
+    !updateAuthorization.allAuthorized
+  ) {
     return null;
   }
 
   return (
-    <AuthVisible item={projectNamespaces[0]} authVerb="update">
+    <>
       <ActionButton
         description={t('Delete project')}
         buttonStyle={buttonStyle}
@@ -53,7 +75,8 @@ export function ProjectDeleteButton({ project, buttonStyle }: ProjectDeleteButto
         project={project}
         onClose={() => setOpenDialog(false)}
         namespaces={projectNamespaces}
+        canDeleteNamespaces={deleteAuthorization.allAuthorized}
       />
-    </AuthVisible>
+    </>
   );
 }

--- a/frontend/src/components/project/ProjectDeleteDialog.test.tsx
+++ b/frontend/src/components/project/ProjectDeleteDialog.test.tsx
@@ -66,11 +66,6 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
-vi.mock('../common/Resource/AuthVisible', () => ({
-  __esModule: true,
-  default: ({ children }: any) => <div>{children}</div>,
-}));
-
 import { TestContext } from '../../test';
 import { ProjectDeleteDialog } from './ProjectDeleteDialog';
 import { PROJECT_ID_LABEL } from './projectUtils';
@@ -111,6 +106,7 @@ describe('ProjectDeleteDialog', () => {
           project={mockProject}
           onClose={mockOnClose}
           namespaces={makeMockNamespaces()}
+          canDeleteNamespaces
         />
       </TestContext>
     );
@@ -130,6 +126,7 @@ describe('ProjectDeleteDialog', () => {
           project={mockProject}
           onClose={mockOnClose}
           namespaces={makeMockNamespaces()}
+          canDeleteNamespaces
         />
       </TestContext>
     );
@@ -154,6 +151,7 @@ describe('ProjectDeleteDialog', () => {
           project={mockProject}
           onClose={mockOnClose}
           namespaces={namespaces}
+          canDeleteNamespaces
         />
       </TestContext>
     );
@@ -196,6 +194,7 @@ describe('ProjectDeleteDialog', () => {
           project={mockProject}
           onClose={mockOnClose}
           namespaces={namespaces}
+          canDeleteNamespaces
         />
       </TestContext>
     );
@@ -226,6 +225,7 @@ describe('ProjectDeleteDialog', () => {
           project={mockProject}
           onClose={mockOnClose}
           namespaces={makeMockNamespaces()}
+          canDeleteNamespaces
         />
       </TestContext>
     );
@@ -235,5 +235,70 @@ describe('ProjectDeleteDialog', () => {
     fireEvent.click(screen.getByRole('checkbox', { name: /also delete the namespaces/i }));
 
     expect(screen.getByText(/This action cannot be undone/i)).toBeInTheDocument();
+  });
+
+  test('hides namespace deletion option when not authorized for every namespace', () => {
+    render(
+      <TestContext>
+        <ProjectDeleteDialog
+          open
+          project={mockProject}
+          onClose={mockOnClose}
+          namespaces={makeMockNamespaces()}
+          canDeleteNamespaces={false}
+        />
+      </TestContext>
+    );
+
+    expect(
+      screen.queryByRole('checkbox', { name: /also delete the namespaces/i })
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete Project' })).toBeInTheDocument();
+  });
+
+  test('does not delete namespaces when delete authorization is lost before confirmation', async () => {
+    let capturedActionFn: (() => Promise<void>) | null = null;
+    mockClusterAction.mockImplementation((actionFn: () => Promise<void>) => {
+      capturedActionFn = actionFn;
+      return { type: 'clusterAction/mock' };
+    });
+
+    const namespaces = makeMockNamespaces();
+    const { rerender } = render(
+      <TestContext>
+        <ProjectDeleteDialog
+          open
+          project={mockProject}
+          onClose={mockOnClose}
+          namespaces={namespaces}
+          canDeleteNamespaces
+        />
+      </TestContext>
+    );
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /also delete the namespaces/i }));
+
+    rerender(
+      <TestContext>
+        <ProjectDeleteDialog
+          open
+          project={mockProject}
+          onClose={mockOnClose}
+          namespaces={namespaces}
+          canDeleteNamespaces={false}
+        />
+      </TestContext>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Project' }));
+
+    if (capturedActionFn) {
+      await (capturedActionFn as () => Promise<void>)();
+    }
+
+    expect(namespaces[0].update).toHaveBeenCalled();
+    expect(namespaces[1].update).toHaveBeenCalled();
+    expect(namespaces[0].delete).not.toHaveBeenCalled();
+    expect(namespaces[1].delete).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/project/ProjectDeleteDialog.test.tsx
+++ b/frontend/src/components/project/ProjectDeleteDialog.test.tsx
@@ -112,6 +112,7 @@ describe('ProjectDeleteDialog', () => {
           project={mockProject}
           onClose={mockOnClose}
           namespaces={makeMockNamespaces()}
+          canDeleteNamespaces
         />
       </TestContext>
     );
@@ -131,6 +132,7 @@ describe('ProjectDeleteDialog', () => {
           project={mockProject}
           onClose={mockOnClose}
           namespaces={makeMockNamespaces()}
+          canDeleteNamespaces
         />
       </TestContext>
     );
@@ -155,6 +157,7 @@ describe('ProjectDeleteDialog', () => {
           project={mockProject}
           onClose={mockOnClose}
           namespaces={namespaces}
+          canDeleteNamespaces
         />
       </TestContext>
     );
@@ -197,6 +200,7 @@ describe('ProjectDeleteDialog', () => {
           project={mockProject}
           onClose={mockOnClose}
           namespaces={namespaces}
+          canDeleteNamespaces
         />
       </TestContext>
     );
@@ -229,6 +233,7 @@ describe('ProjectDeleteDialog', () => {
           project={mockProject}
           onClose={mockOnClose}
           namespaces={makeMockNamespaces()}
+          canDeleteNamespaces
         />
       </TestContext>
     );
@@ -257,6 +262,7 @@ describe('ProjectDeleteDialog', () => {
           project={mockProject}
           onClose={mockOnClose}
           namespaces={makeMockNamespaces()}
+          canDeleteNamespaces
         />
       </TestContext>
     );
@@ -284,6 +290,7 @@ describe('ProjectDeleteDialog', () => {
           project={mockProject}
           onClose={mockOnClose}
           namespaces={makeMockNamespaces()}
+          canDeleteNamespaces
         />
       </TestContext>
     );
@@ -293,5 +300,70 @@ describe('ProjectDeleteDialog', () => {
     fireEvent.click(screen.getByRole('checkbox', { name: /also delete the namespaces/i }));
 
     expect(screen.getByText(/This action cannot be undone/i)).toBeInTheDocument();
+  });
+
+  test('hides namespace deletion option when not authorized for every namespace', () => {
+    render(
+      <TestContext>
+        <ProjectDeleteDialog
+          open
+          project={mockProject}
+          onClose={mockOnClose}
+          namespaces={makeMockNamespaces()}
+          canDeleteNamespaces={false}
+        />
+      </TestContext>
+    );
+
+    expect(
+      screen.queryByRole('checkbox', { name: /also delete the namespaces/i })
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete Project' })).toBeInTheDocument();
+  });
+
+  test('does not delete namespaces when delete authorization is lost before confirmation', async () => {
+    let capturedActionFn: (() => Promise<void>) | null = null;
+    mockClusterAction.mockImplementation((actionFn: () => Promise<void>) => {
+      capturedActionFn = actionFn;
+      return { type: 'clusterAction/mock' };
+    });
+
+    const namespaces = makeMockNamespaces();
+    const { rerender } = render(
+      <TestContext>
+        <ProjectDeleteDialog
+          open
+          project={mockProject}
+          onClose={mockOnClose}
+          namespaces={namespaces}
+          canDeleteNamespaces
+        />
+      </TestContext>
+    );
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /also delete the namespaces/i }));
+
+    rerender(
+      <TestContext>
+        <ProjectDeleteDialog
+          open
+          project={mockProject}
+          onClose={mockOnClose}
+          namespaces={namespaces}
+          canDeleteNamespaces={false}
+        />
+      </TestContext>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Project' }));
+
+    if (capturedActionFn) {
+      await (capturedActionFn as () => Promise<void>)();
+    }
+
+    expect(namespaces[0].update).toHaveBeenCalled();
+    expect(namespaces[1].update).toHaveBeenCalled();
+    expect(namespaces[0].delete).not.toHaveBeenCalled();
+    expect(namespaces[1].delete).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/project/ProjectDeleteDialog.tsx
+++ b/frontend/src/components/project/ProjectDeleteDialog.tsx
@@ -33,7 +33,6 @@ import { EventStatus, HeadlampEventType, useEventCallback } from '../../redux/he
 import { ProjectDefinition } from '../../redux/projectsSlice';
 import { AppDispatch } from '../../redux/stores/store';
 import { DialogTitle } from '../common/Dialog';
-import AuthVisible from '../common/Resource/AuthVisible';
 import { PROJECT_ID_LABEL } from './projectUtils';
 
 interface ProjectDeleteDialogProps {
@@ -41,6 +40,7 @@ interface ProjectDeleteDialogProps {
   project: ProjectDefinition;
   onClose: () => void;
   namespaces: Namespace[];
+  canDeleteNamespaces: boolean;
 }
 
 export function ProjectDeleteDialog({
@@ -48,6 +48,7 @@ export function ProjectDeleteDialog({
   project,
   onClose,
   namespaces,
+  canDeleteNamespaces,
 }: ProjectDeleteDialogProps) {
   const { t } = useTranslation();
   const dispatch: AppDispatch = useDispatch();
@@ -58,17 +59,18 @@ export function ProjectDeleteDialog({
     const projectNamespaces = namespaces.filter(ns =>
       project.namespaces.includes(ns.metadata.name)
     );
+    const shouldDeleteNamespaces = deleteNamespaces && canDeleteNamespaces;
 
     dispatchDeleteProjectEvent({
       project,
-      deleteNamespaces,
+      deleteNamespaces: shouldDeleteNamespaces,
       status: EventStatus.CONFIRMED,
     });
 
     dispatch(
       clusterAction(
         async () => {
-          if (deleteNamespaces) {
+          if (shouldDeleteNamespaces) {
             // Delete the entire namespaces
             await Promise.all(projectNamespaces.map(namespace => namespace.delete()));
           } else {
@@ -135,31 +137,33 @@ export function ProjectDeleteDialog({
             ))}
           </ul>
 
-          <AuthVisible item={namespaces[0]} authVerb="delete">
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={deleteNamespaces}
-                  onChange={e => setDeleteNamespaces(e.target.checked)}
-                  name="deleteNamespaces"
-                  color="primary"
-                />
-              }
-              label={
-                <Typography variant="body2">
-                  {t('Also delete the namespaces (this will remove all resources within them)')}
-                </Typography>
-              }
-            />
+          {canDeleteNamespaces && (
+            <>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={deleteNamespaces}
+                    onChange={e => setDeleteNamespaces(e.target.checked)}
+                    name="deleteNamespaces"
+                    color="primary"
+                  />
+                }
+                label={
+                  <Typography variant="body2">
+                    {t('Also delete the namespaces (this will remove all resources within them)')}
+                  </Typography>
+                }
+              />
 
-            {deleteNamespaces && (
-              <Typography variant="body2" color="error" sx={{ mt: 1, fontWeight: 'bold' }}>
-                {t(
-                  'Warning: This action cannot be undone. All resources in these namespaces will be permanently deleted.'
-                )}
-              </Typography>
-            )}
-          </AuthVisible>
+              {deleteNamespaces && (
+                <Typography variant="body2" color="error" sx={{ mt: 1, fontWeight: 'bold' }}>
+                  {t(
+                    'Warning: This action cannot be undone. All resources in these namespaces will be permanently deleted.'
+                  )}
+                </Typography>
+              )}
+            </>
+          )}
         </DialogContentText>
       </DialogContent>
       <DialogActions>
@@ -172,7 +176,9 @@ export function ProjectDeleteDialog({
           variant="contained"
           sx={{ minWidth: '200px' }} // Fixed width to prevent button resize
         >
-          {deleteNamespaces ? t('Delete Project & Namespaces') : t('Delete Project')}
+          {deleteNamespaces && canDeleteNamespaces
+            ? t('Delete Project & Namespaces')
+            : t('Delete Project')}
         </Button>
       </DialogActions>
     </Dialog>

--- a/frontend/src/components/project/ProjectDeleteDialog.tsx
+++ b/frontend/src/components/project/ProjectDeleteDialog.tsx
@@ -32,7 +32,6 @@ import { clusterAction } from '../../redux/clusterActionSlice';
 import { ProjectDefinition } from '../../redux/projectsSlice';
 import { AppDispatch } from '../../redux/stores/store';
 import { DialogTitle } from '../common/Dialog';
-import AuthVisible from '../common/Resource/AuthVisible';
 import { PROJECT_ID_LABEL } from './projectUtils';
 
 interface ProjectDeleteDialogProps {
@@ -40,6 +39,7 @@ interface ProjectDeleteDialogProps {
   project: ProjectDefinition;
   onClose: () => void;
   namespaces: Namespace[];
+  canDeleteNamespaces: boolean;
 }
 
 export function ProjectDeleteDialog({
@@ -47,6 +47,7 @@ export function ProjectDeleteDialog({
   project,
   onClose,
   namespaces,
+  canDeleteNamespaces,
 }: ProjectDeleteDialogProps) {
   const { t } = useTranslation();
   const dispatch: AppDispatch = useDispatch();
@@ -60,7 +61,7 @@ export function ProjectDeleteDialog({
     dispatch(
       clusterAction(
         async () => {
-          if (deleteNamespaces) {
+          if (deleteNamespaces && canDeleteNamespaces) {
             // Delete the entire namespaces
             await Promise.all(projectNamespaces.map(namespace => namespace.delete()));
           } else {
@@ -127,31 +128,33 @@ export function ProjectDeleteDialog({
             ))}
           </ul>
 
-          <AuthVisible item={namespaces[0]} authVerb="delete">
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={deleteNamespaces}
-                  onChange={e => setDeleteNamespaces(e.target.checked)}
-                  name="deleteNamespaces"
-                  color="primary"
-                />
-              }
-              label={
-                <Typography variant="body2">
-                  {t('Also delete the namespaces (this will remove all resources within them)')}
-                </Typography>
-              }
-            />
+          {canDeleteNamespaces && (
+            <>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={deleteNamespaces}
+                    onChange={e => setDeleteNamespaces(e.target.checked)}
+                    name="deleteNamespaces"
+                    color="primary"
+                  />
+                }
+                label={
+                  <Typography variant="body2">
+                    {t('Also delete the namespaces (this will remove all resources within them)')}
+                  </Typography>
+                }
+              />
 
-            {deleteNamespaces && (
-              <Typography variant="body2" color="error" sx={{ mt: 1, fontWeight: 'bold' }}>
-                {t(
-                  'Warning: This action cannot be undone. All resources in these namespaces will be permanently deleted.'
-                )}
-              </Typography>
-            )}
-          </AuthVisible>
+              {deleteNamespaces && (
+                <Typography variant="body2" color="error" sx={{ mt: 1, fontWeight: 'bold' }}>
+                  {t(
+                    'Warning: This action cannot be undone. All resources in these namespaces will be permanently deleted.'
+                  )}
+                </Typography>
+              )}
+            </>
+          )}
         </DialogContentText>
       </DialogContent>
       <DialogActions>
@@ -164,7 +167,9 @@ export function ProjectDeleteDialog({
           variant="contained"
           sx={{ minWidth: '200px' }} // Fixed width to prevent button resize
         >
-          {deleteNamespaces ? t('Delete Project & Namespaces') : t('Delete Project')}
+          {deleteNamespaces && canDeleteNamespaces
+            ? t('Delete Project & Namespaces')
+            : t('Delete Project')}
         </Button>
       </DialogActions>
     </Dialog>


### PR DESCRIPTION
## Summary

This PR prevents the known mixed-RBAC partial update path during Headlamp project deletion.

Previously, the project delete action checked `update` authorization only against the first namespace in the project. When a user could update the first namespace but not another namespace, Headlamp displayed the delete action and attempted to remove the project label from every namespace. One namespace could be updated before another request failed with `Forbidden`, leaving the project partially modified.

The delete action is now displayed only when the user has `update` permission for every namespace in the project. The option to also delete the namespaces is displayed only when the user has `delete` permission for every namespace.

## Related Issue

Fixes #6647

## Changes

- Check `update` authorization for every namespace before displaying the project delete action.
- Check `delete` authorization for every namespace before displaying the option to delete the namespaces.
- Hide the project delete action while update authorization checks are pending or when a check fails.
- Keep namespace deletion guarded if delete authorization changes before confirmation.
- Add regression tests for:
  - Authorization across multiple namespaces.
  - Mixed update permissions.
  - Mixed delete permissions.
  - Pending and failed authorization checks.
  - Delete authorization being lost before confirmation.
  - Hiding the namespace deletion option when authorization is incomplete.

## Steps to Test

### Manual Verification

1. Create a project containing two namespaces:

   - `hl-rbac-a-authorized`
   - `hl-rbac-z-denied`

2. Label both namespaces with the same project ID:

   ```bash
   kubectl get namespaces hl-rbac-a-authorized hl-rbac-z-denied -L headlamp.dev/project-id
   ```

3. Configure a service account so that it can update the first namespace but not the second:

   ```bash
   kubectl auth can-i update namespace/hl-rbac-a-authorized --as=system:serviceaccount:default:headlamp-project-repro
   ```

   **Expected:**

   ```text
   yes
   ```

4. Verify that the same service account cannot update the second namespace:

   ```bash
   kubectl auth can-i update namespace/hl-rbac-z-denied --as=system:serviceaccount:default:headlamp-project-repro
   ```

   **Expected:**

   ```text
   no
   ```

5. Authenticate to Headlamp using the restricted service-account token.

6. Open the project details page:

   ```
   http://localhost:3000/project/rbac-repro-project?group=namespace
   ```

7. Verify that the project delete action is **not** displayed.

8. Verify that both namespaces still have the project label:

   ```bash
   kubectl get namespaces hl-rbac-a-authorized hl-rbac-z-denied -L headlamp.dev/project-id
   ```

### Automated Tests

1. From the `frontend` directory, run:

   ```bash
   npm test -- --run src/components/project/ProjectDeleteButton.test.tsx src/components/project/ProjectDeleteDialog.test.tsx
   ```

   **Expected Result:**

   ```text
   Test Files  2 passed
   Tests       14 passed
   ```

2. Also run:

   ```bash
   npm run tsc
   ```

## Screenshots

### Before

With mixed namespace permissions, the project delete action was displayed and could result in only some namespace labels being removed.

See the full reproduction evidence in #6647.
<img width="1366" height="717" alt="before" src="https://github.com/user-attachments/assets/b7bbb0c2-5f8c-4190-8bc0-7f276033f2d2" />



### After

With the same mixed permissions, the project remains visible, but the project delete action is not displayed.

<img width="1366" height="719" alt="trash icon remove" src="https://github.com/user-attachments/assets/c6dabc00-ad2f-4ae6-a5b6-dc2a140407c3" />


## Notes for the Reviewer

- This follows Headlamp's existing `AuthVisible` convention of hiding actions that the current user is not authorized to perform.
- Removing a project label requires `update` permission on **every** namespace.
- The optional destructive namespace removal requires `delete` permission on **every** namespace.
- Authorization failures are handled conservatively by not exposing the corresponding action.
- This is a frontend-only change; no backend APIs are modified.