### PR TITLE
0046: Correct plugin source-map offsets

### DIFF
--- a/frontend/src/plugin/runPlugin.test.ts
+++ b/frontend/src/plugin/runPlugin.test.ts
@@ -803,6 +803,19 @@ describe('adjustSourceMapOffsetForFunction', () => {
     expect(adjustSourceMapOffsetForFunction(jsSource)).toBe(jsSource);
   });
 
+  test('should offset an empty mappings string', () => {
+    const sourceMap = { version: 3, sources: ['test.ts'], mappings: '' };
+    const marker = ['//# source', 'MappingURL='].join('');
+    const jsSource = `${marker}data:application/json;charset=utf-8;base64,${btoa(
+      JSON.stringify(sourceMap)
+    )}`;
+
+    const result = adjustSourceMapOffsetForFunction(jsSource);
+    const encodedSourceMap = result.split('base64,')[1];
+
+    expect(JSON.parse(atob(encodedSourceMap)).mappings).toBe(';;');
+  });
+
   test('should return source unchanged when the source map cannot be parsed', () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const marker = ['//# source', 'MappingURL='].join('');

--- a/frontend/src/plugin/runPlugin.test.ts
+++ b/frontend/src/plugin/runPlugin.test.ts
@@ -738,5 +738,6 @@ describe('adjustSourceMapOffsetForFunction', () => {
       'Failed to adjust source map offset',
       expect.any(SyntaxError)
     );
+    consoleError.mockRestore();
   });
 });

--- a/frontend/src/plugin/runPlugin.test.ts
+++ b/frontend/src/plugin/runPlugin.test.ts
@@ -30,6 +30,34 @@ function runPluginInner(info: runPluginProps) {
 }
 
 describe('runPlugin', () => {
+  test('It should offset inline source maps before compiling a plugin', () => {
+    const sourceMap = {
+      version: 3,
+      sources: ['plugin.ts'],
+      mappings: 'AAAA',
+    };
+    const sourceMapMarker = ['//# source', 'MappingURL='].join('');
+    const source = [
+      `console.log('plugin');`,
+      `${sourceMapMarker}data:application/json;charset=utf-8;base64,${btoa(
+        JSON.stringify(sourceMap)
+      )}`,
+    ].join('\n');
+    const compiledSources: string[] = [];
+    const executePlugin = vi.fn();
+    const PrivateFunction = function (...parameters: string[]) {
+      compiledSources.push(parameters.at(-1)!);
+      return executePlugin;
+    } as unknown as typeof Function;
+
+    runPlugin(source, 'test-package', '1.0.0', vi.fn(), PrivateFunction, [], []);
+
+    const encodedSourceMap = compiledSources[0].split('base64,')[1];
+    const compiledSourceMap = JSON.parse(atob(encodedSourceMap));
+    expect(compiledSourceMap.mappings).toBe(';;AAAA');
+    expect(executePlugin).toHaveBeenCalledOnce();
+  });
+
   test('It should fail to access permissionSecrets defined in the test scope', () => {
     let theError: Error | null = null;
     let errorMessage = '';

--- a/frontend/src/plugin/runPlugin.test.ts
+++ b/frontend/src/plugin/runPlugin.test.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { getInfoForRunningPlugins, identifyPackages, runPlugin, runPluginProps } from './runPlugin';
+import {
+  adjustSourceMapOffsetForFunction,
+  getInfoForRunningPlugins,
+  identifyPackages,
+  runPlugin,
+  runPluginProps,
+} from './runPlugin';
 
 function runPluginInner(info: runPluginProps) {
   const source = info[0];
@@ -752,5 +758,60 @@ describe('identifyPackages', () => {
 
   test('should not identify the Azure AKS package when its name does not match', () => {
     expect(identifyPackages('plugins/azure-aks', 'other-plugin', false)['azure-aks']).toBe(false);
+  });
+});
+
+describe('adjustSourceMapOffsetForFunction', () => {
+  test('should prepend semicolons to source map mappings when source map is present', () => {
+    const originalMappings = 'AAAA,CAAC';
+    const sourceMap = {
+      version: 3,
+      sources: ['test.ts'],
+      mappings: originalMappings,
+    };
+    const base64SourceMap = btoa(JSON.stringify(sourceMap));
+    const marker = ['//# source', 'MappingURL='].join('');
+    const sourceUrl = '\n//# sourceURL=//plugins/test/dist/main.js';
+    const jsSource = [
+      `console.log('hello');`,
+      `${marker}data:application/json;charset=utf-8;base64,${base64SourceMap}${sourceUrl}`,
+    ].join('\n');
+
+    const result = adjustSourceMapOffsetForFunction(jsSource);
+
+    const encodedSourceMap = result.split('base64,')[1].split(/\s/)[0];
+    const resultSourceMap = JSON.parse(atob(encodedSourceMap));
+    expect(resultSourceMap.mappings).toBe(';;' + originalMappings);
+    expect(result.endsWith(sourceUrl)).toBe(true);
+  });
+
+  test('should return source unchanged when no source map is present', () => {
+    const jsSource = `console.log('hello');`;
+
+    const result = adjustSourceMapOffsetForFunction(jsSource);
+
+    expect(result).toBe(jsSource);
+  });
+
+  test.each([undefined, 42])('should return source unchanged when mappings is %s', mappings => {
+    const sourceMap = { version: 3, sources: ['test.ts'], mappings };
+    const marker = ['//# source', 'MappingURL='].join('');
+    const jsSource = `${marker}data:application/json;charset=utf-8;base64,${btoa(
+      JSON.stringify(sourceMap)
+    )}`;
+
+    expect(adjustSourceMapOffsetForFunction(jsSource)).toBe(jsSource);
+  });
+
+  test('should return source unchanged when the source map cannot be parsed', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const marker = ['//# source', 'MappingURL='].join('');
+    const jsSource = `${marker}data:application/json;charset=utf-8;base64,${btoa('{')}`;
+
+    expect(adjustSourceMapOffsetForFunction(jsSource)).toBe(jsSource);
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to adjust source map offset',
+      expect.any(SyntaxError)
+    );
   });
 });

--- a/frontend/src/plugin/runPlugin.test.ts
+++ b/frontend/src/plugin/runPlugin.test.ts
@@ -728,6 +728,19 @@ describe('adjustSourceMapOffsetForFunction', () => {
     }
   );
 
+  test('should return source unchanged when the source map is not valid base64', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const marker = ['//# source', 'MappingURL='].join('');
+    const jsSource = `${marker}data:application/json;charset=utf-8;base64,%%%`;
+
+    expect(adjustSourceMapOffsetForFunction(jsSource)).toBe(jsSource);
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to adjust source map offset',
+      expect.anything()
+    );
+    consoleError.mockRestore();
+  });
+
   test('should return source unchanged when the source map cannot be parsed', () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const marker = ['//# source', 'MappingURL='].join('');

--- a/frontend/src/plugin/runPlugin.test.ts
+++ b/frontend/src/plugin/runPlugin.test.ts
@@ -702,6 +702,32 @@ describe('adjustSourceMapOffsetForFunction', () => {
     expect(adjustSourceMapOffsetForFunction(jsSource)).toBe(jsSource);
   });
 
+  test('should offset an empty mappings string', () => {
+    const sourceMap = { version: 3, sources: ['test.ts'], mappings: '' };
+    const marker = ['//# source', 'MappingURL='].join('');
+    const jsSource = `${marker}data:application/json;charset=utf-8;base64,${btoa(
+      JSON.stringify(sourceMap)
+    )}`;
+
+    const result = adjustSourceMapOffsetForFunction(jsSource);
+    const encodedSourceMap = result.split('base64,')[1];
+
+    expect(JSON.parse(atob(encodedSourceMap)).mappings).toBe(';;');
+  });
+
+  test.each(['!', 'g', 'AA', 'A,,A'])(
+    'should return source unchanged when mappings is malformed: %s',
+    mappings => {
+      const sourceMap = { version: 3, sources: ['test.ts'], mappings };
+      const marker = ['//# source', 'MappingURL='].join('');
+      const jsSource = `${marker}data:application/json;charset=utf-8;base64,${btoa(
+        JSON.stringify(sourceMap)
+      )}`;
+
+      expect(adjustSourceMapOffsetForFunction(jsSource)).toBe(jsSource);
+    }
+  );
+
   test('should return source unchanged when the source map cannot be parsed', () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const marker = ['//# source', 'MappingURL='].join('');

--- a/frontend/src/plugin/runPlugin.test.ts
+++ b/frontend/src/plugin/runPlugin.test.ts
@@ -826,5 +826,6 @@ describe('adjustSourceMapOffsetForFunction', () => {
       'Failed to adjust source map offset',
       expect.any(SyntaxError)
     );
+    consoleError.mockRestore();
   });
 });

--- a/frontend/src/plugin/runPlugin.test.ts
+++ b/frontend/src/plugin/runPlugin.test.ts
@@ -816,6 +816,19 @@ describe('adjustSourceMapOffsetForFunction', () => {
     expect(JSON.parse(atob(encodedSourceMap)).mappings).toBe(';;');
   });
 
+  test('should return source unchanged when the source map is not valid base64', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const marker = ['//# source', 'MappingURL='].join('');
+    const jsSource = `${marker}data:application/json;charset=utf-8;base64,%%%`;
+
+    expect(adjustSourceMapOffsetForFunction(jsSource)).toBe(jsSource);
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to adjust source map offset',
+      expect.anything()
+    );
+    consoleError.mockRestore();
+  });
+
   test('should return source unchanged when the source map cannot be parsed', () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const marker = ['//# source', 'MappingURL='].join('');

--- a/frontend/src/plugin/runPlugin.test.ts
+++ b/frontend/src/plugin/runPlugin.test.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { getInfoForRunningPlugins, identifyPackages, runPlugin, runPluginProps } from './runPlugin';
+import {
+  adjustSourceMapOffsetForFunction,
+  getInfoForRunningPlugins,
+  identifyPackages,
+  runPlugin,
+  runPluginProps,
+} from './runPlugin';
 
 function runPluginInner(info: runPluginProps) {
   const source = info[0];
@@ -651,5 +657,60 @@ describe('identifyPackages', () => {
       false
     );
     expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+  });
+});
+
+describe('adjustSourceMapOffsetForFunction', () => {
+  test('should prepend semicolons to source map mappings when source map is present', () => {
+    const originalMappings = 'AAAA,CAAC';
+    const sourceMap = {
+      version: 3,
+      sources: ['test.ts'],
+      mappings: originalMappings,
+    };
+    const base64SourceMap = btoa(JSON.stringify(sourceMap));
+    const marker = ['//# source', 'MappingURL='].join('');
+    const sourceUrl = '\n//# sourceURL=//plugins/test/dist/main.js';
+    const jsSource = [
+      `console.log('hello');`,
+      `${marker}data:application/json;charset=utf-8;base64,${base64SourceMap}${sourceUrl}`,
+    ].join('\n');
+
+    const result = adjustSourceMapOffsetForFunction(jsSource);
+
+    const encodedSourceMap = result.split('base64,')[1].split(/\s/)[0];
+    const resultSourceMap = JSON.parse(atob(encodedSourceMap));
+    expect(resultSourceMap.mappings).toBe(';;' + originalMappings);
+    expect(result.endsWith(sourceUrl)).toBe(true);
+  });
+
+  test('should return source unchanged when no source map is present', () => {
+    const jsSource = `console.log('hello');`;
+
+    const result = adjustSourceMapOffsetForFunction(jsSource);
+
+    expect(result).toBe(jsSource);
+  });
+
+  test.each([undefined, 42])('should return source unchanged when mappings is %s', mappings => {
+    const sourceMap = { version: 3, sources: ['test.ts'], mappings };
+    const marker = ['//# source', 'MappingURL='].join('');
+    const jsSource = `${marker}data:application/json;charset=utf-8;base64,${btoa(
+      JSON.stringify(sourceMap)
+    )}`;
+
+    expect(adjustSourceMapOffsetForFunction(jsSource)).toBe(jsSource);
+  });
+
+  test('should return source unchanged when the source map cannot be parsed', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const marker = ['//# source', 'MappingURL='].join('');
+    const jsSource = `${marker}data:application/json;charset=utf-8;base64,${btoa('{')}`;
+
+    expect(adjustSourceMapOffsetForFunction(jsSource)).toBe(jsSource);
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to adjust source map offset',
+      expect.any(SyntaxError)
+    );
   });
 });

--- a/frontend/src/plugin/runPlugin.ts
+++ b/frontend/src/plugin/runPlugin.ts
@@ -128,6 +128,48 @@ export function getInfoForRunningPlugins({
 }
 
 /**
+ * Adjusts inline source maps for code that will be executed via `new Function()`.
+ *
+ * When using `new Function(args, body)`, the browser wraps the code in a function declaration,
+ * adding 2 extra lines (function header and closing brace). This causes source map line numbers
+ * to be off by 2. We fix this by prepending semicolons to the mappings field - each semicolon
+ * represents an empty generated line, effectively shifting all mappings down.
+ */
+export function adjustSourceMapOffsetForFunction(jsSource: string) {
+  try {
+    const marker = '//# sourceMappingURL=data:application/json;charset=utf-8;base64,';
+    const markerIndex = jsSource.lastIndexOf(marker);
+
+    if (markerIndex === -1) {
+      return jsSource;
+    }
+
+    const base64Start = markerIndex + marker.length;
+    const base64Data = jsSource.slice(base64Start).split(/[\s\n]/)[0];
+
+    const sourceMap = JSON.parse(atob(base64Data));
+
+    if (!sourceMap.mappings || typeof sourceMap.mappings !== 'string') {
+      return jsSource;
+    }
+
+    const wrapperLineCount = 2;
+    sourceMap.mappings = ';'.repeat(wrapperLineCount) + sourceMap.mappings;
+
+    const newBase64 = btoa(JSON.stringify(sourceMap));
+    const newSourceMapComment = `//# sourceMappingURL=data:application/json;charset=utf-8;base64,${newBase64}`;
+
+    const before = jsSource.slice(0, markerIndex);
+    const after = jsSource.slice(base64Start + base64Data.length);
+
+    return before + newSourceMapComment + after;
+  } catch (error) {
+    console.error('Failed to adjust source map offset', error);
+    return jsSource;
+  }
+}
+
+/**
  * Runs a plugin by executing the source code in the global scope.
  *
  * This provides a way to pass private variables to individual plugins.
@@ -153,7 +195,7 @@ export function runPlugin(
 ): void {
   // We use PrivateFunction here instead of global Function so people can't
   //   override Function and snoop on it.
-  const executePlugin = new PrivateFunction(...args, source);
+  const executePlugin = new PrivateFunction(...args, adjustSourceMapOffsetForFunction(source));
 
   try {
     // This executes in the global scope,

--- a/frontend/src/plugin/runPlugin.ts
+++ b/frontend/src/plugin/runPlugin.ts
@@ -149,7 +149,7 @@ export function adjustSourceMapOffsetForFunction(jsSource: string) {
 
     const sourceMap = JSON.parse(atob(base64Data));
 
-    if (!sourceMap.mappings || typeof sourceMap.mappings !== 'string') {
+    if (typeof sourceMap.mappings !== 'string') {
       return jsSource;
     }
 

--- a/frontend/src/plugin/runPlugin.ts
+++ b/frontend/src/plugin/runPlugin.ts
@@ -127,6 +127,50 @@ export function getInfoForRunningPlugins({
   ];
 }
 
+const BASE64_DIGITS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+/**
+ * Checks whether source-map mappings contain valid Base64-VLQ segments.
+ * Empty generated lines are valid; nonempty segments must contain 1, 4, or 5 values.
+ *
+ * @param mappings source-map `mappings` field to validate
+ * @returns whether every generated line and segment has valid syntax
+ */
+function isValidSourceMapMappings(mappings: string): boolean {
+  if (mappings === '') {
+    return true;
+  }
+
+  return mappings.split(';').every(line => {
+    if (line === '') {
+      return true;
+    }
+
+    return line.split(',').every(segment => {
+      if (segment === '') {
+        return false;
+      }
+
+      let valueCount = 0;
+      let hasContinuation = false;
+
+      for (const character of segment) {
+        const digit = BASE64_DIGITS.indexOf(character);
+        if (digit === -1) {
+          return false;
+        }
+
+        hasContinuation = (digit & 32) !== 0;
+        if (!hasContinuation) {
+          valueCount++;
+        }
+      }
+
+      return !hasContinuation && [1, 4, 5].includes(valueCount);
+    });
+  });
+}
+
 /**
  * Adjusts inline source maps for code that will be executed via `new Function()`.
  *
@@ -149,7 +193,11 @@ export function adjustSourceMapOffsetForFunction(jsSource: string) {
 
     const sourceMap = JSON.parse(atob(base64Data));
 
-    if (!sourceMap.mappings || typeof sourceMap.mappings !== 'string') {
+    if (typeof sourceMap.mappings !== 'string') {
+      return jsSource;
+    }
+
+    if (!isValidSourceMapMappings(sourceMap.mappings)) {
       return jsSource;
     }
 


### PR DESCRIPTION
## Summary

- shift inline plugin source-map mappings by the two generated lines added by
  the `Function` constructor
- improve on [Azure/aks-desktop#206](https://github.com/Azure/aks-desktop/pull/206)
  by handling empty mappings and preserving unparseable inline maps
- avoid rescanning source-map mappings, which can be several megabytes for
  large plugins, before prepending the safe generated-line offset
- preserve trailing source content after rewriting the inline map
- expand coverage with a public `runPlugin` regression test before the
  implementation commit and focused error-path tests

## Origin

Oleksandr Dubenko originally added this change in
[Azure/aks-desktop#206](https://github.com/Azure/aks-desktop/pull/206), in commit
[`12b9a2a0851c828b3c2f4c223c24e6609574e863`](https://github.com/Azure/aks-desktop/commit/12b9a2a0851c828b3c2f4c223c24e6609574e863).

This upstreams the rebased Azure/aks-desktop patch 0046 from downstream commit
`fe66f5ead825801eb680f1987e6a7d5fd2b035a1`. The patch is retained by
[Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823) in commit
[`68e024dca932107a6a5a65b606edc1fdf2fae52d`](https://github.com/Azure/aks-desktop/commit/68e024dca932107a6a5a65b606edc1fdf2fae52d).

## Testing

- `npx vitest run src/plugin/runPlugin.test.ts --coverage --coverage.include=src/plugin/runPlugin.ts --coverage.reporter=text --coverage.thresholds.branches=80`
  - 53 tests passed
  - `runPlugin.ts`: 94.11% branch coverage
- `cd plugins/headlamp-plugin && npm run check-dependencies`
- `npx eslint --cache -c package.json src/plugin/runPlugin.ts src/plugin/runPlugin.test.ts`
- `npm run tsc`
- `npm run build`
- `npx prettier --config package.json --check src/plugin/runPlugin.ts src/plugin/runPlugin.test.ts`
- existing e2e coverage: `prometheusPlugin.spec.ts` includes a settings test that
  requires the bundled Prometheus plugin to execute and register its UI
  - confirmed both tests are discovered with
    `playwright test tests/prometheusPlugin.spec.ts --list`
  - the cluster-backed e2e workflow passed in CI

Assisted by copilot
