### PR TITLE
frontend: Lists: Reflect the search filter in the URL

### DIFF
--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -175,6 +175,7 @@ function EventsSection() {
 
   return (
     <ResourceListView
+      reflectInURL
       title={t('glossary|Events')}
       headerProps={{
         noNamespaceFilter: false,

--- a/frontend/src/components/configmap/List.tsx
+++ b/frontend/src/components/configmap/List.tsx
@@ -25,6 +25,7 @@ export default function ConfigMapList() {
     <ResourceListView
       title={t('glossary|Config Maps')}
       resourceClass={ConfigMap}
+      reflectInURL
       columns={[
         'name',
         'namespace',

--- a/frontend/src/components/crd/CustomResourceInstancesList.tsx
+++ b/frontend/src/components/crd/CustomResourceInstancesList.tsx
@@ -81,6 +81,7 @@ function CrInstancesView({ crds }: { crds: CRD[]; key: string }) {
         </Alert>
       )}
       <ResourceListView
+        reflectInURL
         title={t('translation|Custom Resource Instances')}
         headerProps={{
           noNamespaceFilter: false,

--- a/frontend/src/components/crd/CustomResourceList.tsx
+++ b/frontend/src/components/crd/CustomResourceList.tsx
@@ -187,6 +187,7 @@ export function CustomResourceListTable(props: CustomResourceTableProps) {
         ),
       }}
       resourceClass={CRClass}
+      reflectInURL
       columns={cols}
     />
   );

--- a/frontend/src/components/crd/List.tsx
+++ b/frontend/src/components/crd/List.tsx
@@ -41,6 +41,7 @@ export default function CustomResourceDefinitionList() {
 
   return (
     <ResourceListView
+      reflectInURL
       title={t('glossary|Custom Resources')}
       headerProps={{
         noNamespaceFilter: true,

--- a/frontend/src/components/endpointSlices/List.tsx
+++ b/frontend/src/components/endpointSlices/List.tsx
@@ -46,6 +46,7 @@ export default function EndpointSliceList() {
     <ResourceListView
       title={t('glossary|Endpoint Slices')}
       resourceClass={EndpointSlice}
+      reflectInURL
       columns={[
         'name',
         'namespace',

--- a/frontend/src/components/endpoints/List.tsx
+++ b/frontend/src/components/endpoints/List.tsx
@@ -32,6 +32,7 @@ export default function EndpointList() {
     <ResourceListView
       title={t('glossary|Endpoints')}
       resourceClass={Endpoints}
+      reflectInURL
       filterFunction={filterFunc}
       columns={[
         'name',

--- a/frontend/src/components/gateway/BackendTLSPolicyList.tsx
+++ b/frontend/src/components/gateway/BackendTLSPolicyList.tsx
@@ -26,6 +26,7 @@ export default function BackendTLSPolicyList() {
     <ResourceListView
       title={t('Backend TLS Policies')}
       resourceClass={BackendTLSPolicy}
+      reflectInURL
       columns={[
         'name',
         'namespace',

--- a/frontend/src/components/gateway/BackendTrafficPolicyList.tsx
+++ b/frontend/src/components/gateway/BackendTrafficPolicyList.tsx
@@ -26,6 +26,7 @@ export default function BackendTrafficPolicyList() {
     <ResourceListView
       title={t('Backend Traffic Policies')}
       resourceClass={BackendTrafficPolicy}
+      reflectInURL
       columns={[
         'name',
         'namespace',

--- a/frontend/src/components/gateway/ClassList.tsx
+++ b/frontend/src/components/gateway/ClassList.tsx
@@ -68,6 +68,7 @@ export default function GatewayClassList() {
         noNamespaceFilter: true,
       }}
       resourceClass={GatewayClass}
+      reflectInURL
       columns={[
         'name',
         'cluster',

--- a/frontend/src/components/gateway/GRPCRouteList.tsx
+++ b/frontend/src/components/gateway/GRPCRouteList.tsx
@@ -25,6 +25,7 @@ export default function GRPCRouteList() {
     <ResourceListView
       title={t('GRPCRoutes')}
       resourceClass={GRPCRoute}
+      reflectInURL
       columns={['name', 'namespace', 'cluster', 'age']}
     />
   );

--- a/frontend/src/components/gateway/GatewayList.tsx
+++ b/frontend/src/components/gateway/GatewayList.tsx
@@ -27,6 +27,7 @@ export default function GatewayList() {
     <ResourceListView
       title={t('Gateways')}
       resourceClass={Gateway}
+      reflectInURL
       columns={[
         'name',
         'namespace',

--- a/frontend/src/components/gateway/HTTPRouteList.tsx
+++ b/frontend/src/components/gateway/HTTPRouteList.tsx
@@ -26,6 +26,7 @@ export default function HTTPRouteList() {
     <ResourceListView
       title={t('HttpRoutes')}
       resourceClass={HTTPRoute}
+      reflectInURL
       columns={[
         'name',
         'namespace',

--- a/frontend/src/components/gateway/ReferenceGrantList.tsx
+++ b/frontend/src/components/gateway/ReferenceGrantList.tsx
@@ -26,6 +26,7 @@ export default function ReferenceGrantList() {
     <ResourceListView
       title={t('Reference Grants')}
       resourceClass={ReferenceGrant}
+      reflectInURL
       columns={[
         'name',
         'namespace',

--- a/frontend/src/components/horizontalPodAutoscaler/List.tsx
+++ b/frontend/src/components/horizontalPodAutoscaler/List.tsx
@@ -43,6 +43,7 @@ export default function HpaList() {
     <ResourceListView
       title={t('glossary|Horizontal Pod Autoscalers')}
       resourceClass={HPA}
+      reflectInURL
       columns={[
         'name',
         'namespace',

--- a/frontend/src/components/ingress/ClassList.tsx
+++ b/frontend/src/components/ingress/ClassList.tsx
@@ -28,6 +28,7 @@ export default function IngressClassList() {
         noNamespaceFilter: true,
       }}
       resourceClass={IngressClass}
+      reflectInURL
       columns={[
         'name',
         {

--- a/frontend/src/components/ingress/List.tsx
+++ b/frontend/src/components/ingress/List.tsx
@@ -57,6 +57,7 @@ export default function IngressList() {
     <ResourceListView
       title={t('Ingresses')}
       resourceClass={Ingress}
+      reflectInURL
       columns={[
         'name',
         'namespace',

--- a/frontend/src/components/lease/List.tsx
+++ b/frontend/src/components/lease/List.tsx
@@ -24,6 +24,7 @@ export function LeaseList() {
     <ResourceListView
       title={t('glossary|Lease')}
       resourceClass={Lease}
+      reflectInURL
       columns={[
         'name',
         'namespace',

--- a/frontend/src/components/namespace/List.tsx
+++ b/frontend/src/components/namespace/List.tsx
@@ -124,6 +124,7 @@ export default function NamespacesList() {
 
   return (
     <ResourceListView
+      reflectInURL
       title={t('Namespaces')}
       headerProps={{
         titleSideActions: [<CreateNamespaceButton />],

--- a/frontend/src/components/networkpolicy/List.tsx
+++ b/frontend/src/components/networkpolicy/List.tsx
@@ -26,6 +26,7 @@ export function NetworkPolicyList() {
     <ResourceListView
       title={t('Network Policies')}
       resourceClass={NetworkPolicy}
+      reflectInURL
       columns={[
         'name',
         'namespace',

--- a/frontend/src/components/podDisruptionBudget/List.tsx
+++ b/frontend/src/components/podDisruptionBudget/List.tsx
@@ -25,6 +25,7 @@ export default function PDBList() {
     <ResourceListView
       title={t('glossary|Pod Disruption Budget')}
       resourceClass={PDB}
+      reflectInURL
       columns={[
         'name',
         'namespace',

--- a/frontend/src/components/priorityClass/List.tsx
+++ b/frontend/src/components/priorityClass/List.tsx
@@ -25,6 +25,7 @@ export default function PriorityClassList() {
     <ResourceListView
       title={t('glossary|PriorityClass')}
       resourceClass={PriorityClass}
+      reflectInURL
       columns={[
         'name',
         'cluster',

--- a/frontend/src/components/role/BindingList.tsx
+++ b/frontend/src/components/role/BindingList.tsx
@@ -86,6 +86,7 @@ export default function RoleBindingList() {
 
   return (
     <ResourceListView
+      reflectInURL
       title={t('glossary|Role Bindings')}
       errors={allErrors}
       columns={[

--- a/frontend/src/components/role/List.tsx
+++ b/frontend/src/components/role/List.tsx
@@ -53,6 +53,7 @@ export default function RoleList({ namespaces }: { namespaces?: string[] }) {
 
   return (
     <ResourceListView
+      reflectInURL
       title={t('Roles')}
       errors={allErrors}
       columns={[

--- a/frontend/src/components/runtimeClass/List.tsx
+++ b/frontend/src/components/runtimeClass/List.tsx
@@ -25,6 +25,7 @@ export function RuntimeClassList() {
     <ResourceListView
       title={t('glossary|RuntimeClass')}
       resourceClass={RuntimeClass}
+      reflectInURL
       columns={[
         'name',
         'cluster',

--- a/frontend/src/components/secret/List.tsx
+++ b/frontend/src/components/secret/List.tsx
@@ -38,6 +38,7 @@ export default function SecretList() {
 
   return (
     <ResourceListView
+      reflectInURL
       id="headlamp-secrets"
       title={t('Secrets')}
       data={filteredSecrets}

--- a/frontend/src/components/service/List.tsx
+++ b/frontend/src/components/service/List.tsx
@@ -27,6 +27,7 @@ export default function ServiceList() {
     <ResourceListView
       title={t('Services')}
       resourceClass={Service}
+      reflectInURL
       columns={[
         'name',
         'namespace',

--- a/frontend/src/components/serviceaccount/List.tsx
+++ b/frontend/src/components/serviceaccount/List.tsx
@@ -25,6 +25,7 @@ export default function ServiceAccountList() {
     <ResourceListView
       title={t('Service Accounts')}
       resourceClass={ServiceAccount}
+      reflectInURL
       columns={[
         'name',
         'namespace',

--- a/frontend/src/components/storage/ClaimList.tsx
+++ b/frontend/src/components/storage/ClaimList.tsx
@@ -28,6 +28,7 @@ export default function VolumeClaimList() {
     <ResourceListView
       title={t('Persistent Volume Claims')}
       resourceClass={PersistentVolumeClaim}
+      reflectInURL
       columns={[
         'name',
         'namespace',

--- a/frontend/src/components/storage/ClassList.tsx
+++ b/frontend/src/components/storage/ClassList.tsx
@@ -28,6 +28,7 @@ export default function ClassList() {
         noNamespaceFilter: true,
       }}
       resourceClass={StorageClass}
+      reflectInURL
       columns={[
         'name',
         {

--- a/frontend/src/components/storage/VolumeAttributesClassList.tsx
+++ b/frontend/src/components/storage/VolumeAttributesClassList.tsx
@@ -28,6 +28,7 @@ export default function VolumeAttributesClassList() {
         noNamespaceFilter: true,
       }}
       resourceClass={VolumeAttributesClass}
+      reflectInURL
       columns={[
         'name',
         {

--- a/frontend/src/components/storage/VolumeList.tsx
+++ b/frontend/src/components/storage/VolumeList.tsx
@@ -32,6 +32,7 @@ export default function VolumeList() {
         noNamespaceFilter: true,
       }}
       resourceClass={PersistentVolume}
+      reflectInURL
       columns={[
         'name',
         {

--- a/frontend/src/components/verticalPodAutoscaler/List.tsx
+++ b/frontend/src/components/verticalPodAutoscaler/List.tsx
@@ -52,6 +52,7 @@ export default function VpaList() {
         <ResourceListView
           title={t('glossary|Vertical Pod Autoscalers')}
           resourceClass={VPA}
+          reflectInURL
           columns={[
             'name',
             'namespace',

--- a/frontend/src/components/webhookconfiguration/MutatingWebhookConfigList.tsx
+++ b/frontend/src/components/webhookconfiguration/MutatingWebhookConfigList.tsx
@@ -25,6 +25,7 @@ export default function MutatingWebhookConfigurationList() {
     <ResourceListView
       title={t('Mutating Webhook Configurations')}
       resourceClass={MutatingWebhookConfiguration}
+      reflectInURL
       columns={[
         'name',
         {

--- a/frontend/src/components/webhookconfiguration/ValidatingWebhookConfigList.tsx
+++ b/frontend/src/components/webhookconfiguration/ValidatingWebhookConfigList.tsx
@@ -25,6 +25,7 @@ export default function ValidatingWebhookConfigurationList() {
     <ResourceListView
       title={t('Validating Webhook Configurations')}
       resourceClass={ValidatingWebhookConfiguration}
+      reflectInURL
       columns={[
         'name',
         'cluster',


### PR DESCRIPTION
## Summary

Enables `reflectInURL` on the list views that were missing it, so the search filter (and page) is kept in the URL on every single-table list instead of only on a handful of them.

Today `?filter=` works on Pods, Jobs, JobSets, LimitRanges, ResourceQuotas and the Workloads overview, because those views hand-roll their table and opt into `reflectInURL`. Every other list renders through `ResourceListView`, which never received the prop, so the filter is lost on reload and on back navigation, and a filtered list cannot be shared as a link.

## Related Issue

Follow-up to #3175 ("Remember filter when going back"), which introduced the behaviour in #3354 but only for the views that already had `reflectInURL` enabled.

## Changes

- Added `reflectInURL` to 35 single-table list views:
  - **Config**: ConfigMaps, Secrets, PriorityClasses, RuntimeClasses, Leases, PodDisruptionBudgets, HPAs, VPAs, MutatingWebhookConfigurations, ValidatingWebhookConfigurations
  - **Network**: Services, Ingresses, IngressClasses, Endpoints, EndpointSlices, NetworkPolicies
  - **Storage**: PersistentVolumeClaims, PersistentVolumes, StorageClasses, VolumeAttributesClasses
  - **Security**: ServiceAccounts, Roles, RoleBindings, Namespaces
  - **Gateway API**: Gateways, GatewayClasses, HTTPRoutes, GRPCRoutes, ReferenceGrants, BackendTLSPolicies, BackendTrafficPolicies
  - **Custom resources**: CRDs, CustomResourceList, CustomResourceInstancesList
  - **Cluster overview**: the Events table

The prop is passed as a bare boolean, which gives an empty prefix and therefore the same unprefixed `?filter=` key the Pods list already uses.

## Steps to Test

1. Run Headlamp against any cluster: `npm start`, then open `http://localhost:3000`.
2. Go to **Config → Secrets** and type something into the table search box.
3. Observe the URL becomes `.../secrets?filter=<text>`.
4. Reload the page: the filter is still applied and the search box is open.
5. Open one of the listed Secrets, then press **Back**: the filter is restored instead of cleared.
6. Copy the filtered URL into a new tab and confirm it opens already filtered.
7. Repeat on any other list touched here (for example Services, PersistentVolumeClaims, or a Gateway API list) — behaviour should be identical to the existing Pods list.

## Screenshots (if applicable)

No visual change: the tables render exactly as before, the only difference is the query string. Verified by the storyshot suite, which passes with no snapshot changes.

## Notes for the Reviewer

- **Deliberately not included:** CronJobs, DaemonSets, Deployments, Nodes, ReplicaSets and StatefulSets. #6748 already adds the identical line to those six, so leaving them out avoids a conflict. They can be folded in here if that PR stalls.
- **Also not included:** `project/ProjectDetails.tsx` and `verticalPodAutoscaler/Details.tsx`. Both render several tables on one page, so they need distinct prefixes (`reflectInURL="..."`) rather than the bare flag, and picking those keys is a per-table judgement call rather than a mechanical change.
- **Scope of the flag:** `reflectInURL` is a single switch that controls URL persistence for the search filter *and* pagination. These pages therefore also start reflecting `p` and `perPage`. That matches the existing behaviour of the Pods list, but it is a visible URL change on 35 pages, so worth a conscious ack.
- An alternative to touching each page would be to default `reflectInURL` to true inside `ResourceListView`. I avoided that because it silently changes behaviour for every consumer, including plugins that render their own lists through it. Happy to switch approach if maintainers prefer the central default.

## Validation

- `npm run frontend:tsc` — passes
- `npm run frontend:lint` — eslint passes; the 14 Prettier warnings it reports are pre-existing on a clean tree (yaml/css/md files untouched by this PR)
- Storyshots (`src/storybook.test.tsx`) — 651 passed, no snapshot changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * List and filter state is now reflected in the URL across resource views, including workloads, networking, storage, access control, and configuration resources.
  * Resource list views can now be bookmarked, shared, and restored with their current state intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->