### PR TITLE
backend: helm: Preserve server-side repo fields in AddRepo

### DIFF
--- a/backend/pkg/helm/repository.go
+++ b/backend/pkg/helm/repository.go
@@ -171,6 +171,14 @@ func addRepository(request AddUpdateRepoRequest, settings *cli.EnvSettings) erro
 		URL:  request.URL,
 	}
 
+	// repo.File.Update replaces the entry wholesale, so carry over the
+	// server-side fields (credentials, TLS file paths) that the HTTP API
+	// deliberately does not accept from clients. Fields supplied in the
+	// request still win because applyRequestFields runs afterwards.
+	if existing := repoFile.Get(request.Name); existing != nil {
+		copyExistingRepoFields(newRepo, existing)
+	}
+
 	applyRequestFields(newRepo, request)
 
 	r, err := repo.NewChartRepository(newRepo, getter.All(settings))

--- a/backend/pkg/helm/repository_test.go
+++ b/backend/pkg/helm/repository_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -440,6 +441,127 @@ func TestUpdateRepositoryPreservesAuth(t *testing.T) {
 
 	assert.Equal(t, testUsername, updatedEntry.Username)
 	assert.Equal(t, testPassword, updatedEntry.Password)
+}
+
+// newHelmHandlerWithRepoFile creates a Handler whose repository config is
+// seeded with the given entries, so tests can set server-side fields
+// (credentials, TLS file paths) that the HTTP API does not accept.
+func newHelmHandlerWithRepoFile(t *testing.T, entries ...*repo.Entry) *helm.Handler {
+	t.Helper()
+
+	customSettings := cli.New()
+	customSettings.RepositoryConfig = filepath.Join(t.TempDir(), "repositories.yaml")
+
+	repoFile := repo.NewFile()
+	for _, entry := range entries {
+		repoFile.Update(entry)
+	}
+
+	require.NoError(t, repoFile.WriteFile(customSettings.RepositoryConfig, 0o644))
+
+	c := cache.New[interface{}]()
+	require.NotNil(t, c)
+
+	helmHandler, err := helm.NewHandlerWithSettings(c, customSettings)
+	require.NoError(t, err)
+
+	return helmHandler
+}
+
+// TestAddRepoPreservesExistingServerSideFields is a regression test for
+// AddRepo replacing an existing repository entry wholesale, silently wiping
+// the server-side fields (username, password, certFile, keyFile, caFile) that
+// the HTTP API deliberately does not accept from clients.
+func TestAddRepoPreservesExistingServerSideFields(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != testUsername || pass != testPassword {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"apiVersion":"v1","entries":{},"generated":"2025-01-01T00:00:00Z"}`))
+	}))
+	defer ts.Close()
+
+	// The server certificate acts as the CA file the entry references, so the
+	// index download only succeeds if the preserved fields are actually used.
+	caPath := filepath.Join(t.TempDir(), "ca.pem")
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ts.Certificate().Raw})
+	require.NoError(t, os.WriteFile(caPath, caPEM, 0o600))
+
+	helmHandler := newHelmHandlerWithRepoFile(t, &repo.Entry{
+		Name:     "private_repo",
+		URL:      ts.URL,
+		Username: testUsername,
+		Password: testPassword,
+		CAFile:   caPath,
+	})
+
+	// Re-add the same repository with only name and URL, as the frontend does.
+	addRepo := helm.AddUpdateRepoRequest{
+		Name: "private_repo",
+		URL:  ts.URL,
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), "POST",
+		"/clusters/minikube/helm/repositories/charts", mustJSONBody(t, addRepo))
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	helmHandler.AddRepo(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	repoFile, err := repo.LoadFile(helmHandler.RepositoryConfig)
+	require.NoError(t, err)
+
+	entry := repoFile.Get("private_repo")
+	require.NotNil(t, entry)
+	assert.Equal(t, testUsername, entry.Username)
+	assert.Equal(t, testPassword, entry.Password)
+	assert.Equal(t, caPath, entry.CAFile)
+}
+
+// TestAddRepoRequestFieldsOverrideExisting verifies that fields supplied in
+// the add request still win over the preserved server-side values.
+func TestAddRepoRequestFieldsOverrideExisting(t *testing.T) {
+	ts := newAuthRepoIndexServer(t)
+	defer ts.Close()
+
+	helmHandler := newHelmHandlerWithRepoFile(t, &repo.Entry{
+		Name:     "auth_override_repo",
+		URL:      ts.URL,
+		Username: "olduser",
+		Password: "oldpass",
+	})
+
+	username := testUsername
+	password := testPassword
+
+	addRepo := helm.AddUpdateRepoRequest{
+		Name:     "auth_override_repo",
+		URL:      ts.URL,
+		Username: &username,
+		Password: &password,
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), "POST",
+		"/clusters/minikube/helm/repositories/charts", mustJSONBody(t, addRepo))
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	helmHandler.AddRepo(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	repoFile, err := repo.LoadFile(helmHandler.RepositoryConfig)
+	require.NoError(t, err)
+
+	entry := repoFile.Get("auth_override_repo")
+	require.NotNil(t, entry)
+	assert.Equal(t, testUsername, entry.Username)
+	assert.Equal(t, testPassword, entry.Password)
 }
 
 func TestCreateFileIfNotThere(t *testing.T) {


### PR DESCRIPTION
## Summary 
addRepository built a fresh repo.Entry and called repo.File.Update, which replaces the existing entry wholesale. Re-adding an existing repository silently wiped Username/Password (when omitted from the request) and always wiped CertFile/KeyFile/CAFile, which the HTTP API intentionally never accepts from clients. Subsequent operations against private/mTLS repositories then failed until reconfigured outside Headlamp. This PR carries over the existing entry's fields before applying request fields, mirroring updateRepositoryWithRequest.

Related Issue Fixes #6840

## Changes

addRepository now calls the existing copyExistingRepoFields helper for pre-existing entries, before applyRequestFields, so request-supplied values still override.
Add TestAddRepoPreservesExistingServerSideFields: seeds repositories.yaml with username/password/CAFile, re-adds with only name+URL against a TLS + basic-auth index server (its cert is the CA file), asserts 200 and all fields preserved.
Add TestAddRepoRequestFieldsOverrideExisting: request credentials override stored ones.

## Steps to Test

cd backend && go test ./pkg/helm -run 'TestAddRepoPreserves|TestAddRepoRequestFields' -count=1 -v
Optionally the manual repro from the issue (helm repo with credentials, re-add via API, inspect repositories.yaml).

## Notes for the Reviewer 
The preservation also applies before DownloadIndexFile, so the index refresh itself uses the stored credentials/CA — that's the exact failure mode the TLS test locks in (it returns 500 without the fix)

##Screenshot of Tests

<img width="971" height="162" alt="image" src="https://github.com/user-attachments/assets/479811a4-95e4-4370-b8e8-dfd2feafdbc3" />
