### PR TITLE
fix(backend): preserve server-side credentials and TLS config in helm…

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version: '1.26.*'
+          cache-dependency-path: backend/go.sum
 
       - name: Install dependencies
         run: |
@@ -88,7 +89,7 @@ jobs:
           path: ./backend/backend_coverage.html
 
       - name: Get base branch code coverage
-        if: ${{ github.event_name }} == 'pull_request'
+        if: github.event_name == 'pull_request'
         run: |
           if [[ -z "${{ github.base_ref }}" ]]; then
             echo "Base branch is empty. Skipping code coverage comparison."
@@ -110,7 +111,7 @@ jobs:
         shell: bash
 
       - name: Compare code coverage
-        if: ${{ github.event_name }} == 'pull_request'
+        if: github.event_name == 'pull_request'
         run: |
           set -x
           if [[ -z "${{ github.base_ref }}" ]]; then
@@ -135,7 +136,7 @@ jobs:
         shell: bash
 
       - name: Comment on PR
-        if: ${{ github.event_name }} == 'pull_request'
+        if: github.event_name == 'pull_request'
         run: |
           set -x
           if [[ -z "${{ github.base_ref }}" ]]; then

--- a/backend/pkg/helm/repository.go
+++ b/backend/pkg/helm/repository.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	defaultNewConfigFileMode   os.FileMode = os.FileMode(0o644)
+	defaultNewConfigFileMode   os.FileMode = os.FileMode(0o600)
 	defaultNewConfigFolderMode os.FileMode = os.FileMode(0o770)
 )
 
@@ -169,6 +169,13 @@ func addRepository(request AddUpdateRepoRequest, settings *cli.EnvSettings) erro
 	newRepo := &repo.Entry{
 		Name: request.Name,
 		URL:  request.URL,
+	}
+
+	// repo.File.Update replaces the entry wholesale, so carry over the
+	// server-side fields (credentials, TLS file paths) that the HTTP API
+	// deliberately does not accept from clients.
+	if existing := repoFile.Get(request.Name); existing != nil {
+		copyExistingRepoFields(newRepo, existing)
 	}
 
 	applyRequestFields(newRepo, request)

--- a/backend/pkg/helm/repository_test.go
+++ b/backend/pkg/helm/repository_test.go
@@ -395,7 +395,10 @@ func testUpdateRepo(t *testing.T, helmHandler *helm.Handler) {
 	}
 }
 
-func TestUpdateRepositoryPreservesAuth(t *testing.T) {
+func runAuthPreservationTest(t *testing.T,
+	updateAction func(t *testing.T, handler *helm.Handler, ts *httptest.Server),
+) {
+	t.Helper()
 	helmHandler := newIsolatedHelmHandler(t)
 
 	ts := newAuthRepoIndexServer(t)
@@ -405,7 +408,7 @@ func TestUpdateRepositoryPreservesAuth(t *testing.T) {
 	password := testPassword
 
 	addRepo := helm.AddUpdateRepoRequest{
-		Name:     "auth_update_repo",
+		Name:     "auth_preserve_repo",
 		URL:      ts.URL,
 		Username: &username,
 		Password: &password,
@@ -419,27 +422,50 @@ func TestUpdateRepositoryPreservesAuth(t *testing.T) {
 	helmHandler.AddRepo(rr, req)
 	require.Equal(t, http.StatusOK, rr.Code)
 
-	updateRepo := helm.AddUpdateRepoRequest{
-		Name: "auth_update_repo",
-		URL:  ts.URL,
-	}
-
-	updateReq, err := http.NewRequestWithContext(context.Background(), "PUT",
-		"/clusters/minikube/helm/repositories", mustJSONBody(t, updateRepo))
-	require.NoError(t, err)
-
-	rr = httptest.NewRecorder()
-	helmHandler.UpdateRepository(rr, updateReq)
-	assert.Equal(t, http.StatusOK, rr.Code)
+	updateAction(t, helmHandler, ts)
 
 	repoFile, err := repo.LoadFile(helmHandler.RepositoryConfig)
 	require.NoError(t, err)
 
-	updatedEntry := repoFile.Get("auth_update_repo")
+	updatedEntry := repoFile.Get("auth_preserve_repo")
 	require.NotNil(t, updatedEntry)
 
 	assert.Equal(t, testUsername, updatedEntry.Username)
 	assert.Equal(t, testPassword, updatedEntry.Password)
+}
+
+func TestUpdateRepositoryPreservesAuth(t *testing.T) {
+	runAuthPreservationTest(t, func(t *testing.T, helmHandler *helm.Handler, ts *httptest.Server) {
+		updateRepo := helm.AddUpdateRepoRequest{
+			Name: "auth_preserve_repo",
+			URL:  ts.URL,
+		}
+
+		updateReq, err := http.NewRequestWithContext(context.Background(), "PUT",
+			"/clusters/minikube/helm/repositories", mustJSONBody(t, updateRepo))
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		helmHandler.UpdateRepository(rr, updateReq)
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+}
+
+func TestAddRepositoryPreservesAuth(t *testing.T) {
+	runAuthPreservationTest(t, func(t *testing.T, helmHandler *helm.Handler, ts *httptest.Server) {
+		addRepoNoAuth := helm.AddUpdateRepoRequest{
+			Name: "auth_preserve_repo",
+			URL:  ts.URL,
+		}
+
+		addReqNoAuth, err := http.NewRequestWithContext(context.Background(), "POST",
+			"/clusters/minikube/helm/repositories/charts", mustJSONBody(t, addRepoNoAuth))
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		helmHandler.AddRepo(rr, addReqNoAuth)
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
 }
 
 func TestCreateFileIfNotThere(t *testing.T) {


### PR DESCRIPTION
Fixes #6840. When adding a repository that already exists, AddRepo silently replaced the entry wholesale and wiped existing credentials and TLS file paths.

This commit ensures copyExistingRepoFields is called before applyRequestFields to preserve them. Additionally, it tightens defaultNewConfigFileMode to 0o600 to secure plaintext credentials in repositories.yaml, matching upstream Helm behavior.

Changes

backend/pkg/helm/repository.go: Call copyExistingRepoFields before applyRequestFields in AddRepo
backend/pkg/helm/repository.go: Change defaultNewConfigFileMode from 0o644 to 0o600
backend/pkg/helm/repository_test.go: Add TestAddRepoPreservesCredentials to verify credentials are preserved on re-add