### PR TITLE
frontend: LogViewer: Clean up blob URL and DOM element after log download

### DIFF
--- a/frontend/src/components/common/LogViewer.tsx
+++ b/frontend/src/components/common/LogViewer.tsx
@@ -89,6 +89,8 @@ export function LogViewer(props: LogViewerProps) {
     // Required for FireFox
     document.body.appendChild(element);
     element.click();
+    document.body.removeChild(element);
+    URL.revokeObjectURL(element.href);
   }
 
   React.useEffect(() => {


### PR DESCRIPTION
## Summary

This PR fixes a resource leak in `LogViewer` by cleaning up the temporary blob URL and `<a>` element created during log downloads.

## Related Issue

Fixes #6925

## Changes

- Removed the temporary `<a>` element from the DOM after the download.
- Revoked the blob URL using `URL.revokeObjectURL()` after triggering the download.

## Steps to Test

1. Open any **Pod → Logs** tab.
2. Run `document.body.childElementCount` in DevTools.
3. Click the **Download** button several times.
4. Run `document.body.childElementCount` again and verify the count remains unchanged.

## Notes for Reviewers
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log downloads by cleaning up temporary browser resources after the download starts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->