### PR TITLE
fix: add underscore folder name variants for ai-assistant plugin

### DIFF
--- a/app/electron/runCmd.test.ts
+++ b/app/electron/runCmd.test.ts
@@ -51,9 +51,11 @@ vi.mock('./main', () => ({
 }));
 
 import {
+  addRunCmdConsent,
   checkPermissionSecret,
   environmentOverrides,
   handleRunCommand,
+  removeRunCmdConsent,
   validateCommandData,
 } from './runCmd';
 
@@ -423,5 +425,38 @@ describe('runScript', () => {
 
     expect(consoleErrorMock).toHaveBeenCalledTimes(1);
     expect(exitMock).toHaveBeenCalledWith(1);
+  });
+});
+
+describe('addRunCmdConsent and removeRunCmdConsent', () => {
+  it('adds consent for ai-assistant plugin with underscore and hyphen variants', async () => {
+    const { saveSettings } = await import('./settings');
+    const saveSettingsMock = saveSettings as Mock;
+
+    addRunCmdConsent({ name: 'headlamp_ai_assistant' });
+    expect(saveSettingsMock).toHaveBeenCalledWith(
+      '/fake/settings.json',
+      expect.objectContaining({
+        confirmedCommands: expect.objectContaining({
+          'gh auth': true,
+          'az account': true,
+          'az cognitiveservices': true,
+        }),
+      })
+    );
+
+    addRunCmdConsent({ name: 'headlamp_ai_assistantprerelease' });
+    expect(saveSettingsMock).toHaveBeenCalled();
+  });
+
+  it('removes consent for ai-assistant plugin with underscore and hyphen variants', async () => {
+    const { saveSettings } = await import('./settings');
+    const saveSettingsMock = saveSettings as Mock;
+
+    removeRunCmdConsent('@headlamp-k8s/ai_assistant');
+    expect(saveSettingsMock).toHaveBeenCalled();
+
+    removeRunCmdConsent('@headlamp-k8s/ai_assistantprerelease');
+    expect(saveSettingsMock).toHaveBeenCalled();
   });
 });

--- a/app/electron/runCmd.ts
+++ b/app/electron/runCmd.ts
@@ -156,7 +156,13 @@ export function addRunCmdConsent(pluginInfo: { name: string }): void {
   const pluginIsAiAssistant =
     pluginInfo.name === 'headlamp_ai-assistant' ||
     pluginInfo.name === 'headlamp_ai-assistantprerelease' ||
-    (process.env.NODE_ENV === 'development' && pluginInfo.name === 'ai-assistant');
+    pluginInfo.name === 'headlamp_ai_assistant' ||
+    pluginInfo.name === 'headlamp_ai_assistantprerelease' ||
+    (process.env.NODE_ENV === 'development' &&
+      (pluginInfo.name === 'ai-assistant' ||
+        pluginInfo.name === 'ai_assistant' ||
+        pluginInfo.name === 'ai-assistantprerelease' ||
+        pluginInfo.name === 'ai_assistantprerelease'));
   if (pluginIsAiAssistant) {
     commands = COMMANDS_WITH_CONSENT.headlamp_ai_assistant;
   }
@@ -189,7 +195,9 @@ export function removeRunCmdConsent(pluginName: string): void {
   }
   if (
     pluginName === '@headlamp-k8s/ai-assistant' ||
-    pluginName === '@headlamp-k8s/ai-assistantprerelease'
+    pluginName === '@headlamp-k8s/ai-assistantprerelease' ||
+    pluginName === '@headlamp-k8s/ai_assistant' ||
+    pluginName === '@headlamp-k8s/ai_assistantprerelease'
   ) {
     commands = COMMANDS_WITH_CONSENT.headlamp_ai_assistant;
   }

--- a/frontend/src/plugin/runPlugin.test.ts
+++ b/frontend/src/plugin/runPlugin.test.ts
@@ -542,4 +542,27 @@ describe('identifyPackages', () => {
     );
     expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
   });
+
+  test('should identify ai-assistant package with underscore folder name variant in production mode', () => {
+    const result = identifyPackages(
+      'plugins/headlamp_ai_assistant',
+      '@headlamp-k8s/ai_assistant',
+      false
+    );
+    expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+  });
+
+  test('should identify ai-assistant package with underscore prerelease folder name variant in production mode', () => {
+    const result = identifyPackages(
+      'plugins/headlamp_ai_assistantprerelease',
+      '@headlamp-k8s/ai_assistantprerelease',
+      false
+    );
+    expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+  });
+
+  test('should identify ai-assistant package with underscore dev path variant in development mode', () => {
+    const result = identifyPackages('plugins/ai_assistant', '@headlamp-k8s/ai_assistant', true);
+    expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+  });
 });

--- a/frontend/src/plugin/runPlugin.ts
+++ b/frontend/src/plugin/runPlugin.ts
@@ -207,6 +207,12 @@ export function identifyPackages(
       'plugins/headlamp_ai-assistantprerelease',
       'user-plugins/headlamp_ai-assistantprerelease',
       'static-plugins/headlamp_ai-assistantprerelease',
+      'plugins/headlamp_ai_assistant',
+      'user-plugins/headlamp_ai_assistant',
+      'static-plugins/headlamp_ai_assistant',
+      'plugins/headlamp_ai_assistantprerelease',
+      'user-plugins/headlamp_ai_assistantprerelease',
+      'static-plugins/headlamp_ai_assistantprerelease',
     ],
   };
 
@@ -215,7 +221,9 @@ export function identifyPackages(
       'plugins/minikube';
     pluginPaths['@headlamp-k8s/ai-assistant'].push(
       'plugins/ai-assistant',
-      'plugins/ai-assistantprerelease'
+      'plugins/ai-assistantprerelease',
+      'plugins/ai_assistant',
+      'plugins/ai_assistantprerelease'
     );
   }
   const pluginPackageNames: Record<string, string[]> = {
@@ -223,6 +231,8 @@ export function identifyPackages(
     '@headlamp-k8s/ai-assistant': [
       '@headlamp-k8s/ai-assistant',
       '@headlamp-k8s/ai-assistantprerelease',
+      '@headlamp-k8s/ai_assistant',
+      '@headlamp-k8s/ai_assistantprerelease',
     ],
   };
   const isPackage: Record<string, boolean> = {};


### PR DESCRIPTION
## Summary
Fixes an issue where the AI Assistant plugin installed from the marketplace (which uses folder name `headlamp_ai_assistant` with underscores) fails to inject `pluginRunCommand` and does not pre-approve `gh` / `az` command consents.

## Related Issue
Fixes #6736

## Changes
- `app/electron/runCmd.ts`: Added underscore folder and package name variants to `addRunCmdConsent` and `removeRunCmdConsent`.
- `frontend/src/plugin/runPlugin.ts`: Added underscore folder and package name variants to `identifyPackages()`.
- Added unit tests in `app/electron/runCmd.test.ts` and `frontend/src/plugin/runPlugin.test.ts`.

## Steps to Test
1. Install `@headlamp-k8s/ai-assistant` plugin (or create `user-plugins/headlamp_ai_assistant`).
2. Open Headlamp -> Settings -> AI Assistant.
3. Verify `pluginRunCommand` is available and Auto Detect button renders.
4. Verify `gh auth` and `az account` commands are added to `settings.json` `confirmedCommands`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of AI Assistant plugin names across hyphenated, underscored, and prerelease variants.
  * Fixed plugin detection in both standard and development environments.
  * Updated command consent handling to consistently apply permissions across supported plugin naming formats.
* **Tests**
  * Added coverage for plugin discovery and command consent behavior across supported naming variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->