### PR TITLE
frontend: PodDetails: Hide empty Host IPs and Pod IPs rows

### DIFF
--- a/frontend/src/components/pod/Details.test.tsx
+++ b/frontend/src/components/pod/Details.test.tsx
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-import { act, render } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { act, render, screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { SnackbarProvider } from 'notistack';
 import { Provider } from 'react-redux';
 import { Route, Router } from 'react-router-dom';
+import { createMuiTheme } from '../../lib/themes';
 import defaultStore from '../../redux/stores/store';
 import { TestContext } from '../../test';
+import NameValueTable from '../common/NameValueTable';
 
 const { mockActivityLaunch, mockDispatchHeadlampEvent } = vi.hoisted(() => ({
   mockActivityLaunch: vi.fn(),
@@ -45,14 +48,17 @@ vi.mock('../../redux/headlampEventSlice', async () => {
   };
 });
 let capturedOnResourceUpdate: ((item: any, error?: any) => void) | undefined;
+let capturedExtraInfo: ((item: any) => any[]) | undefined;
 
 vi.mock('../common/Resource', () => ({
   DetailsGrid: (props: any) => {
     capturedOnResourceUpdate = props.onResourceUpdate;
+    capturedExtraInfo = props.extraInfo;
     return <div data-testid="details-grid" />;
   },
   ConditionsSection: () => null,
   ContainersSection: () => null,
+  MetadataDictGrid: () => null,
   VolumeSection: () => null,
 }));
 
@@ -544,5 +550,72 @@ describe('PodLogViewer prettifyLogs persistence', () => {
       (args: any[]) => args[2]?.prettifyLogs === true
     );
     expect(anyWithPrettify).toBe(false);
+  });
+});
+
+describe('PodDetails IP rows', () => {
+  // Renders the extraInfo rows through the real NameValueTable so the hide
+  // filtering is exercised by the actual integration path, not reimplemented.
+  function renderIPTable(item: any) {
+    const rows = capturedExtraInfo?.(item) || [];
+    render(
+      <ThemeProvider theme={createMuiTheme({ name: 'light', base: 'light' })}>
+        <NameValueTable rows={rows} />
+      </ThemeProvider>
+    );
+  }
+
+  it('shows only singular IP rows when the pod has no IPs', () => {
+    const podWithoutIPs = {
+      ...mockPod,
+      status: {
+        ...mockPod.status,
+        hostIPs: [],
+        podIPs: [],
+      },
+    };
+
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'test-pod' }} urlPrefix="/c/main/pods">
+        <PodDetails name="test-pod" namespace="default" />
+      </TestContext>
+    );
+
+    act(() => {
+      capturedOnResourceUpdate?.(podWithoutIPs);
+    });
+
+    renderIPTable(podWithoutIPs);
+    expect(screen.getByText('Host IP')).toBeInTheDocument();
+    expect(screen.getByText('Pod IP')).toBeInTheDocument();
+    expect(screen.queryByText('Host IPs')).not.toBeInTheDocument();
+    expect(screen.queryByText('Pod IPs')).not.toBeInTheDocument();
+  });
+
+  it('shows only plural IP rows when the pod has multiple IPs', () => {
+    const podWithIPs = {
+      ...mockPod,
+      status: {
+        ...mockPod.status,
+        hostIPs: [{ ip: '10.0.0.1' }],
+        podIPs: [{ ip: '10.0.0.2' }],
+      },
+    };
+
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'test-pod' }} urlPrefix="/c/main/pods">
+        <PodDetails name="test-pod" namespace="default" />
+      </TestContext>
+    );
+
+    act(() => {
+      capturedOnResourceUpdate?.(podWithIPs);
+    });
+
+    renderIPTable(podWithIPs);
+    expect(screen.getByText('Host IPs')).toBeInTheDocument();
+    expect(screen.getByText('Pod IPs')).toBeInTheDocument();
+    expect(screen.queryByText('Host IP')).not.toBeInTheDocument();
+    expect(screen.queryByText('Pod IP')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -679,7 +679,7 @@ export default function PodDetails(props: PodDetailsProps) {
   }, [podItem, launchTerminal, autoLaunchView, autoLaunchContainer]);
 
   function prepareExtraInfo(item: Pod | null) {
-    let extraInfo: (NameValueTableRow & { hideLabel?: boolean })[] = [];
+    let extraInfo: NameValueTableRow[] = [];
     if (item) {
       extraInfo = [
         {
@@ -733,7 +733,7 @@ export default function PodDetails(props: PodDetailsProps) {
           value: item.status.hostIPs
             ? item.status.hostIPs.map((ipObj: { ip: string }) => ipObj.ip).join(', ')
             : '',
-          hideLabel: !item.status.hostIPs || item.status.hostIPs.length === 0,
+          hide: !item.status.hostIPs || item.status.hostIPs.length === 0,
         },
         // Show Pod IP only if Pod IPs doesn't exist or is empty
         ...(item.status.podIPs && item.status.podIPs.length > 0
@@ -750,7 +750,7 @@ export default function PodDetails(props: PodDetailsProps) {
           value: item.status.podIPs
             ? item.status.podIPs.map((ipObj: { ip: string }) => ipObj.ip).join(', ')
             : '',
-          hideLabel: !item.status.podIPs || item.status.podIPs.length === 0,
+          hide: !item.status.podIPs || item.status.podIPs.length === 0,
         },
         {
           name: t('QoS Class'),


### PR DESCRIPTION
 ## Summary                                    

  This PR fixes the Pod details page showing duplicate blank `Host IPs` and `Pod IPs` rows by using
   the correct `hide` prop that `NameValueTable` actually supports.
                                                                                                   
  ## Related Issue

  Fixes #6941

## Screenshots

<img width="375" height="64" alt="image" src="https://github.com/user-attachments/assets/49bc9464-7481-496d-b62e-de39dd3dfea5" />

  ## Steps to Test

  1. Create a pod that stays Pending (e.g. with an unsatisfiable nodeSelector)
  2. Open its details page
  3. Info section shows only `Host IP` and `Pod IP` rows (blank) — no duplicate `Host IPs` / `Pod
  IPs` rows
  4. Open a running pod's details — only `Host IPs` / `Pod IPs` rows shown with IPs

  ## Notes for the Reviewer
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Host IP and Pod IP row visibility in pod details.
  * Singular labels now appear when no IPs are available, while plural labels appear when multiple IPs are available.
  * Alternate labels are correctly hidden when not applicable.
  * Pod metadata now presents IP information more clearly and consistently across pod configurations.

* **Tests**
  * Added coverage for singular and plural IP display scenarios.
  * Added validation that unavailable alternate labels remain hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->