### PR TITLE
0044: app: Test shell-free plugin listing

### DIFF
--- a/app/e2e-tests/tests/listPluginsCli.spec.ts
+++ b/app/e2e-tests/tests/listPluginsCli.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+const appDir = path.resolve(__dirname, '../..');
+const electronExecutable =
+  process.platform === 'darwin'
+    ? path.join(appDir, 'node_modules/electron/dist/Electron.app/Contents/MacOS/Electron')
+    : path.join(appDir, 'node_modules/electron/dist/electron');
+const resourcesDir =
+  process.platform === 'darwin'
+    ? path.join(appDir, 'node_modules/electron/dist/Electron.app/Contents/Resources')
+    : path.join(appDir, 'node_modules/electron/dist/resources');
+
+test('lists plugins through the desktop CLI', () => {
+  test.skip(process.platform === 'win32', 'The executable fixture requires a POSIX shell.');
+
+  const backendPath = path.join(resourcesDir, 'headlamp-server');
+  const backupPath = `${backendPath}.list-plugins-e2e-backup-${process.pid}`;
+  const hadBackend = fs.existsSync(backendPath);
+
+  if (hadBackend) {
+    fs.renameSync(backendPath, backupPath);
+  }
+
+  try {
+    fs.writeFileSync(
+      backendPath,
+      '#!/bin/sh\n' +
+        'if [ "$1" != "list-plugins" ]; then exit 2; fi\n' +
+        'printf "plugin-one\\nplugin-two\\n"\n',
+      { mode: 0o755 }
+    );
+
+    const env = { ...process.env, ELECTRON_DEV: 'true' };
+    delete env.ELECTRON_RUN_AS_NODE;
+    const result = spawnSync(electronExecutable, [appDir, 'list-plugins'], {
+      cwd: appDir,
+      encoding: 'utf8',
+      env,
+      timeout: 30_000,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('plugin-one\nplugin-two\n');
+  } finally {
+    fs.rmSync(backendPath, { force: true });
+    if (hadBackend) {
+      fs.renameSync(backupPath, backendPath);
+    }
+  }
+});

--- a/app/e2e-tests/tests/listPluginsCli.spec.ts
+++ b/app/e2e-tests/tests/listPluginsCli.spec.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+const appDir = path.resolve(__dirname, '../..');
+const electronExecutable =
+  process.platform === 'darwin'
+    ? path.join(appDir, 'node_modules/electron/dist/Electron.app/Contents/MacOS/Electron')
+    : path.join(appDir, 'node_modules/electron/dist/electron');
+const resourcesDir =
+  process.platform === 'darwin'
+    ? path.join(appDir, 'node_modules/electron/dist/Electron.app/Contents/Resources')
+    : path.join(appDir, 'node_modules/electron/dist/resources');
+
+test('lists plugins through the desktop CLI', () => {
+  test.skip(process.env.PLAYWRIGHT_TEST_MODE !== 'app', 'Requires Electron app mode');
+  test.skip(process.platform === 'win32', 'The executable fixture requires a POSIX shell.');
+
+  expect(fs.existsSync(resourcesDir)).toBe(true);
+
+  const backendPath = path.join(resourcesDir, 'headlamp-server');
+  const backupPath = `${backendPath}.list-plugins-e2e-backup-${process.pid}`;
+  const hadBackend = fs.existsSync(backendPath);
+
+  if (hadBackend) {
+    fs.renameSync(backendPath, backupPath);
+  }
+
+  try {
+    fs.writeFileSync(
+      backendPath,
+      '#!/bin/sh\n' +
+        'if [ "$1" != "list-plugins" ]; then exit 2; fi\n' +
+        'printf "plugin-one\\nplugin-two\\n"\n',
+      { mode: 0o755 }
+    );
+
+    const env = { ...process.env, ELECTRON_DEV: 'true' };
+    delete env.ELECTRON_RUN_AS_NODE;
+    const result = spawnSync(electronExecutable, [appDir, 'list-plugins'], {
+      cwd: appDir,
+      encoding: 'utf8',
+      env,
+      timeout: 30_000,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('plugin-one\nplugin-two\n');
+  } finally {
+    fs.rmSync(backendPath, { force: true });
+    if (hadBackend) {
+      fs.renameSync(backupPath, backendPath);
+    }
+  }
+});

--- a/app/electron/list-plugins.test.ts
+++ b/app/electron/list-plugins.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import path from 'path';
+import { describe, expect, it, vi } from 'vitest';
+import { runListPluginsCommand } from './list-plugins';
+
+const execSync = vi.hoisted(() => vi.fn());
+
+vi.mock('child_process', () => ({ execSync }));
+
+describe('runListPluginsCommand', () => {
+  it('writes the plugin list and succeeds', () => {
+    const output = Buffer.from('plugin-one\nplugin-two\n');
+    const execute = vi.fn(() => output);
+    const writeOutput = vi.fn();
+    const reportError = vi.fn();
+    const resourcesPath = path.join('resources with spaces');
+
+    const exitCode = runListPluginsCommand(resourcesPath, execute, writeOutput, reportError);
+
+    expect(exitCode).toBe(0);
+    expect(execute).toHaveBeenCalledWith(
+      `${path.join(resourcesPath, 'headlamp-server')} list-plugins`
+    );
+    expect(writeOutput).toHaveBeenCalledWith(output);
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it('reports execution errors and fails', () => {
+    const error = new Error('backend failed');
+    const execute = vi.fn(() => {
+      throw error;
+    });
+    const writeOutput = vi.fn();
+    const reportError = vi.fn();
+
+    const exitCode = runListPluginsCommand('resources', execute, writeOutput, reportError);
+
+    expect(exitCode).toBe(1);
+    expect(writeOutput).not.toHaveBeenCalled();
+    expect(reportError).toHaveBeenCalledWith(error);
+  });
+
+  it('uses the process streams by default', () => {
+    const output = Buffer.from('plugin-one\n');
+    execSync.mockReturnValue(output);
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const exitCode = runListPluginsCommand('resources');
+
+    expect(exitCode).toBe(0);
+    expect(execSync).toHaveBeenCalledWith(path.join('resources', 'headlamp-server list-plugins'));
+    expect(write).toHaveBeenCalledWith(output);
+    write.mockRestore();
+  });
+
+  it('reports errors to the console by default', () => {
+    const error = new Error('backend failed');
+    execSync.mockImplementation(() => {
+      throw error;
+    });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const exitCode = runListPluginsCommand('resources');
+
+    expect(exitCode).toBe(1);
+    expect(consoleError).toHaveBeenCalledWith(`Error listing plugins: ${error}`);
+    consoleError.mockRestore();
+  });
+});

--- a/app/electron/list-plugins.test.ts
+++ b/app/electron/list-plugins.test.ts
@@ -18,9 +18,9 @@ import path from 'path';
 import { describe, expect, it, vi } from 'vitest';
 import { runListPluginsCommand } from './list-plugins';
 
-const execSync = vi.hoisted(() => vi.fn());
+const execFileSync = vi.hoisted(() => vi.fn());
 
-vi.mock('child_process', () => ({ execSync }));
+vi.mock('child_process', () => ({ execFileSync }));
 
 describe('runListPluginsCommand', () => {
   it('writes the plugin list and succeeds', () => {
@@ -33,9 +33,9 @@ describe('runListPluginsCommand', () => {
     const exitCode = runListPluginsCommand(resourcesPath, execute, writeOutput, reportError);
 
     expect(exitCode).toBe(0);
-    expect(execute).toHaveBeenCalledWith(
-      `${path.join(resourcesPath, 'headlamp-server')} list-plugins`
-    );
+    expect(execute).toHaveBeenCalledWith(path.join(resourcesPath, 'headlamp-server'), [
+      'list-plugins',
+    ]);
     expect(writeOutput).toHaveBeenCalledWith(output);
     expect(reportError).not.toHaveBeenCalled();
   });
@@ -57,20 +57,22 @@ describe('runListPluginsCommand', () => {
 
   it('uses the process streams by default', () => {
     const output = Buffer.from('plugin-one\n');
-    execSync.mockReturnValue(output);
+    execFileSync.mockReturnValue(output);
     const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
 
     const exitCode = runListPluginsCommand('resources');
 
     expect(exitCode).toBe(0);
-    expect(execSync).toHaveBeenCalledWith(path.join('resources', 'headlamp-server list-plugins'));
+    expect(execFileSync).toHaveBeenCalledWith(path.join('resources', 'headlamp-server'), [
+      'list-plugins',
+    ]);
     expect(write).toHaveBeenCalledWith(output);
     write.mockRestore();
   });
 
   it('reports errors to the console by default', () => {
     const error = new Error('backend failed');
-    execSync.mockImplementation(() => {
+    execFileSync.mockImplementation(() => {
       throw error;
     });
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/app/electron/list-plugins.test.ts
+++ b/app/electron/list-plugins.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import path from 'path';
+import { describe, expect, it, vi } from 'vitest';
+import { runListPluginsCommand } from './list-plugins';
+
+const execFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock('child_process', () => ({ execFileSync }));
+
+describe('runListPluginsCommand', () => {
+  it('writes the plugin list and succeeds', () => {
+    const output = Buffer.from('plugin-one\nplugin-two\n');
+    const execute = vi.fn(() => output);
+    const writeOutput = vi.fn();
+    const reportError = vi.fn();
+    const resourcesPath = path.join('resources with spaces');
+
+    const exitCode = runListPluginsCommand(resourcesPath, execute, writeOutput, reportError);
+
+    expect(exitCode).toBe(0);
+    expect(execute).toHaveBeenCalledWith(path.join(resourcesPath, 'headlamp-server'), [
+      'list-plugins',
+    ]);
+    expect(writeOutput).toHaveBeenCalledWith(output);
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it('reports execution errors and fails', () => {
+    const error = new Error('backend failed');
+    const execute = vi.fn(() => {
+      throw error;
+    });
+    const writeOutput = vi.fn();
+    const reportError = vi.fn();
+
+    const exitCode = runListPluginsCommand('resources', execute, writeOutput, reportError);
+
+    expect(exitCode).toBe(1);
+    expect(writeOutput).not.toHaveBeenCalled();
+    expect(reportError).toHaveBeenCalledWith(error);
+  });
+
+  it('uses the process streams by default', () => {
+    const output = Buffer.from('plugin-one\n');
+    execFileSync.mockReturnValue(output);
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const exitCode = runListPluginsCommand('resources');
+
+    expect(exitCode).toBe(0);
+    expect(execFileSync).toHaveBeenCalledWith(path.join('resources', 'headlamp-server'), [
+      'list-plugins',
+    ]);
+    expect(write).toHaveBeenCalledWith(output);
+    write.mockRestore();
+  });
+
+  it('reports errors to the console by default', () => {
+    const error = new Error('backend failed');
+    execFileSync.mockImplementation(() => {
+      throw error;
+    });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const exitCode = runListPluginsCommand('resources');
+
+    expect(exitCode).toBe(1);
+    expect(consoleError).toHaveBeenCalledWith(`Error listing plugins: ${error}`);
+    consoleError.mockRestore();
+  });
+});

--- a/app/electron/list-plugins.ts
+++ b/app/electron/list-plugins.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { execSync } from 'child_process';
+import path from 'path';
+
+type ExecuteListPlugins = (command: string) => Buffer;
+type WriteOutput = (output: Buffer) => unknown;
+type ReportError = (error: unknown) => unknown;
+
+export function runListPluginsCommand(
+  resourcesPath: string,
+  execute: ExecuteListPlugins = execSync,
+  writeOutput: WriteOutput = output => process.stdout.write(output),
+  reportError: ReportError = error => console.error(`Error listing plugins: ${error}`)
+): number {
+  try {
+    const backendPath = path.join(resourcesPath, 'headlamp-server');
+    const stdout = execute(`${backendPath} list-plugins`);
+    writeOutput(stdout);
+    return 0;
+  } catch (error) {
+    reportError(error);
+    return 1;
+  }
+}

--- a/app/electron/list-plugins.ts
+++ b/app/electron/list-plugins.ts
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import path from 'path';
 
-type ExecuteListPlugins = (command: string) => Buffer;
+type ExecuteListPlugins = (file: string, args: string[]) => Buffer;
 type WriteOutput = (output: Buffer) => unknown;
 type ReportError = (error: unknown) => unknown;
 
 export function runListPluginsCommand(
   resourcesPath: string,
-  execute: ExecuteListPlugins = execSync,
+  execute: ExecuteListPlugins = execFileSync,
   writeOutput: WriteOutput = output => process.stdout.write(output),
   reportError: ReportError = error => console.error(`Error listing plugins: ${error}`)
 ): number {
   try {
     const backendPath = path.join(resourcesPath, 'headlamp-server');
-    const stdout = execute(`${backendPath} list-plugins`);
+    const stdout = execute(backendPath, ['list-plugins']);
     writeOutput(stdout);
     return 0;
   } catch (error) {

--- a/app/electron/list-plugins.ts
+++ b/app/electron/list-plugins.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { execFileSync } from 'child_process';
+import path from 'path';
+
+type ExecuteListPlugins = (file: string, args: string[]) => Buffer;
+type WriteOutput = (output: Buffer) => unknown;
+type ReportError = (error: unknown) => unknown;
+
+/**
+ * Runs the backend's `list-plugins` command and forwards its output.
+ *
+ * @param resourcesPath - Directory containing the packaged Headlamp backend executable.
+ * @param execute - Synchronous executable runner used to invoke the backend.
+ * @param writeOutput - Callback that receives the backend's standard output.
+ * @param reportError - Callback that receives command or output handling errors.
+ * @returns `0` when the command and output handling succeed; otherwise `1`.
+ */
+export function runListPluginsCommand(
+  resourcesPath: string,
+  execute: ExecuteListPlugins = execFileSync,
+  writeOutput: WriteOutput = output => process.stdout.write(output),
+  reportError: ReportError = error => console.error(`Error listing plugins: ${error}`)
+): number {
+  try {
+    const backendPath = path.join(resourcesPath, 'headlamp-server');
+    const stdout = execute(backendPath, ['list-plugins']);
+    writeOutput(stdout);
+    return 0;
+  } catch (error) {
+    reportError(error);
+    return 1;
+  }
+}

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -42,6 +42,7 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { setupCustomCAs, setupSystemCAs } from './certificates';
 import i18n from './i18next.config';
+import { runListPluginsCommand } from './list-plugins';
 import MCPClient from './mcp/MCPClient';
 import { filterUserOwnedPids } from './ownedProcesses';
 import {
@@ -130,15 +131,7 @@ const args = yargs(hideBin(process.argv))
     'List all static and user-added plugins.',
     () => {},
     () => {
-      try {
-        const backendPath = path.join(process.resourcesPath, 'headlamp-server');
-        const stdout = execSync(`${backendPath} list-plugins`);
-        process.stdout.write(stdout);
-        process.exit(0);
-      } catch (error) {
-        console.error(`Error listing plugins: ${error}`);
-        process.exit(1);
-      }
+      process.exit(runListPluginsCommand(process.resourcesPath));
     }
   )
   .options({

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -44,6 +44,7 @@ import {
   loadLegalDocuments,
   readLegalDocument,
 } from './legal-documents';
+import { runListPluginsCommand } from './list-plugins';
 import MCPClient from './mcp/MCPClient';
 import { filterUserOwnedPids } from './ownedProcesses';
 import {
@@ -144,15 +145,7 @@ const args = yargs(hideBin(process.argv))
     'List all static and user-added plugins.',
     () => {},
     () => {
-      try {
-        const backendPath = path.join(process.resourcesPath, 'headlamp-server');
-        const stdout = execFileSync(backendPath, ['list-plugins']);
-        process.stdout.write(stdout);
-        process.exit(0);
-      } catch (error) {
-        console.error(`Error listing plugins: ${error}`);
-        process.exit(1);
-      }
+      process.exit(runListPluginsCommand(process.resourcesPath));
     }
   )
   .options({


### PR DESCRIPTION
## Summary

- extract the existing shell-free `list-plugins` invocation into a focused helper
- cover success, failure, default output, and default error handling
- add an Electron CLI end-to-end test using a temporary backend executable

The unit and end-to-end test commits remain ordered for easy review.

## Rebase update

Headlamp PR 4099 landed the original behavior while this PR was open:

- https://github.com/kubernetes-sigs/headlamp/pull/4099
- `execSync(`${backendPath} list-plugins`)` became `execFileSync(backendPath, ['list-plugins'])`

Rebasing onto current `main` therefore made the original implementation commit
empty, and Git dropped it automatically. This PR now contains only the unique
follow-up work:

- extracts main's existing `execFileSync` call into `app/electron/list-plugins`
- adds four unit tests with 100% branch coverage for the helper
- asserts the executable-and-arguments contract directly
- adds a Playwright test that launches the compiled Electron CLI

No commit in this branch reintroduces shell execution.

## Compared with the original Azure change

The original Azure commit only changed the inline backend invocation from a shell
command string to `execFileSync`. This rebased PR adds the helper-level unit
coverage and Electron CLI e2e that were not in the original change.

This PR remains narrower than Azure PR 756: it excludes the other downstream
CI-repair commits in that PR.

## Provenance

- Original Azure PR: https://github.com/Azure/aks-desktop/pull/756
- Original Azure commit: https://github.com/Azure/aks-desktop/commit/badc4713bb431591fdde9394b035cfc11db0473b
- Patch-retention PR: https://github.com/Azure/aks-desktop/pull/823
- Retained patch commit: https://github.com/Azure/aks-desktop/commit/68e024dca932107a6a5a65b606edc1fdf2fae52d
- Related Azure issue: https://github.com/Azure/aks-desktop/issues/153

Oleksandr Dubenko authored the original Azure change on 2026-07-10 to support
backend paths containing whitespace. Its implementation is now present on
Headlamp `main` through PR 4099, so this branch no longer duplicates that commit.

## Testing / proof it works?

- focused Vitest suite: 4 passed
- `app/electron/list-plugins.ts`: 100% branch coverage
- app TypeScript check: passed
- focused Playwright Electron CLI e2e: 1 passed
- repository lint and formatting checks: passed

Assisted by copilot.
