### PR TITLE
frontend: workloads: Fix 0/0 pod count for Jobs and JobSets

### DIFF
--- a/frontend/src/components/workload/Overview.tsx
+++ b/frontend/src/components/workload/Overview.tsx
@@ -64,6 +64,9 @@ export default function Overview() {
   const { t } = useTranslation('glossary');
 
   function getPods(item: Workload) {
+    if (item.kind === 'CronJob') {
+      return '-';
+    }
     return `${getReadyReplicas(item)}/${getTotalReplicas(item)}`;
   }
 

--- a/frontend/src/lib/util.test.ts
+++ b/frontend/src/lib/util.test.ts
@@ -20,6 +20,8 @@ import {
   flattenClusterListItems,
   formatDuration,
   getPercentStr,
+  getReadyReplicas,
+  getTotalReplicas,
   isValidTimezone,
   normalizeUnit,
   timeAgo,
@@ -416,5 +418,119 @@ describe('compareUnits', () => {
     expect(compareUnits('abc', '1')).toBe(false);
     expect(compareUnits('1', 'abc')).toBe(false);
     expect(compareUnits('', '')).toBe(false);
+  });
+});
+
+describe('getReadyReplicas', () => {
+  it('returns status.ready for Jobs', () => {
+    const job = { kind: 'Job', status: { ready: 2, active: 3, succeeded: 1 } } as any;
+    expect(getReadyReplicas(job)).toBe(2);
+  });
+
+  it('falls back to status.active when ready is missing (older K8s)', () => {
+    const job = { kind: 'Job', status: { active: 3 } } as any;
+    expect(getReadyReplicas(job)).toBe(3);
+  });
+
+  it('does not fall back to active when ready is 0', () => {
+    const job = { kind: 'Job', status: { ready: 0, active: 2 } } as any;
+    expect(getReadyReplicas(job)).toBe(0);
+  });
+
+  it('returns 0 for CronJobs', () => {
+    const cronJob = { kind: 'CronJob', status: { active: [{ name: 'x' }] } } as any;
+    expect(getReadyReplicas(cronJob)).toBe(0);
+  });
+
+  it('sums readyJobs * parallelism for each replicated job in JobSets', () => {
+    const jobSet = {
+      kind: 'JobSet',
+      spec: {
+        replicatedJobs: [
+          { name: 'a', replicas: 2, template: { spec: { parallelism: 3 } } },
+          { name: 'b', replicas: 1, template: { spec: { parallelism: 2 } } },
+        ],
+      },
+      status: {
+        replicatedJobsStatus: [
+          { name: 'a', ready: 1 },
+          { name: 'b', ready: 1 },
+        ],
+      },
+    } as any;
+    // a: 1 ready * 3 = 3, b: 1 ready * 2 = 2 → total = 5
+    expect(getReadyReplicas(jobSet)).toBe(5);
+  });
+
+  it('returns 0 for JobSets with no replicatedJobsStatus', () => {
+    const jobSet = { kind: 'JobSet', spec: { replicatedJobs: [] }, status: {} } as any;
+    expect(getReadyReplicas(jobSet)).toBe(0);
+  });
+
+  it('returns status.readyReplicas for Deployments', () => {
+    const deployment = { kind: 'Deployment', status: { readyReplicas: 3 } } as any;
+    expect(getReadyReplicas(deployment)).toBe(3);
+  });
+
+  it('falls back to status.numberReady for DaemonSets', () => {
+    const ds = { kind: 'DaemonSet', status: { numberReady: 5 } } as any;
+    expect(getReadyReplicas(ds)).toBe(5);
+  });
+});
+
+describe('getTotalReplicas', () => {
+  it('returns spec.parallelism for Jobs', () => {
+    const job = { kind: 'Job', spec: { parallelism: 3 } } as any;
+    expect(getTotalReplicas(job)).toBe(3);
+  });
+
+  it('defaults parallelism to 1 for Jobs without it', () => {
+    const job = { kind: 'Job', spec: {} } as any;
+    expect(getTotalReplicas(job)).toBe(1);
+  });
+
+  it('returns 0 for CronJobs', () => {
+    const cronJob = { kind: 'CronJob', spec: { suspend: false } } as any;
+    expect(getTotalReplicas(cronJob)).toBe(0);
+  });
+
+  it('sums replicas * parallelism for each replicated job in JobSets', () => {
+    const jobSet = {
+      kind: 'JobSet',
+      spec: {
+        replicatedJobs: [
+          { replicas: 2, template: { spec: { parallelism: 3 } } },
+          { replicas: 1, template: { spec: { parallelism: 2 } } },
+        ],
+      },
+    } as any;
+    // 2*3 + 1*2 = 8
+    expect(getTotalReplicas(jobSet)).toBe(8);
+  });
+
+  it('defaults parallelism to 1 for JobSet child jobs without it', () => {
+    const jobSet = {
+      kind: 'JobSet',
+      spec: {
+        replicatedJobs: [{ replicas: 3 }],
+      },
+    } as any;
+    // 3*1 = 3
+    expect(getTotalReplicas(jobSet)).toBe(3);
+  });
+
+  it('returns 0 for JobSets with no replicatedJobs', () => {
+    const jobSet = { kind: 'JobSet', spec: {} } as any;
+    expect(getTotalReplicas(jobSet)).toBe(0);
+  });
+
+  it('returns spec.replicas for Deployments', () => {
+    const deployment = { kind: 'Deployment', spec: { replicas: 4 } } as any;
+    expect(getTotalReplicas(deployment)).toBe(4);
+  });
+
+  it('falls back to status.desiredNumberScheduled for DaemonSets', () => {
+    const ds = { kind: 'DaemonSet', spec: {}, status: { desiredNumberScheduled: 7 } } as any;
+    expect(getTotalReplicas(ds)).toBe(7);
   });
 });

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -266,10 +266,40 @@ export function getPercentStr(value: number, total: number) {
 }
 
 export function getReadyReplicas(item: Workload) {
+  if (item.kind === 'Job') {
+    return item.status.ready ?? item.status.active ?? 0;
+  }
+  if (item.kind === 'CronJob') {
+    return 0;
+  }
+  if (item.kind === 'JobSet') {
+    const replicatedJobs = (item.spec as any).replicatedJobs || [];
+    const statuses = (item.status as any).replicatedJobsStatus || [];
+    return replicatedJobs.reduce((sum: number, rj: any) => {
+      const parallelism = rj.template?.spec?.parallelism ?? 1;
+      const jobStatus = statuses.find((s: any) => s.name === rj.name);
+      const readyJobs = jobStatus?.ready || 0;
+      return sum + readyJobs * parallelism;
+    }, 0);
+  }
   return item.status.readyReplicas || item.status.numberReady || 0;
 }
 
 export function getTotalReplicas(item: Workload) {
+  if (item.kind === 'Job') {
+    return item.spec.parallelism ?? 1;
+  }
+  if (item.kind === 'CronJob') {
+    return 0;
+  }
+  if (item.kind === 'JobSet') {
+    const replicatedJobs = (item.spec as any).replicatedJobs || [];
+    return replicatedJobs.reduce((sum: number, rj: any) => {
+      const replicas = rj.replicas || 0;
+      const parallelism = rj.template?.spec?.parallelism ?? 1;
+      return sum + replicas * parallelism;
+    }, 0);
+  }
   return (
     item.spec.replicas ||
     item.status.currentNumberScheduled ||


### PR DESCRIPTION
## Summary

This PR fixes the **Pods** column in the Workloads overview, which incorrectly displayed **0/0** for Jobs, CronJobs, and JobSets. The replica helpers only handled Deployment-style workloads, causing these resource types to always fall back to `0`.

## Related Issue

Fixes #6949

## Changes

- Added Job, CronJob, and JobSet support to `getReadyReplicas()`.
- Added Job, CronJob, and JobSet support to `getTotalReplicas()`.
- Display `-` for CronJobs in the **Pods** column, since they do not directly manage pods.
- Added unit tests covering the new code paths.

## Steps to Test

1. Create a Job:
   ```bash
   kubectl create job test-job --image=busybox -- sleep 300
   ```
2. Open the **Workloads** page.
3. Verify the **Pods** column shows **1/1** instead of **0/0**.
4. After the Job completes, verify it shows **0/1**.

## Screenshots

<img width="850" height="253" alt="Screenshot 2026-08-06 162726" src="https://github.com/user-attachments/assets/7752436a-dccc-4e1e-866f-dedf3b37e61b" />
<img width="737" height="161" alt="Screenshot 2026-08-06 162741" src="https://github.com/user-attachments/assets/6ebd03a2-9a3d-43df-959a-0b13787b0a77" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workload replica counts for Jobs and JobSets, including readiness and parallelism details.
  * CronJobs now display “-” instead of an estimated ready/total replica count.
  * Added fallback handling when workload status or specification details are unavailable.
  * Preserved existing replica-count behavior for Deployments and DaemonSets.

* **Tests**
  * Added coverage for replica calculations across Jobs, CronJobs, JobSets, Deployments, and DaemonSets, including missing status and specification data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->