### PR TITLE
frontend: resourceMap: Persist source selection in localStorage

### DIFF
--- a/frontend/src/components/resourceMap/sources/GraphSources.test.tsx
+++ b/frontend/src/components/resourceMap/sources/GraphSources.test.tsx
@@ -109,6 +109,10 @@ describe('GraphSources helpers', () => {
 describe('GraphSourceManager', () => {
   let context: ReturnType<typeof useSources>;
 
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   const Probe = () => {
     const value = useSources();
     useEffect(() => {
@@ -239,5 +243,38 @@ describe('GraphSourceManager', () => {
         label: undefined,
       },
     ]);
+  });
+
+  it('persists selection to localStorage and loads it on initialization', async () => {
+    const first = source('first', { nodes: [] });
+    const second = source('second', { nodes: [] });
+    const group: GraphSource = { id: 'group', label: 'Group', sources: [first, second] };
+
+    // Initially all are selected
+    const { unmount } = render(
+      <GraphSourceManager sources={[group]} relations={[]}>
+        <Probe />
+      </GraphSourceManager>
+    );
+    await waitFor(() => expect(context.isLoading).toBe(false));
+    expect(context.selectedSources).toEqual(new Set(['group', 'first', 'second']));
+
+    // Deselect 'first'
+    act(() => context.toggleSelection(first));
+    expect(context.selectedSources).toEqual(new Set(['group', 'second']));
+
+    // Check localStorage contains the disabled source ID
+    expect(localStorage.getItem('headlamp_resource_map_disabled_sources')).toContain('first');
+
+    unmount();
+
+    // Re-render and check that selection was restored
+    render(
+      <GraphSourceManager sources={[group]} relations={[]}>
+        <Probe />
+      </GraphSourceManager>
+    );
+    await waitFor(() => expect(context.isLoading).toBe(false));
+    expect(context.selectedSources).toEqual(new Set(['group', 'second']));
   });
 });

--- a/frontend/src/components/resourceMap/sources/GraphSources.tsx
+++ b/frontend/src/components/resourceMap/sources/GraphSources.tsx
@@ -185,17 +185,40 @@ export function GraphSourceManager({ sources, children, relations }: GraphSource
   const [selectedSources, setSelectedSources] = useState(() => {
     const _selectedSources = new Set<string>();
 
+    let disabledSources: string[] = [];
+    try {
+      const stored = localStorage.getItem('headlamp_resource_map_disabled_sources');
+      if (stored) {
+        disabledSources = JSON.parse(stored);
+      }
+    } catch (e) {
+      console.error('Error loading disabled map sources from localStorage:', e);
+    }
+    const disabledSet = new Set(disabledSources);
+
     const step = (source: GraphSource) => {
-      if (source.isEnabledByDefault ?? true) {
+      if (disabledSet.has(source.id)) {
+        // Skip selecting this source
+      } else if (source.isEnabledByDefault ?? true) {
         _selectedSources.add(source.id);
-        if ('sources' in source) {
-          source.sources.forEach(step);
-        }
+      }
+      if ('sources' in source) {
+        source.sources.forEach(step);
       }
     };
     sources.map(step);
     return _selectedSources;
   });
+
+  useEffect(() => {
+    const allFlatSources = getFlatSources(sources);
+    const disabled = allFlatSources.filter(s => !selectedSources.has(s.id)).map(s => s.id);
+    try {
+      localStorage.setItem('headlamp_resource_map_disabled_sources', JSON.stringify(disabled));
+    } catch (e) {
+      console.error('Error saving disabled map sources to localStorage:', e);
+    }
+  }, [selectedSources, sources]);
 
   const toggleSelection = useCallback(
     (source: GraphSource) => {


### PR DESCRIPTION
Fixes #6555. In `GraphSourceManager`, the selected resource map sources are currently reset on every navigation or page reload. On clusters where certain workload queries hang or fail, this forces the user to manually deselect the Workloads group on every single visit to avoid infinite spinners.

This PR loads the list of disabled sources from `localStorage` during initialization and saves any subsequent changes to `selectedSources` using a `useEffect`.

**Changes:**
- `frontend/src/components/resourceMap/sources/GraphSources.tsx`: Initialize `selectedSources` from `localStorage` and persist selections inside `useEffect`.
- `frontend/src/components/resourceMap/sources/GraphSources.test.tsx`: Add a unit test to verify that selections are persisted and correctly restored, along with `beforeEach` to reset `localStorage` state between test runs.
