### PR TITLE
AI-Review: disable coderabbit integration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,3 @@
+reviews:
+  auto_review:
+    enabled: false


### PR DESCRIPTION
## Summary

https://github.com/kubernetes/org/issues/6533

Seems removing the github integration is not preventing coderabbit from dropping comments on the PRs.
