### PR TITLE
app: tray: Use app name in tray tooltip and menu

### DIFF
--- a/app/electron/tray.ts
+++ b/app/electron/tray.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { BrowserWindow, Menu, nativeImage, Tray } from 'electron';
+import { app, BrowserWindow, Menu, nativeImage, Tray } from 'electron';
 import { MenuItemConstructorOptions } from 'electron/main';
 import path from 'path';
 import { loadSettings, saveSettings, SETTINGS_PATH } from './settings';
@@ -136,7 +136,7 @@ export function createHeadlampTray(options: HeadlampTrayOptions): boolean {
     return false;
   }
 
-  tray.setToolTip('Headlamp');
+  tray.setToolTip(app.name);
   tray.setContextMenu(buildTrayMenu(options, [{ label: 'Loading...', enabled: false }]));
 
   trayUpdateTimeout = setTimeout(() => {
@@ -225,7 +225,7 @@ function buildTrayMenu(
 ): Menu {
   return Menu.buildFromTemplate([
     {
-      label: 'Open Headlamp',
+      label: `Open ${app.name}`,
       click: () => {
         void showWindow(options);
       },
@@ -243,7 +243,7 @@ function buildTrayMenu(
     },
     { type: 'separator' },
     {
-      label: 'About Headlamp',
+      label: `About ${app.name}`,
       click: () => openAboutDialog(options),
     },
     { type: 'separator' },


### PR DESCRIPTION
## Summary

The system tray hardcodes `Headlamp` in the tooltip and in the Open/About menu
labels, so a build that sets a different `productName` still shows "Headlamp" in
the tray while the rest of the app uses its configured name.

This switches those three strings to Electron's `app.name`, which resolves to
`productName` from `app/package.json`. Upstream that value is `Headlamp`, so
there is no visible change here; it only stops the tray from contradicting the
configured product name in rebranded builds.

## Related Issue

Reported downstream in Azure/aks-desktop#825, where the tray showed "Headlamp"
instead of the configured product name.

## Changes

- Use `app.name` for the tray tooltip instead of the literal `'Headlamp'`.
- Use `Open ${app.name}` and `About ${app.name}` for the tray menu labels.
- Import `app` from `electron` in `app/electron/tray.ts`.

## Steps to Test

Automated checks:

```bash
npm run app:install
npm run app:tsc
npm run app:test:unit
```

Manual verification that upstream behavior is unchanged:

1. Build and start the desktop app:
   ```bash
   npm run app:build
   npm run app:start
   ```
2. Open the system tray icon and confirm the tooltip reads `Headlamp` and the
   menu shows `Open Headlamp` and `About Headlamp`, exactly as before.
3. Confirm both menu entries still work: `Open Headlamp` focuses (or creates)
   the main window, and `About Headlamp` opens the About dialog.

Verify the rebranding case that motivated the change:

4. Temporarily set `"productName": "Test Desktop"` in `app/package.json`.
5. Restart the app and confirm the tray tooltip reads `Test Desktop` and the menu
   shows `Open Test Desktop` and `About Test Desktop`.
6. Revert the `productName` change.

## Notes for the Reviewer

- No user-visible change upstream: `app.name` returns `productName`, which is
  already `Headlamp` in `app/package.json`.
- `app.name` falls back to the package `name` when `productName` is unset, so
  there is no empty-label case for builds that only set one of them.
- The existing `app/electron/tray.test.ts` covers the tray enable/disable
  setting and does not assert the tooltip or menu labels, so no test changes were
  needed. Asserting these strings requires mocking the Electron `app` module;
  happy to add that if you'd prefer coverage here.
- Internal identifiers (`createHeadlampTray`, `HeadlampTrayOptions`,
  `isHeadlampTrayCreated`) and log messages are intentionally untouched to keep
  the diff minimal, since they are not user-facing.
- Tray labels are not currently translated, and this change keeps that as-is
  rather than introducing i18n to the tray module.

### Screenshots

#### e.g. AKS desktop: Before -> After

<img width="173" height="70" alt="Image" src="https://github.com/user-attachments/assets/293bbadd-0f77-4fc8-a85e-2c8676830a51" />

<img width="190" height="71" alt="image" src="https://github.com/user-attachments/assets/7f498744-242c-4155-b002-ace681df5bd5" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Tray and menu labels now use the application’s configured name dynamically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->