### PR TITLE
backend: renameCluster: Require backend token

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -2726,6 +2726,14 @@ func (c *HeadlampConfig) renameCluster(w http.ResponseWriter, r *http.Request) {
 	c.TelemetryHandler.RecordEvent(span, "Rename cluster request started")
 	c.TelemetryHandler.RecordRequestCount(ctx, r, attribute.String("cluster", clusterName))
 
+	if err := c.checkHeadlampBackendToken(w, r); err != nil {
+		c.TelemetryHandler.RecordError(span, err, "invalid backend token")
+		c.TelemetryHandler.RecordErrorCount(ctx, attribute.String("error.type", "invalid_token"))
+		logger.Log(logger.LevelError, nil, err, "invalid token")
+
+		return
+	}
+
 	// Parse request and validate
 	var reqBody RenameClusterRequest
 	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -2599,6 +2599,14 @@ func (c *HeadlampConfig) renameCluster(w http.ResponseWriter, r *http.Request) {
 	c.TelemetryHandler.RecordEvent(span, "Rename cluster request started")
 	c.TelemetryHandler.RecordRequestCount(ctx, r, attribute.String("cluster", clusterName))
 
+	if err := c.checkHeadlampBackendToken(w, r); err != nil {
+		c.TelemetryHandler.RecordError(span, err, "invalid backend token")
+		c.TelemetryHandler.RecordErrorCount(ctx, attribute.String("error.type", "invalid_token"))
+		logger.Log(logger.LevelError, nil, err, "invalid token")
+
+		return
+	}
+
 	// Parse request and validate
 	var reqBody RenameClusterRequest
 	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -1256,7 +1256,6 @@ func TestDeletePlugin(t *testing.T) {
 
 // TestRestrictedEndpointsRequireToken is the canary for the backend-token gate:
 // dropping checkHeadlampBackendToken from any listed route would fail here.
-// PUT /cluster/{name} (renameCluster) is omitted because it isn't gated yet.
 func TestRestrictedEndpointsRequireToken(t *testing.T) {
 	const validToken = "valid-token-for-test"
 
@@ -1284,6 +1283,12 @@ func TestRestrictedEndpointsRequireToken(t *testing.T) {
 			method: http.MethodDelete,
 			path:   "/cluster/" + minikubeName,
 			body:   nil,
+		},
+		{
+			name:   "PUT /cluster/{name} (renameCluster)",
+			method: http.MethodPut,
+			path:   "/cluster/" + minikubeName,
+			body:   RenameClusterRequest{NewClusterName: "minikube-renamed", Stateless: true},
 		},
 		{
 			name:   "DELETE /plugins/{name} (deletePlugin)",

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -1584,7 +1584,7 @@ func TestRestrictedEndpointsRequireToken(t *testing.T) {
 			name:   "PUT /cluster/{name} (renameCluster)",
 			method: http.MethodPut,
 			path:   "/cluster/" + minikubeName,
-			body:   nil,
+			body:   RenameClusterRequest{NewClusterName: "minikube-renamed", Stateless: true},
 		},
 		{
 			name:   "POST /parseKubeConfig",


### PR DESCRIPTION
## Summary

This PR fixes an authorization inconsistency by requiring backend token authentication for the `renameCluster` endpoint, bringing it in line with the existing `addCluster` and `deleteCluster` endpoints.

Previously, `PUT /cluster/{name}` did not validate the `X-HEADLAMP_BACKEND-TOKEN` header, allowing cluster rename requests to bypass the backend authentication check. This change adds the same `checkHeadlampBackendToken(...)` validation used by the other cluster-management endpoints and extends the existing restricted endpoint tests to cover this behavior.

## Related Issue

Fixes #6883 

## Changes

- Added backend token validation to the `renameCluster` handler using the existing `checkHeadlampBackendToken(...)` helper.
- Ensured unauthorized `PUT /cluster/{name}` requests are rejected before any rename operation is performed.
- Extended the existing restricted endpoint test table to include the `renameCluster` endpoint.
- Added test coverage verifying:
  - Requests without `X-HEADLAMP-BACKEND-TOKEN` return `403 Forbidden`.
  - Requests with an invalid backend token return `403 Forbidden`.
  - Requests with a valid backend token succeed.
- Removed the outdated comment indicating that `renameCluster` was not yet covered by restricted endpoint tests.

## Steps to Test

1. Run the backend test suite:
   ```bash
   npm run backend:test
   ```

2. Run the backend linter:
   ```bash
   npm run backend:lint
   ```

3. Send a `PUT /cluster/{name}` request without the `X-HEADLAMP-BACKEND-TOKEN` header and verify it returns `403 Forbidden`.

4. Send the same request with an invalid backend token and verify it also returns `403 Forbidden`.

5. Send the request with a valid backend token and verify the cluster is renamed successfully.

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- This is a targeted security fix that aligns the `renameCluster` endpoint with the existing authorization model already used by `addCluster` and `deleteCluster`.
- The implementation reuses the existing `checkHeadlampBackendToken(...)` helper, keeping authentication behavior consistent across all cluster-management endpoints.
- Test coverage was added to the existing restricted endpoint test suite rather than introducing new test infrastructure.
- No unrelated behavior or API changes were introduced.