### PR TITLE
0037: DMG license support

### DIFF
--- a/app/electron/package.test.ts
+++ b/app/electron/package.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe.runIf(process.platform === 'darwin')('app package', () => {
+  it('includes DMG license support for macOS packaging', () => {
+    const packageJson = JSON.parse(
+      readFileSync(new URL('../package.json', import.meta.url), 'utf8')
+    );
+    const packageLock = JSON.parse(
+      readFileSync(new URL('../package-lock.json', import.meta.url), 'utf8')
+    );
+
+    expect(packageJson.optionalDependencies).toHaveProperty('dmg-license', expect.any(String));
+    expect(packageLock.packages[''].optionalDependencies).toEqual(packageJson.optionalDependencies);
+  });
+});

--- a/app/electron/package.test.ts
+++ b/app/electron/package.test.ts
@@ -27,6 +27,7 @@ const packageJson = JSON.parse(
   build: {
     artifactName: string;
   };
+  optionalDependencies: Record<string, string>;
 };
 const require = createRequire(import.meta.url);
 const { expandMsiArtifactName } = require('../windows/msi/artifact-name.js') as {
@@ -48,5 +49,16 @@ describe('desktop package configuration', () => {
         arch: 'x64',
       })
     ).toBe(`${packageJson.name}-${packageJson.version}-win-x64.msi`);
+  });
+});
+
+describe.runIf(process.platform === 'darwin')('app package', () => {
+  it('includes DMG license support for macOS packaging', () => {
+    const packageLock = JSON.parse(
+      fs.readFileSync(new URL('../package-lock.json', import.meta.url), 'utf8')
+    );
+
+    expect(packageJson.optionalDependencies).toHaveProperty('dmg-license', expect.any(String));
+    expect(packageLock.packages[''].optionalDependencies).toEqual(packageJson.optionalDependencies);
   });
 });

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -38,6 +38,9 @@
       "engines": {
         "node": ">=22.0.0",
         "npm": ">=11.0.0"
+      },
+      "optionalDependencies": {
+        "dmg-license": "^1.0.11"
       }
     },
     "node_modules/@babel/runtime": {

--- a/app/package.json
+++ b/app/package.json
@@ -216,5 +216,8 @@
     "shx": "^0.4.0",
     "tar": "^7.5.11",
     "yargs": "^17.7.2"
+  },
+  "optionalDependencies": {
+    "dmg-license": "^1.0.11"
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -208,5 +208,8 @@
     "shx": "^0.4.0",
     "tar": "^7.5.11",
     "yargs": "^17.7.2"
+  },
+  "optionalDependencies": {
+    "dmg-license": "^1.0.11"
   }
 }


### PR DESCRIPTION
## Summary

- upstream the original `dmg-license` optional dependency so electron-builder can include license agreements in macOS DMG artifacts
- improve on the original one-file change by synchronizing the direct dependency in `package-lock.json` and adding a macOS-only test-first contract that follows the manifest's declared version range while enforcing lockfile consistency
- improve validation by confirming the existing macOS packaging workflow exercises the DMG builder path and by running the full app unit, type, lint, and format checks

## Provenance

This upstreams patch 0037 retained by [Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823), where it is recorded as commit `43a47bea8704393a5a43dc587df8458770bea230` in `0037-headlamp-upstream-dmg-license.patch`.

The original change was [Azure/aks-desktop__UNCLEAN#254](https://github.com/Azure/aks-desktop__UNCLEAN/pull/254), commit [`cf99c0e72e4930adcca7dc1f67dc48fd90975f62`](https://github.com/Azure/aks-desktop__UNCLEAN/commit/cf99c0e72e4930adcca7dc1f67dc48fd90975f62), authored by Joaquim Rocha.

## Test Coverage

- `npm --prefix app test` (16 files, 225 tests)
- `npm --prefix app run tsc`
- `npm --prefix frontend run lint -- --max-warnings 0`
- `npm --prefix frontend run format-check`
- `npm --prefix app ci --dry-run --ignore-scripts --offline`
- `git diff --check upstream/main...HEAD`

The changed production surface is declarative JSON and contains no executable branches, so branch coverage is not applicable. The new unit assertion covers the complete changed package contract and was committed before the implementation; it fails without the optional dependency and passes with it.

The existing macOS app workflow provides end-to-end coverage for this area: it runs `make app-mac` through electron-builder, verifies that a DMG was produced, and runs the packaged app/backend checks through `app:verify-build-mac`. A Playwright test is not added because the desktop Playwright suite launches unpackaged source and cannot observe DMG generation.

Assisted by copilot.
