### PR TITLE
package.json: backend: Use cross-env in start scripts for Windows 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "concurrently": "^8.2.2"
+        "concurrently": "^8.2.2",
+        "cross-env": "^7.0.3"
       },
       "engines": {
         "node": ">=22.0.0",
@@ -145,6 +146,40 @@
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -209,12 +244,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -234,6 +286,29 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/shell-quote": {
@@ -315,6 +390,22 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "backend:coverage": "cd backend && go test -v -p 1 -coverprofile=coverage.out ./... && go tool cover -func=coverage.out",
     "backend:coverage:html": "cd backend && go test -v -p 1 -coverprofile=coverage.out ./... && go tool cover -html=coverage.out",
     "backend:format": "cd backend && go fmt ./cmd/ ./pkg/**",
-    "backend:start": "echo 'Warning: Running with Helm and dynamic-clusters endpoints enabled.' && HEADLAMP_BACKEND_TOKEN=headlamp HEADLAMP_CONFIG_ENABLE_HELM=true HEADLAMP_CONFIG_ENABLE_DYNAMIC_CLUSTERS=true ./backend/headlamp-server -dev -proxy-urls https://artifacthub.io/* -listen-addr=localhost",
+    "backend:start": "echo 'Warning: Running with Helm and dynamic-clusters endpoints enabled.' && cross-env HEADLAMP_BACKEND_TOKEN=headlamp HEADLAMP_CONFIG_ENABLE_HELM=true HEADLAMP_CONFIG_ENABLE_DYNAMIC_CLUSTERS=true ./backend/headlamp-server -dev -proxy-urls https://artifacthub.io/* -listen-addr=localhost",
     "backend:dev": "echo 'Starting Headlamp backend in dev mode with Air...' && cd backend && air",
-    "backend:start:metrics": "echo 'Running backend with Prometheus metrics enabled' && HEADLAMP_BACKEND_TOKEN=headlamp HEADLAMP_CONFIG_METRICS_ENABLED=true HEADLAMP_CONFIG_ENABLE_HELM=true HEADLAMP_CONFIG_ENABLE_DYNAMIC_CLUSTERS=true ./backend/headlamp-server -dev -proxy-urls https://artifacthub.io/* -listen-addr=localhost",
-    "backend:start:traces": "echo 'Running backend with distributed tracing enabled' && HEADLAMP_BACKEND_TOKEN=headlamp HEADLAMP_CONFIG_TRACING_ENABLED=true HEADLAMP_CONFIG_ENABLE_HELM=true HEADLAMP_CONFIG_ENABLE_DYNAMIC_CLUSTERS=true ./backend/headlamp-server -dev -proxy-urls https://artifacthub.io/* -listen-addr=localhost",
+    "backend:start:metrics": "echo 'Running backend with Prometheus metrics enabled' && cross-env HEADLAMP_BACKEND_TOKEN=headlamp HEADLAMP_CONFIG_METRICS_ENABLED=true HEADLAMP_CONFIG_ENABLE_HELM=true HEADLAMP_CONFIG_ENABLE_DYNAMIC_CLUSTERS=true ./backend/headlamp-server -dev -proxy-urls https://artifacthub.io/* -listen-addr=localhost",
+    "backend:start:traces": "echo 'Running backend with distributed tracing enabled' && cross-env HEADLAMP_BACKEND_TOKEN=headlamp HEADLAMP_CONFIG_TRACING_ENABLED=true HEADLAMP_CONFIG_ENABLE_HELM=true HEADLAMP_CONFIG_ENABLE_DYNAMIC_CLUSTERS=true ./backend/headlamp-server -dev -proxy-urls https://artifacthub.io/* -listen-addr=localhost",
     "frontend:install": "cd frontend && npm install",
     "frontend:install:ci": "cd frontend && npm ci",
     "frontend:build": "cd frontend && npm run build",
@@ -88,7 +88,8 @@
     "image:verify-image-digests": "node tools/verify-image-digests.js"
   },
   "devDependencies": {
-    "concurrently": "^8.2.2"
+    "concurrently": "^8.2.2",
+    "cross-env": "^7.0.3"
   },
   "keywords": [
     "kubernetes",


### PR DESCRIPTION
## Summary

This PR fixes `npm start` on Windows, where the backend half of the dev setup could never launch.

The `backend:start` script sets its environment variables using the POSIX `VAR=value command` prefix. npm on Windows runs scripts through `%ComSpec%` (`cmd.exe`), which has no equivalent syntax, so it treats `HEADLAMP_BACKEND_TOKEN=headlamp` as the *name of the program to run* and aborts:

```
'HEADLAMP_BACKEND_TOKEN' is not recognized as an internal or external command,
operable program or batch file.
```

The backend therefore exits immediately. Because `npm start` runs both halves under `concurrently`, the frontend stays up but has nothing to talk to on port 4466, so every proxied call (`/api`, `/clusters`, `/config`, `/plugins`, ...) fails. That makes it present as a broken UI rather than a backend that never launched, which is a confusing first experience for contributors on Windows. There is a second, independent `cmd.exe` incompatibility on the same line: it also rejects the forward-slash path `./backend/headlamp-server` with `'.' is not recognized as an internal or external command`.

Prefixing the variable list with `cross-env` resolves both problems, because `cross-env` consumes the `VAR=value` pairs itself and then launches the target binary directly instead of handing the line back to `cmd.exe`.

Worth noting for reviewers: this is **not** about the missing `.exe` extension. `backend:build` runs `go build -o ./headlamp-server`, which on Windows produces an extensionless `headlamp-server`, but Windows still executes that fine from its PE header (`cmd /c ".\backend\headlamp-server -h"` prints the flag list normally). The script died before it ever reached the binary, so building a `headlamp-server.exe` by hand changes nothing.

## Related Issue

Fixes #6904

## Changes

- Updated `backend:start`, `backend:start:metrics` and `backend:start:traces` in the root `package.json` to prefix their environment variables with `cross-env`.
- Added `cross-env` (`^7.0.3`) to the root `devDependencies`. This is not a new dependency for the project: `frontend/package.json` already pins the same `^7.0.3` and uses it in its own scripts. It is added at the root because that is where these scripts live and where npm resolves `node_modules/.bin`.
- Updated `package-lock.json` accordingly. The install adds exactly 7 entries: `cross-env` plus the standard `cross-spawn` chain (`cross-spawn`, `which`, `isexe`, `path-key`, `shebang-command`, `shebang-regex`). The resolved `cross-spawn` is 7.0.6, i.e. the version that includes the fix for the known ReDoS advisory.

No source code is touched, and the change is POSIX-neutral: `cross-env VAR=value ./binary args` behaves identically to the previous inline form on Linux and macOS.

## Steps to Test

On Windows (PowerShell or `cmd`):

1. `npm install` and `npm run frontend:install`
2. `npm run backend:build`
3. `npm run backend:start` — before this change it fails immediately with `'HEADLAMP_BACKEND_TOKEN' is not recognized ...`; with this change the server starts and logs `Listen address: localhost:4466`.
4. Confirm the environment variables actually reached the Go process by checking the startup log for `Helm support: true` and `Dynamic clusters support: true`.
5. `curl http://localhost:4466/config` returns 200.
6. Stop it, then run `npm start`. Both `[backend]` and `[frontend]` come up, and `curl http://localhost:3000/config` returns 200, proving Vite's dev proxy reaches the backend.

On Linux/macOS, `npm start` should continue to behave exactly as before.

## Screenshots (if applicable)

Not applicable — no UI changes.

## Notes for the Reviewer

Verification performed on Windows 10.0.26200 with Node v24.5.0, npm 11.12.0 and Go 1.26.5. All six steps above pass, including `npm start` bringing up both halves and returning 200 through the Vite proxy.

`npm run frontend:test` passes in full: **182 test files, 2396 tests, 0 failures**.

`npm run frontend:lint` passes ESLint. Its `format-check` stage reports pre-existing Prettier complaints in 14 `.yaml`/`.css`/`.md` files (for example `src/index.css` and `src/components/gateway/manifests/*.yaml`). These are unrelated to this PR: none of those files are modified here, the working tree is otherwise clean, and the cause is local — `core.autocrlf=true` rewrote them with CRLF on checkout, which Prettier flags. They should not appear in CI on Linux.

I have deliberately kept the scope to the scripts that block `npm start`. Two other root scripts are POSIX-only for the same underlying reason and still fail on Windows, but they need more than `cross-env` and seem better handled separately:

- `clean` uses `rm -rf`, which would mean pulling in a new dependency such as `rimraf`.
- `backend:install:linter` uses `` GOBIN=`pwd`/backend/tools ``; the backtick command substitution cannot be expressed with `cross-env` alone.

Happy to fold either of those in here instead if you would prefer a single, broader fix for Windows contributors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved backend startup commands to set environment variables consistently across operating systems.
  * Added support for reliable development and diagnostic startup modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->