### PR TITLE
frontend: Tabs: Use Math.max instead of Math.min for defaultIndex clamp

### DIFF
--- a/frontend/src/components/common/Tabs.test.tsx
+++ b/frontend/src/components/common/Tabs.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import Tabs from './Tabs';
+
+describe('Tabs', () => {
+  const tabs = [
+    { label: 'Tab 1', component: <p>Content 1</p> },
+    { label: 'Tab 2', component: <p>Content 2</p> },
+    { label: 'Tab 3', component: <p>Content 3</p> },
+  ];
+
+  it('should select defaultIndex tab on initial render (before effects)', () => {
+    // Suppress the useEffect that corrects tabIndex post-mount, so the
+    // initial useState value is what renders.
+    const spy = vi.spyOn(React, 'useEffect').mockImplementation(() => {});
+    try {
+      render(<Tabs tabs={tabs} defaultIndex={2} ariaLabel="test tabs" />);
+
+      const tabElements = screen.getAllByRole('tab');
+      expect(tabElements[0]).toHaveAttribute('aria-selected', 'false');
+      expect(tabElements[1]).toHaveAttribute('aria-selected', 'false');
+      expect(tabElements[2]).toHaveAttribute('aria-selected', 'true');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('should render the first tab when defaultIndex is 0', () => {
+    render(<Tabs tabs={tabs} defaultIndex={0} ariaLabel="test tabs" />);
+
+    const tabElements = screen.getAllByRole('tab');
+    expect(tabElements[0]).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/frontend/src/components/common/Tabs.tsx
+++ b/frontend/src/components/common/Tabs.tsx
@@ -65,7 +65,7 @@ export interface TabsProps {
 export default function Tabs(props: TabsProps) {
   const { tabs, tabProps = {}, defaultIndex = 0, onTabChanged = null, ariaLabel } = props;
   const [tabIndex, setTabIndex] = React.useState<TabsProps['defaultIndex']>(
-    defaultIndex && Math.min(defaultIndex as number, 0)
+    defaultIndex && Math.max(defaultIndex as number, 0)
   );
 
   /**


### PR DESCRIPTION
## Summary

This PR fixes an inverted clamp in the `Tabs` component where `Math.min` was used instead of `Math.max`, causing any positive `defaultIndex` to initialize to `0` on the first render.

## Related Issue

Fixes #6921

## Changes

- Replaced `Math.min` with `Math.max` when initializing `tabIndex` in `frontend/src/components/common/Tabs.tsx`.

## Steps to Test

1. Render:
   ```tsx
   <Tabs tabs={[...]} defaultIndex={2} ariaLabel="test" />
   ```
2. Verify tab 2 is selected on the initial render.
3. Verify `defaultIndex={0}` behaves as before.

## Notes for Reviewers

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented tabs from opening with a negative initial tab index.
  * Preserved valid nonnegative default tab selections.
  * Improved reliability when tabs are initialized with different starting positions.

* **Tests**
  * Added coverage for initial tab selection across multiple default values.
  * Verified accessibility states accurately reflect the selected tab during initial rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->