### PR TITLE
0039: Electron zoom menu actions

### DIFF
--- a/app/e2e-tests/tests/appMenuZoom.spec.ts
+++ b/app/e2e-tests/tests/appMenuZoom.spec.ts
@@ -58,6 +58,21 @@ test.describe('application menu zoom actions', () => {
   });
 
   test('changes and resets the window zoom factor', async () => {
+    await electronPage.evaluate(() => {
+      window.desktopApi.send('setMenu', [
+        {
+          id: 'serialized-view',
+          label: 'View',
+          submenu: [
+            { id: 'original-reset-zoom', label: 'Reset Zoom' },
+            { id: 'original-zoom-in', label: 'Zoom In' },
+            { id: 'original-zoom-out', label: 'Zoom Out' },
+          ],
+        },
+      ]);
+    });
+
+    await expect.poll(() => hasMenuItem('original-zoom-in')).toBe(true);
     await clickMenuItem('original-reset-zoom');
     await expect.poll(() => getZoomFactor()).toBe(1);
 
@@ -88,4 +103,10 @@ async function getZoomFactor() {
   return electronApp.evaluate(({ BrowserWindow }) => {
     return BrowserWindow.getAllWindows()[0]?.webContents.getZoomFactor();
   });
+}
+
+async function hasMenuItem(id: string) {
+  return electronApp.evaluate(({ Menu }, menuId) => {
+    return Boolean(Menu.getApplicationMenu()?.getMenuItemById(menuId));
+  }, id);
 }

--- a/app/e2e-tests/tests/appMenuZoom.spec.ts
+++ b/app/e2e-tests/tests/appMenuZoom.spec.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { _electron, ElectronApplication, Page } from 'playwright';
+
+const electronExecutable = process.platform === 'win32' ? 'electron.cmd' : 'electron';
+const electronPath = path.resolve(__dirname, `../../node_modules/.bin/${electronExecutable}`);
+const appPath = path.resolve(__dirname, '../../');
+const userDataDir = path.join(os.tmpdir(), `headlamp-e2e-zoom-${process.pid}`);
+
+let electronApp: ElectronApplication;
+let electronPage: Page;
+
+if (process.env.PLAYWRIGHT_TEST_MODE === 'app') {
+  test.beforeAll(async () => {
+    electronApp = await _electron.launch({
+      cwd: appPath,
+      executablePath: electronPath,
+      args: ['.', `--user-data-dir=${userDataDir}`],
+      env: {
+        ...process.env,
+        ELECTRON_DEV: 'true',
+        ELECTRON_START_URL: 'data:text/html,<title>Headlamp zoom test</title>',
+        EXTERNAL_SERVER: 'true',
+      },
+    });
+
+    electronPage = await electronApp.firstWindow();
+    await electronPage.waitForLoadState('load');
+  });
+
+  test.afterAll(async () => {
+    await electronApp?.close();
+    fs.rmSync(userDataDir, { force: true, recursive: true });
+  });
+}
+
+test.describe('application menu zoom actions', () => {
+  test.beforeEach(() => {
+    test.skip(process.env.PLAYWRIGHT_TEST_MODE !== 'app', 'This test only runs in app mode');
+  });
+
+  test('changes and resets the window zoom factor', async () => {
+    await clickMenuItem('original-reset-zoom');
+    await expect.poll(() => getZoomFactor()).toBe(1);
+
+    await clickMenuItem('original-zoom-in');
+    await expect.poll(() => getZoomFactor()).toBeCloseTo(1.1);
+
+    await clickMenuItem('original-reset-zoom');
+    await expect.poll(() => getZoomFactor()).toBe(1);
+
+    await clickMenuItem('original-zoom-out');
+    await expect.poll(() => getZoomFactor()).toBeCloseTo(0.9);
+  });
+});
+
+async function clickMenuItem(id: string) {
+  await electronApp.evaluate(async ({ BrowserWindow, Menu }, menuId) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    const menuItem = Menu.getApplicationMenu()?.getMenuItemById(menuId);
+    if (!window || !menuItem?.click) {
+      throw new Error(`Menu item ${menuId} is not clickable`);
+    }
+
+    menuItem.click(menuItem, window, {} as Electron.KeyboardEvent);
+  }, id);
+}
+
+async function getZoomFactor() {
+  return electronApp.evaluate(({ BrowserWindow }) => {
+    return BrowserWindow.getAllWindows()[0]?.webContents.getZoomFactor();
+  });
+}

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -43,6 +43,7 @@ import { hideBin } from 'yargs/helpers';
 import { setupCustomCAs, setupSystemCAs } from './certificates';
 import i18n from './i18next.config';
 import MCPClient from './mcp/MCPClient';
+import { AppMenu, menusToTemplate } from './menu';
 import { filterUserOwnedPids } from './ownedProcesses';
 import {
   addToPath,
@@ -1215,7 +1216,10 @@ function setMenu(appWindow: BrowserWindow | null, newAppMenu: AppMenu[] = []) {
   let menu: Electron.Menu;
   try {
     const menuTemplate: (MenuItemConstructorOptions | MenuItem)[] =
-      menusToTemplate(appWindow, appMenu) || [];
+      menusToTemplate(appWindow, appMenu, loadFullMenu, {
+        openExternal: url => shell.openExternal(url),
+        openAboutDialog: () => appWindow?.webContents.send('open-about-dialog'),
+      }) || [];
     menu = Menu.buildFromTemplate(menuTemplate);
   } catch (e) {
     console.error(`Failed to build menus from template ${appMenu}:`, e);
@@ -1264,55 +1268,6 @@ function updateMenuLabels(menus: AppMenu[]) {
       menu.label = defaultMenusObj[menu.id].label;
     }
   });
-}
-
-export interface AppMenu extends Omit<Partial<MenuItemConstructorOptions>, 'click'> {
-  /** A URL to open (if not starting with http, then it'll be opened in the external browser) */
-  url?: string;
-  /** The submenus of this menu */
-  submenu?: AppMenu[];
-  /** A string identifying this menu */
-  id: string;
-  /** Whether to render this menu only after plugins are loaded (to give it time for the plugins
-   * to override the menu) */
-  afterPlugins?: boolean;
-}
-
-function menusToTemplate(mainWindow: BrowserWindow | null, menusFromPlugins: AppMenu[]) {
-  const menusToDisplay: MenuItemConstructorOptions[] = [];
-  menusFromPlugins.forEach(appMenu => {
-    const { url, afterPlugins = false, ...otherProps } = appMenu;
-    const menu: MenuItemConstructorOptions = otherProps;
-
-    if (!loadFullMenu && !!afterPlugins) {
-      return;
-    }
-
-    // Handle the "About" menu item from the Help menu specially
-    if (appMenu.id === 'original-about-help') {
-      menu.click = () => {
-        mainWindow?.webContents.send('open-about-dialog');
-      };
-    } else if (!!url) {
-      menu.click = async () => {
-        // Open external links in the external browser.
-        if (!!mainWindow && !url.startsWith('http')) {
-          mainWindow.webContents.loadURL(url);
-        } else {
-          await shell.openExternal(url);
-        }
-      };
-    }
-
-    // If the menu has a submenu, then recursively convert it.
-    if (Array.isArray(otherProps.submenu)) {
-      menu.submenu = menusToTemplate(mainWindow, otherProps.submenu);
-    }
-
-    menusToDisplay.push(menu);
-  });
-
-  return menusToDisplay;
 }
 
 async function getRunningHeadlampPIDs() {

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1219,6 +1219,8 @@ function setMenu(appWindow: BrowserWindow | null, newAppMenu: AppMenu[] = []) {
       menusToTemplate(appWindow, appMenu, loadFullMenu, {
         openExternal: url => shell.openExternal(url),
         openAboutDialog: () => appWindow?.webContents.send('open-about-dialog'),
+        adjustZoom,
+        setZoom,
       }) || [];
     menu = Menu.buildFromTemplate(menuTemplate);
   } catch (e) {

--- a/app/electron/menu.test.ts
+++ b/app/electron/menu.test.ts
@@ -22,6 +22,8 @@ function setup(mainWindow: BrowserWindow | null = null) {
   const actions = {
     openExternal: vi.fn().mockResolvedValue(undefined),
     openAboutDialog: vi.fn(),
+    adjustZoom: vi.fn(),
+    setZoom: vi.fn(),
   };
 
   return {
@@ -55,6 +57,27 @@ describe('menusToTemplate', () => {
     about.click?.({} as never, {} as never, {} as never);
 
     expect(actions.openAboutDialog).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ['original-zoom-in', 0.1],
+    ['original-zoom-out', -0.1],
+  ])('restores the %s adjustment action', (id, delta) => {
+    const { actions, convert } = setup();
+    const [zoom] = convert([{ id }]);
+
+    zoom.click?.({} as never, {} as never, {} as never);
+
+    expect(actions.adjustZoom).toHaveBeenCalledWith(delta);
+  });
+
+  it('restores the reset zoom action', () => {
+    const { actions, convert } = setup();
+    const [reset] = convert([{ id: 'original-reset-zoom' }]);
+
+    reset.click?.({} as never, {} as never, {} as never);
+
+    expect(actions.setZoom).toHaveBeenCalledWith(1);
   });
 
   it('loads internal URLs in the app window', async () => {

--- a/app/electron/menu.test.ts
+++ b/app/electron/menu.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { BrowserWindow } from 'electron';
+import { describe, expect, it, vi } from 'vitest';
+import { AppMenu, menusToTemplate } from './menu';
+
+function setup(mainWindow: BrowserWindow | null = null) {
+  const actions = {
+    openExternal: vi.fn().mockResolvedValue(undefined),
+    openAboutDialog: vi.fn(),
+  };
+
+  return {
+    actions,
+    convert: (menus: AppMenu[], loadFullMenu = true) =>
+      menusToTemplate(mainWindow, menus, loadFullMenu, actions),
+  };
+}
+
+describe('menusToTemplate', () => {
+  it('keeps regular menu properties and recursively converts submenus', () => {
+    const { convert } = setup();
+
+    expect(
+      convert([{ id: 'parent', label: 'Parent', submenu: [{ id: 'child', label: 'Child' }] }])
+    ).toEqual([{ id: 'parent', label: 'Parent', submenu: [{ id: 'child', label: 'Child' }] }]);
+  });
+
+  it('omits afterPlugins items until the full menu is enabled', () => {
+    const { convert } = setup();
+    const menus = [{ id: 'deferred', afterPlugins: true }];
+
+    expect(convert(menus, false)).toEqual([]);
+    expect(convert(menus, true)).toEqual([{ id: 'deferred' }]);
+  });
+
+  it('restores the About dialog action', () => {
+    const { actions, convert } = setup();
+    const [about] = convert([{ id: 'original-about-help' }]);
+
+    about.click?.({} as never, {} as never, {} as never);
+
+    expect(actions.openAboutDialog).toHaveBeenCalledOnce();
+  });
+
+  it('loads internal URLs in the app window', async () => {
+    const loadURL = vi.fn().mockResolvedValue(undefined);
+    const mainWindow = { webContents: { loadURL } } as unknown as BrowserWindow;
+    const { actions, convert } = setup(mainWindow);
+    const [internal] = convert([{ id: 'internal', url: 'file:///settings' }]);
+
+    await internal.click?.({} as never, {} as never, {} as never);
+
+    expect(loadURL).toHaveBeenCalledWith('file:///settings');
+    expect(actions.openExternal).not.toHaveBeenCalled();
+  });
+
+  it('opens HTTP URLs externally even when an app window exists', async () => {
+    const loadURL = vi.fn();
+    const mainWindow = { webContents: { loadURL } } as unknown as BrowserWindow;
+    const { actions, convert } = setup(mainWindow);
+    const [external] = convert([{ id: 'external', url: 'https://headlamp.dev' }]);
+
+    await external.click?.({} as never, {} as never, {} as never);
+
+    expect(actions.openExternal).toHaveBeenCalledWith('https://headlamp.dev');
+    expect(loadURL).not.toHaveBeenCalled();
+  });
+
+  it('opens URLs externally when there is no app window', async () => {
+    const { actions, convert } = setup();
+    const [external] = convert([{ id: 'external', url: 'headlamp://cluster' }]);
+
+    await external.click?.({} as never, {} as never, {} as never);
+
+    expect(actions.openExternal).toHaveBeenCalledWith('headlamp://cluster');
+  });
+
+  it('logs rejected URL actions', async () => {
+    const error = new Error('open failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { actions, convert } = setup();
+    actions.openExternal.mockRejectedValue(error);
+    const [external] = convert([{ id: 'external', url: 'https://headlamp.dev' }]);
+
+    external.click?.({} as never, {} as never, {} as never);
+
+    await vi.waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        'Failed to open menu URL https://headlamp.dev:',
+        error
+      );
+    });
+    consoleError.mockRestore();
+  });
+});

--- a/app/electron/menu.ts
+++ b/app/electron/menu.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { BrowserWindow, MenuItemConstructorOptions } from 'electron';
+
+export interface AppMenu extends Omit<Partial<MenuItemConstructorOptions>, 'click'> {
+  /** A URL to open (if not starting with http, then it'll be opened in the app window) */
+  url?: string;
+  /** The submenus of this menu */
+  submenu?: AppMenu[];
+  /** A string identifying this menu */
+  id: string;
+  /** Whether to render this menu only after plugins are loaded */
+  afterPlugins?: boolean;
+}
+
+interface MenuActions {
+  openExternal(url: string): Promise<void>;
+  openAboutDialog(): void;
+}
+
+export function menusToTemplate(
+  mainWindow: BrowserWindow | null,
+  menusFromPlugins: AppMenu[],
+  loadFullMenu: boolean,
+  actions: MenuActions
+) {
+  const menusToDisplay: MenuItemConstructorOptions[] = [];
+  menusFromPlugins.forEach(appMenu => {
+    const { url, afterPlugins = false, ...otherProps } = appMenu;
+    const menu: MenuItemConstructorOptions = otherProps;
+
+    if (!loadFullMenu && afterPlugins) {
+      return;
+    }
+
+    if (appMenu.id === 'original-about-help') {
+      menu.click = () => {
+        actions.openAboutDialog();
+      };
+    } else if (url) {
+      menu.click = () => {
+        const openUrl =
+          mainWindow && !url.startsWith('http')
+            ? mainWindow.webContents.loadURL(url)
+            : actions.openExternal(url);
+        void openUrl.catch(error => console.error(`Failed to open menu URL ${url}:`, error));
+      };
+    }
+
+    if (Array.isArray(otherProps.submenu)) {
+      menu.submenu = menusToTemplate(mainWindow, otherProps.submenu, loadFullMenu, actions);
+    }
+
+    menusToDisplay.push(menu);
+  });
+
+  return menusToDisplay;
+}

--- a/app/electron/menu.ts
+++ b/app/electron/menu.ts
@@ -30,6 +30,8 @@ export interface AppMenu extends Omit<Partial<MenuItemConstructorOptions>, 'clic
 interface MenuActions {
   openExternal(url: string): Promise<void>;
   openAboutDialog(): void;
+  adjustZoom(delta: number): void;
+  setZoom(factor: number): void;
 }
 
 export function menusToTemplate(
@@ -51,6 +53,12 @@ export function menusToTemplate(
       menu.click = () => {
         actions.openAboutDialog();
       };
+    } else if (appMenu.id === 'original-zoom-in') {
+      menu.click = () => actions.adjustZoom(0.1);
+    } else if (appMenu.id === 'original-zoom-out') {
+      menu.click = () => actions.adjustZoom(-0.1);
+    } else if (appMenu.id === 'original-reset-zoom') {
+      menu.click = () => actions.setZoom(1.0);
     } else if (url) {
       menu.click = () => {
         const openUrl =


### PR DESCRIPTION
## Summary

Restore Electron Zoom In, Zoom Out, and Reset actions after plugin menu
serialization strips function callbacks.

Compared with the original Azure/aks-desktop PR, this upstream version also:

- extracts serialized menu reconstruction into a focused, testable module;
- adds unit coverage for the full reconstruction path and all zoom actions;
- reaches 100% branch coverage for the extracted menu helper;
- catches and logs rejected URL menu actions instead of allowing unhandled
  promise rejections;
- exercises the serialized IPC menu path in a deterministic Electron e2e test;
- isolates Electron user data and avoids launching Electron in web-mode runs;
- places the testability and e2e commits before the behavior change for easier
  review.

## Related Issue

- Original Azure/aks-desktop change: https://github.com/Azure/aks-desktop/pull/286
- Original commit: https://github.com/Azure/aks-desktop/commit/3add21c450cebd0a562a2c61686b678d5114d83e
- Rebased Azure/aks-desktop commit: https://github.com/Azure/aks-desktop/commit/95c52466bdb31af86c4fd26db10a008e22aab686
- Related Azure/aks-desktop rebase PR: https://github.com/Azure/aks-desktop/pull/318
- Current source-package PR: https://github.com/Azure/aks-desktop/pull/823
- Patch 0039 in that PR: https://github.com/Azure/aks-desktop/blob/204643ded57d644003f7185e6a90362678e16788/patches/0039-headlamp-upstream-electron-zoom-menu-actions.patch

## Changes

- Extract serialized menu reconstruction into a focused, testable module.
- Restore Zoom In, Zoom Out, and Reset callbacks by their stable menu IDs.
- Add unit coverage for menu filtering, recursion, About, URL, and all zoom
  actions.
- Add an Electron e2e test that sends a plain serialized menu over IPC before
  exercising all three zoom actions.

## Steps to Test

1. Run `npm --prefix app run tsc -- --noEmit`.
2. Run `npm --prefix app test -- --run electron/menu.test.ts --coverage
   --coverage.include=electron/menu.ts --coverage.reporter=text
   --coverage.thresholds.branches=80`.
3. Run `PLAYWRIGHT_TEST_MODE=app npm --prefix app/e2e-tests run test-app --
   appMenuZoom.spec.ts`.
4. Run `PLAYWRIGHT_TEST_MODE=web npm --prefix app/e2e-tests exec -- playwright
   test appMenuZoom.spec.ts` and verify the app-only test is skipped.

## Notes for the Reviewer

The first two commits add testability and e2e coverage before the behavior
change. The final commit preserves Evangelos Skopelitis as the original author
and retains the original author date, with René Dudfield as co-author.

Assisted by copilot