### PR TITLE
0053: Resource-map label reflow

### DIFF
--- a/e2e-tests/tests/resourceMap.spec.ts
+++ b/e2e-tests/tests/resourceMap.spec.ts
@@ -28,13 +28,15 @@ const namespace = {
   status: { phase: 'Active' },
 };
 
+const longPodName = 'resize-test-pod-with-a-long-name-that-needs-to-wrap';
+
 const pods = Array.from({ length: 1001 }, (_, index) => ({
   apiVersion: 'v1',
   kind: 'Pod',
   metadata: {
-    name: `resize-test-pod-${index}`,
+    name: index === 0 ? longPodName : `resize-test-pod-${index}`,
     namespace: namespace.metadata.name,
-    uid: `resize-test-pod-${index}`,
+    uid: index === 0 ? longPodName : `resize-test-pod-${index}`,
     resourceVersion: String(index + 1),
   },
   spec: {
@@ -181,4 +183,29 @@ test('groups scheduled and unscheduled pods by node', async ({ page }) => {
 
   await expect(page.locator('[data-id="Node-worker-1"]')).toBeVisible({ timeout: 30_000 });
   await expect(page.locator('[data-id="Node-Unscheduled"]')).toBeVisible();
+});
+
+test('reflows long resource labels without clipping', async ({ page }) => {
+  test.setTimeout(60_000);
+  const cluster = process.env.HEADLAMP_TEST_CLUSTER || 'test';
+  const headlampPage = new HeadlampPage(page);
+  await mockResourceMapCollections(page, cluster);
+  await headlampPage.navigateToCluster(cluster, process.env.HEADLAMP_TEST_TOKEN);
+
+  await headlampPage.navigateTopage(`/c/${cluster}/map`);
+
+  const namespaceNode = page.locator(`[data-id="${namespace.metadata.uid}"]`);
+  await expect(namespaceNode).toBeVisible({ timeout: 30_000 });
+  await namespaceNode.getByRole('button').click();
+
+  const podNode = page.locator(`[data-id="${longPodName}"]`);
+  const button = podNode.getByRole('button');
+  const label = button.getByText(longPodName);
+  await expect(label).toBeVisible({ timeout: 30_000 });
+  await button.focus();
+
+  await expect(label).toHaveCSS('white-space', 'normal');
+  await expect(label).toHaveCSS('word-break', 'break-word');
+  await expect(label.locator('..')).toHaveCSS('overflow', 'visible');
+  await expect(label.locator('../..')).toHaveCSS('min-height', '48px');
 });

--- a/e2e-tests/tests/resourceMap.spec.ts
+++ b/e2e-tests/tests/resourceMap.spec.ts
@@ -28,13 +28,15 @@ const namespace = {
   status: { phase: 'Active' },
 };
 
+const longPodName = 'resize-test-pod-with-a-long-name-that-needs-to-wrap';
+
 const pods = Array.from({ length: 1001 }, (_, index) => ({
   apiVersion: 'v1',
   kind: 'Pod',
   metadata: {
-    name: `resize-test-pod-${index}`,
+    name: index === 0 ? longPodName : `resize-test-pod-${index}`,
     namespace: namespace.metadata.name,
-    uid: `resize-test-pod-${index}`,
+    uid: index === 0 ? longPodName : `resize-test-pod-${index}`,
     resourceVersion: String(index + 1),
   },
   status: {
@@ -141,4 +143,29 @@ test('keeps a simplified namespace expanded while resizing', async ({ page }) =>
     await page.setViewportSize(viewport);
     await assertExpandedTopology();
   }
+});
+
+test('reflows long resource labels without clipping', async ({ page }) => {
+  test.setTimeout(60_000);
+  const cluster = process.env.HEADLAMP_TEST_CLUSTER || 'test';
+  const headlampPage = new HeadlampPage(page);
+  await mockResourceMapCollections(page, cluster);
+  await headlampPage.navigateToCluster(cluster, process.env.HEADLAMP_TEST_TOKEN);
+
+  await headlampPage.navigateTopage(`/c/${cluster}/map`);
+
+  const namespaceNode = page.locator(`[data-id="${namespace.metadata.uid}"]`);
+  await expect(namespaceNode).toBeVisible({ timeout: 30_000 });
+  await namespaceNode.getByRole('button').click();
+
+  const podNode = page.locator(`[data-id="${longPodName}"]`);
+  const button = podNode.getByRole('button');
+  const label = button.getByText(longPodName);
+  await expect(label).toBeVisible({ timeout: 30_000 });
+  await button.focus();
+
+  await expect(label).toHaveCSS('white-space', 'normal');
+  await expect(label).toHaveCSS('word-break', 'break-word');
+  await expect(label.locator('..')).toHaveCSS('overflow', 'visible');
+  await expect(label.locator('../..')).toHaveCSS('min-height', '48px');
 });

--- a/frontend/src/components/resourceMap/nodes/KubeObjectNode.test.tsx
+++ b/frontend/src/components/resourceMap/nodes/KubeObjectNode.test.tsx
@@ -199,6 +199,24 @@ describe('KubeObjectNodeComponent', () => {
     expect(screen.queryByTestId('kube-icon')).not.toBeInTheDocument();
   });
 
+  it('allows long labels to wrap without clipping', () => {
+    mocks.node = {
+      id: 'deployment',
+      kubeObject: makeKubeObject({
+        apiVersion: 'apps/v1',
+        kind: 'Deployment',
+        name: 'frontend-deployment-with-a-long-name',
+      }),
+      status: 'success',
+    };
+
+    render(<KubeObjectNodeComponent {...nodeProps('deployment')} />);
+
+    const label = screen.getByText('frontend-deployment-with-a-long-name');
+    expect(label).toHaveStyle({ whiteSpace: 'normal', wordBreak: 'break-word' });
+    expect(label.parentElement).toHaveClass('label-container');
+  });
+
   it('uses the highest-weight child object and shows a collapsed warning and count', () => {
     mocks.node = {
       id: 'group',

--- a/frontend/src/components/resourceMap/nodes/KubeObjectNode.tsx
+++ b/frontend/src/components/resourceMap/nodes/KubeObjectNode.tsx
@@ -57,6 +57,17 @@ const Container = styled('div')<{
   ':hover': {
     borderColor: isSelected ? undefined : alpha(theme.palette.action.active, 0.2),
     boxShadow: '4px 4px 6px rgba(0,0,0,0.06)',
+    zIndex: 10,
+    '& .label-container': {
+      overflow: 'visible',
+    },
+  },
+
+  ':focus-within': {
+    zIndex: 10,
+    '& .label-container': {
+      overflow: 'visible',
+    },
   },
 
   '::before':
@@ -118,7 +129,7 @@ const TextContainer = styled('div')({
   display: 'flex',
   alignItems: 'center',
   gap: '8px',
-  height: '48px',
+  minHeight: '48px',
 });
 
 const LabelContainer = styled('div')<{ isCollapsed?: boolean }>(({ isCollapsed }) => ({
@@ -135,9 +146,8 @@ const Subtitle = styled('div')({
 });
 
 const Title = styled('div')({
-  textOverflow: 'ellipsis',
-  overflow: 'hidden',
-  whiteSpace: 'nowrap',
+  whiteSpace: 'normal',
+  wordBreak: 'break-word',
 });
 
 const EXPAND_DELAY = 450;
@@ -277,17 +287,9 @@ export const KubeObjectNodeComponent = memo(({ id }: NodeProps) => {
 
       <TextContainer>
         {icon}
-        <LabelContainer isCollapsed={isCollapsed}>
+        <LabelContainer className="label-container" isCollapsed={isCollapsed}>
           <Subtitle>{subtitle}</Subtitle>
-          <Title
-            sx={{
-              textOverflow: 'ellipsis',
-              overflow: 'hidden',
-              whiteSpace: 'nowrap',
-            }}
-          >
-            {label}
-          </Title>
+          <Title>{label}</Title>
         </LabelContainer>
       </TextContainer>
       {isExpanded && <NodeGlance node={node} />}


### PR DESCRIPTION
## Summary

### Original patch

The resource-map change originated in [Azure/aks-desktop#473](https://github.com/Azure/aks-desktop/pull/473), commit [`379b4e4df`](https://github.com/Azure/aks-desktop/commit/379b4e4dfd724ded219173b486bba0c8130ca707). That PR fixed content clipped at 200% text zoom; this PR upstreams its resource-map portion.

The original change:

- Replaced the fixed 48-pixel text row with a minimum height so nodes can grow.
- Replaced ellipsis truncation with normal wrapping and long-word breaking.
- Exposed label overflow and raised hovered or focused nodes above their neighbors.

The change was later retained as patch 0053 in [Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823), commit [`68e024dca`](https://github.com/Azure/aks-desktop/commit/68e024dca932107a6a5a65b606edc1fdf2fae52d). Patch 0053 also added a focused component regression test.

### Improvements over patch 0053

- Adds an end-to-end regression before the implementation commit.
- Exercises a long pod name and checks wrapping, word breaking, visible overflow, and a growable text row after keyboard focus.
- Verifies the focused component suite exceeds the requested 80% branch target.


## Related Issues

- Azure/aks-desktop#474
- Azure/aks-desktop#404

## Authorship

The upstreamed implementation commit preserves Thomas Gamble's authorship and the date from patch 0053. René Dudfield is included as co-author.

## Steps to Test

1. Open the resource map with a resource that has a long name.
2. Increase text zoom to 200%.
3. Confirm the label wraps without clipping on hover and keyboard focus.

## Validation

- Focused component tests: 13 passed.
- Scoped coverage: 91.3% branches; 100% statements, functions, and lines.
- Frontend TypeScript check passed.
- ESLint passed for all three changed TypeScript files.
- Production frontend build passed.
- Playwright discovered both resource-map tests.
- Full Playwright execution requires the documented two-cluster environment, which was unavailable locally because there is no `test` Kubernetes context. CI provides that environment.

## Screenshot

Original downstream validation at 200% text zoom:

![Resource-map label reflow at 200% text zoom](https://github.com/user-attachments/assets/35ed69d4-ff1a-409e-ba7a-2e58925e8f30)

Assisted by copilot
