### PR TITLE
0043: app: Derive the Linux executable name

### DIFF
--- a/app/electron/package.test.ts
+++ b/app/electron/package.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import { describe, expect, it } from 'vitest';
+
+const packageJson = JSON.parse(
+  fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8')
+) as {
+  build: {
+    linux: {
+      executableName?: string;
+    };
+  };
+};
+
+describe('desktop package configuration', () => {
+  it('derives the Linux executable name from package metadata', () => {
+    expect(packageJson.build.linux.executableName).toBeUndefined();
+  });
+});

--- a/app/electron/package.test.ts
+++ b/app/electron/package.test.ts
@@ -26,6 +26,9 @@ const packageJson = JSON.parse(
   version: string;
   build: {
     artifactName: string;
+    linux: {
+      executableName?: string;
+    };
   };
 };
 const require = createRequire(import.meta.url);
@@ -48,5 +51,9 @@ describe('desktop package configuration', () => {
         arch: 'x64',
       })
     ).toBe(`${packageJson.name}-${packageJson.version}-win-x64.msi`);
+  });
+
+  it('derives the Linux executable name from package metadata', () => {
+    expect(packageJson.build.linux.executableName).toBeUndefined();
   });
 });

--- a/app/package.json
+++ b/app/package.json
@@ -93,7 +93,6 @@
           ]
         }
       ],
-      "executableName": "headlamp",
       "maintainer": "Kinvolk <hello@kinvolk.io>",
       "category": "Network",
       "extraResources": [


### PR DESCRIPTION
## Summary

Remove the hardcoded Linux `executableName` so Electron Builder derives it from the package and product metadata


## Provenance

This upstreams patch 0043 retained by [Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823). The source patch metadata identifies commit `a13a74312748b7247cc8f3487e47a10534d89abb`, authored by Joaquim Rocha on 2026-07-31. That SHA is recorded here as source provenance; this description does not claim that it resolves publicly.

Related umbrella tracking: [Azure/aks-desktop#153](https://github.com/Azure/aks-desktop/issues/153).


## Proof this still works?

`.github/workflows/app.yml` runs the Linux package verification, and `app/scripts/verify-build-linux.sh` finds and launches the packaged `headlamp` executable with `list-plugins`. That existing package smoke directly exercises the derived executable name, so no duplicate end-to-end test is added.


Assisted by copilot