### PR TITLE
frontend: ShortcutsSettings: Add missing aria-label to reset button

### DIFF
--- a/frontend/src/components/App/Settings/ShortcutsSettings.tsx
+++ b/frontend/src/components/App/Settings/ShortcutsSettings.tsx
@@ -203,7 +203,7 @@ function ShortcutEditor({
       </Button>
       {isModified && (
         <Tooltip title={t('Reset to default')}>
-          <IconButton size="small" onClick={onReset} aria-label={t('translation|Reset to default')}>
+          <IconButton size="small" onClick={onReset} aria-label={t('Reset to default')}>
             <Icon icon="mdi:restore" width={16} />
           </IconButton>
         </Tooltip>

--- a/frontend/src/components/App/Settings/ShortcutsSettings.tsx
+++ b/frontend/src/components/App/Settings/ShortcutsSettings.tsx
@@ -203,7 +203,7 @@ function ShortcutEditor({
       </Button>
       {isModified && (
         <Tooltip title={t('Reset to default')}>
-          <IconButton size="small" onClick={onReset}>
+          <IconButton size="small" onClick={onReset} aria-label={t('translation|Reset to default')}>
             <Icon icon="mdi:restore" width={16} />
           </IconButton>
         </Tooltip>


### PR DESCRIPTION
## Summary

This PR fixes an accessibility bug by adding an explicitly translated `aria-label` to the shortcut reset button within the `ShortcutsSettings` component.

## Related Issue

Fixes #6954 

## Changes

- Updated `frontend/src/components/App/Settings/ShortcutsSettings.tsx`
- Added the `aria-label` prop wrapped in the `t()` translation function to the reset `IconButton`.

## Steps to Test

1. Build and run the Headlamp application locally.
2. Navigate to **Settings** and open the **Shortcuts** section in the sidebar.
3. Modify any existing keyboard shortcut so that the 'Reset to default' icon button appears.
4. Using browser dev tools or a screen reader, inspect the reset button to verify the `aria-label="Reset to default"` attribute is correctly applied and announced.

## Notes for the Reviewer

- While Material-UI attempts to inject `aria-label` via the `Tooltip` component, explicitly defining it on the `IconButton` ensures it passes static a11y checks and works reliably across all testing environments. 
- This change brings `ShortcutsSettings.tsx` into alignment with existing repository conventions seen in `ActionButton.tsx` and `ClusterContextMenu.tsx`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added a translated “Reset to default” label to the shortcut reset button for improved screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->