### PR TITLE
e2e-tests: Normalize dynamic cluster kubeconfigs

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -78,49 +78,17 @@ of exposing the Service will do, as long as `HEADLAMP_TEST_URL` points at it.
 (`playwright.config.ts`), so an unset variable shows up as connection errors
 rather than as an obvious configuration problem.
 
-### Kubeconfig with certificates on disk
+### Kubeconfig certificate handling
 
-`dynamicCluster.spec.ts` reads your kubeconfig with `kubectl config view`, which
-redacts embedded `certificate-authority-data` and the client certificate fields,
-and then reads the referenced files from disk. If those fields are embedded
-rather than file paths, seven tests in that file fail with `ENOENT`.
-
-CI works around this by rewriting the kubeconfig so the certificates live in
-files. If you hit those failures, do the same, and note that the paths must be
-absolute, because the test resolves them relative to its own working directory:
-
-```bash
-umask 077
-mkdir -p ~/headlamp-e2e-certs
-
-# test cluster
-kubectl config view --raw --minify --context=test -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' | base64 --decode > ~/headlamp-e2e-certs/test-ca.crt
-kubectl config view --raw --minify --context=test -o jsonpath='{.users[0].user.client-certificate-data}' | base64 --decode > ~/headlamp-e2e-certs/test-client.crt
-kubectl config view --raw --minify --context=test -o jsonpath='{.users[0].user.client-key-data}' | base64 --decode > ~/headlamp-e2e-certs/test-client.key
-
-kubectl config set-cluster kind-test \
-  --certificate-authority="$HOME/headlamp-e2e-certs/test-ca.crt" \
-  --embed-certs=false
-
-kubectl config set-credentials admin@kind-test \
-  --client-certificate="$HOME/headlamp-e2e-certs/test-client.crt" \
-  --client-key="$HOME/headlamp-e2e-certs/test-client.key" \
-  --embed-certs=false
-
-# test2 cluster
-kubectl config view --raw --minify --context=test2 -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' | base64 --decode > ~/headlamp-e2e-certs/test2-ca.crt
-kubectl config view --raw --minify --context=test2 -o jsonpath='{.users[0].user.client-certificate-data}' | base64 --decode > ~/headlamp-e2e-certs/test2-client.crt
-kubectl config view --raw --minify --context=test2 -o jsonpath='{.users[0].user.client-key-data}' | base64 --decode > ~/headlamp-e2e-certs/test2-client.key
-
-kubectl config set-cluster kind-test2 \
-  --certificate-authority="$HOME/headlamp-e2e-certs/test2-ca.crt" \
-  --embed-certs=false
-
-kubectl config set-credentials admin@kind-test2 \
-  --client-certificate="$HOME/headlamp-e2e-certs/test2-client.crt" \
-  --client-key="$HOME/headlamp-e2e-certs/test2-client.key" \
-  --embed-certs=false
-```
+`dynamicCluster.spec.ts` reads your kubeconfig with
+`kubectl config view --minify --raw --flatten --context test`, which embeds
+the certificate data directly in the output and includes only the `test`
+context (selected explicitly — the current context may point elsewhere, e.g.
+at `test2` after `setup-multicluster.sh`), so credentials for unrelated
+contexts stay out of the tests. Embedded
+`certificate-authority-data`/client certificate fields and file-based
+certificates (absolute or kubeconfig-relative paths) all work as-is, so no
+kubeconfig rewriting is needed.
 
 ### Additional suites
 

--- a/e2e-tests/tests/dynamicCluster.spec.ts
+++ b/e2e-tests/tests/dynamicCluster.spec.ts
@@ -15,201 +15,306 @@
  */
 
 import { expect, test } from '@playwright/test';
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
 import { HeadlampPage } from './headlampPage';
 const yaml = require('yaml');
-const fs = require('fs').promises;
-const util = require('util');
-const exec = util.promisify(require('child_process').exec);
+
+const execFileAsync = promisify(execFile);
 
 let headlampPage: HeadlampPage;
+const KUBECONFIG_ONLY_TAG = '@kubeconfig-only';
 
-test.beforeEach(async ({ page }) => {
-  headlampPage = new HeadlampPage(page);
+test.describe('dynamic cluster UI', () => {
+  test.beforeEach(async ({ page }) => {
+    headlampPage = new HeadlampPage(page);
 
-  // Navigate to the test cluster page
-  await headlampPage.navigateTopage('/c/test');
+    // Navigate to the test cluster page
+    await headlampPage.navigateTopage('/c/test');
 
-  // Authenticate only when the auth page appears (e.g. minikube with token auth).
-  // Use a short wait to avoid racing page hydration in slower environments.
-  const authHeader = page.locator('h1:has-text("Authentication")');
-  const hasAuthPage = await authHeader
-    .waitFor({ state: 'visible', timeout: 2000 })
-    .then(() => true)
-    .catch(() => false);
-  if (hasAuthPage) {
-    await headlampPage.authenticate(process.env.HEADLAMP_TEST_TOKEN);
-  }
-});
-
-test('There is cluster choose button and test cluster is selected', async () => {
-  await headlampPage.pageLocatorContent(
-    'button:has-text("Our Cluster Chooser button. Cluster: test")',
-    'Our Cluster Chooser button. Cluster: test'
-  );
-});
-
-test('Store modified kubeconfig to IndexDB and check if present', async ({ page }) => {
-  const base64EncodedKubeconfig = await getBase64EncodedKubeconfig();
-  await saveKubeconfigToIndexDB(page, base64EncodedKubeconfig);
-  await page.waitForLoadState('load');
-
-  const storedKubeconfig = await getKubeconfigFromIndexDB(page);
-  await page.waitForLoadState('load');
-
-  expect(storedKubeconfig).not.toBeNull();
-});
-
-test('parseKubeConfig endpoint accepts kubeconfigs array format', async ({ page }) => {
-  const base64EncodedKubeconfig = await getBase64EncodedKubeconfig();
-
-  // Call /parseKubeConfig with the correct kubeconfigs (plural, array) format
-  const response = await page.evaluate(async (kubeconfig: string) => {
-    const resp = await fetch('/parseKubeConfig', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ kubeconfigs: [kubeconfig] }),
-    });
-    return { status: resp.status, body: await resp.json() };
-  }, base64EncodedKubeconfig);
-
-  expect(response.status).toBe(200);
-  expect(response.body).toHaveProperty('clusters');
-  expect(Array.isArray(response.body.clusters)).toBe(true);
-  expect(response.body.clusters.length).toBeGreaterThan(0);
-  expect(response.body.clusters.some((c: { name: string }) => c.name === 'dummy')).toBe(true);
-});
-
-test('parseKubeConfig endpoint rejects singular kubeconfig format', async ({ page }) => {
-  const base64EncodedKubeconfig = await getBase64EncodedKubeconfig();
-
-  // Verify the old singular kubeconfig format is rejected by the backend
-  const rejectResponse = await page.evaluate(async (kubeconfig: string) => {
-    const resp = await fetch('/parseKubeConfig', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ kubeconfig: kubeconfig }),
-    });
-    return { status: resp.status };
-  }, base64EncodedKubeconfig);
-
-  // The backend requires kubeconfigs (plural, array) and rejects kubeconfig (singular)
-  expect(rejectResponse.status).toBe(400);
-});
-
-test('stateless cluster loads without errors after storing kubeconfig', async ({ page }) => {
-  const base64EncodedKubeconfig = await getBase64EncodedKubeconfig();
-  const parseKubeConfigStatuses: number[] = [];
-  const browserErrors: string[] = [];
-
-  page.on('response', response => {
-    if (response.url().includes('/parseKubeConfig')) {
-      parseKubeConfigStatuses.push(response.status());
+    // Authenticate only when the auth page appears (e.g. minikube with token auth).
+    // Use a short wait to avoid racing page hydration in slower environments.
+    const authHeader = page.locator('h1:has-text("Authentication")');
+    const hasAuthPage = await authHeader
+      .waitFor({ state: 'visible', timeout: 2000 })
+      .then(() => true)
+      .catch(() => false);
+    if (hasAuthPage) {
+      await headlampPage.authenticate(process.env.HEADLAMP_TEST_TOKEN);
     }
   });
 
-  page.on('console', msg => {
-    if (msg.type() === 'error') {
-      browserErrors.push(msg.text());
-    }
+  test('There is cluster choose button and test cluster is selected', async () => {
+    await headlampPage.pageLocatorContent(
+      'button:has-text("Our Cluster Chooser button. Cluster: test")',
+      'Our Cluster Chooser button. Cluster: test'
+    );
   });
 
-  // Step 1: Store kubeconfig in IndexedDB (simulates the user adding a cluster)
-  await saveKubeconfigToIndexDB(page, base64EncodedKubeconfig);
+  test('Store modified kubeconfig to IndexDB and check if present', async ({ page }) => {
+    const base64EncodedKubeconfig = await getBase64EncodedKubeconfig();
+    await saveKubeconfigToIndexDB(page, base64EncodedKubeconfig);
+    await page.waitForLoadState('load');
 
-  // Step 2: Reload to trigger stateless startup parsing flow.
-  await page.reload({ waitUntil: 'load' });
-  await page.waitForResponse(response => response.url().includes('/parseKubeConfig'));
+    const storedKubeconfig = await getKubeconfigFromIndexDB(page);
+    await page.waitForLoadState('load');
 
-  expect(parseKubeConfigStatuses.length).toBeGreaterThan(0);
-  expect(parseKubeConfigStatuses.every(status => status === 200)).toBe(true);
-  expect(browserErrors.some(msg => msg.includes('kubeconfigs is required'))).toBe(false);
-
-  // Confirm the stateless cluster can be loaded after reload.
-  await headlampPage.navigateTopage('/c/dummy');
-  await headlampPage.pageLocatorContent(
-    'button:has-text("Our Cluster Chooser button. Cluster: dummy")',
-    'Our Cluster Chooser button. Cluster: dummy'
-  );
-});
-
-test('reload does not trigger stateless parsing when IndexedDB is empty', async ({ page }) => {
-  await clearKubeconfigsFromIndexDB(page);
-
-  const parseKubeConfigStatuses: number[] = [];
-
-  page.on('response', response => {
-    if (response.url().includes('/parseKubeConfig')) {
-      parseKubeConfigStatuses.push(response.status());
-    }
+    expect(storedKubeconfig).not.toBeNull();
   });
 
-  await page.reload({ waitUntil: 'load' });
-  await page.waitForTimeout(1500);
+  test('parseKubeConfig endpoint accepts kubeconfigs array format', async ({ page }) => {
+    const base64EncodedKubeconfig = await getBase64EncodedKubeconfig();
 
-  expect(parseKubeConfigStatuses).toHaveLength(0);
-});
-
-test('adding another stateless cluster keeps previously added clusters available', async ({
-  page,
-}) => {
-  await clearKubeconfigsFromIndexDB(page);
-
-  const firstClusterName = 'dummy';
-  const secondClusterName = 'dummy-two';
-  const firstKubeconfig = await getBase64EncodedKubeconfig(firstClusterName);
-  const secondKubeconfig = await getBase64EncodedKubeconfig(secondClusterName);
-
-  await saveKubeconfigToIndexDB(page, firstKubeconfig);
-  await saveKubeconfigToIndexDB(page, secondKubeconfig);
-
-  await page.reload({ waitUntil: 'load' });
-  await page.waitForResponse(response => response.url().includes('/parseKubeConfig'));
-
-  await headlampPage.navigateTopage(`/c/${firstClusterName}`);
-  await headlampPage.pageLocatorContent(
-    `button:has-text("Our Cluster Chooser button. Cluster: ${firstClusterName}")`,
-    `Our Cluster Chooser button. Cluster: ${firstClusterName}`
-  );
-
-  await headlampPage.navigateTopage(`/c/${secondClusterName}`);
-  await headlampPage.pageLocatorContent(
-    `button:has-text("Our Cluster Chooser button. Cluster: ${secondClusterName}")`,
-    `Our Cluster Chooser button. Cluster: ${secondClusterName}`
-  );
-});
-
-test('valid kubeconfig is still parsed when an invalid one is also sent', async ({ page }) => {
-  const validKubeconfig = await getBase64EncodedKubeconfig();
-  // A clearly invalid kubeconfig that cannot be decoded
-  const invalidKubeconfig = 'not-valid-base64-!!!';
-
-  // Send both in one request — one valid, one invalid.
-  // The backend should return the valid cluster rather than discarding it entirely.
-  const response = await page.evaluate(
-    async ({ valid, invalid }: { valid: string; invalid: string }) => {
+    // Call /parseKubeConfig with the correct kubeconfigs (plural, array) format
+    const response = await page.evaluate(async (kubeconfig: string) => {
       const resp = await fetch('/parseKubeConfig', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ kubeconfigs: [valid, invalid] }),
+        body: JSON.stringify({ kubeconfigs: [kubeconfig] }),
       });
-      const body = resp.status === 200 ? await resp.json() : await resp.text();
-      return { status: resp.status, body };
-    },
-    { valid: validKubeconfig, invalid: invalidKubeconfig }
-  );
+      return { status: resp.status, body: await resp.json() };
+    }, base64EncodedKubeconfig);
 
-  expect(response.status).toBe(200);
-  expect(Array.isArray(response.body.clusters)).toBe(true);
-  expect(response.body.clusters.some((c: { name: string }) => c.name === 'dummy')).toBe(true);
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('clusters');
+    expect(Array.isArray(response.body.clusters)).toBe(true);
+    expect(response.body.clusters.length).toBeGreaterThan(0);
+    expect(response.body.clusters.some((c: { name: string }) => c.name === 'dummy')).toBe(true);
+  });
+
+  test('parseKubeConfig endpoint rejects singular kubeconfig format', async ({ page }) => {
+    const base64EncodedKubeconfig = await getBase64EncodedKubeconfig();
+
+    // Verify the old singular kubeconfig format is rejected by the backend
+    const rejectResponse = await page.evaluate(async (kubeconfig: string) => {
+      const resp = await fetch('/parseKubeConfig', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ kubeconfig: kubeconfig }),
+      });
+      return { status: resp.status };
+    }, base64EncodedKubeconfig);
+
+    // The backend requires kubeconfigs (plural, array) and rejects kubeconfig (singular)
+    expect(rejectResponse.status).toBe(400);
+  });
+
+  test('stateless cluster loads without errors after storing kubeconfig', async ({ page }) => {
+    const base64EncodedKubeconfig = await getBase64EncodedKubeconfig();
+    const parseKubeConfigStatuses: number[] = [];
+    const browserErrors: string[] = [];
+
+    page.on('response', response => {
+      if (response.url().includes('/parseKubeConfig')) {
+        parseKubeConfigStatuses.push(response.status());
+      }
+    });
+
+    page.on('console', msg => {
+      if (msg.type() === 'error') {
+        browserErrors.push(msg.text());
+      }
+    });
+
+    // Step 1: Store kubeconfig in IndexedDB (simulates the user adding a cluster)
+    await saveKubeconfigToIndexDB(page, base64EncodedKubeconfig);
+
+    // Step 2: Reload to trigger stateless startup parsing flow.
+    await page.reload({ waitUntil: 'load' });
+    await page.waitForResponse(response => response.url().includes('/parseKubeConfig'));
+
+    expect(parseKubeConfigStatuses.length).toBeGreaterThan(0);
+    expect(parseKubeConfigStatuses.every(status => status === 200)).toBe(true);
+    expect(browserErrors.some(msg => msg.includes('kubeconfigs is required'))).toBe(false);
+
+    // Confirm the stateless cluster can be loaded after reload.
+    await headlampPage.navigateTopage('/c/dummy');
+    await headlampPage.pageLocatorContent(
+      'button:has-text("Our Cluster Chooser button. Cluster: dummy")',
+      'Our Cluster Chooser button. Cluster: dummy'
+    );
+  });
+
+  test('reload does not trigger stateless parsing when IndexedDB is empty', async ({ page }) => {
+    await clearKubeconfigsFromIndexDB(page);
+
+    const parseKubeConfigStatuses: number[] = [];
+
+    page.on('response', response => {
+      if (response.url().includes('/parseKubeConfig')) {
+        parseKubeConfigStatuses.push(response.status());
+      }
+    });
+
+    await page.reload({ waitUntil: 'load' });
+    await page.waitForTimeout(1500);
+
+    expect(parseKubeConfigStatuses).toHaveLength(0);
+  });
+
+  test('adding another stateless cluster keeps previously added clusters available', async ({
+    page,
+  }) => {
+    await clearKubeconfigsFromIndexDB(page);
+
+    const firstClusterName = 'dummy';
+    const secondClusterName = 'dummy-two';
+    const firstKubeconfig = await getBase64EncodedKubeconfig(firstClusterName);
+    const secondKubeconfig = await getBase64EncodedKubeconfig(secondClusterName);
+
+    await saveKubeconfigToIndexDB(page, firstKubeconfig);
+    await saveKubeconfigToIndexDB(page, secondKubeconfig);
+
+    await page.reload({ waitUntil: 'load' });
+    await page.waitForResponse(response => response.url().includes('/parseKubeConfig'));
+
+    await headlampPage.navigateTopage(`/c/${firstClusterName}`);
+    await headlampPage.pageLocatorContent(
+      `button:has-text("Our Cluster Chooser button. Cluster: ${firstClusterName}")`,
+      `Our Cluster Chooser button. Cluster: ${firstClusterName}`
+    );
+
+    await headlampPage.navigateTopage(`/c/${secondClusterName}`);
+    await headlampPage.pageLocatorContent(
+      `button:has-text("Our Cluster Chooser button. Cluster: ${secondClusterName}")`,
+      `Our Cluster Chooser button. Cluster: ${secondClusterName}`
+    );
+  });
+
+  test('valid kubeconfig is still parsed when an invalid one is also sent', async ({ page }) => {
+    const validKubeconfig = await getBase64EncodedKubeconfig();
+    // A clearly invalid kubeconfig that cannot be decoded
+    const invalidKubeconfig = 'not-valid-base64-!!!';
+
+    // Send both in one request — one valid, one invalid.
+    // The backend should return the valid cluster rather than discarding it entirely.
+    const response = await page.evaluate(
+      async ({ valid, invalid }: { valid: string; invalid: string }) => {
+        const resp = await fetch('/parseKubeConfig', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ kubeconfigs: [valid, invalid] }),
+        });
+        const body = resp.status === 200 ? await resp.json() : await resp.text();
+        return { status: resp.status, body };
+      },
+      { valid: validKubeconfig, invalid: invalidKubeconfig }
+    );
+
+    expect(response.status).toBe(200);
+    expect(Array.isArray(response.body.clusters)).toBe(true);
+    expect(response.body.clusters.some((c: { name: string }) => c.name === 'dummy')).toBe(true);
+  });
 });
 
-const getBase64EncodedKubeconfig = async (clusterName: string = 'dummy') => {
-  // Use kubectl command-line tool to get the kubeconfig
-  const { stdout, stderr } = await exec('kubectl config view --output json');
-  if (stderr) {
-    console.error('Error fetching Minikube kubeconfig:', stderr);
-    return;
+const makeKubeconfig = (cluster: Record<string, string>, user: Record<string, string>) => ({
+  apiVersion: 'v1',
+  kind: 'Config',
+  clusters: [
+    {
+      name: 'source',
+      cluster: { server: 'https://127.0.0.1:6443', ...cluster },
+    },
+  ],
+  contexts: [{ name: 'source', context: { cluster: 'source', user: 'source' } }],
+  users: [{ name: 'source', user }],
+  'current-context': 'source',
+});
+
+test('normalizes embedded kubeconfig certificates', { tag: KUBECONFIG_ONLY_TAG }, async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'headlamp-kubeconfig-'));
+  const kubeconfigPath = join(directory, 'config');
+
+  try {
+    await writeFile(
+      kubeconfigPath,
+      yaml.stringify(
+        makeKubeconfig(
+          {
+            'certificate-authority-data': Buffer.from('embedded-ca').toString('base64'),
+          },
+          {
+            'client-certificate-data': Buffer.from('embedded-cert').toString('base64'),
+            'client-key-data': Buffer.from('embedded-key').toString('base64'),
+          }
+        )
+      )
+    );
+
+    const encoded = await getBase64EncodedKubeconfig('embedded', kubeconfigPath);
+    const normalized = yaml.parse(Buffer.from(encoded, 'base64').toString());
+
+    expect(normalized.clusters[0].cluster).toMatchObject({
+      'certificate-authority-data': 'ZW1iZWRkZWQtY2E=',
+    });
+    expect(normalized.users[0].user).toMatchObject({
+      'client-certificate-data': 'ZW1iZWRkZWQtY2VydA==',
+      'client-key-data': 'ZW1iZWRkZWQta2V5',
+    });
+  } finally {
+    await rm(directory, { recursive: true, force: true });
   }
+});
+
+test(
+  'normalizes certificate paths relative to the kubeconfig',
+  { tag: KUBECONFIG_ONLY_TAG },
+  async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'headlamp-kubeconfig-'));
+    const kubeconfigPath = join(directory, 'config');
+
+    try {
+      await Promise.all([
+        writeFile(join(directory, 'ca.crt'), 'relative-ca'),
+        writeFile(join(directory, 'client.crt'), 'relative-cert'),
+        writeFile(join(directory, 'client.key'), 'relative-key'),
+      ]);
+      await writeFile(
+        kubeconfigPath,
+        yaml.stringify(
+          makeKubeconfig(
+            { 'certificate-authority': 'ca.crt' },
+            { 'client-certificate': 'client.crt', 'client-key': 'client.key' }
+          )
+        )
+      );
+
+      const encoded = await getBase64EncodedKubeconfig('relative', kubeconfigPath);
+      const normalized = yaml.parse(Buffer.from(encoded, 'base64').toString());
+
+      expect(normalized.clusters[0].cluster).toMatchObject({
+        'certificate-authority-data': 'cmVsYXRpdmUtY2E=',
+      });
+      expect(normalized.clusters[0].cluster).not.toHaveProperty('certificate-authority');
+      expect(normalized.users[0].user).toMatchObject({
+        'client-certificate-data': 'cmVsYXRpdmUtY2VydA==',
+        'client-key-data': 'cmVsYXRpdmUta2V5',
+      });
+      expect(normalized.users[0].user).not.toHaveProperty('client-certificate');
+      expect(normalized.users[0].user).not.toHaveProperty('client-key');
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  }
+);
+
+const getBase64EncodedKubeconfig = async (
+  clusterName: string = 'dummy',
+  kubeconfigPath?: string
+): Promise<string> => {
+  // Use kubectl command-line tool to get the kubeconfig
+  const { stdout } = await execFileAsync('kubectl', [
+    ...(kubeconfigPath ? ['--kubeconfig', kubeconfigPath] : []),
+    'config',
+    'view',
+    '--raw',
+    '--flatten',
+    '--output',
+    'json',
+  ]);
 
   // Parse the kubeconfig JSON
   const kubeconfig = JSON.parse(stdout);
@@ -223,29 +328,6 @@ const getBase64EncodedKubeconfig = async (clusterName: string = 'dummy') => {
   kubeconfig.users[0].name = clusterName;
   kubeconfig.contexts[0].context.user = clusterName;
   kubeconfig.contexts[0].context.cluster = clusterName;
-
-  // Get the contents of certificate-authority file and convert to base64
-  const caFilePath = kubeconfig.clusters[0].cluster['certificate-authority'];
-  const caFileContent = await fs.readFile(caFilePath, 'utf-8');
-  kubeconfig.clusters[0].cluster['certificate-authority-data'] =
-    Buffer.from(caFileContent).toString('base64');
-
-  // Get the contents of client-certificate file and convert to base64
-  const clientCertFilePath = kubeconfig.users[0].user['client-certificate'];
-  const clientCertFileContent = await fs.readFile(clientCertFilePath, 'utf-8');
-  kubeconfig.users[0].user['client-certificate-data'] =
-    Buffer.from(clientCertFileContent).toString('base64');
-
-  // Get the contents of client-key file and convert to base64
-  const clientKeyFilePath = kubeconfig.users[0].user['client-key'];
-  const clientKeyFileContent = await fs.readFile(clientKeyFilePath, 'utf-8');
-  kubeconfig.users[0].user['client-key-data'] =
-    Buffer.from(clientKeyFileContent).toString('base64');
-
-  // Remove client-key, client-certificate, and certificate-authority keys
-  delete kubeconfig.users[0].user['client-key'];
-  delete kubeconfig.users[0].user['client-certificate'];
-  delete kubeconfig.clusters[0].cluster['certificate-authority'];
 
   // Set the current context to the generated cluster name.
   kubeconfig['current-context'] = clusterName;

--- a/e2e-tests/tests/dynamicCluster.spec.ts
+++ b/e2e-tests/tests/dynamicCluster.spec.ts
@@ -17,13 +17,28 @@
 import { expect, Page, test } from '@playwright/test';
 import { HeadlampPage } from './headlampPage';
 const yaml = require('yaml');
-const fs = require('fs').promises;
 const util = require('util');
-const exec = util.promisify(require('child_process').exec);
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const execFile = util.promisify(require('child_process').execFile);
+
+// The kubeconfig context the e2e environment targets; setup-multicluster.sh
+// creates it as the hub cluster (test2 is created afterwards, so the current
+// context cannot be relied upon to point here).
+const TEST_CONTEXT = 'test';
+
+// Tests tagged with this run against kubeconfig fixtures only and skip the
+// UI setup in beforeEach — they never talk to the Headlamp page.
+const KUBECONFIG_ONLY_TAG = '@kubeconfig-only';
 
 let headlampPage: HeadlampPage;
 
-test.beforeEach(async ({ page }) => {
+test.beforeEach(async ({ page }, testInfo) => {
+  if (testInfo.tags.includes(KUBECONFIG_ONLY_TAG)) {
+    return;
+  }
+
   headlampPage = new HeadlampPage(page);
 
   // Navigate to the test cluster page
@@ -324,15 +339,24 @@ test('valid kubeconfig is still parsed when an invalid one is also sent', async 
   expect(response.body.clusters.some((c: { name: string }) => c.name === 'dummy')).toBe(true);
 });
 
-const getBase64EncodedKubeconfig = async (clusterName: string = 'dummy') => {
-  // Use kubectl command-line tool to get the kubeconfig
-  const { stdout, stderr } = await exec('kubectl config view --output json');
-  if (stderr) {
-    throw new Error(`Error fetching Minikube kubeconfig: ${stderr}`);
-  }
+// Produce a self-contained kubeconfig for one context. --minify keeps only
+// the selected context so credentials for unrelated contexts are never
+// embedded or sent to the test Headlamp instance, --context pins which one
+// (the current context is whatever was last touched, e.g. test2 after
+// setup-multicluster.sh), and --raw --flatten inlines certificate data, so
+// kubeconfigs that embed certificates (*-data keys) or reference them with
+// relative paths work without manual file handling.
+const normalizeKubeconfig = async (context: string, kubeconfigPath?: string) => {
+  const { stdout } = await execFile(
+    'kubectl',
+    ['config', 'view', '--minify', '--raw', '--flatten', '--context', context, '--output', 'json'],
+    kubeconfigPath ? { env: { ...process.env, KUBECONFIG: kubeconfigPath } } : undefined
+  );
+  return JSON.parse(stdout);
+};
 
-  // Parse the kubeconfig JSON
-  const kubeconfig = JSON.parse(stdout);
+const getBase64EncodedKubeconfig = async (clusterName: string = 'dummy') => {
+  const kubeconfig = await normalizeKubeconfig(TEST_CONTEXT);
   // Update the existing cluster and context names to the requested test cluster.
   kubeconfig.clusters[0].name = clusterName;
   // The 10.96.0.0/12: is the CIDR used by service cluster IP’s
@@ -344,29 +368,6 @@ const getBase64EncodedKubeconfig = async (clusterName: string = 'dummy') => {
   kubeconfig.contexts[0].context.user = clusterName;
   kubeconfig.contexts[0].context.cluster = clusterName;
 
-  // Get the contents of certificate-authority file and convert to base64
-  const caFilePath = kubeconfig.clusters[0].cluster['certificate-authority'];
-  const caFileContent = await fs.readFile(caFilePath, 'utf-8');
-  kubeconfig.clusters[0].cluster['certificate-authority-data'] =
-    Buffer.from(caFileContent).toString('base64');
-
-  // Get the contents of client-certificate file and convert to base64
-  const clientCertFilePath = kubeconfig.users[0].user['client-certificate'];
-  const clientCertFileContent = await fs.readFile(clientCertFilePath, 'utf-8');
-  kubeconfig.users[0].user['client-certificate-data'] =
-    Buffer.from(clientCertFileContent).toString('base64');
-
-  // Get the contents of client-key file and convert to base64
-  const clientKeyFilePath = kubeconfig.users[0].user['client-key'];
-  const clientKeyFileContent = await fs.readFile(clientKeyFilePath, 'utf-8');
-  kubeconfig.users[0].user['client-key-data'] =
-    Buffer.from(clientKeyFileContent).toString('base64');
-
-  // Remove client-key, client-certificate, and certificate-authority keys
-  delete kubeconfig.users[0].user['client-key'];
-  delete kubeconfig.users[0].user['client-certificate'];
-  delete kubeconfig.clusters[0].cluster['certificate-authority'];
-
   // Set the current context to the generated cluster name.
   kubeconfig['current-context'] = clusterName;
 
@@ -375,6 +376,118 @@ const getBase64EncodedKubeconfig = async (clusterName: string = 'dummy') => {
 
   return Buffer.from(kubeconfigYaml).toString('base64');
 };
+
+// Regression coverage for the kubeconfig normalization itself. These run
+// kubectl against on-disk fixtures, so they need no cluster and no UI.
+test.describe('kubeconfig normalization', () => {
+  let fixtureDir: string;
+
+  const writeFixture = (kubeconfig: object) => {
+    const kubeconfigPath = path.join(fixtureDir, 'kubeconfig');
+    fs.writeFileSync(kubeconfigPath, yaml.stringify(kubeconfig));
+    return kubeconfigPath;
+  };
+
+  test.beforeEach(() => {
+    fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-kubeconfig-'));
+  });
+
+  test.afterEach(() => {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+  });
+
+  test(
+    'keeps embedded certificate data and excludes unrelated contexts',
+    { tag: KUBECONFIG_ONLY_TAG },
+    async () => {
+      const caData = Buffer.from('FIXTURE-CA').toString('base64');
+      const unrelatedSecret = Buffer.from('UNRELATED-SECRET').toString('base64');
+      const kubeconfigPath = writeFixture({
+        apiVersion: 'v1',
+        kind: 'Config',
+        // The unrelated context is current — normalization must not follow it.
+        'current-context': 'unrelated',
+        clusters: [
+          {
+            name: 'target',
+            cluster: { server: 'https://127.0.0.1:65535', 'certificate-authority-data': caData },
+          },
+          {
+            name: 'unrelated',
+            cluster: {
+              server: 'https://127.0.0.2:65535',
+              'certificate-authority-data': unrelatedSecret,
+            },
+          },
+        ],
+        users: [
+          { name: 'target', user: { token: 'target-token' } },
+          { name: 'unrelated', user: { token: 'unrelated-token' } },
+        ],
+        contexts: [
+          { name: 'target', context: { cluster: 'target', user: 'target' } },
+          { name: 'unrelated', context: { cluster: 'unrelated', user: 'unrelated' } },
+        ],
+      });
+
+      const normalized = await normalizeKubeconfig('target', kubeconfigPath);
+
+      expect(normalized.clusters).toHaveLength(1);
+      expect(normalized.clusters[0].name).toBe('target');
+      expect(normalized.clusters[0].cluster['certificate-authority-data']).toBe(caData);
+      expect(normalized['current-context']).toBe('target');
+
+      // Nothing from the unrelated context may leak into the output.
+      const serialized = JSON.stringify(normalized);
+      expect(serialized).not.toContain('unrelated');
+      expect(serialized).not.toContain(unrelatedSecret);
+    }
+  );
+
+  test(
+    'inlines certificates referenced with kubeconfig-relative paths',
+    { tag: KUBECONFIG_ONLY_TAG },
+    async () => {
+      const caContent = 'FIXTURE-RELATIVE-CA\n';
+      const certContent = 'FIXTURE-RELATIVE-CERT\n';
+      const keyContent = 'FIXTURE-RELATIVE-KEY\n';
+      fs.writeFileSync(path.join(fixtureDir, 'ca.crt'), caContent);
+      fs.writeFileSync(path.join(fixtureDir, 'client.crt'), certContent);
+      fs.writeFileSync(path.join(fixtureDir, 'client.key'), keyContent);
+      const kubeconfigPath = writeFixture({
+        apiVersion: 'v1',
+        kind: 'Config',
+        'current-context': 'target',
+        clusters: [
+          {
+            name: 'target',
+            cluster: { server: 'https://127.0.0.1:65535', 'certificate-authority': 'ca.crt' },
+          },
+        ],
+        users: [
+          {
+            name: 'target',
+            user: { 'client-certificate': 'client.crt', 'client-key': 'client.key' },
+          },
+        ],
+        contexts: [{ name: 'target', context: { cluster: 'target', user: 'target' } }],
+      });
+
+      const normalized = await normalizeKubeconfig('target', kubeconfigPath);
+
+      const cluster = normalized.clusters[0].cluster;
+      const user = normalized.users[0].user;
+      expect(cluster['certificate-authority-data']).toBe(
+        Buffer.from(caContent).toString('base64')
+      );
+      expect(cluster['certificate-authority']).toBeUndefined();
+      expect(user['client-certificate-data']).toBe(Buffer.from(certContent).toString('base64'));
+      expect(user['client-key-data']).toBe(Buffer.from(keyContent).toString('base64'));
+      expect(user['client-certificate']).toBeUndefined();
+      expect(user['client-key']).toBeUndefined();
+    }
+  );
+});
 
 const saveKubeconfigToIndexDB = async (page: Page, base64EncodedKubeconfig: string) => {
   await page.evaluate(base64EncodedKubeconfig => {


### PR DESCRIPTION
## Summary

Make the dynamic-cluster E2E helper work with embedded certificates and certificate paths relative to the kubeconfig.

## Related Issue

Fixes #6939

## Changes

- Use `kubectl config view --raw --flatten` instead of reading certificate paths from the Playwright working directory.
- Add regression tests for embedded certificate data and relative certificate paths.

## Steps to Test

1. Run `cd e2e-tests`.
2. Run `npx playwright test tests/dynamicCluster.spec.ts` with the documented E2E environment.

Result: all 10 tests pass locally.

## Screenshots (if applicable)

Not applicable; this only changes E2E kubeconfig preparation.

## Notes for the Reviewer

No product or CI code is changed. Kubeconfig path resolution and certificate embedding are delegated to `kubectl`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded automated coverage for dynamic cluster connections using tagged, kubeconfig-only scenarios.
  - Added validation for embedded certificates and certificate files referenced through relative paths.
  - Improved kubeconfig generation and certificate handling coverage.
  - Enhanced test reliability through temporary-resource cleanup.
  - Streamlined relevant test runs by skipping unnecessary browser setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->