### PR TITLE
0042: frontend: avoid CRD watches in GraphView story

### DIFF
--- a/frontend/src/components/resourceMap/GraphView.stories.test.tsx
+++ b/frontend/src/components/resourceMap/GraphView.stories.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentProps, ReactElement } from 'react';
+
+vi.mock('@iconify/react', () => ({ Icon: () => null }));
+vi.mock('../../lib/k8s/cluster', () => ({ KubeObject: class KubeObject {} }));
+vi.mock('../../lib/k8s/deployment', () => ({ default: class Deployment {} }));
+vi.mock('../../lib/k8s/pod', () => ({ default: class Pod {} }));
+vi.mock('../../lib/k8s/replicaSet', () => ({ default: class ReplicaSet {} }));
+vi.mock('../../lib/k8s/service', () => ({ default: class Service {} }));
+vi.mock('../../test', () => ({
+  API_BASE: 'http://localhost',
+  TestContext: ({ children }: { children: ReactElement }) => children,
+}));
+vi.mock('../pod/storyHelper', () => ({ podList: [{ metadata: {} }] }));
+vi.mock('./GraphView', () => ({ GraphView: () => null }));
+
+test('BasicExample disables default relation discovery', async () => {
+  const { GraphView } = await import('./GraphView');
+  const { BasicExample } = await import('./GraphView.stories');
+  const story = BasicExample() as ReactElement<{
+    children: ReactElement<ComponentProps<typeof GraphView>>;
+  }>;
+  const graphView = story.props.children;
+
+  expect(graphView.type).toBe(GraphView);
+  expect(graphView.props.defaultRelations).toEqual([]);
+});

--- a/frontend/src/components/resourceMap/GraphView.stories.tsx
+++ b/frontend/src/components/resourceMap/GraphView.stories.tsx
@@ -212,7 +212,7 @@ const mockSource: GraphSource = {
 
 export const BasicExample = () => (
   <TestContext>
-    <GraphView height="600px" defaultSources={[mockSource]} />
+    <GraphView height="600px" defaultSources={[mockSource]} defaultRelations={[]} />
   </TestContext>
 );
 BasicExample.args = {};

--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -64,10 +64,9 @@ import {
 import { GraphControlButton } from './GraphControls';
 import { GraphRenderer } from './GraphRenderer';
 import { FullGraphContext, GraphViewContext } from './graphViewContext';
+import { GraphViewDefinitions } from './GraphViewDefinitions';
 import { PerformanceStats } from './PerformanceStats';
 import { SelectionBreadcrumbs } from './SelectionBreadcrumbs';
-import { useGetAllRelations } from './sources/definitions/relations';
-import { useGetAllSources } from './sources/definitions/sources';
 import { GraphSourceManager, useSources } from './sources/GraphSources';
 import { GraphSourcesView } from './sources/GraphSourcesView';
 import { useGraphViewport } from './useGraphViewport';
@@ -696,13 +695,15 @@ function CustomThemeProvider({ children }: { children: ReactNode }) {
  * @param params - Map parameters
  * @returns
  */
-export function GraphView(props: GraphViewProps) {
-  const allSources = useGetAllSources();
-  const allRelations = useGetAllRelations();
-
-  const propsSources = props.defaultSources ?? allSources;
-  const propsRelations = props.defaultRelations ?? allRelations;
-
+function GraphViewWithDefinitions({
+  props,
+  sources: propsSources,
+  relations,
+}: {
+  props: GraphViewProps;
+  sources: GraphSource[];
+  relations: Relation[];
+}) {
   // Load plugin defined sources
   const pluginGraphSources = useTypedSelector(state => state.graphView.graphSources);
 
@@ -714,10 +715,23 @@ export function GraphView(props: GraphViewProps) {
   return (
     <StrictMode>
       <ReactFlowProvider>
-        <GraphSourceManager sources={sources} relations={propsRelations}>
+        <GraphSourceManager sources={sources} relations={relations}>
           <GraphViewContent {...props} sources={sources} />
         </GraphSourceManager>
       </ReactFlowProvider>
     </StrictMode>
+  );
+}
+
+export function GraphView(props: GraphViewProps) {
+  return (
+    <GraphViewDefinitions
+      defaultSources={props.defaultSources}
+      defaultRelations={props.defaultRelations}
+    >
+      {({ sources, relations }) => (
+        <GraphViewWithDefinitions props={props} sources={sources} relations={relations} />
+      )}
+    </GraphViewDefinitions>
   );
 }

--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -64,10 +64,9 @@ import {
 } from './graph/graphSimplification';
 import { GraphControlButton } from './GraphControls';
 import { GraphRenderer } from './GraphRenderer';
+import { GraphViewDefinitions } from './GraphViewDefinitions';
 import { PerformanceStats } from './PerformanceStats';
 import { SelectionBreadcrumbs } from './SelectionBreadcrumbs';
-import { useGetAllRelations } from './sources/definitions/relations';
-import { useGetAllSources } from './sources/definitions/sources';
 import { GraphSourceManager, useSources } from './sources/GraphSources';
 import { GraphSourcesView } from './sources/GraphSourcesView';
 import { useGraphViewport } from './useGraphViewport';
@@ -697,13 +696,15 @@ function CustomThemeProvider({ children }: { children: ReactNode }) {
  * @param params - Map parameters
  * @returns
  */
-export function GraphView(props: GraphViewContentProps) {
-  const allSources = useGetAllSources();
-  const allRelations = useGetAllRelations();
-
-  const propsSources = props.defaultSources ?? allSources;
-  const propsRelations = props.defaultRelations ?? allRelations;
-
+function GraphViewWithDefinitions({
+  props,
+  sources: propsSources,
+  relations,
+}: {
+  props: GraphViewContentProps;
+  sources: GraphSource[];
+  relations: Relation[];
+}) {
   // Load plugin defined sources
   const pluginGraphSources = useTypedSelector(state => state.graphView.graphSources);
 
@@ -715,10 +716,23 @@ export function GraphView(props: GraphViewContentProps) {
   return (
     <StrictMode>
       <ReactFlowProvider>
-        <GraphSourceManager sources={sources} relations={propsRelations}>
+        <GraphSourceManager sources={sources} relations={relations}>
           <GraphViewContent {...props} sources={sources} />
         </GraphSourceManager>
       </ReactFlowProvider>
     </StrictMode>
+  );
+}
+
+export function GraphView(props: GraphViewContentProps) {
+  return (
+    <GraphViewDefinitions
+      defaultSources={props.defaultSources}
+      defaultRelations={props.defaultRelations}
+    >
+      {({ sources, relations }) => (
+        <GraphViewWithDefinitions props={props} sources={sources} relations={relations} />
+      )}
+    </GraphViewDefinitions>
   );
 }

--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -689,12 +689,6 @@ function CustomThemeProvider({ children }: { children: ReactNode }) {
   );
 }
 
-/**
- * Renders Map of Kubernetes resources
- *
- * @param params - Map parameters
- * @returns
- */
 function GraphViewWithDefinitions({
   props,
   sources: propsSources,
@@ -723,6 +717,21 @@ function GraphViewWithDefinitions({
   );
 }
 
+/**
+ * Renders a map of Kubernetes resources and their relationships.
+ *
+ * Sources and relations are discovered only when their corresponding default
+ * is omitted. Passing an explicit array, including an empty array, skips that
+ * definition's discovery hooks.
+ *
+ * @param props - Graph display options and optional definition overrides.
+ * @param props.height - CSS height of the map container.
+ * @param props.defaultNodeSelection - ID of the node selected on first render.
+ * @param props.defaultSources - Sources to use instead of built-in discovery.
+ * @param props.defaultRelations - Relations to use instead of built-in discovery.
+ * @param props.defaultFilters - Filters applied before user-selected filters.
+ * @returns The rendered Kubernetes resource map.
+ */
 export function GraphView(props: GraphViewProps) {
   return (
     <GraphViewDefinitions

--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -690,12 +690,6 @@ function CustomThemeProvider({ children }: { children: ReactNode }) {
   );
 }
 
-/**
- * Renders Map of Kubernetes resources
- *
- * @param params - Map parameters
- * @returns
- */
 function GraphViewWithDefinitions({
   props,
   sources: propsSources,
@@ -724,6 +718,21 @@ function GraphViewWithDefinitions({
   );
 }
 
+/**
+ * Renders a map of Kubernetes resources and their relationships.
+ *
+ * Sources and relations are discovered only when their corresponding default
+ * is omitted. Passing an explicit array, including an empty array, skips that
+ * definition's discovery hooks.
+ *
+ * @param props - Graph display options and optional definition overrides.
+ * @param props.height - CSS height of the map container.
+ * @param props.defaultNodeSelection - ID of the node selected on first render.
+ * @param props.defaultSources - Sources to use instead of built-in discovery.
+ * @param props.defaultRelations - Relations to use instead of built-in discovery.
+ * @param props.defaultFilters - Filters applied before user-selected filters.
+ * @returns The rendered Kubernetes resource map.
+ */
 export function GraphView(props: GraphViewContentProps) {
   return (
     <GraphViewDefinitions

--- a/frontend/src/components/resourceMap/GraphViewDefinitions.test.tsx
+++ b/frontend/src/components/resourceMap/GraphViewDefinitions.test.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { GraphSource, Relation } from './graph/graphModel';
+import { GraphViewDefinitions } from './GraphViewDefinitions';
+import { useGetAllRelations } from './sources/definitions/relations';
+import { useGetAllSources } from './sources/definitions/sources';
+
+vi.mock('./sources/definitions/relations', () => ({
+  useGetAllRelations: vi.fn(),
+}));
+
+vi.mock('./sources/definitions/sources', () => ({
+  useGetAllSources: vi.fn(),
+}));
+
+const explicitSources = [{ id: 'explicit-source', label: 'Explicit source' }] as GraphSource[];
+const defaultSources = [{ id: 'default-source', label: 'Default source' }] as GraphSource[];
+const explicitRelations = [{ fromSource: 'explicit-source' }] as Relation[];
+const defaultRelations = [{ fromSource: 'default-source' }] as Relation[];
+
+function Definitions({ sources, relations }: { sources: GraphSource[]; relations: Relation[] }) {
+  return <div>{`${sources[0].id}:${relations[0].fromSource}`}</div>;
+}
+
+describe('GraphViewDefinitions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useGetAllSources).mockReturnValue(defaultSources);
+    vi.mocked(useGetAllRelations).mockReturnValue(defaultRelations);
+  });
+
+  test('uses explicit definitions without loading defaults', () => {
+    render(
+      <GraphViewDefinitions defaultSources={explicitSources} defaultRelations={explicitRelations}>
+        {Definitions}
+      </GraphViewDefinitions>
+    );
+
+    expect(screen.getByText('explicit-source:explicit-source')).toBeInTheDocument();
+    expect(useGetAllSources).not.toHaveBeenCalled();
+    expect(useGetAllRelations).not.toHaveBeenCalled();
+  });
+
+  test('loads default relations only when sources are explicit', () => {
+    render(
+      <GraphViewDefinitions defaultSources={explicitSources}>{Definitions}</GraphViewDefinitions>
+    );
+
+    expect(screen.getByText('explicit-source:default-source')).toBeInTheDocument();
+    expect(useGetAllSources).not.toHaveBeenCalled();
+    expect(useGetAllRelations).toHaveBeenCalledOnce();
+  });
+
+  test('loads default sources only when relations are explicit', () => {
+    render(
+      <GraphViewDefinitions defaultRelations={explicitRelations}>
+        {Definitions}
+      </GraphViewDefinitions>
+    );
+
+    expect(screen.getByText('default-source:explicit-source')).toBeInTheDocument();
+    expect(useGetAllSources).toHaveBeenCalledOnce();
+    expect(useGetAllRelations).not.toHaveBeenCalled();
+  });
+
+  test('loads both defaults when no definitions are explicit', () => {
+    render(<GraphViewDefinitions>{Definitions}</GraphViewDefinitions>);
+
+    expect(screen.getByText('default-source:default-source')).toBeInTheDocument();
+    expect(useGetAllSources).toHaveBeenCalledOnce();
+    expect(useGetAllRelations).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/components/resourceMap/GraphViewDefinitions.tsx
+++ b/frontend/src/components/resourceMap/GraphViewDefinitions.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactNode } from 'react';
+import { GraphSource, Relation } from './graph/graphModel';
+import { useGetAllRelations } from './sources/definitions/relations';
+import { useGetAllSources } from './sources/definitions/sources';
+
+interface GraphDefinitions {
+  sources: GraphSource[];
+  relations: Relation[];
+}
+
+interface GraphViewDefinitionsProps {
+  defaultSources?: GraphSource[];
+  defaultRelations?: Relation[];
+  children: (definitions: GraphDefinitions) => ReactNode;
+}
+
+function DefaultSources({
+  relations,
+  children,
+}: {
+  relations: Relation[];
+  children: GraphViewDefinitionsProps['children'];
+}) {
+  const sources = useGetAllSources();
+  return children({ sources, relations });
+}
+
+function DefaultRelations({
+  sources,
+  children,
+}: {
+  sources: GraphSource[];
+  children: GraphViewDefinitionsProps['children'];
+}) {
+  const relations = useGetAllRelations();
+  return children({ sources, relations });
+}
+
+function DefaultDefinitions({ children }: Pick<GraphViewDefinitionsProps, 'children'>) {
+  const sources = useGetAllSources();
+  const relations = useGetAllRelations();
+  return children({ sources, relations });
+}
+
+function getDefinitionsMode(
+  defaultSources?: GraphSource[],
+  defaultRelations?: Relation[]
+): 'explicit' | 'default-sources' | 'default-relations' | 'defaults' {
+  if (defaultSources !== undefined) {
+    return defaultRelations !== undefined ? 'explicit' : 'default-relations';
+  }
+  return defaultRelations !== undefined ? 'default-sources' : 'defaults';
+}
+
+export function GraphViewDefinitions({
+  defaultSources,
+  defaultRelations,
+  children,
+}: GraphViewDefinitionsProps) {
+  switch (getDefinitionsMode(defaultSources, defaultRelations)) {
+    case 'explicit':
+      return children({ sources: defaultSources!, relations: defaultRelations! });
+    case 'default-relations':
+      return <DefaultRelations sources={defaultSources!}>{children}</DefaultRelations>;
+    case 'default-sources':
+      return <DefaultSources relations={defaultRelations!}>{children}</DefaultSources>;
+    default:
+      return <DefaultDefinitions>{children}</DefaultDefinitions>;
+  }
+}

--- a/frontend/src/components/resourceMap/GraphViewDefinitions.tsx
+++ b/frontend/src/components/resourceMap/GraphViewDefinitions.tsx
@@ -19,14 +19,18 @@ import { GraphSource, Relation } from './graph/graphModel';
 import { useGetAllRelations } from './sources/definitions/relations';
 import { useGetAllSources } from './sources/definitions/sources';
 
+/** Sources and relations resolved for a GraphView. */
 interface GraphDefinitions {
   sources: GraphSource[];
   relations: Relation[];
 }
 
 interface GraphViewDefinitionsProps {
+  /** Sources to use instead of discovering the built-in sources. */
   defaultSources?: GraphSource[];
+  /** Relations to use instead of discovering the built-in relations. */
   defaultRelations?: Relation[];
+  /** Renders content with the explicit or discovered graph definitions. */
   children: (definitions: GraphDefinitions) => ReactNode;
 }
 
@@ -68,6 +72,18 @@ function getDefinitionsMode(
   return defaultRelations !== undefined ? 'default-sources' : 'defaults';
 }
 
+/**
+ * Resolves the sources and relations used by a GraphView.
+ *
+ * Explicit arrays, including empty arrays, are used as provided. A discovery
+ * hook is invoked only for a definition that the caller omits.
+ *
+ * @param props - Definition overrides and the render callback.
+ * @param props.defaultSources - Sources to use without source discovery.
+ * @param props.defaultRelations - Relations to use without relation discovery.
+ * @param props.children - Renders with the resolved sources and relations.
+ * @returns The content rendered by `children` with the resolved definitions.
+ */
 export function GraphViewDefinitions({
   defaultSources,
   defaultRelations,


### PR DESCRIPTION
## Summary

Prevent the GraphView BasicExample story from starting unnecessary CRD watches.

Compared with the original Azure/aks-desktop PR, which only passed an empty
relation list to the story, this upstream version also:

- makes default source and relation discovery lazy, so explicit definitions
  actually skip the Kubernetes discovery hooks;
- preserves existing behavior for every explicit/default source and relation
  combination;
- documents GraphView and GraphViewDefinitions parameters, return values, and
  lazy definition-resolution behavior;
- adds focused tests for all four definition-selection paths with 100% branch
  coverage;
- adds a regression test for the BasicExample story and validates it through
  Headlamp's Storybook harness;
- confirms that the existing Resource Map Playwright test covers the affected
  end-to-end area.

## Downstream history

This upstreams `patches/0042-headlamp-upstream-graphview-crd-watch.patch` from Azure/aks-desktop#823. The original change was authored by Evangelos Skopelitis in Azure/aks-desktop@354e284828e9950d3e2c85d44148800ab697e9af and merged through Azure/aks-desktop#256.

The original author and authored date are preserved on the upstreamed commit. René Dudfield is recorded as co-author.

## Screenshot

This is intentionally a behavior-only change. The BasicExample story remains
visually unchanged while explicit definitions skip default discovery hooks.

![GraphView BasicExample with mock Kubernetes resources](https://raw.githubusercontent.com/illume/headlamp/89b628560517865489b34675f4db64351220cdb9/pr-screenshots/0042-graphview-basic-desktop.png)

## Testing

- focused GraphView definition tests: 4 passed, 100% branch coverage (threshold: 80%)
- focused GraphView story regression: 1 passed
- Headlamp Storybook harness: `GraphView > BasicExample` passed
- frontend TypeScript: passed
- targeted ESLint: passed
- Playwright discovers the existing `e2e-tests/tests/resourceMap.spec.ts` test, which navigates to the Resource Map, mocks CRD collection responses, and exercises the rendered topology

Assisted by copilot.