### PR TITLE
fix(backend): preserve server-side credentials and TLS config in helm AddRepo

### DIFF
--- a/backend/pkg/helm/repository.go
+++ b/backend/pkg/helm/repository.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	defaultNewConfigFileMode   os.FileMode = os.FileMode(0o644)
+	defaultNewConfigFileMode   os.FileMode = os.FileMode(0o600)
 	defaultNewConfigFolderMode os.FileMode = os.FileMode(0o770)
 )
 
@@ -169,6 +169,13 @@ func addRepository(request AddUpdateRepoRequest, settings *cli.EnvSettings) erro
 	newRepo := &repo.Entry{
 		Name: request.Name,
 		URL:  request.URL,
+	}
+
+	// repo.File.Update replaces the entry wholesale, so carry over the
+	// server-side fields (credentials, TLS file paths) that the HTTP API
+	// deliberately does not accept from clients.
+	if existing := repoFile.Get(request.Name); existing != nil {
+		copyExistingRepoFields(newRepo, existing)
 	}
 
 	applyRequestFields(newRepo, request)

--- a/backend/pkg/helm/repository_test.go
+++ b/backend/pkg/helm/repository_test.go
@@ -442,6 +442,54 @@ func TestUpdateRepositoryPreservesAuth(t *testing.T) {
 	assert.Equal(t, testPassword, updatedEntry.Password)
 }
 
+func TestAddRepositoryPreservesAuth(t *testing.T) {
+	helmHandler := newIsolatedHelmHandler(t)
+
+	ts := newAuthRepoIndexServer(t)
+	defer ts.Close()
+
+	username := testUsername
+	password := testPassword
+
+	addRepo := helm.AddUpdateRepoRequest{
+		Name:     "auth_add_repo",
+		URL:      ts.URL,
+		Username: &username,
+		Password: &password,
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), "POST",
+		"/clusters/minikube/helm/repositories/charts", mustJSONBody(t, addRepo))
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	helmHandler.AddRepo(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Add the same repo again without credentials
+	addRepoNoAuth := helm.AddUpdateRepoRequest{
+		Name: "auth_add_repo",
+		URL:  ts.URL,
+	}
+
+	addReqNoAuth, err := http.NewRequestWithContext(context.Background(), "POST",
+		"/clusters/minikube/helm/repositories/charts", mustJSONBody(t, addRepoNoAuth))
+	require.NoError(t, err)
+
+	rr = httptest.NewRecorder()
+	helmHandler.AddRepo(rr, addReqNoAuth)
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	repoFile, err := repo.LoadFile(helmHandler.RepositoryConfig)
+	require.NoError(t, err)
+
+	updatedEntry := repoFile.Get("auth_add_repo")
+	require.NotNil(t, updatedEntry)
+
+	assert.Equal(t, testUsername, updatedEntry.Username)
+	assert.Equal(t, testPassword, updatedEntry.Password)
+}
+
 func TestCreateFileIfNotThere(t *testing.T) {
 	t.Run("creates_missing_file_and_directories", func(t *testing.T) {
 		dir := t.TempDir()


### PR DESCRIPTION
Fixes #6840.

**Problem:**
When calling `AddRepo` for a repository that already exists, the entry is completely replaced. This destroys server-side fields like `Username`, `Password`, `CAFile`, etc., causing subsequent chart operations against a private or mTLS-protected repository to fail. Additionally, `repositories.yaml` was being created with `0o644` permissions, while upstream Helm creates it with `0o600` to protect plaintext basic-auth credentials.

**Fix:**
1. Modified `addRepository` in `backend/pkg/helm/repository.go` to fetch the existing repository entry and invoke `copyExistingRepoFields(newRepo, existing)` **before** applying the new request fields. This ensures any omitted credentials or TLS paths are preserved.
2. Updated `defaultNewConfigFileMode` to `0o600`.
3. Added `TestAddRepositoryPreservesAuth` in `backend/pkg/helm/repository_test.go` to assert that credentials survive a subsequent `AddRepo` call without auth.