### PR TITLE
frontend: AppContainer: Fix success snackbar contrast

### DIFF
--- a/frontend/src/components/App/AppContainer.test.tsx
+++ b/frontend/src/components/App/AppContainer.test.tsx
@@ -14,7 +14,22 @@
  * limitations under the License.
  */
 
-import { isValidRedirectPath } from './AppContainer';
+import { createTheme } from '@mui/material/styles';
+import { getSuccessSnackbarBackground, isValidRedirectPath } from './AppContainer';
+
+describe('getSuccessSnackbarBackground', () => {
+  it('uses the active theme success background for each color mode', () => {
+    const lightTheme = createTheme({
+      palette: { mode: 'light', success: { main: '#123456' } },
+    });
+    const darkTheme = createTheme({
+      palette: { mode: 'dark', success: { main: '#abcdef', light: '#654321' } },
+    });
+
+    expect(getSuccessSnackbarBackground(lightTheme)).toBe('#123456');
+    expect(getSuccessSnackbarBackground(darkTheme)).toBe('#654321');
+  });
+});
 
 describe('isValidRedirectPath', () => {
   it('should allow safe internal paths', () => {

--- a/frontend/src/components/App/AppContainer.test.tsx
+++ b/frontend/src/components/App/AppContainer.test.tsx
@@ -14,12 +14,49 @@
  * limitations under the License.
  */
 
+import { createTheme, getContrastRatio } from '@mui/material/styles';
 import { act, render } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter, useHistory } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as isElectronModule from '../../helpers/isElectron';
-import { isValidRedirectPath, RouteZoomSync } from './AppContainer';
+import { createMuiTheme } from '../../lib/themes';
+import { getSuccessSnackbarBackground, isValidRedirectPath, RouteZoomSync } from './AppContainer';
+
+describe('getSuccessSnackbarBackground', () => {
+  it('uses the active theme success background for each color mode', () => {
+    const lightTheme = createTheme({
+      palette: { mode: 'light', success: { main: '#123456' } },
+    });
+    const darkTheme = createTheme({
+      palette: { mode: 'dark', success: { main: '#abcdef', light: '#654321' } },
+    });
+
+    expect(getSuccessSnackbarBackground(lightTheme)).toBe('#123456');
+    expect(getSuccessSnackbarBackground(darkTheme)).toBe('#654321');
+  });
+
+  // WCAG 2.1 SC 1.4.3 (Contrast Minimum, Level AA) requires 4.5:1 for normal
+  // text. Notistack renders the success snackbar's text in white, so the
+  // background picked from Headlamp's real themes must clear that bar.
+  it.each([
+    ['light', 'light'],
+    ['dark', 'dark'],
+  ] as const)(
+    'meets WCAG AA contrast against white text for the built-in %s theme',
+    (name, base) => {
+      const muiTheme = createMuiTheme({ name, base });
+
+      expect(muiTheme.palette.mode).toBe(base);
+
+      const background = getSuccessSnackbarBackground(muiTheme);
+      expect(
+        getContrastRatio('#fff', background),
+        `white text vs success snackbar background (${background})`
+      ).toBeGreaterThanOrEqual(4.5);
+    }
+  );
+});
 
 describe('isValidRedirectPath', () => {
   it('should allow safe internal paths', () => {

--- a/frontend/src/components/App/AppContainer.tsx
+++ b/frontend/src/components/App/AppContainer.tsx
@@ -15,6 +15,7 @@
  */
 
 import GlobalStyles from '@mui/material/GlobalStyles';
+import type { Theme } from '@mui/material/styles';
 import { SnackbarProvider } from 'notistack';
 import React, { useEffect } from 'react';
 import { BrowserRouter, HashRouter, useHistory, useLocation } from 'react-router-dom';
@@ -132,6 +133,9 @@ const Router = ({ children }: React.PropsWithChildren<{}>) =>
     <BrowserRouter basename={getBaseUrl()}>{children}</BrowserRouter>
   );
 
+export const getSuccessSnackbarBackground = (theme: Theme) =>
+  theme.palette.mode === 'dark' ? theme.palette.success.light : theme.palette.success.main;
+
 export default function AppContainer() {
   return (
     <SnackbarProvider
@@ -141,7 +145,10 @@ export default function AppContainer() {
       }}
     >
       <GlobalStyles
-        styles={{
+        styles={theme => ({
+          '.notistack-MuiContent-success': {
+            backgroundColor: getSuccessSnackbarBackground(theme),
+          },
           ':root': {
             '@media (prefers-reduced-motion: reduce)': {
               '& *': {
@@ -152,7 +159,7 @@ export default function AppContainer() {
               },
             },
           },
-        }}
+        })}
       />
       <Router>
         <PreviousRouteProvider>

--- a/frontend/src/components/App/AppContainer.tsx
+++ b/frontend/src/components/App/AppContainer.tsx
@@ -15,6 +15,7 @@
  */
 
 import GlobalStyles from '@mui/material/GlobalStyles';
+import type { Theme } from '@mui/material/styles';
 import { SnackbarProvider } from 'notistack';
 import React, { useEffect } from 'react';
 import { BrowserRouter, HashRouter, useHistory, useLocation } from 'react-router-dom';
@@ -164,6 +165,9 @@ const Router = ({ children }: React.PropsWithChildren<{}>) =>
     <BrowserRouter basename={getBaseUrl()}>{children}</BrowserRouter>
   );
 
+export const getSuccessSnackbarBackground = (theme: Theme) =>
+  theme.palette.mode === 'dark' ? theme.palette.success.light : theme.palette.success.main;
+
 export default function AppContainer() {
   const [backendTokenReady, setBackendTokenReady] = React.useState(!window.desktopApi);
 
@@ -194,7 +198,10 @@ export default function AppContainer() {
       }}
     >
       <GlobalStyles
-        styles={{
+        styles={theme => ({
+          '.notistack-MuiContent-success': {
+            backgroundColor: getSuccessSnackbarBackground(theme),
+          },
           ':root': {
             '@media (prefers-reduced-motion: reduce)': {
               '& *': {
@@ -205,7 +212,7 @@ export default function AppContainer() {
               },
             },
           },
-        }}
+        })}
       />
       <Router>
         <PreviousRouteProvider>


### PR DESCRIPTION
## Summary

Fixes the success snackbar contrast without changing Headlamp's global success palette.

## Related Issue

Fixes #6916

## Changes

- Override only `.notistack-MuiContent-success`
- Change its background from `#43a047` to `#2e7d32`
- Raise white-text contrast from 3.30:1 to 5.13:1

## Steps to Test

1. Start Headlamp and connect to a cluster.
2. Apply a resource from the YAML editor.
3. Check the green “Applied…” snackbar in light and dark themes.

## Screenshots

Before:

![Success snackbar before](https://github.com/user-attachments/assets/4b0206e8-f3f4-456a-beaf-5d678740cd21)

After:

<img width="1280" height="720" alt="Success snackbar after" src="https://github.com/user-attachments/assets/3d2176ac-ca26-41e4-a513-8874fa176305" />

## Notes for the Reviewer

- `npm run frontend:lint`
- `npm run frontend:tsc`
- `npm run frontend:test`
- Browser-verified in light and dark themes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated success notifications to use theme-aware colors, improving readability in both light and dark modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->