### PR TITLE
0051: Project header actions can select tabs

### DIFF
--- a/docs/development/plugins/functionality/index.md
+++ b/docs/development/plugins/functionality/index.md
@@ -284,6 +284,22 @@ Add custom sections to the project overview page with
 [registerProjectOverviewSection](../../api/plugin/registry/functions/registerProjectOverviewSection).
 These sections appear in the project's main overview area.
 
+Add action buttons to the project details header with
+[registerProjectHeaderAction](../../api/plugin/registry/functions/registerProjectHeaderAction).
+The action component receives the current project and an optional
+`setSelectedTab?: (tabId: string) => void` callback. Call it with the ID of a
+registered, enabled tab to select that tab. Unknown tabs and tabs without a
+component are ignored.
+
+```tsx
+registerProjectHeaderAction({
+  id: 'view-metrics',
+  component: ({ setSelectedTab }) => (
+    <Button onClick={() => setSelectedTab?.('my-plugin.metrics')}>View metrics</Button>
+  ),
+});
+```
+
 Register custom API resources (e.g. CRDs) for project resource tracking with
 [registerProjectApiResource](../../api/plugin/registry/functions/registerProjectApiResource).
 Once registered, the CRD resources will appear in the project's resource count,

--- a/docs/development/plugins/functionality/index.md
+++ b/docs/development/plugins/functionality/index.md
@@ -312,6 +312,22 @@ registerProjectOverviewSection({
 });
 ```
 
+Add action buttons to the project details header with
+[registerProjectHeaderAction](../../api/plugin/registry/functions/registerProjectHeaderAction).
+The action component receives the current project and an optional
+`setSelectedTab?: (tabId: string) => void` callback. Call it with the ID of a
+registered, enabled tab to select that tab. Unknown tabs and tabs without a
+component are ignored.
+
+```tsx
+registerProjectHeaderAction({
+  id: 'view-metrics',
+  component: ({ setSelectedTab }) => (
+    <Button onClick={() => setSelectedTab?.('my-plugin.metrics')}>View metrics</Button>
+  ),
+});
+```
+
 Register custom API resources (e.g. CRDs) for project resource tracking with
 [registerProjectApiResource](../../api/plugin/registry/functions/registerProjectApiResource).
 Once registered, the CRD resources will appear in the project's resource count,

--- a/e2e-tests/tests/projects.spec.ts
+++ b/e2e-tests/tests/projects.spec.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import { HeadlampPage } from './headlampPage';
+
+let projectName: string;
+let namespaceCreated = false;
+
+test.beforeEach(async ({ page }, testInfo) => {
+  const headlampPage = new HeadlampPage(page);
+  const token = process.env.HEADLAMP_TEST_TOKEN;
+  projectName = `header-action-e2e-${testInfo.workerIndex}-${Date.now()}`;
+  namespaceCreated = false;
+
+  await page.route('**/apis/argoproj.io/v1alpha1/namespaces/*/applications*', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        apiVersion: 'argoproj.io/v1alpha1',
+        kind: 'ApplicationList',
+        metadata: {},
+        items: [],
+      }),
+    })
+  );
+
+  await headlampPage.navigateToCluster('test', token);
+  await headlampPage.navigateToCluster('test2', process.env.HEADLAMP_TEST2_TOKEN);
+
+  const response = await page.request.post('/clusters/test/api/v1/namespaces', {
+    headers: { Authorization: `Bearer ${token}` },
+    data: {
+      apiVersion: 'v1',
+      kind: 'Namespace',
+      metadata: {
+        name: projectName,
+        labels: { 'headlamp.dev/project-id': projectName },
+      },
+    },
+  });
+
+  namespaceCreated = response.status() === 201;
+  expect([201, 409]).toContain(response.status());
+});
+
+test.afterEach(async ({ page }) => {
+  if (!namespaceCreated) {
+    return;
+  }
+
+  const response = await page.request.delete(`/clusters/test/api/v1/namespaces/${projectName}`, {
+    headers: { Authorization: `Bearer ${process.env.HEADLAMP_TEST_TOKEN}` },
+  });
+
+  expect([200, 202, 404]).toContain(response.status());
+});
+
+test('project header action selects a registered tab', async ({ page }) => {
+  const headlampPage = new HeadlampPage(page);
+  await headlampPage.navigateTopage(`/project/${projectName}`, /Project Details/);
+
+  const metricsTab = page.getByRole('tab', { name: 'Metrics' });
+  await expect(metricsTab).toHaveAttribute('aria-selected', 'false');
+
+  await page.getByRole('button', { name: 'Custom Action' }).click();
+
+  await expect(metricsTab).toHaveAttribute('aria-selected', 'true');
+  await expect(page.getByText(`Metrics for project ${projectName}`)).toBeVisible();
+});

--- a/e2e-tests/tests/projects.spec.ts
+++ b/e2e-tests/tests/projects.spec.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import { HeadlampPage } from './headlampPage';
+
+const projectName = 'header-action-e2e';
+const namespacePath = `/clusters/test/api/v1/namespaces/${projectName}`;
+
+test.beforeEach(async ({ page }) => {
+  const headlampPage = new HeadlampPage(page);
+  const token = process.env.HEADLAMP_TEST_TOKEN;
+  await headlampPage.navigateToCluster('test', token);
+
+  const response = await page.request.post('/clusters/test/api/v1/namespaces', {
+    headers: { Authorization: `Bearer ${token}` },
+    data: {
+      apiVersion: 'v1',
+      kind: 'Namespace',
+      metadata: {
+        name: projectName,
+        labels: { 'headlamp.dev/project-id': projectName },
+      },
+    },
+  });
+
+  expect([201, 409]).toContain(response.status());
+});
+
+test.afterEach(async ({ page }) => {
+  const response = await page.request.delete(namespacePath, {
+    headers: { Authorization: `Bearer ${process.env.HEADLAMP_TEST_TOKEN}` },
+  });
+
+  expect([200, 202, 404]).toContain(response.status());
+});
+
+test('project header action selects a registered tab', async ({ page }) => {
+  const headlampPage = new HeadlampPage(page);
+  await headlampPage.navigateTopage(`/project/${projectName}`, /Project Details/);
+
+  const metricsTab = page.getByRole('tab', { name: 'Metrics' });
+  await expect(metricsTab).toHaveAttribute('aria-selected', 'false');
+
+  await page.getByRole('button', { name: 'Custom Action' }).click();
+
+  await expect(metricsTab).toHaveAttribute('aria-selected', 'true');
+  await expect(page.getByText(`Metrics for project ${projectName}`)).toBeVisible();
+});

--- a/e2e-tests/tests/projects.spec.ts
+++ b/e2e-tests/tests/projects.spec.ts
@@ -17,13 +17,30 @@
 import { expect, test } from '@playwright/test';
 import { HeadlampPage } from './headlampPage';
 
-const projectName = 'header-action-e2e';
-const namespacePath = `/clusters/test/api/v1/namespaces/${projectName}`;
+let projectName: string;
+let namespaceCreated = false;
 
-test.beforeEach(async ({ page }) => {
+test.beforeEach(async ({ page }, testInfo) => {
   const headlampPage = new HeadlampPage(page);
   const token = process.env.HEADLAMP_TEST_TOKEN;
+  projectName = `header-action-e2e-${testInfo.workerIndex}-${Date.now()}`;
+  namespaceCreated = false;
+
+  await page.route('**/apis/argoproj.io/v1alpha1/namespaces/*/applications*', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        apiVersion: 'argoproj.io/v1alpha1',
+        kind: 'ApplicationList',
+        metadata: {},
+        items: [],
+      }),
+    })
+  );
+
   await headlampPage.navigateToCluster('test', token);
+  await headlampPage.navigateToCluster('test2', process.env.HEADLAMP_TEST2_TOKEN);
 
   const response = await page.request.post('/clusters/test/api/v1/namespaces', {
     headers: { Authorization: `Bearer ${token}` },
@@ -37,11 +54,16 @@ test.beforeEach(async ({ page }) => {
     },
   });
 
+  namespaceCreated = response.status() === 201;
   expect([201, 409]).toContain(response.status());
 });
 
 test.afterEach(async ({ page }) => {
-  const response = await page.request.delete(namespacePath, {
+  if (!namespaceCreated) {
+    return;
+  }
+
+  const response = await page.request.delete(`/clusters/test/api/v1/namespaces/${projectName}`, {
     headers: { Authorization: `Bearer ${process.env.HEADLAMP_TEST_TOKEN}` },
   });
 

--- a/frontend/src/components/project/ProjectDetails.test.tsx
+++ b/frontend/src/components/project/ProjectDetails.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import { configureStore } from '@reduxjs/toolkit';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { vi } from 'vitest';
 import App from '../../App';
@@ -40,13 +40,22 @@ vi.mock('./ProjectDeleteButton', () => ({
 }));
 
 describe('ProjectDetailsContent', () => {
+  const project: ProjectDefinition = {
+    id: 'project-one',
+    namespaces: ['project-one'],
+    clusters: ['test'],
+  };
+
+  function createStore() {
+    return configureStore({
+      reducer: { projects: projectsReducer },
+      middleware: getDefaultMiddleware =>
+        getDefaultMiddleware({ serializableCheck: false, immutableCheck: false }),
+    });
+  }
+
   it('lets a project header action select a registered tab', async () => {
-    const store = configureStore({ reducer: { projects: projectsReducer } });
-    const project: ProjectDefinition = {
-      id: 'project-one',
-      namespaces: ['project-one'],
-      clusters: ['test'],
-    };
+    const store = createStore();
 
     store.dispatch(
       addDetailsTab({
@@ -74,5 +83,76 @@ describe('ProjectDetailsContent', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Open metrics' }));
 
     expect(await screen.findByText('Metrics panel')).toBeInTheDocument();
+  });
+
+  it('renders only header actions whose enablement check succeeds', async () => {
+    const store = createStore();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    store.dispatch(
+      addHeaderAction({
+        id: 'enabled',
+        component: () => <button>Enabled action</button>,
+        isEnabled: async () => true,
+      })
+    );
+    store.dispatch(
+      addHeaderAction({
+        id: 'disabled',
+        component: () => <button>Disabled action</button>,
+        isEnabled: async () => false,
+      })
+    );
+    store.dispatch(
+      addHeaderAction({
+        id: 'rejected',
+        component: () => <button>Rejected action</button>,
+        isEnabled: async () => {
+          throw new Error('enablement failed');
+        },
+      })
+    );
+
+    render(
+      <TestContext store={store}>
+        <ProjectDetailsContent project={project} />
+      </TestContext>
+    );
+
+    expect(await screen.findByRole('button', { name: 'Enabled action' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Disabled action' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Rejected action' })).not.toBeInTheDocument();
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to check if header action is enabled',
+      expect.objectContaining({ id: 'rejected' }),
+      expect.any(Error)
+    );
+  });
+
+  it('does not update header actions after unmounting', async () => {
+    const store = createStore();
+    let resolveEnablement: (enabled: boolean) => void = () => {};
+
+    store.dispatch(
+      addHeaderAction({
+        id: 'delayed',
+        component: () => <button>Delayed action</button>,
+        isEnabled: () =>
+          new Promise(resolve => {
+            resolveEnablement = resolve;
+          }),
+      })
+    );
+
+    const view = render(
+      <TestContext store={store}>
+        <ProjectDetailsContent project={project} />
+      </TestContext>
+    );
+    view.unmount();
+
+    await act(async () => resolveEnablement(true));
+
+    expect(screen.queryByRole('button', { name: 'Delayed action' })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/project/ProjectDetails.test.tsx
+++ b/frontend/src/components/project/ProjectDetails.test.tsx
@@ -18,7 +18,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ReactNode } from 'react';
-import { vi } from 'vitest';
+import { afterEach, vi } from 'vitest';
 
 const { MockKubeObject } = vi.hoisted(() => {
   class MockKubeObject {
@@ -39,7 +39,6 @@ const { MockKubeObject } = vi.hoisted(() => {
 
 vi.mock('../../lib/k8s/KubeObject', () => ({ KubeObject: MockKubeObject }));
 vi.mock('./ProjectDeleteButton', () => ({ ProjectDeleteButton: () => null }));
-
 const eventProject = {
   id: 'project-1',
   namespaces: ['ns1'],
@@ -52,7 +51,12 @@ vi.mock('./ProjectList', () => ({
 
 import App from '../../App';
 import { HeadlampEventType } from '../../redux/headlampEventSlice';
-import { addOverviewSection, ProjectDefinition } from '../../redux/projectsSlice';
+import {
+  addDetailsTab,
+  addHeaderAction,
+  addOverviewSection,
+  ProjectDefinition,
+} from '../../redux/projectsSlice';
 import reducers from '../../redux/reducers/reducers';
 import { recordHeadlampEvents, TestContext } from '../../test';
 import ProjectDetails, { ProjectDetailsContent } from './ProjectDetails';
@@ -359,5 +363,146 @@ describe('ProjectDetails overview sections', () => {
     await act(async () => resolveFirstPredicate(true));
 
     expect(screen.queryByText('Stale project section')).not.toBeInTheDocument();
+  });
+});
+
+describe('ProjectDetailsContent', () => {
+  beforeEach(() => {
+    vi.mocked(useProjectItems).mockReturnValue({ items: [], errors: [], isLoading: false });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const actionProject: ProjectDefinition = {
+    id: 'project-one',
+    namespaces: ['project-one'],
+    clusters: ['test'],
+  };
+
+  function createStore() {
+    return configureStore({
+      reducer: reducers,
+      middleware: getDefaultMiddleware =>
+        getDefaultMiddleware({ serializableCheck: false, immutableCheck: false }),
+    });
+  }
+
+  it('lets a project header action select a registered tab', async () => {
+    const store = createStore();
+
+    store.dispatch(
+      addDetailsTab({
+        id: 'metrics',
+        label: 'Metrics',
+        icon: 'mdi:view-dashboard',
+        component: () => <div>Metrics panel</div>,
+      })
+    );
+    store.dispatch(
+      addDetailsTab({
+        id: 'unavailable',
+        label: 'Unavailable',
+        icon: 'mdi:view-dashboard',
+        component: undefined,
+      })
+    );
+    store.dispatch(
+      addHeaderAction({
+        id: 'open-metrics',
+        component: ({ setSelectedTab }) => (
+          <>
+            <button onClick={() => setSelectedTab?.('metrics')}>Open metrics</button>
+            <button onClick={() => setSelectedTab?.('unavailable')}>Open unavailable</button>
+          </>
+        ),
+      })
+    );
+
+    render(
+      <TestContext store={store}>
+        <ProjectDetailsContent project={actionProject} />
+      </TestContext>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open metrics' }));
+
+    expect(await screen.findByText('Metrics panel')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open unavailable' }));
+
+    expect(screen.getByText('Metrics panel')).toBeInTheDocument();
+  });
+
+  it('renders only header actions whose enablement check succeeds', async () => {
+    const store = createStore();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    store.dispatch(
+      addHeaderAction({
+        id: 'enabled',
+        component: () => <button>Enabled action</button>,
+        isEnabled: async () => true,
+      })
+    );
+    store.dispatch(
+      addHeaderAction({
+        id: 'disabled',
+        component: () => <button>Disabled action</button>,
+        isEnabled: async () => false,
+      })
+    );
+    store.dispatch(
+      addHeaderAction({
+        id: 'rejected',
+        component: () => <button>Rejected action</button>,
+        isEnabled: async () => {
+          throw new Error('enablement failed');
+        },
+      })
+    );
+
+    render(
+      <TestContext store={store}>
+        <ProjectDetailsContent project={actionProject} />
+      </TestContext>
+    );
+
+    expect(await screen.findByRole('button', { name: 'Enabled action' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Disabled action' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Rejected action' })).not.toBeInTheDocument();
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to check if header action is enabled',
+      expect.objectContaining({ id: 'rejected' }),
+      expect.any(Error)
+    );
+  });
+
+  it('does not update header actions after unmounting', async () => {
+    const store = createStore();
+    let resolveEnablement: (enabled: boolean) => void = () => {};
+
+    store.dispatch(
+      addHeaderAction({
+        id: 'delayed',
+        component: () => <button>Delayed action</button>,
+        isEnabled: () =>
+          new Promise(resolve => {
+            resolveEnablement = resolve;
+          }),
+      })
+    );
+
+    const view = render(
+      <TestContext store={store}>
+        <ProjectDetailsContent project={actionProject} />
+      </TestContext>
+    );
+    view.unmount();
+
+    await act(async () => resolveEnablement(true));
+
+    expect(screen.queryByRole('button', { name: 'Delayed action' })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/project/ProjectDetails.test.tsx
+++ b/frontend/src/components/project/ProjectDetails.test.tsx
@@ -17,7 +17,7 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { vi } from 'vitest';
+import { afterEach, vi } from 'vitest';
 import App from '../../App';
 import projectsReducer, {
   addDetailsTab,
@@ -40,6 +40,10 @@ vi.mock('./ProjectDeleteButton', () => ({
 }));
 
 describe('ProjectDetailsContent', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   const project: ProjectDefinition = {
     id: 'project-one',
     namespaces: ['project-one'],
@@ -61,15 +65,26 @@ describe('ProjectDetailsContent', () => {
       addDetailsTab({
         id: 'metrics',
         label: 'Metrics',
-        icon: 'mdi:chart-line',
+        icon: 'mdi:view-dashboard',
         component: () => <div>Metrics panel</div>,
+      })
+    );
+    store.dispatch(
+      addDetailsTab({
+        id: 'unavailable',
+        label: 'Unavailable',
+        icon: 'mdi:view-dashboard',
+        component: undefined,
       })
     );
     store.dispatch(
       addHeaderAction({
         id: 'open-metrics',
         component: ({ setSelectedTab }) => (
-          <button onClick={() => setSelectedTab?.('metrics')}>Open metrics</button>
+          <>
+            <button onClick={() => setSelectedTab?.('metrics')}>Open metrics</button>
+            <button onClick={() => setSelectedTab?.('unavailable')}>Open unavailable</button>
+          </>
         ),
       })
     );
@@ -83,6 +98,10 @@ describe('ProjectDetailsContent', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Open metrics' }));
 
     expect(await screen.findByText('Metrics panel')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open unavailable' }));
+
+    expect(screen.getByText('Metrics panel')).toBeInTheDocument();
   });
 
   it('renders only header actions whose enablement check succeeds', async () => {

--- a/frontend/src/components/project/ProjectDetails.test.tsx
+++ b/frontend/src/components/project/ProjectDetails.test.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { vi } from 'vitest';
+import App from '../../App';
+import projectsReducer, {
+  addDetailsTab,
+  addHeaderAction,
+  ProjectDefinition,
+} from '../../redux/projectsSlice';
+import { TestContext } from '../../test';
+import { ProjectDetailsContent } from './ProjectDetails';
+
+// cyclic imports fix
+// eslint-disable-next-line no-unused-vars
+const _dont_delete_me = App;
+
+vi.mock('./useProjectResources', () => ({
+  useProjectItems: () => ({ items: [], isLoading: false }),
+}));
+
+vi.mock('./ProjectDeleteButton', () => ({
+  ProjectDeleteButton: () => null,
+}));
+
+describe('ProjectDetailsContent', () => {
+  it('lets a project header action select a registered tab', async () => {
+    const store = configureStore({ reducer: { projects: projectsReducer } });
+    const project: ProjectDefinition = {
+      id: 'project-one',
+      namespaces: ['project-one'],
+      clusters: ['test'],
+    };
+
+    store.dispatch(
+      addDetailsTab({
+        id: 'metrics',
+        label: 'Metrics',
+        icon: 'mdi:chart-line',
+        component: () => <div>Metrics panel</div>,
+      })
+    );
+    store.dispatch(
+      addHeaderAction({
+        id: 'open-metrics',
+        component: ({ setSelectedTab }) => (
+          <button onClick={() => setSelectedTab?.('metrics')}>Open metrics</button>
+        ),
+      })
+    );
+
+    render(
+      <TestContext store={store}>
+        <ProjectDetailsContent project={project} />
+      </TestContext>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open metrics' }));
+
+    expect(await screen.findByText('Metrics panel')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/project/ProjectDetails.tsx
+++ b/frontend/src/components/project/ProjectDetails.tsx
@@ -382,6 +382,8 @@ export function ProjectDetailsContent({ project }: { project: ProjectDefinition 
   >(() => ProjectDeleteButton);
 
   const [headerActions, setHeaderActions] = useState<ReactNode[]>([]);
+  const [selectedTab, setSelectedTab] = useState<string>();
+  const [selectedCategoryName, setSelectedCategoryName] = React.useState<string>();
 
   // Load custom delete button
   useEffect(() => {
@@ -436,7 +438,11 @@ export function ProjectDetailsContent({ project }: { project: ProjectDefinition 
 
       if (isCurrent) {
         const actions = enabledActions
-          .map(action => (action ? <action.component key={action.id} project={project} /> : null))
+          .map(action =>
+            action ? (
+              <action.component key={action.id} project={project} setSelectedTab={setSelectedTab} />
+            ) : null
+          )
           .filter(Boolean);
         setHeaderActions(actions);
       }
@@ -448,9 +454,6 @@ export function ProjectDetailsContent({ project }: { project: ProjectDefinition 
       isCurrent = false;
     };
   }, [registeredHeaderActions, project]);
-
-  const [selectedTab, setSelectedTab] = useState<string>();
-  const [selectedCategoryName, setSelectedCategoryName] = React.useState<string>();
 
   const { items, isLoading } = useProjectItems(project);
 

--- a/frontend/src/components/project/ProjectDetails.tsx
+++ b/frontend/src/components/project/ProjectDetails.tsx
@@ -417,6 +417,9 @@ export function ProjectDetailsContent({ project }: { project: ProjectDefinition 
   >(() => ProjectDeleteButton);
 
   const [headerActions, setHeaderActions] = useState<ReactNode[]>([]);
+  const [selectedTab, setSelectedTab] = useState<string>();
+  const [selectedCategoryName, setSelectedCategoryName] = React.useState<string>();
+  const [allTabs, setAllTabs] = useState<Record<string, ProjectDetailsTab>>(DEFAULT_TABS);
 
   // Load custom delete button
   useEffect(() => {
@@ -451,6 +454,11 @@ export function ProjectDetailsContent({ project }: { project: ProjectDefinition 
 
     async function loadHeaderActions() {
       const actionsList = Object.values(registeredHeaderActions);
+      const selectAvailableTab = (tabId: string) => {
+        if (allTabs[tabId]?.component) {
+          setSelectedTab(tabId);
+        }
+      };
 
       // Get a list of enabled header actions
       const enabledActions = (
@@ -471,7 +479,15 @@ export function ProjectDetailsContent({ project }: { project: ProjectDefinition 
 
       if (isCurrent) {
         const actions = enabledActions
-          .map(action => (action ? <action.component key={action.id} project={project} /> : null))
+          .map(action =>
+            action ? (
+              <action.component
+                key={action.id}
+                project={project}
+                setSelectedTab={selectAvailableTab}
+              />
+            ) : null
+          )
           .filter(Boolean);
         setHeaderActions(actions);
       }
@@ -482,10 +498,7 @@ export function ProjectDetailsContent({ project }: { project: ProjectDefinition 
     return () => {
       isCurrent = false;
     };
-  }, [registeredHeaderActions, project]);
-
-  const [selectedTab, setSelectedTab] = useState<string>();
-  const [selectedCategoryName, setSelectedCategoryName] = React.useState<string>();
+  }, [registeredHeaderActions, project, allTabs]);
 
   const { items, isLoading } = useProjectItems(project);
 
@@ -498,8 +511,6 @@ export function ProjectDetailsContent({ project }: { project: ProjectDefinition 
     dispatchHeadlampEvent({ project, resources: items });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [project, items, isLoading]);
-
-  const [allTabs, setAllTabs] = useState<Record<string, ProjectDetailsTab>>(DEFAULT_TABS);
 
   useEffect(() => {
     async function loadTabs() {

--- a/frontend/src/components/project/ProjectDetails.tsx
+++ b/frontend/src/components/project/ProjectDetails.tsx
@@ -384,6 +384,7 @@ export function ProjectDetailsContent({ project }: { project: ProjectDefinition 
   const [headerActions, setHeaderActions] = useState<ReactNode[]>([]);
   const [selectedTab, setSelectedTab] = useState<string>();
   const [selectedCategoryName, setSelectedCategoryName] = React.useState<string>();
+  const [allTabs, setAllTabs] = useState<Record<string, ProjectDetailsTab>>(DEFAULT_TABS);
 
   // Load custom delete button
   useEffect(() => {
@@ -418,6 +419,11 @@ export function ProjectDetailsContent({ project }: { project: ProjectDefinition 
 
     async function loadHeaderActions() {
       const actionsList = Object.values(registeredHeaderActions);
+      const selectAvailableTab = (tabId: string) => {
+        if (allTabs[tabId]?.component) {
+          setSelectedTab(tabId);
+        }
+      };
 
       // Get a list of enabled header actions
       const enabledActions = (
@@ -440,7 +446,11 @@ export function ProjectDetailsContent({ project }: { project: ProjectDefinition 
         const actions = enabledActions
           .map(action =>
             action ? (
-              <action.component key={action.id} project={project} setSelectedTab={setSelectedTab} />
+              <action.component
+                key={action.id}
+                project={project}
+                setSelectedTab={selectAvailableTab}
+              />
             ) : null
           )
           .filter(Boolean);
@@ -453,11 +463,9 @@ export function ProjectDetailsContent({ project }: { project: ProjectDefinition 
     return () => {
       isCurrent = false;
     };
-  }, [registeredHeaderActions, project]);
+  }, [registeredHeaderActions, project, allTabs]);
 
   const { items, isLoading } = useProjectItems(project);
-
-  const [allTabs, setAllTabs] = useState<Record<string, ProjectDetailsTab>>(DEFAULT_TABS);
 
   useEffect(() => {
     async function loadTabs() {

--- a/frontend/src/components/project/ProjectDetails.tsx
+++ b/frontend/src/components/project/ProjectDetails.tsx
@@ -371,7 +371,7 @@ const ProjectDetailsContext = createContext<
 /**
  * Project Details page
  */
-function ProjectDetailsContent({ project }: { project: ProjectDefinition }) {
+export function ProjectDetailsContent({ project }: { project: ProjectDefinition }) {
   const { t } = useTranslation();
   const registeredTabs = useTypedSelector(state => state.projects.detailsTabs);
   const customDeleteButton = useTypedSelector(state => state.projects.projectDeleteButton);

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -1180,7 +1180,7 @@ export function registerProjectDeleteButton(projectDeleteButton: ProjectDeleteBu
  *
  * @param projectHeaderAction - The action configuration to register
  * @param projectHeaderAction.id - Unique identifier for the action
- * @param projectHeaderAction.component - React component to render as the action button
+ * @param projectHeaderAction.component - React component to render as the action button; receives an optional callback for selecting a project tab
  * @param projectHeaderAction.isEnabled - Optional function to determine if action is displayed
  *
  * @example

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -1180,16 +1180,16 @@ export function registerProjectDeleteButton(projectDeleteButton: ProjectDeleteBu
  *
  * @param projectHeaderAction - The action configuration to register
  * @param projectHeaderAction.id - Unique identifier for the action
- * @param projectHeaderAction.component - React component to render as the action button; receives an optional callback for selecting a project tab
+ * @param projectHeaderAction.component - React component to render as the action button. It receives the project and an optional `setSelectedTab?: (tabId: string) => void` callback.
  * @param projectHeaderAction.isEnabled - Optional function to determine if action is displayed
  *
  * @example
  * ```tsx
  * registerProjectHeaderAction({
- *   id: 'deploy-app',
- *   component: ({ project }) => (
- *     <Button onClick={() => navigate(`/deploy/${project.id}`)}>
- *       Deploy App
+ *   id: 'view-resources',
+ *   component: ({ setSelectedTab }) => (
+ *     <Button onClick={() => setSelectedTab?.('headlamp-projects.tabs.resources')}>
+ *       View resources
  *     </Button>
  *   )
  * });

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -1229,16 +1229,16 @@ export function registerProjectDeleteButton(projectDeleteButton: ProjectDeleteBu
  *
  * @param projectHeaderAction - The action configuration to register
  * @param projectHeaderAction.id - Unique identifier for the action
- * @param projectHeaderAction.component - React component to render as the action button
+ * @param projectHeaderAction.component - React component to render as the action button. It receives the project and an optional `setSelectedTab?: (tabId: string) => void` callback.
  * @param projectHeaderAction.isEnabled - Optional function to determine if action is displayed
  *
  * @example
  * ```tsx
  * registerProjectHeaderAction({
- *   id: 'deploy-app',
- *   component: ({ project }) => (
- *     <Button onClick={() => navigate(`/deploy/${project.id}`)}>
- *       Deploy App
+ *   id: 'view-resources',
+ *   component: ({ setSelectedTab }) => (
+ *     <Button onClick={() => setSelectedTab?.('headlamp-projects.tabs.resources')}>
+ *       View resources
  *     </Button>
  *   )
  * });

--- a/frontend/src/redux/projectsSlice.ts
+++ b/frontend/src/redux/projectsSlice.ts
@@ -66,7 +66,10 @@ export interface ProjectDeleteButton {
 
 export interface ProjectHeaderAction {
   id: string;
-  component: (props: { project: ProjectDefinition }) => ReactNode;
+  component: (props: {
+    project: ProjectDefinition;
+    setSelectedTab?: (tabId: string) => void;
+  }) => ReactNode;
   /** Function to check if this action should be displayed in the given project. If not provided the action will be enabled. */
   isEnabled?: ({ project }: { project: ProjectDefinition }) => Promise<boolean>;
 }

--- a/frontend/src/redux/projectsSlice.ts
+++ b/frontend/src/redux/projectsSlice.ts
@@ -86,7 +86,10 @@ export interface ProjectDeleteButton {
 
 export interface ProjectHeaderAction {
   id: string;
-  component: (props: { project: ProjectDefinition }) => ReactNode;
+  component: (props: {
+    project: ProjectDefinition;
+    setSelectedTab?: (tabId: string) => void;
+  }) => ReactNode;
   /** Function to check if this action should be displayed in the given project. If not provided the action will be enabled. */
   isEnabled?: ({ project }: { project: ProjectDefinition }) => Promise<boolean>;
 }

--- a/plugins/examples/projects/src/index.tsx
+++ b/plugins/examples/projects/src/index.tsx
@@ -193,6 +193,7 @@ registerProjectHeaderAction({
     <button
       onClick={() => {
         console.log('Custom header action for project:', project.id);
+        // Select the project details tab registered above with the ID "my-tab".
         setSelectedTab?.('my-tab');
       }}
     >

--- a/plugins/examples/projects/src/index.tsx
+++ b/plugins/examples/projects/src/index.tsx
@@ -198,10 +198,12 @@ registerProjectDeleteButton({
 // Example of adding a custom action button to the project details header
 registerProjectHeaderAction({
   id: 'custom-header-action',
-  component: ({ project }) => (
+  component: ({ project, setSelectedTab }) => (
     <button
       onClick={() => {
         console.log('Custom header action for project:', project.id);
+        // Select the project details tab registered above with the ID "my-tab".
+        setSelectedTab?.('my-tab');
       }}
     >
       Custom Action

--- a/plugins/examples/projects/src/index.tsx
+++ b/plugins/examples/projects/src/index.tsx
@@ -189,10 +189,11 @@ registerProjectDeleteButton({
 // Example of adding a custom action button to the project details header
 registerProjectHeaderAction({
   id: 'custom-header-action',
-  component: ({ project }) => (
+  component: ({ project, setSelectedTab }) => (
     <button
       onClick={() => {
         console.log('Custom header action for project:', project.id);
+        setSelectedTab?.('my-tab');
       }}
     >
       Custom Action


### PR DESCRIPTION
## Summary

Patch 0051 extends `ProjectHeaderAction` so action components receive an optional
`setSelectedTab` callback. Plugins can use normal React data flow to select a
registered project details tab without DOM events. Headlamp ignores unknown,
disabled, and non-rendered tab IDs so invalid plugin input preserves the current
content.

This upstream version improves on the original Azure PR by adding:

- three focused unit tests for tab selection, enabled and disabled actions,
  rejected enablement checks, unavailable tab IDs, and stale async results;
- 90% branch coverage (9/10 branches) for the changed header-action loader and
  guarded selector;
- a Playwright e2e test that uses the real projects example plugin and verifies
  its header action selects the registered Metrics tab in deployed Headlamp,
  with unique test-owned resources and both CI clusters authenticated;
- plugin registry and functionality documentation for the callback contract.

## Related Work

- Original implementation: https://github.com/Azure/aks-desktop/pull/406
- Original Azure commit: https://github.com/Azure/aks-desktop/commit/ceb2006e460bd7c1a9c45d2135189d5a7825584c
- Plugin consumer: https://github.com/Azure/aks-desktop/pull/407
- Source-package migration containing patch 0051: https://github.com/Azure/aks-desktop/pull/823
- Feature context: https://github.com/Azure/aks-desktop/issues/408
- Rebased patch commit recorded by PR 823: `af9ab90d4b6d13ccc0a4881da648b87fa8a54a77`

The upstreamed feature commit preserves Thomas Gamble's original author date and
adds René Dudfield as co-author.

## Changes

- Pass a guarded project tab selector to registered header action components.
- Add the optional callback to the public `ProjectHeaderAction` component props.
- Document the callback in the plugin registry API and plugin functionality docs.
- Exercise the callback through unit and e2e coverage.

## Steps to Test

1. Run `cd frontend && ./node_modules/.bin/vitest --run src/components/project/ProjectDetails.test.tsx`.
2. Run `cd frontend && ./node_modules/.bin/tsgo`.
3. Build the e2e plugins image and deploy Headlamp using `e2e-tests/README.md`.
4. Run `cd e2e-tests && npx playwright test tests/projects.spec.ts`.

## Validation

- Focused unit tests: 3 passed.
- Icon cache audit: passed.
- Changed header-action loader branch coverage: 90% (9/10).
- Focused ESLint: passed.
- Frontend and script TypeScript checks: passed.
- Playwright test discovery: 1 test found.
- Full deployed Playwright execution: passed in CI.
- Frontend, plugin, docs, Storybook, container, and platform workflows: passed.

## Screenshots

Not applicable. This adds a plugin API callback without changing the default UI.

## Notes for the Reviewer

The feature commit contains the implementation, API documentation, and unit
coverage so it passes frontend tests, lint, type checking, and builds on its own.
The second commit adds the example-plugin usage and deployed e2e coverage, with
test-owned resources for shared, multi-cluster CI environments.

Assisted by copilot
