### PR TITLE
backend: externalproxy: Match proxy URL host separately from the path

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -79,23 +79,58 @@ import (
 type HeadlampConfig struct {
 	*headlampconfig.HeadlampConfig
 	proxyURLMu        sync.Mutex
-	compiledProxyURLs []glob.Glob
+	compiledProxyURLs []proxyURLMatcher
 	oidcStateReader   io.Reader
 }
 
-func compileProxyURLPatterns(patterns []string) ([]glob.Glob, error) {
-	compiledProxyURLs := make([]glob.Glob, 0, len(patterns))
+// proxyURLMatcher matches a request URL against a single proxyURLs allowlist
+// entry. The host is matched on its own so a wildcard in the host part of a
+// pattern cannot reach into the path, query or fragment of a different host --
+// that would be an SSRF allowlist bypass (e.g. "https://*.example.com" must not
+// match "https://evil.com/a.example.com"). The path keeps normal glob matching
+// so an entry like "https://host/*" still covers nested paths.
+type proxyURLMatcher struct {
+	scheme string
+	host   glob.Glob
+	path   glob.Glob
+}
+
+func compileProxyURLPatterns(patterns []string) ([]proxyURLMatcher, error) {
+	matchers := make([]proxyURLMatcher, 0, len(patterns))
 
 	for _, pattern := range patterns {
-		g, err := glob.Compile(pattern)
+		parsed, err := url.Parse(pattern)
 		if err != nil {
 			return nil, fmt.Errorf("compiling proxy URL pattern %q: %w", pattern, err)
 		}
 
-		compiledProxyURLs = append(compiledProxyURLs, g)
+		// A pattern without a host (e.g. "example.com/path" parsed as a path, or
+		// a bare path) is not a usable allowlist entry -- reject it so a typo
+		// can't silently compile into an entry that never matches.
+		if parsed.Host == "" {
+			return nil, fmt.Errorf("compiling proxy URL pattern %q: pattern has no host", pattern)
+		}
+
+		hostGlob, err := glob.Compile(parsed.Host)
+		if err != nil {
+			return nil, fmt.Errorf("compiling proxy URL pattern %q: %w", pattern, err)
+		}
+
+		// An empty path in the pattern allows any path on the matched host.
+		pathPattern := parsed.Path
+		if pathPattern == "" {
+			pathPattern = "*"
+		}
+
+		pathGlob, err := glob.Compile(pathPattern)
+		if err != nil {
+			return nil, fmt.Errorf("compiling proxy URL pattern %q: %w", pattern, err)
+		}
+
+		matchers = append(matchers, proxyURLMatcher{scheme: parsed.Scheme, host: hostGlob, path: pathGlob})
 	}
 
-	return compiledProxyURLs, nil
+	return matchers, nil
 }
 
 func (c *HeadlampConfig) proxyURLAllowed(proxyURL string) (bool, error) {
@@ -115,8 +150,13 @@ func (c *HeadlampConfig) proxyURLAllowed(proxyURL string) (bool, error) {
 	compiledProxyURLs := c.compiledProxyURLs
 	c.proxyURLMu.Unlock()
 
-	for _, g := range compiledProxyURLs {
-		if g.Match(proxyURL) {
+	parsed, err := url.Parse(proxyURL)
+	if err != nil {
+		return false, nil
+	}
+
+	for _, m := range compiledProxyURLs {
+		if m.scheme == parsed.Scheme && m.host.Match(parsed.Host) && m.path.Match(parsed.Path) {
 			return true, nil
 		}
 	}

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -669,6 +669,15 @@ func TestCompileProxyURLPatternsInvalidPattern(t *testing.T) {
 	assert.Contains(t, err.Error(), "compiling proxy URL pattern")
 }
 
+func TestCompileProxyURLPatternsRejectsPatternsWithoutHost(t *testing.T) {
+	for _, pattern := range []string{"example.com/path", "/just/a/path", "artifacthub.io"} {
+		_, err := compileProxyURLPatterns([]string{pattern})
+
+		require.Error(t, err, "pattern %q should be rejected", pattern)
+		assert.Contains(t, err.Error(), "compiling proxy URL pattern")
+	}
+}
+
 func TestProxyURLAllowedCompilesConfiguredProxyURLs(t *testing.T) {
 	config := &HeadlampConfig{
 		HeadlampConfig: &headlampconfig.HeadlampConfig{
@@ -683,6 +692,93 @@ func TestProxyURLAllowedCompilesConfiguredProxyURLs(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, allowed)
 	assert.NotEmpty(t, config.compiledProxyURLs)
+}
+
+func TestProxyURLAllowedDoesNotBypassAllowlist(t *testing.T) { //nolint:funlen
+	tests := []struct {
+		name    string
+		pattern string
+		url     string
+		allowed bool
+	}{
+		{
+			name:    "exact host matches",
+			pattern: "https://prometheus.example.com/*",
+			url:     "https://prometheus.example.com/api",
+			allowed: true,
+		},
+		{
+			name:    "subdomain wildcard matches a real subdomain",
+			pattern: "https://*.example.com",
+			url:     "https://api.example.com",
+			allowed: true,
+		},
+		{
+			name:    "wildcard matches a nested path on the allowed host",
+			pattern: "https://artifacthub.io/*",
+			url:     "https://artifacthub.io/api/v1/packages/search",
+			allowed: true,
+		},
+		{
+			name:    "wildcard matches a nested path even with a query string",
+			pattern: "https://artifacthub.io/*",
+			url:     "https://artifacthub.io/api/v1/packages/search?query=up",
+			allowed: true,
+		},
+		{
+			name:    "double star matches across path segments",
+			pattern: "https://prometheus.example.com/**",
+			url:     "https://prometheus.example.com/api/v1/query",
+			allowed: true,
+		},
+		{
+			name:    "subdomain wildcard does not match host with allowed suffix in the path",
+			pattern: "https://*.example.com",
+			url:     "https://evil.com/a.example.com",
+			allowed: false,
+		},
+		{
+			name:    "wildcard does not cross the path boundary onto another host",
+			pattern: "https://prometheus.example.com/*",
+			url:     "https://prometheus.example.com.evil.com/api",
+			allowed: false,
+		},
+		{
+			name:    "wildcard does not cross the query boundary onto another host",
+			pattern: "https://*.example.com",
+			url:     "https://evil.com?target=.example.com",
+			allowed: false,
+		},
+		{
+			name:    "wildcard does not cross the fragment boundary onto another host",
+			pattern: "https://*.example.com",
+			url:     "https://evil.com#.example.com",
+			allowed: false,
+		},
+		{
+			name:    "unrelated host is rejected",
+			pattern: "https://*.example.com",
+			url:     "https://evil.com",
+			allowed: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			config := &HeadlampConfig{
+				HeadlampConfig: &headlampconfig.HeadlampConfig{
+					HeadlampCFG: &headlampconfig.HeadlampCFG{
+						ProxyURLs: []string{tc.pattern},
+					},
+				},
+			}
+
+			allowed, err := config.proxyURLAllowed(tc.url)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.allowed, allowed)
+		})
+	}
 }
 
 func newLargeBodyUpstream(t *testing.T, size int) *httptest.Server {


### PR DESCRIPTION
## Summary

The /externalproxy allowlist matched proxyURLs patterns against the whole request URL with a glob, so `*` could cross from the host into the path or query — `https://*.example.com` also matched `https://evil.com/a.example.com`, forwarding the request (and the auth headers) to evil.com (SSRF). This parses both the pattern and the request URL and matches scheme, host and path separately, so a wildcard in the host can't leak into another host's path/query/fragment. The path is still a normal glob, so an entry like `https://host/*` keeps covering nested paths — no allowlist changes needed.

## Related Issue

Fixes #6895

## Changes

- `compileProxyURLPatterns` / `proxyURLAllowed` (`backend/cmd/headlamp.go`) now parse each pattern and the request URL and match scheme, host and path separately instead of globbing the whole URL string. An empty pattern path allows any path on the host; invalid request URLs are denied.
- Added a table-driven test (`TestProxyURLAllowedDoesNotBypassAllowlist`) covering the bypass cases (host suffix in the path, query and fragment boundaries, look-alike hosts) and the legitimate ones (exact host, subdomain wildcard, nested paths, nested path with a query string).

## Steps to Test

1. Run the backend with a `proxyURLs` entry such as `https://*.example.com`
2. Send a request to `/externalproxy` with header `proxy-to: https://evil.com/a.example.com` and confirm it is now rejected (before this change it was forwarded)
3. Confirm a legitimate target like `https://api.example.com` is still allowed
4. Confirm a nested path still works: with `https://artifacthub.io/*`, a request to `https://artifacthub.io/api/v1/packages/search` is allowed
5. Or run the unit tests: `go test ./cmd/ -run TestProxyURLAllowed`

## Screenshots (if applicable)


## Notes for the Reviewer

- Matching host and path separately (rather than globbing the whole URL) is what closes the bypass, and it keeps existing behaviour intact — `host/*` still matches nested paths, so the shipped `artifacthub.io/*` default and any existing configs work unchanged.
- Related to #6587 (auth headers forwarded to the target) — that's what turns this allowlist bypass into a credential leak; this PR closes the bypass side.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved proxy URL allowlist matching for more accurate scheme, host, and path validation.
  - Prevented wildcard patterns from crossing URL component boundaries.
  - Requests with invalid or malformed URLs are now denied safely.
  - Patterns without a valid host are rejected.
  - Improved handling of subdomains, nested paths, query strings, fragments, and wildcard patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->