### PR TITLE
frontend: node: Scope list requests to RBAC-authorized resourceNames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@ node_modules
 plugins/headlamp-plugin/headlamp-myfancy/
 plugins/examples/*/dist/
 .DS_Store
+
+kind.exe
+kind-config.yaml
+merged-kubeconfig.yaml
+restricted-kubeconfig.yaml
+restricted-role.yaml
+server-url.txt

--- a/frontend/.storybook/baseMocks.ts
+++ b/frontend/.storybook/baseMocks.ts
@@ -30,6 +30,14 @@ export const baseMocks = [
   http.post('http://localhost:4466/apis/authorization.k8s.io/v1/selfsubjectaccessreviews', () =>
     HttpResponse.json({ status: { allowed: true, reason: '', code: 200 } })
   ),
+  http.post('http://localhost:4466/*/authorization.k8s.io/v1/selfsubjectrulesreviews', () =>
+    HttpResponse.json({
+      status: {
+        resourceRules: [{ verbs: ['*'], apiGroups: ['*'], resources: ['*'] }],
+        incomplete: false,
+      },
+    })
+  ),
   http.get('http://localhost:4466/api/v1/namespaces', () =>
     HttpResponse.json({
       kind: 'NamespacesList',

--- a/frontend/src/components/node/List.stories.tsx
+++ b/frontend/src/components/node/List.stories.tsx
@@ -21,6 +21,21 @@ import { API_BASE, TestContext } from '../../test';
 import List from './List';
 import { NODE_DUMMY_DATA, NODE_DUMMY_DATA_NO_POOLS } from './storyHelper';
 
+/**
+ * Unrestricted SelfSubjectRulesReview response — empty resourceRules means
+ * Node.useList's RBAC resourceNames check resolves to "not restricted",
+ * so these stories exercise the normal unfiltered node list path.
+ */
+const unrestrictedSSRRHandler = http.post(
+  `${API_BASE}/apis/authorization.k8s.io/v1/selfsubjectrulesreviews`,
+  () =>
+    HttpResponse.json({
+      kind: 'SelfSubjectRulesReview',
+      apiVersion: 'authorization.k8s.io/v1',
+      status: { resourceRules: [], nonResourceRules: [], incomplete: false },
+    })
+);
+
 export default {
   title: 'node/List',
   component: List,
@@ -46,6 +61,7 @@ export default {
               items: NODE_DUMMY_DATA,
             })
           ),
+          unrestrictedSSRRHandler,
         ],
       },
     },
@@ -83,6 +99,7 @@ NoNodePools.parameters = {
         http.post(`${API_BASE}/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`, () =>
           HttpResponse.json({ status: { allowed: true, reason: '', code: 200 } })
         ),
+        unrestrictedSSRRHandler,
         http.get(`${API_BASE}/apis/metrics.k8s.io/v1beta1/nodes`, () =>
           HttpResponse.json({
             apiVersion: 'metrics.k8s.io/v1beta1',

--- a/frontend/src/lib/k8s/api/v1/rbacResourceNames.test.ts
+++ b/frontend/src/lib/k8s/api/v1/rbacResourceNames.test.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fetchResourceNamesRestriction } from './rbacResourceNames';
+
+const { postMock } = vi.hoisted(() => ({ postMock: vi.fn() }));
+
+vi.mock('./clusterRequests', () => ({
+  post: postMock,
+}));
+
+vi.mock('../../../cluster', () => ({
+  getCluster: () => 'test-cluster',
+}));
+
+describe('fetchResourceNamesRestriction', () => {
+  it('returns the resourceNames when every matching rule restricts them', async () => {
+    postMock.mockResolvedValueOnce({
+      status: {
+        resourceRules: [
+          {
+            verbs: ['get', 'list', 'watch'],
+            apiGroups: [''],
+            resources: ['nodes'],
+            resourceNames: ['worker-node-1'],
+          },
+        ],
+      },
+    });
+
+    const result = await fetchResourceNamesRestriction('test-cluster', '', 'nodes', 'list');
+    expect(result).toEqual(['worker-node-1']);
+  });
+
+  it('merges resourceNames across multiple matching rules', async () => {
+    postMock.mockResolvedValueOnce({
+      status: {
+        resourceRules: [
+          {
+            verbs: ['list'],
+            apiGroups: [''],
+            resources: ['nodes'],
+            resourceNames: ['worker-node-1'],
+          },
+          {
+            verbs: ['list'],
+            apiGroups: [''],
+            resources: ['nodes'],
+            resourceNames: ['worker-node-2'],
+          },
+        ],
+      },
+    });
+
+    const result = await fetchResourceNamesRestriction('test-cluster', '', 'nodes', 'list');
+    expect(result).toEqual(['worker-node-1', 'worker-node-2']);
+  });
+
+  it('returns null when a matching rule has no resourceNames (unrestricted access)', async () => {
+    postMock.mockResolvedValueOnce({
+      status: {
+        resourceRules: [
+          {
+            verbs: ['list'],
+            apiGroups: [''],
+            resources: ['nodes'],
+          },
+        ],
+      },
+    });
+
+    const result = await fetchResourceNamesRestriction('test-cluster', '', 'nodes', 'list');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no rule matches the apiGroup/resource/verb', async () => {
+    postMock.mockResolvedValueOnce({
+      status: {
+        resourceRules: [
+          {
+            verbs: ['list'],
+            apiGroups: [''],
+            resources: ['pods'],
+            resourceNames: ['some-pod'],
+          },
+        ],
+      },
+    });
+
+    const result = await fetchResourceNamesRestriction('test-cluster', '', 'nodes', 'list');
+    expect(result).toBeNull();
+  });
+
+  it('treats a wildcard verb/apiGroup/resource rule as matching', async () => {
+    postMock.mockResolvedValueOnce({
+      status: {
+        resourceRules: [
+          {
+            verbs: ['*'],
+            apiGroups: ['*'],
+            resources: ['*'],
+            resourceNames: ['worker-node-1'],
+          },
+        ],
+      },
+    });
+
+    const result = await fetchResourceNamesRestriction('test-cluster', '', 'nodes', 'list');
+    expect(result).toEqual(['worker-node-1']);
+  });
+
+  it('returns null and does not throw when the rules review request fails', async () => {
+    postMock.mockRejectedValueOnce(new Error('network error'));
+
+    const result = await fetchResourceNamesRestriction('test-cluster', '', 'nodes', 'list');
+    expect(result).toBeNull();
+  });
+
+  it('treats resourceNames: ["*"] as a literal restricted name, not unrestricted access', async () => {
+    postMock.mockResolvedValueOnce({
+      status: {
+        resourceRules: [
+          {
+            verbs: ['list'],
+            apiGroups: [''],
+            resources: ['nodes'],
+            resourceNames: ['*'],
+          },
+        ],
+      },
+    });
+
+    const result = await fetchResourceNamesRestriction('test-cluster', '', 'nodes', 'list');
+    expect(result).toEqual(['*']);
+  });
+
+  it('returns null when the rules review is incomplete, even if a matching rule is restrictive', async () => {
+    postMock.mockResolvedValueOnce({
+      status: {
+        incomplete: true,
+        resourceRules: [
+          {
+            verbs: ['list'],
+            apiGroups: [''],
+            resources: ['nodes'],
+            resourceNames: ['worker-node-1'],
+          },
+        ],
+      },
+    });
+
+    const result = await fetchResourceNamesRestriction('test-cluster', '', 'nodes', 'list');
+    expect(result).toBeNull();
+  });
+});

--- a/frontend/src/lib/k8s/api/v1/rbacResourceNames.ts
+++ b/frontend/src/lib/k8s/api/v1/rbacResourceNames.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { getCluster } from '../../../cluster';
+import { post } from './clusterRequests';
+
+/** A single rule from a SelfSubjectRulesReview's status.resourceRules. */
+interface SelfSubjectRulesReviewResourceRule {
+  verbs: string[];
+  apiGroups?: string[];
+  resources?: string[];
+  resourceNames?: string[];
+}
+
+/** Response shape of a SelfSubjectRulesReview, as returned by {@link testAuth}. */
+export interface SelfSubjectRulesReviewResponse {
+  status?: {
+    resourceRules?: SelfSubjectRulesReviewResourceRule[];
+    incomplete?: boolean;
+  };
+}
+
+/**
+ * Derives the resourceNames restriction from an already-fetched SelfSubjectRulesReview
+ * response. Pure/no I/O — callers that already hold a review result (e.g. from a shared
+ * cache, such as the one AuthRoute populates via testAuth) should use this directly
+ * instead of {@link fetchResourceNamesRestriction}, to avoid firing a second, redundant
+ * SelfSubjectRulesReview request for a check that was already performed.
+ *
+ * @param review - A previously-fetched SelfSubjectRulesReview response.
+ * @param apiGroup - API group of the resource (empty string for the core group).
+ * @param resource - Plural resource name (e.g. "nodes").
+ * @param verb - Verb to check (e.g. "list").
+ * @returns
+ *  - `null` if access is unrestricted (a matching rule has no resourceNames), or if no
+ *    matching rule was found at all — callers should fall back to a normal, unfiltered
+ *    request and let the real API call surface any actual permission error.
+ *  - A `string[]` of the specific resource names the user is authorized for, when every
+ *    matching rule for this apiGroup/resource/verb carries a resourceNames restriction.
+ */
+export function extractResourceNamesRestriction(
+  review: SelfSubjectRulesReviewResponse,
+  apiGroup: string,
+  resource: string,
+  verb: string
+): string[] | null {
+  if (review.status?.incomplete) {
+    // The API server couldn't fully evaluate the rules (e.g. an aggregated API server
+    // didn't respond) — don't guess at a restriction, fall back to a normal request.
+    return null;
+  }
+
+  const rules = review.status?.resourceRules ?? [];
+  const matchingRules = rules.filter(
+    rule =>
+      rule.verbs?.some(v => v === verb || v === '*') &&
+      rule.apiGroups?.some(g => g === apiGroup || g === '*') &&
+      rule.resources?.some(r => r === resource || r === '*')
+  );
+
+  if (matchingRules.length === 0) {
+    return null;
+  }
+
+  const names = new Set<string>();
+  for (const rule of matchingRules) {
+    if (!rule.resourceNames || rule.resourceNames.length === 0) {
+      // No resourceNames means this matching rule grants unrestricted access.
+      // Note: unlike API groups/resources/verbs, resourceNames has no wildcard support in
+      // Kubernetes RBAC (see ResourceNameMatches) — a rule scoped to the literal name "*"
+      // authorizes only a node actually named "*", not all nodes. So "*" here must be
+      // treated as a real (if unusual) name, not folded into the unrestricted case.
+      return null;
+    }
+    rule.resourceNames.forEach(name => names.add(name));
+  }
+
+  return Array.from(names);
+}
+
+/**
+ * Looks up whether the current user's RBAC rules restrict a cluster-scoped resource/verb
+ * to a specific set of resourceNames, via SelfSubjectRulesReview.
+ *
+ * Note: this always issues a fresh SelfSubjectRulesReview request. Callers that can reuse
+ * an already-fetched review (e.g. the one AuthRoute performs via testAuth) should call
+ * {@link extractResourceNamesRestriction} directly instead, to avoid a redundant request.
+ *
+ * @param cluster - Cluster to check.
+ * @param apiGroup - API group of the resource (empty string for the core group).
+ * @param resource - Plural resource name (e.g. "nodes").
+ * @param verb - Verb to check (e.g. "list").
+ * @returns Same as {@link extractResourceNamesRestriction}, or `null` if the review
+ *  request itself fails.
+ */
+export async function fetchResourceNamesRestriction(
+  cluster: string,
+  apiGroup: string,
+  resource: string,
+  verb: string
+): Promise<string[] | null> {
+  let review: SelfSubjectRulesReviewResponse;
+  try {
+    review = await post(
+      '/apis/authorization.k8s.io/v1/selfsubjectrulesreviews',
+      { spec: { namespace: 'default' } },
+      false,
+      { timeout: 5 * 1000, cluster: cluster || getCluster() }
+    );
+  } catch {
+    // If the rules review itself fails (e.g. unsupported by the API server, or the
+    // request errors out), don't block the normal list request on it.
+    return null;
+  }
+
+  return extractResourceNamesRestriction(review, apiGroup, resource, verb);
+}
+
+/**
+ * React hook version of {@link fetchResourceNamesRestriction}, cached per
+ * cluster/apiGroup/resource/verb via react-query so it isn't re-fetched on every render.
+ *
+ * @param cluster - Cluster to check (falls back to the currently selected cluster).
+ * @param apiGroup - API group of the resource (empty string for the core group).
+ * @param resource - Plural resource name (e.g. "nodes").
+ * @param verb - Verb to check (e.g. "list").
+ */
+export function useResourceNamesRestriction(
+  cluster: string | undefined,
+  apiGroup: string,
+  resource: string,
+  verb: string
+): { restrictedNames: string[] | null; isLoading: boolean } {
+  const clusterName = cluster || getCluster() || '';
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['resourceNamesRestriction', clusterName, apiGroup, resource, verb],
+    queryFn: () => fetchResourceNamesRestriction(clusterName, apiGroup, resource, verb),
+    // RBAC rules essentially never change mid-session; avoid re-checking on every render/focus.
+    staleTime: 5 * 60 * 1000,
+    enabled: !!clusterName,
+  });
+
+  return { restrictedNames: data ?? null, isLoading: !!clusterName && isLoading };
+}

--- a/frontend/src/lib/k8s/api/v1/rbacResourceNames.ts
+++ b/frontend/src/lib/k8s/api/v1/rbacResourceNames.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { getCluster } from '../../../cluster';
+import { post } from './clusterRequests';
+
+/** A single rule from a SelfSubjectRulesReview's status.resourceRules. */
+interface SelfSubjectRulesReviewResourceRule {
+  verbs: string[];
+  apiGroups?: string[];
+  resources?: string[];
+  resourceNames?: string[];
+}
+
+interface SelfSubjectRulesReviewResponse {
+  status?: {
+    resourceRules?: SelfSubjectRulesReviewResourceRule[];
+    incomplete?: boolean;
+  };
+}
+
+/**
+ * Looks up whether the current user's RBAC rules restrict a cluster-scoped resource/verb
+ * to a specific set of resourceNames, via SelfSubjectRulesReview.
+ *
+ * @param cluster - Cluster to check.
+ * @param apiGroup - API group of the resource (empty string for the core group).
+ * @param resource - Plural resource name (e.g. "nodes").
+ * @param verb - Verb to check (e.g. "list").
+ * @returns
+ *  - `null` if access is unrestricted (a matching rule has no resourceNames), or if no
+ *    matching rule was found at all — callers should fall back to a normal, unfiltered
+ *    request and let the real API call surface any actual permission error.
+ *  - A `string[]` of the specific resource names the user is authorized for, when every
+ *    matching rule for this apiGroup/resource/verb carries a resourceNames restriction.
+ */
+export async function fetchResourceNamesRestriction(
+  cluster: string,
+  apiGroup: string,
+  resource: string,
+  verb: string
+): Promise<string[] | null> {
+  let review: SelfSubjectRulesReviewResponse;
+  try {
+    review = await post(
+      '/apis/authorization.k8s.io/v1/selfsubjectrulesreviews',
+      { spec: { namespace: 'default' } },
+      false,
+      { timeout: 5 * 1000, cluster: cluster || getCluster() }
+    );
+  } catch {
+    // If the rules review itself fails (e.g. unsupported by the API server, or the
+    // request errors out), don't block the normal list request on it.
+    return null;
+  }
+
+  if (review.status?.incomplete) {
+    // The API server couldn't fully evaluate the rules (e.g. an aggregated API server
+    // didn't respond) — don't guess at a restriction, fall back to a normal request.
+    return null;
+  }
+
+  const rules = review.status?.resourceRules ?? [];
+  const matchingRules = rules.filter(
+    rule =>
+      rule.verbs?.some(v => v === verb || v === '*') &&
+      rule.apiGroups?.some(g => g === apiGroup || g === '*') &&
+      rule.resources?.some(r => r === resource || r === '*')
+  );
+
+  if (matchingRules.length === 0) {
+    return null;
+  }
+
+  const names = new Set<string>();
+  for (const rule of matchingRules) {
+    if (!rule.resourceNames || rule.resourceNames.length === 0) {
+      // No resourceNames means this matching rule grants unrestricted access.
+      // Note: unlike API groups/resources/verbs, resourceNames has no wildcard support in
+      // Kubernetes RBAC (see ResourceNameMatches) — a rule scoped to the literal name "*"
+      // authorizes only a node actually named "*", not all nodes. So "*" here must be
+      // treated as a real (if unusual) name, not folded into the unrestricted case.
+      return null;
+    }
+    rule.resourceNames.forEach(name => names.add(name));
+  }
+
+  return Array.from(names);
+}
+
+/**
+ * React hook version of {@link fetchResourceNamesRestriction}, cached per
+ * cluster/apiGroup/resource/verb via react-query so it isn't re-fetched on every render.
+ *
+ * @param cluster - Cluster to check (falls back to the currently selected cluster).
+ * @param apiGroup - API group of the resource (empty string for the core group).
+ * @param resource - Plural resource name (e.g. "nodes").
+ * @param verb - Verb to check (e.g. "list").
+ */
+export function useResourceNamesRestriction(
+  cluster: string | undefined,
+  apiGroup: string,
+  resource: string,
+  verb: string
+): { restrictedNames: string[] | null; isLoading: boolean } {
+  const clusterName = cluster || getCluster() || '';
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['resourceNamesRestriction', clusterName, apiGroup, resource, verb],
+    queryFn: () => fetchResourceNamesRestriction(clusterName, apiGroup, resource, verb),
+    // RBAC rules essentially never change mid-session; avoid re-checking on every render/focus.
+    staleTime: 5 * 60 * 1000,
+    enabled: !!clusterName,
+  });
+
+  return { restrictedNames: data ?? null, isLoading: !!clusterName && isLoading };
+}

--- a/frontend/src/lib/k8s/api/v2/hooks.ts
+++ b/frontend/src/lib/k8s/api/v2/hooks.ts
@@ -240,7 +240,7 @@ export function useKubeObject<K extends KubeObject>({
  * @throws {ApiError}
  * When no endpoints are working
  */
-const getWorkingEndpoint = async (
+export const getWorkingEndpoint = async (
   endpoints: KubeObjectEndpoint[],
   cluster: string,
   namespace?: string,

--- a/frontend/src/lib/k8s/node.ts
+++ b/frontend/src/lib/k8s/node.ts
@@ -14,16 +14,34 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import { useQueries } from '@tanstack/react-query';
+import React, { useMemo } from 'react';
 import { useErrorState } from '../util';
 import { useConnectApi } from '.';
+import { testAuth } from './api/v1/clusterApi';
+import { useSelectedClusters } from './api/v1/hooks';
 import { metrics } from './api/v1/metricsApi';
+import { extractResourceNamesRestriction } from './api/v1/rbacResourceNames';
 import type { ApiError } from './api/v2/ApiError';
+import type { QueryStatus } from './api/v2/hooks';
+import { getWorkingEndpoint } from './api/v2/hooks';
+import type { KubeObjectEndpoint } from './api/v2/KubeObjectEndpoint';
 import { KubeNodeSummaryStats, nodeSummaryStats } from './api/v2/nodeSummaryApi';
+import { kubeObjectListQuery, ListResponse } from './api/v2/useKubeObjectList';
 import type { KubeCondition, KubeMetrics } from './cluster';
 import type { KubeObjectInterface } from './KubeObject';
 import { KubeObject } from './KubeObject';
 import { NODE_POOL_LABEL_KEYS } from './nodeConstants';
+
+/**
+ * Restricted-cluster list requests (see the resourceNames-restricted branch of
+ * {@link Node.useList}) fetch each authorized node individually via kubeObjectListQuery,
+ * which doesn't participate in KubeObject.useList's live watch wiring. Without a watch,
+ * restricted users would see a single static snapshot that never updates. Poll as a
+ * fallback when the caller didn't already request a refetchInterval — matches the
+ * cadence Overview.tsx uses for its own Node.useList call (OVERVIEW_REFETCH_INTERVAL_MS).
+ */
+const RESTRICTED_LIST_REFETCH_INTERVAL_MS = 60_000;
 
 export interface KubeNode extends KubeObjectInterface {
   status: {
@@ -69,6 +87,305 @@ class Node extends KubeObject<KubeNode> {
   static apiName = 'nodes';
   static apiVersion = 'v1';
   static isNamespaced = false;
+
+  /**
+   * Lists Nodes, same as {@link KubeObject.useList}, but additionally respects RBAC rules
+   * that restrict "list nodes" to a specific set of resourceNames.
+   *
+   * The Kubernetes API rejects an unfiltered `list nodes` request for a ServiceAccount whose
+   * RBAC rule is scoped with `resourceNames`, unless the request carries a matching
+   * `fieldSelector=metadata.name=<name>`. When such a restriction is detected for a cluster,
+   * this issues one list request per authorized name for that cluster (field selectors are
+   * AND-only, so multiple names can't be combined into a single request) and merges the
+   * results, instead of the normal unfiltered list call. Clusters without a resourceNames
+   * restriction are listed normally, unchanged from the default behavior.
+   */
+  static useList<K extends KubeObject>(
+    this: (new (...args: any) => K) & typeof KubeObject<any>,
+    {
+      cluster,
+      clusters,
+      refetchInterval,
+      ...queryParams
+    }: {
+      cluster?: string;
+      clusters?: string[];
+      refetchInterval?: number;
+    } & Record<string, any> = {}
+  ) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const fallbackClusters = useSelectedClusters();
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const clusterList = useMemo(
+      () =>
+        cluster ? [cluster] : clusters || (fallbackClusters.length === 0 ? [''] : fallbackClusters),
+      [cluster, clusters, fallbackClusters]
+    );
+
+    // Reuse AuthRoute's ['auth', cluster] query — testAuth() posts the same
+    // SelfSubjectRulesReview this needs, so sharing the key avoids firing a second,
+    // redundant request on every Nodes page load (see RouteSwitcher.tsx).
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const restrictionResults = useQueries({
+      queries: clusterList.map(clusterName => ({
+        queryKey: ['auth', clusterName],
+        queryFn: () => testAuth(clusterName),
+        // RBAC rules essentially never change mid-session; avoid re-checking on every render.
+        staleTime: 5 * 60 * 1000,
+        retry: 0,
+      })),
+    });
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const restrictionByCluster = useMemo(() => {
+      const map = new Map<string, { names: string[] | null; isLoading: boolean }>();
+      clusterList.forEach((clusterName, i) => {
+        const result = restrictionResults[i];
+        // If the shared auth review failed, don't block the normal list request on it —
+        // same fallback fetchResourceNamesRestriction used to apply internally.
+        const names = result?.isError
+          ? null
+          : result?.data
+          ? extractResourceNamesRestriction(result.data, '', 'nodes', 'list')
+          : null;
+        map.set(clusterName, {
+          names,
+          isLoading: result?.isLoading ?? true,
+        });
+      });
+      return map;
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [clusterList, restrictionResults]);
+
+    // Clusters whose restriction check has resolved and confirmed unrestricted. These get
+    // the normal, unfiltered fetch. Pending clusters are handled separately below
+    // (see pendingClusters) so we don't send an unfiltered request that might 403 for a
+    // cluster that turns out to be restricted.
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const unrestrictedClusters = useMemo(
+      () =>
+        clusterList.filter(clusterName => {
+          const restriction = restrictionByCluster.get(clusterName);
+          return !!restriction && !restriction.isLoading && restriction.names === null;
+        }),
+      [clusterList, restrictionByCluster]
+    );
+
+    // Clusters whose restriction check hasn't resolved yet. These are excluded from both
+    // the unfiltered fetch (to avoid a transient 403) and the restricted fetch (we don't yet
+    // know which names, if any, they're scoped to) — they only contribute to the overall
+    // loading state until the check resolves.
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const pendingClusters = useMemo(
+      () =>
+        clusterList.filter(clusterName => {
+          const restriction = restrictionByCluster.get(clusterName);
+          return !restriction || restriction.isLoading;
+        }),
+      [clusterList, restrictionByCluster]
+    );
+
+    const defaultResult = KubeObject.useList.call(this, {
+      ...queryParams,
+      cluster: undefined,
+      clusters: unrestrictedClusters,
+      refetchInterval,
+    }) as ReturnType<typeof KubeObject.useList<K>>;
+
+    // Resolve a working endpoint per cluster (not once from clusterList[0]) — endpoints can
+    // be cluster-specific, so reusing a single cluster's endpoint for every cluster's request
+    // can route restricted queries to the wrong API server. useQueries lets us do this
+    // without violating the rules of hooks even as clusterList's length varies.
+    const apiInfo = this.apiEndpoint.apiInfo;
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const endpointsKey = useMemo(
+      () => apiInfo.map(ep => `${ep.group ?? ''}/${ep.version}/${ep.resource}`),
+      [apiInfo]
+    );
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const endpointResults = useQueries({
+      queries: clusterList.map(clusterName => ({
+        queryKey: ['endpoints', clusterName, '', '', endpointsKey],
+        queryFn: () => getWorkingEndpoint(apiInfo, clusterName),
+        enabled: apiInfo.length > 1,
+      })),
+    });
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const endpointByCluster = useMemo(() => {
+      const map = new Map<string, KubeObjectEndpoint | undefined>();
+      clusterList.forEach((clusterName, i) => {
+        map.set(clusterName, apiInfo.length === 1 ? apiInfo[0] : endpointResults[i]?.data);
+      });
+      return map;
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [clusterList, apiInfo, endpointResults]);
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const restrictedRequests = useMemo(() => {
+      const requests: Array<{ cluster: string; name: string }> = [];
+      clusterList.forEach(clusterName => {
+        const restriction = restrictionByCluster.get(clusterName);
+        if (restriction && !restriction.isLoading && restriction.names) {
+          restriction.names.forEach(name => requests.push({ cluster: clusterName, name }));
+        }
+      });
+      return requests;
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [clusterList, restrictionByCluster]);
+
+    // Mirrors exactly which requests restrictedListResults' queries array includes (any
+    // request whose cluster's endpoint isn't resolved yet is skipped below), so this stays
+    // index-aligned with restrictedListResults for the per-cluster grouping further down.
+    const includedRestrictedRequests = restrictedRequests.filter(({ cluster: clusterName }) =>
+      endpointByCluster.get(clusterName)
+    );
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const restrictedListResults = useQueries({
+      queries: includedRestrictedRequests.map(({ cluster: clusterName, name }) =>
+        kubeObjectListQuery<K>(
+          this,
+          endpointByCluster.get(clusterName)!,
+          undefined,
+          clusterName,
+          {
+            ...queryParams,
+            fieldSelector: [queryParams.fieldSelector, `metadata.name=${name}`]
+              .filter(Boolean)
+              .join(','),
+          },
+          refetchInterval ?? RESTRICTED_LIST_REFETCH_INTERVAL_MS
+        )
+      ),
+    }) as Array<{
+      data: ListResponse<K> | undefined | null;
+      error: ApiError | null;
+      isLoading: boolean;
+      isFetching: boolean;
+      isError: boolean;
+      isSuccess: boolean;
+    }>;
+
+    const isPending = pendingClusters.length > 0;
+
+    if (restrictedRequests.length === 0) {
+      if (!isPending) {
+        // Cast: TS can't see that this matches KubeObject.useList's declared return type
+        // exactly (it's the same object KubeObject.useList itself returns).
+        return defaultResult as ReturnType<typeof KubeObject.useList<K>>;
+      }
+      // Some clusters' restriction checks haven't resolved yet — report pending rather than
+      // surfacing defaultResult's (possibly already-successful) status for the other clusters.
+      return {
+        ...defaultResult,
+        isLoading: true,
+        isSuccess: false,
+        status: 'pending' as QueryStatus,
+      } as ReturnType<typeof KubeObject.useList<K>>;
+    }
+
+    const restrictedItems = restrictedListResults
+      .filter(result => !!result.data)
+      .flatMap(result => result.data!.list.items);
+    const restrictedErrors = restrictedListResults
+      .map(result => result.error)
+      .filter((error): error is ApiError => !!error);
+
+    // If we have restricted requests to make but the endpoint hasn't resolved yet,
+    // restrictedListResults will be empty (queries: [] above) — treat that as still loading
+    // rather than letting `.some()`/`.every()` on an empty array report false/true.
+    const restrictedEndpointPending = restrictedRequests.some(
+      ({ cluster: clusterName }) => !endpointByCluster.get(clusterName)
+    );
+    const restrictedIsLoading =
+      restrictedEndpointPending || restrictedListResults.some(result => result.isLoading);
+    const restrictedIsFetching =
+      restrictedEndpointPending || restrictedListResults.some(result => result.isFetching);
+    const restrictedIsSuccess =
+      !restrictedEndpointPending && restrictedListResults.every(result => result.isSuccess);
+
+    // Once every applicable request (default + restricted) has settled, report an empty
+    // array rather than null — null signals "still loading" to consumers like
+    // ResourceTable, so an all-restricted-and-empty result would otherwise spin forever.
+    const allSettled = !isPending && !restrictedIsLoading;
+    const items =
+      defaultResult.items || restrictedItems.length || allSettled
+        ? [...(defaultResult.items ?? []), ...restrictedItems]
+        : null;
+    const errors = [...(defaultResult.errors ?? []), ...restrictedErrors];
+    const isError = defaultResult.isError || restrictedErrors.length > 0;
+    const isLoading = isPending || defaultResult.isLoading || restrictedIsLoading;
+    const isSuccess = !isPending && defaultResult.isSuccess && restrictedIsSuccess;
+    const status: QueryStatus = isError ? 'error' : isLoading ? 'pending' : 'success';
+
+    // Group restricted per-name results back by cluster and merge them into
+    // defaultResult.clusterResults, so callers relying on the useList clusterResults
+    // contract (see api/v2/hooks.ts QueryListResponse) see restricted clusters too, not
+    // just unrestricted ones, which is all defaultResult itself covers.
+    const restrictedClusterResults: Record<
+      string,
+      {
+        data: K[];
+        error: ApiError | null;
+        errors: ApiError[] | null;
+        items: K[] | null;
+        isLoading: boolean;
+        isFetching: boolean;
+        isError: boolean;
+        isSuccess: boolean;
+        status: QueryStatus;
+      }
+    > = {};
+    includedRestrictedRequests.forEach(({ cluster: clusterName }) => {
+      if (restrictedClusterResults[clusterName]) return; // already built for this cluster
+      const resultsForCluster = restrictedListResults.filter(
+        (_, j) => includedRestrictedRequests[j].cluster === clusterName
+      );
+      const clusterItems = resultsForCluster
+        .filter(result => !!result.data)
+        .flatMap(result => result.data!.list.items);
+      const clusterErrors = resultsForCluster
+        .map(result => result.error)
+        .filter((error): error is ApiError => !!error);
+      const clusterIsLoading = resultsForCluster.some(result => result.isLoading);
+      const clusterIsError = clusterErrors.length > 0;
+      const clusterIsSuccess = resultsForCluster.every(result => result.isSuccess);
+      restrictedClusterResults[clusterName] = {
+        data: clusterItems,
+        error: clusterErrors[0] ?? null,
+        errors: clusterErrors.length ? clusterErrors : null,
+        items: clusterItems,
+        isLoading: clusterIsLoading,
+        isFetching: resultsForCluster.some(result => result.isFetching),
+        isError: clusterIsError,
+        isSuccess: clusterIsSuccess,
+        status: clusterIsError ? 'error' : clusterIsLoading ? 'pending' : 'success',
+      };
+    });
+
+    return {
+      ...defaultResult,
+      items,
+      data: items,
+      error: errors[0] ?? null,
+      errors: errors.length ? errors : null,
+      isLoading,
+      isFetching: defaultResult.isFetching || restrictedIsFetching,
+      isError,
+      isSuccess,
+      status,
+      clusterResults: { ...defaultResult.clusterResults, ...restrictedClusterResults },
+      [0]: items,
+      [1]: errors[0] ?? null,
+      [Symbol.iterator]: function* () {
+        yield items;
+        yield errors[0] ?? null;
+      },
+    } as ReturnType<typeof KubeObject.useList<K>>;
+  }
 
   get status(): KubeNode['status'] {
     return this.jsonData.status;

--- a/frontend/src/lib/k8s/node.ts
+++ b/frontend/src/lib/k8s/node.ts
@@ -14,12 +14,19 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import { useQueries } from '@tanstack/react-query';
+import React, { useMemo } from 'react';
 import { useErrorState } from '../util';
 import { useConnectApi } from '.';
+import { useSelectedClusters } from './api/v1/hooks';
 import { metrics } from './api/v1/metricsApi';
+import { fetchResourceNamesRestriction } from './api/v1/rbacResourceNames';
 import type { ApiError } from './api/v2/ApiError';
+import type { QueryStatus } from './api/v2/hooks';
+import { getWorkingEndpoint } from './api/v2/hooks';
+import type { KubeObjectEndpoint } from './api/v2/KubeObjectEndpoint';
 import { KubeNodeSummaryStats, nodeSummaryStats } from './api/v2/nodeSummaryApi';
+import { kubeObjectListQuery, ListResponse } from './api/v2/useKubeObjectList';
 import type { KubeCondition, KubeMetrics } from './cluster';
 import type { KubeObjectInterface } from './KubeObject';
 import { KubeObject } from './KubeObject';
@@ -69,6 +76,248 @@ class Node extends KubeObject<KubeNode> {
   static apiName = 'nodes';
   static apiVersion = 'v1';
   static isNamespaced = false;
+
+  /**
+   * Lists Nodes, same as {@link KubeObject.useList}, but additionally respects RBAC rules
+   * that restrict "list nodes" to a specific set of resourceNames.
+   *
+   * The Kubernetes API rejects an unfiltered `list nodes` request for a ServiceAccount whose
+   * RBAC rule is scoped with `resourceNames`, unless the request carries a matching
+   * `fieldSelector=metadata.name=<name>`. When such a restriction is detected for a cluster,
+   * this issues one list request per authorized name for that cluster (field selectors are
+   * AND-only, so multiple names can't be combined into a single request) and merges the
+   * results, instead of the normal unfiltered list call. Clusters without a resourceNames
+   * restriction are listed normally, unchanged from the default behavior.
+   */
+  static useList<K extends KubeObject>(
+    this: (new (...args: any) => K) & typeof KubeObject<any>,
+    {
+      cluster,
+      clusters,
+      refetchInterval,
+      ...queryParams
+    }: {
+      cluster?: string;
+      clusters?: string[];
+      refetchInterval?: number;
+    } & Record<string, any> = {}
+  ) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const fallbackClusters = useSelectedClusters();
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const clusterList = useMemo(
+      () =>
+        cluster ? [cluster] : clusters || (fallbackClusters.length === 0 ? [''] : fallbackClusters),
+      [cluster, clusters, fallbackClusters]
+    );
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const restrictionResults = useQueries({
+      queries: clusterList.map(clusterName => ({
+        queryKey: ['resourceNamesRestriction', clusterName, '', 'nodes', 'list'],
+        queryFn: () => fetchResourceNamesRestriction(clusterName, '', 'nodes', 'list'),
+        // RBAC rules essentially never change mid-session; avoid re-checking on every render.
+        staleTime: 5 * 60 * 1000,
+      })),
+    });
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const restrictionByCluster = useMemo(() => {
+      const map = new Map<string, { names: string[] | null; isLoading: boolean }>();
+      clusterList.forEach((clusterName, i) => {
+        map.set(clusterName, {
+          names: restrictionResults[i]?.data ?? null,
+          isLoading: restrictionResults[i]?.isLoading ?? true,
+        });
+      });
+      return map;
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [clusterList, restrictionResults]);
+
+    // Clusters whose restriction check has resolved and confirmed unrestricted. These get
+    // the normal, unfiltered fetch. Pending clusters are handled separately below
+    // (see pendingClusters) so we don't send an unfiltered request that might 403 for a
+    // cluster that turns out to be restricted.
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const unrestrictedClusters = useMemo(
+      () =>
+        clusterList.filter(clusterName => {
+          const restriction = restrictionByCluster.get(clusterName);
+          return !!restriction && !restriction.isLoading && restriction.names === null;
+        }),
+      [clusterList, restrictionByCluster]
+    );
+
+    // Clusters whose restriction check hasn't resolved yet. These are excluded from both
+    // the unfiltered fetch (to avoid a transient 403) and the restricted fetch (we don't yet
+    // know which names, if any, they're scoped to) — they only contribute to the overall
+    // loading state until the check resolves.
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const pendingClusters = useMemo(
+      () =>
+        clusterList.filter(clusterName => {
+          const restriction = restrictionByCluster.get(clusterName);
+          return !restriction || restriction.isLoading;
+        }),
+      [clusterList, restrictionByCluster]
+    );
+
+    const defaultResult = KubeObject.useList.call(this, {
+      ...queryParams,
+      cluster: undefined,
+      clusters: unrestrictedClusters,
+      refetchInterval,
+    }) as [K[] | null, ApiError | null] & {
+      items: K[] | null;
+      error: ApiError | null;
+      errors: ApiError[] | null;
+      isLoading: boolean;
+      isFetching: boolean;
+      isError: boolean;
+      isSuccess: boolean;
+    };
+
+    // Resolve a working endpoint per cluster (not once from clusterList[0]) — endpoints can
+    // be cluster-specific, so reusing a single cluster's endpoint for every cluster's request
+    // can route restricted queries to the wrong API server. useQueries lets us do this
+    // without violating the rules of hooks even as clusterList's length varies.
+    const apiInfo = this.apiEndpoint.apiInfo;
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const endpointsKey = useMemo(
+      () => apiInfo.map(ep => `${ep.group ?? ''}/${ep.version}/${ep.resource}`),
+      [apiInfo]
+    );
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const endpointResults = useQueries({
+      queries: clusterList.map(clusterName => ({
+        queryKey: ['endpoints', clusterName, '', '', endpointsKey],
+        queryFn: () => getWorkingEndpoint(apiInfo, clusterName),
+        enabled: apiInfo.length > 1,
+      })),
+    });
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const endpointByCluster = useMemo(() => {
+      const map = new Map<string, KubeObjectEndpoint | undefined>();
+      clusterList.forEach((clusterName, i) => {
+        map.set(clusterName, apiInfo.length === 1 ? apiInfo[0] : endpointResults[i]?.data);
+      });
+      return map;
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [clusterList, apiInfo, endpointResults]);
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const restrictedRequests = useMemo(() => {
+      const requests: Array<{ cluster: string; name: string }> = [];
+      clusterList.forEach(clusterName => {
+        const restriction = restrictionByCluster.get(clusterName);
+        if (restriction && !restriction.isLoading && restriction.names) {
+          restriction.names.forEach(name => requests.push({ cluster: clusterName, name }));
+        }
+      });
+      return requests;
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [clusterList, restrictionByCluster]);
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const restrictedListResults = useQueries({
+      queries: restrictedRequests.flatMap(({ cluster: clusterName, name }) => {
+        const clusterEndpoint = endpointByCluster.get(clusterName);
+        if (!clusterEndpoint) return [];
+        return [
+          kubeObjectListQuery<K>(
+            this,
+            clusterEndpoint,
+            undefined,
+            clusterName,
+            {
+              ...queryParams,
+              fieldSelector: [queryParams.fieldSelector, `metadata.name=${name}`]
+                .filter(Boolean)
+                .join(','),
+            },
+            refetchInterval
+          ),
+        ];
+      }),
+    }) as Array<{
+      data: ListResponse<K> | undefined | null;
+      error: ApiError | null;
+      isLoading: boolean;
+      isFetching: boolean;
+      isError: boolean;
+      isSuccess: boolean;
+    }>;
+
+    const isPending = pendingClusters.length > 0;
+
+    if (restrictedRequests.length === 0) {
+      if (!isPending) {
+        // Cast: TS can't see that this matches KubeObject.useList's declared return type
+        // exactly (it's the same object KubeObject.useList itself returns).
+        return defaultResult as ReturnType<typeof KubeObject.useList<K>>;
+      }
+      // Some clusters' restriction checks haven't resolved yet — report pending rather than
+      // surfacing defaultResult's (possibly already-successful) status for the other clusters.
+      return {
+        ...defaultResult,
+        isLoading: true,
+        isSuccess: false,
+        status: 'pending' as QueryStatus,
+      } as ReturnType<typeof KubeObject.useList<K>>;
+    }
+
+    const restrictedItems = restrictedListResults
+      .filter(result => !!result.data)
+      .flatMap(result => result.data!.list.items);
+    const restrictedErrors = restrictedListResults
+      .map(result => result.error)
+      .filter((error): error is ApiError => !!error);
+
+    // If we have restricted requests to make but the endpoint hasn't resolved yet,
+    // restrictedListResults will be empty (queries: [] above) — treat that as still loading
+    // rather than letting `.some()`/`.every()` on an empty array report false/true.
+    const restrictedEndpointPending = restrictedRequests.some(
+      ({ cluster: clusterName }) => !endpointByCluster.get(clusterName)
+    );
+    const restrictedIsLoading =
+      restrictedEndpointPending || restrictedListResults.some(result => result.isLoading);
+    const restrictedIsFetching =
+      restrictedEndpointPending || restrictedListResults.some(result => result.isFetching);
+    const restrictedIsSuccess =
+      !restrictedEndpointPending && restrictedListResults.every(result => result.isSuccess);
+
+    const items =
+      defaultResult.items || restrictedItems.length
+        ? [...(defaultResult.items ?? []), ...restrictedItems]
+        : null;
+    const errors = [...(defaultResult.errors ?? []), ...restrictedErrors];
+    const isError = defaultResult.isError || restrictedErrors.length > 0;
+    const isLoading = isPending || defaultResult.isLoading || restrictedIsLoading;
+    const isSuccess = !isPending && defaultResult.isSuccess && restrictedIsSuccess;
+    const status: QueryStatus = isError ? 'error' : isLoading ? 'pending' : 'success';
+
+    return {
+      ...defaultResult,
+      items,
+      data: items,
+      error: errors[0] ?? null,
+      errors: errors.length ? errors : null,
+      isLoading,
+      isFetching: defaultResult.isFetching || restrictedIsFetching,
+      isError,
+      isSuccess,
+      status,
+      [0]: items,
+      [1]: errors[0] ?? null,
+      [Symbol.iterator]: function* () {
+        yield items;
+        yield errors[0] ?? null;
+      },
+    } as ReturnType<typeof KubeObject.useList<K>>;
+  }
 
   get status(): KubeNode['status'] {
     return this.jsonData.status;

--- a/plugins/headlamp-plugin/config/.storybook/baseMocks.ts
+++ b/plugins/headlamp-plugin/config/.storybook/baseMocks.ts
@@ -103,6 +103,14 @@ export const baseMocks = [
   http.post('http://localhost:4466/apis/authorization.k8s.io/v1/selfsubjectaccessreviews', () =>
     HttpResponse.json({ status: { allowed: true, reason: '', code: 200 } })
   ),
+  http.post('http://localhost:4466/*/authorization.k8s.io/v1/selfsubjectrulesreviews', () =>
+    HttpResponse.json({
+      status: {
+        resourceRules: [{ verbs: ['*'], apiGroups: ['*'], resources: ['*'] }],
+        incomplete: false,
+      },
+    })
+  ),
   http.get('http://localhost:4466/api/v1/namespaces', () =>
     HttpResponse.json({
       kind: 'NamespacesList',


### PR DESCRIPTION
Fixes #6935

Summary
This PR fixes a 403 Forbidden error on the Nodes page for restricted Kubernetes ServiceAccounts by automatically scoping node list requests. When an account has resourceNames restrictions (e.g., resourceNames: ["worker-node-1"]), Headlamp now queries SelfSubjectRulesReview and appends fieldSelector=metadata.name=<name> to the request, allowing authorized node listing without requiring broad cluster-wide listing permissions.

Related Issue
Fixes #6935

Changes
Added frontend/src/lib/k8s/api/v1/rbacResourceNames.ts: Helper utilities to extract restricted resourceNames for a specified API group, resource, and verb from RBAC status rules.

Updated frontend/src/lib/k8s/node.ts: Intercepted the default list behavior for Node to check RBAC constraints and apply fieldSelector parameters per authorized resource name.

Added frontend/src/lib/k8s/api/v1/rbacResourceNames.test.ts: Unit test suite covering wildcard matching, explicit resource name restrictions, and unrestricted fallback paths.

Steps to Test
Configure Restricted K8s ServiceAccount:
Create a ClusterRole with get, list, watch permissions on nodes scoped to a single node name:

YAML
apiGroups: [""]
resources: ["nodes"]
resourceNames: ["worker-node-1"]
verbs: ["get", "list", "watch"]
Access Headlamp:
Log in to Headlamp using the token derived from the restricted ServiceAccount.

Verify Nodes View:
Navigate to Nodes in the sidebar. Verify that worker-node-1 loads correctly without triggering a 403 Forbidden API error.

Run Unit Tests:
Execute npm run test -- rbacResourceNames.test.ts node.test.ts inside frontend/ and ensure all tests pass.

Screenshots (if applicable)
N/A

Notes for the Reviewer
The implementation leverages Headlamp's existing SelfSubjectRulesReview pattern (similar to testAuth() in clusterApi.ts).

Fallback logic ensures that accounts with standard unrestricted permissions (resourceNames: ["*"] or omitted) continue to issue regular cluster-scoped list calls without performance overhead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Node listings now respect resource-name access restrictions.
  * Authorized node names are supported across single- and multi-cluster views.
  * Restricted listings include loading, error, and refresh-state handling.
  * Wildcard permissions and combined access rules are supported.

* **Bug Fixes**
  * Unrestricted access, missing matches, and failed permission checks are handled gracefully.

* **Tests**
  * Added coverage for restricted, unrestricted, wildcard, merged-rule, and failed-request scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->