### PR TITLE
0052: Avoid retrying permanent HTTP errors

### DIFF
--- a/e2e-tests/tests/podsPage.spec.ts
+++ b/e2e-tests/tests/podsPage.spec.ts
@@ -145,6 +145,42 @@ test('changes column visibility with the keyboard', async ({ page }) => {
   );
 });
 
+test('recovers from a corrected config error on scheduled refetch', async ({ page }) => {
+  let allowRecovery = false;
+  let lastConfigRequestAt = 0;
+  let recoveryStatus: number | undefined;
+  await page.route('**/config', async route => {
+    lastConfigRequestAt = Date.now();
+    if (!allowRecovery) {
+      await route.fulfill({ status: 403, json: { message: 'config is invalid' } });
+      return;
+    }
+
+    const response = await route.fetch();
+    recoveryStatus = response.status();
+    await route.fulfill({ response });
+  });
+
+  await page.goto('/');
+  await expect.poll(() => lastConfigRequestAt).toBeGreaterThan(0);
+  await expect.poll(() => Date.now() - lastConfigRequestAt).toBeGreaterThan(750);
+  allowRecovery = true;
+
+  const testCluster = page.locator('table tbody tr td a', { hasText: /^test$/ });
+  const recoveredDuringRetryWindow = await testCluster
+    .waitFor({ state: 'visible', timeout: 3000 })
+    .then(
+      () => true,
+      () => false
+    );
+  expect(recoveredDuringRetryWindow).toBe(false);
+  expect(recoveryStatus).toBeUndefined();
+
+  await expect.poll(() => recoveryStatus, { timeout: 15_000 }).toBe(200);
+  await expect(testCluster).toBeVisible();
+  await expect(page.locator('table tbody tr td a', { hasText: /^test2$/ })).toBeVisible();
+});
+
 test('multi tab create delete pod', async ({ browser }) => {
   // This test may be slow to create and delete a pod
   test.setTimeout(60000);

--- a/e2e-tests/tests/podsPage.spec.ts
+++ b/e2e-tests/tests/podsPage.spec.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
+import { expect, test } from '@playwright/test';
 import { execFile } from 'node:child_process';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
-import { expect, test } from '@playwright/test';
 import { HeadlampPage } from './headlampPage';
 import { podsPage } from './podsPage';
 
@@ -112,6 +112,42 @@ test('loads the next page of pods', async ({ page }) => {
   expect(listRequests).toHaveLength(2);
   expect(listRequests[1].searchParams.get('limit')).toBe('1000');
   expect(listRequests[1].searchParams.get('continue')).toBe('next-page');
+});
+
+test('recovers from a corrected config error on scheduled refetch', async ({ page }) => {
+  let allowRecovery = false;
+  let lastConfigRequestAt = 0;
+  let recoveryStatus: number | undefined;
+  await page.route('**/config', async route => {
+    lastConfigRequestAt = Date.now();
+    if (!allowRecovery) {
+      await route.fulfill({ status: 403, json: { message: 'config is invalid' } });
+      return;
+    }
+
+    const response = await route.fetch();
+    recoveryStatus = response.status();
+    await route.fulfill({ response });
+  });
+
+  await page.goto('/');
+  await expect.poll(() => lastConfigRequestAt).toBeGreaterThan(0);
+  await expect.poll(() => Date.now() - lastConfigRequestAt).toBeGreaterThan(750);
+  allowRecovery = true;
+
+  const testCluster = page.locator('table tbody tr td a', { hasText: /^test$/ });
+  const recoveredDuringRetryWindow = await testCluster
+    .waitFor({ state: 'visible', timeout: 3000 })
+    .then(
+      () => true,
+      () => false
+    );
+  expect(recoveredDuringRetryWindow).toBe(false);
+  expect(recoveryStatus).toBeUndefined();
+
+  await expect.poll(() => recoveryStatus, { timeout: 15_000 }).toBe(200);
+  await expect(testCluster).toBeVisible();
+  await expect(page.locator('table tbody tr td a', { hasText: /^test2$/ })).toBeVisible();
 });
 
 test('multi tab create delete pod', async ({ browser }) => {

--- a/frontend/src/lib/queryClient.test.ts
+++ b/frontend/src/lib/queryClient.test.ts
@@ -15,33 +15,42 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { queryClient } from './queryClient';
-
-function retryQuery(failureCount: number, error: unknown): boolean {
-  const retry = queryClient.getDefaultOptions().queries?.retry;
-  expect(retry).toBeTypeOf('function');
-  return (retry as (failureCount: number, error: unknown) => boolean)(failureCount, error);
-}
+import { queryClient, shouldRetryQuery } from './queryClient';
 
 describe('queryClient', () => {
   it('keeps the existing query defaults', () => {
     expect(queryClient.getDefaultOptions().queries).toMatchObject({
       staleTime: 3 * 60_000,
       refetchOnWindowFocus: false,
+      retry: shouldRetryQuery,
     });
   });
+});
 
-  it.each([400, 401, 403, 404])('does not retry HTTP %s responses', status => {
-    expect(retryQuery(0, { status })).toBe(false);
+describe('shouldRetryQuery', () => {
+  it.each([400, 401, 403, 404])('does not immediately retry HTTP %s responses', status => {
+    expect(shouldRetryQuery(0, { status })).toBe(false);
   });
 
-  it('keeps the three-attempt limit for server errors', () => {
-    expect(retryQuery(2, { status: 500 })).toBe(true);
-    expect(retryQuery(3, { status: 500 })).toBe(false);
+  it.each([408, 429, 500])('retries transient HTTP %s responses up to three times', status => {
+    expect(shouldRetryQuery(2, { status })).toBe(true);
+    expect(shouldRetryQuery(3, { status })).toBe(false);
   });
 
-  it('keeps the three-attempt limit for network errors', () => {
-    expect(retryQuery(2, new Error('network error'))).toBe(true);
-    expect(retryQuery(3, new Error('network error'))).toBe(false);
+  it.each([
+    null,
+    'network error',
+    new Error('network error'),
+    { message: 'network error' },
+    { status: '403' },
+    { status: Number.NaN },
+  ])('retries errors without a numeric HTTP status up to three times', error => {
+    expect(shouldRetryQuery(2, error)).toBe(true);
+    expect(shouldRetryQuery(3, error)).toBe(false);
+  });
+
+  it('retries responses outside the permanent client-error range', () => {
+    expect(shouldRetryQuery(2, { status: 399 })).toBe(true);
+    expect(shouldRetryQuery(2, { status: undefined })).toBe(true);
   });
 });

--- a/frontend/src/lib/queryClient.test.ts
+++ b/frontend/src/lib/queryClient.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { queryClient } from './queryClient';
+
+function retryQuery(failureCount: number, error: unknown): boolean {
+  const retry = queryClient.getDefaultOptions().queries?.retry;
+  expect(retry).toBeTypeOf('function');
+  return (retry as (failureCount: number, error: unknown) => boolean)(failureCount, error);
+}
+
+describe('queryClient', () => {
+  it('keeps the existing query defaults', () => {
+    expect(queryClient.getDefaultOptions().queries).toMatchObject({
+      staleTime: 3 * 60_000,
+      refetchOnWindowFocus: false,
+    });
+  });
+
+  it.each([400, 401, 403, 404])('does not retry HTTP %s responses', status => {
+    expect(retryQuery(0, { status })).toBe(false);
+  });
+
+  it('keeps the three-attempt limit for server errors', () => {
+    expect(retryQuery(2, { status: 500 })).toBe(true);
+    expect(retryQuery(3, { status: 500 })).toBe(false);
+  });
+
+  it('keeps the three-attempt limit for network errors', () => {
+    expect(retryQuery(2, new Error('network error'))).toBe(true);
+    expect(retryQuery(3, new Error('network error'))).toBe(false);
+  });
+});

--- a/frontend/src/lib/queryClient.ts
+++ b/frontend/src/lib/queryClient.ts
@@ -21,6 +21,19 @@ export const queryClient = new QueryClient({
     queries: {
       staleTime: 3 * 60_000,
       refetchOnWindowFocus: false,
+      retry(failureCount, error: unknown) {
+        // Do not retry for unauthorized or bad requests
+        if (
+          !!error &&
+          typeof error === 'object' &&
+          'status' in error &&
+          !isNaN(Number(error.status)) &&
+          Number(error.status) < 500
+        ) {
+          return false;
+        }
+        return failureCount < 3;
+      },
     },
   },
 });

--- a/frontend/src/lib/queryClient.ts
+++ b/frontend/src/lib/queryClient.ts
@@ -16,24 +16,37 @@
 
 import { QueryClient } from '@tanstack/react-query';
 
+/**
+ * Determines whether React Query should retry a failed query.
+ *
+ * @param failureCount - Number of failed attempts before this retry decision.
+ * @param error - The query error, which may include a numeric HTTP `status`.
+ * @returns `true` while retries remain for transient errors; `false` for
+ * permanent HTTP 4xx errors other than 408 and 429, or after three failures.
+ */
+export function shouldRetryQuery(failureCount: number, error: unknown): boolean {
+  const status =
+    error !== null &&
+    typeof error === 'object' &&
+    'status' in error &&
+    typeof error.status === 'number' &&
+    Number.isFinite(error.status)
+      ? error.status
+      : undefined;
+
+  if (status !== undefined && status >= 400 && status < 500 && status !== 408 && status !== 429) {
+    return false;
+  }
+
+  return failureCount < 3;
+}
+
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 3 * 60_000,
       refetchOnWindowFocus: false,
-      retry(failureCount, error: unknown) {
-        // Do not retry for unauthorized or bad requests
-        if (
-          !!error &&
-          typeof error === 'object' &&
-          'status' in error &&
-          !isNaN(Number(error.status)) &&
-          Number(error.status) < 500
-        ) {
-          return false;
-        }
-        return failureCount < 3;
-      },
+      retry: shouldRetryQuery,
     },
   },
 });


### PR DESCRIPTION
## Summary

- keep the original Azure retry callback and its focused tests in one
  independently passing commit
- preserve the original Azure change as its own commit: stop immediate retries
  when a query error exposes a numeric HTTP status below 500
- add temporary-error handling in a later commit:
  - keep HTTP 408 retryable because a timed-out request may succeed later
  - keep HTTP 429 retryable because rate limiting may clear later
  - keep the existing three-attempt limit for 408, 429, server errors, and
    status-less network failures
  - avoid immediate retries for other 4xx responses, while allowing later
    refetches after permissions, configuration, or external state changes
- accept only finite numeric status values instead of relying on truthiness or
  coercing malformed status values
- add the exported `shouldRetryQuery` policy and document its `failureCount` and
  `error` parameters and return contract
- add a later Playwright regression proving a corrected config error recovers on
  the normal scheduled refetch without restarting the browser
- upstream only the retry-policy change from Azure/aks-desktop#8, excluding its
  unrelated namespace-list and ViewButton changes

## Improvements over the original PR

- keeps the original Azure callback and focused tests in one independently green
  commit, followed by separately reviewable temporary-error refinements
- avoids the original broad `status < 500` rule suppressing transient 408 and
  429 responses
- validates that exposed status values are finite numbers before applying HTTP
  range policy
- clarifies that ordinary 4xx responses are not retried immediately, but are not
  permanently cached and can recover through a later refetch after correction
- extracts a reusable, documented retry policy instead of an anonymous callback
- adds 15 focused unit tests with 100% branch coverage and a browser-level config
  recovery regression; the original change had no dedicated tests

## Test coverage

- `frontend/src/lib/queryClient.ts` has 100% statement, branch, function, and
  line coverage
- the Playwright regression rejects the active `/config` request, verifies the
  cluster UI does not recover during the immediate retry window, confirms the
  scheduled refetch returns HTTP 200, and checks that both cluster links return

## Provenance

- original change: [Azure/aks-desktop@63640716](https://github.com/Azure/aks-desktop/commit/63640716f841d5b321d67c39a935cf10dca7384a)
- original PR: [Azure/aks-desktop#8](https://github.com/Azure/aks-desktop/pull/8)
- retained as patch 0052 by [Azure/aks-desktop@68e024dc](https://github.com/Azure/aks-desktop/commit/68e024dca932107a6a5a65b606edc1fdf2fae52d)
- patch-series PR: [Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823)

The original implementation commit preserves Oleksandr Dubenko as author and
its original author date. René Dudfield is included as co-author. The temporary
error refinements are separate René-authored commits.

## Testing

- `npm --prefix frontend test -- --run src/lib/queryClient.test.ts --coverage --coverage.include=src/lib/queryClient.ts --coverage.reporter=text`
- `npm --prefix frontend test -- --run --coverage`
- `npm --prefix frontend run tsc`
- focused ESLint and Prettier checks for all changed files
- `cd e2e-tests && npx playwright test tests/podsPage.spec.ts --list`

Assisted by copilot
