### PR TITLE
frontend: gateway: Fix undefined retry budget in BackendTrafficPolicy list

### DIFF
--- a/frontend/src/components/gateway/BackendTrafficPolicyList.test.tsx
+++ b/frontend/src/components/gateway/BackendTrafficPolicyList.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TestContext } from '../../test';
 import BackendTrafficPolicyList from './BackendTrafficPolicyList';
@@ -39,6 +39,11 @@ function getRetryConstraintColumn() {
   return props.columns.find((c: any) => c?.id === 'retryConstraint');
 }
 
+function renderedLabel(column: any, policy: any) {
+  render(column.render(policy));
+  return screen.getByText((_, node) => node?.tagName === 'SPAN').textContent;
+}
+
 describe('BackendTrafficPolicyList', () => {
   beforeEach(() => {
     mockListView.mockReset();
@@ -55,10 +60,10 @@ describe('BackendTrafficPolicyList', () => {
     const policy = { retryConstraint: { budget: { percent: 10, interval: '30s' } } } as any;
 
     expect(column.getValue(policy)).toBe('Retry 10% per 30s');
-    expect(column.render(policy).props.labels).toEqual(['Retry 10% per 30s']);
+    expect(renderedLabel(column, policy)).toBe('Retry 10% per 30s');
   });
 
-  it('falls back to the documented defaults when percent/interval are omitted', () => {
+  it('falls back to the documented defaults when percent and interval are both omitted', () => {
     render(
       <TestContext>
         <BackendTrafficPolicyList />
@@ -69,7 +74,35 @@ describe('BackendTrafficPolicyList', () => {
     const policy = { retryConstraint: { budget: {} } } as any;
 
     expect(column.getValue(policy)).toBe('Retry 20% per 10s');
-    expect(column.render(policy).props.labels).toEqual(['Retry 20% per 10s']);
+    expect(renderedLabel(column, policy)).toBe('Retry 20% per 10s');
+  });
+
+  it('falls back to the default interval only when interval is omitted', () => {
+    render(
+      <TestContext>
+        <BackendTrafficPolicyList />
+      </TestContext>
+    );
+
+    const column = getRetryConstraintColumn();
+    const policy = { retryConstraint: { budget: { percent: 10 } } } as any;
+
+    expect(column.getValue(policy)).toBe('Retry 10% per 10s');
+    expect(renderedLabel(column, policy)).toBe('Retry 10% per 10s');
+  });
+
+  it('falls back to the default percent only when percent is omitted', () => {
+    render(
+      <TestContext>
+        <BackendTrafficPolicyList />
+      </TestContext>
+    );
+
+    const column = getRetryConstraintColumn();
+    const policy = { retryConstraint: { budget: { interval: '30s' } } } as any;
+
+    expect(column.getValue(policy)).toBe('Retry 20% per 30s');
+    expect(renderedLabel(column, policy)).toBe('Retry 20% per 30s');
   });
 
   it('shows a dash when there is no retry budget at all', () => {
@@ -83,6 +116,6 @@ describe('BackendTrafficPolicyList', () => {
     const policy = { retryConstraint: undefined } as any;
 
     expect(column.getValue(policy)).toBe('—');
-    expect(column.render(policy).props.labels).toEqual(['—']);
+    expect(renderedLabel(column, policy)).toBe('—');
   });
 });

--- a/frontend/src/components/gateway/BackendTrafficPolicyList.test.tsx
+++ b/frontend/src/components/gateway/BackendTrafficPolicyList.test.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import BackendTrafficPolicyList from './BackendTrafficPolicyList';
+
+const { mockListView } = vi.hoisted(() => ({
+  mockListView: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/backendTrafficPolicy', () => ({
+  default: { kind: 'XBackendTrafficPolicy' },
+}));
+
+vi.mock('../common/Resource/ResourceListView', () => ({
+  default: (props: any) => {
+    mockListView(props);
+    return null;
+  },
+}));
+
+function getRetryConstraintColumn() {
+  const props = mockListView.mock.calls[0][0];
+  return props.columns.find((c: any) => c?.id === 'retryConstraint');
+}
+
+describe('BackendTrafficPolicyList', () => {
+  beforeEach(() => {
+    mockListView.mockReset();
+  });
+
+  it('renders the fully specified budget as-is', () => {
+    render(
+      <TestContext>
+        <BackendTrafficPolicyList />
+      </TestContext>
+    );
+
+    const column = getRetryConstraintColumn();
+    const policy = { retryConstraint: { budget: { percent: 10, interval: '30s' } } } as any;
+
+    expect(column.getValue(policy)).toBe('Retry 10% per 30s');
+    expect(column.render(policy).props.labels).toEqual(['Retry 10% per 30s']);
+  });
+
+  it('falls back to the documented defaults when percent/interval are omitted', () => {
+    render(
+      <TestContext>
+        <BackendTrafficPolicyList />
+      </TestContext>
+    );
+
+    const column = getRetryConstraintColumn();
+    const policy = { retryConstraint: { budget: {} } } as any;
+
+    expect(column.getValue(policy)).toBe('Retry 20% per 10s');
+    expect(column.render(policy).props.labels).toEqual(['Retry 20% per 10s']);
+  });
+
+  it('shows a dash when there is no retry budget at all', () => {
+    render(
+      <TestContext>
+        <BackendTrafficPolicyList />
+      </TestContext>
+    );
+
+    const column = getRetryConstraintColumn();
+    const policy = { retryConstraint: undefined } as any;
+
+    expect(column.getValue(policy)).toBe('—');
+    expect(column.render(policy).props.labels).toEqual(['—']);
+  });
+});

--- a/frontend/src/components/gateway/BackendTrafficPolicyList.tsx
+++ b/frontend/src/components/gateway/BackendTrafficPolicyList.tsx
@@ -48,7 +48,9 @@ export default function BackendTrafficPolicyList() {
           },
           render: (policy: BackendTrafficPolicy) => {
             const budget = policy.retryConstraint?.budget;
-            const label = budget ? `Retry ${budget.percent}% per ${budget.interval}` : '—';
+            const label = budget
+              ? `Retry ${budget.percent ?? 20}% per ${budget.interval ?? '10s'}`
+              : '—';
             return <LabelListItem labels={[label]} />;
           },
         },


### PR DESCRIPTION
## Summary

Fixes `BackendTrafficPolicy` list showing the literal string "undefined" for a partial retry budget.

## Related Issue

Fixes #6942

## Changes

- `BackendTrafficPolicyList.tsx`: `render` now applies the same `?? 20` / `?? '10s'` fallback `getValue` already had
- Added `BackendTrafficPolicyList.test.tsx` (none existed) covering full, partial, and missing budgets
- Tests assert the actual rendered text via testing-library, not internal component props

## Steps to Test

- `cd frontend && npx vitest run src/components/gateway/BackendTrafficPolicyList.test.tsx`
- `cd frontend && npx eslint src/components/gateway/BackendTrafficPolicyList.tsx`
- Apply an `XBackendTrafficPolicy` with `retryConstraint.budget: {}`, check the list shows `Retry 20% per 10s`, not `Retry undefined% per undefined`

## Screenshots (if applicable)

N/A — no existing story fixture exercises a partial budget; covered by the new unit tests instead.
