### PR TITLE
frontend: Overview: Scope charts to the accessible namespaces

### DIFF
--- a/frontend/src/components/cluster/ClusterGroupErrorMessage.test.tsx
+++ b/frontend/src/components/cluster/ClusterGroupErrorMessage.test.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import type React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { storeClusterSettings } from '../../helpers/clusterSettings';
+import { ApiError } from '../../lib/k8s/api/v2/ApiError';
+import { ClusterGroupErrorMessage } from './ClusterGroupErrorMessage';
+
+const CLUSTER = 'test-cluster';
+
+vi.mock('react-i18next', async importOriginal => ({
+  ...(await importOriginal<typeof import('react-i18next')>()),
+  useTranslation: () => ({ t: (key: string) => key.split('|').pop() }),
+}));
+
+vi.mock('../../lib/k8s', () => ({
+  useCluster: () => CLUSTER,
+  useSelectedClusters: () => [CLUSTER],
+}));
+
+vi.mock('../../redux/hooks', () => ({
+  useTypedSelector: (selector: any) => selector({ filter: { namespaces: new Set<string>() } }),
+}));
+
+vi.mock('../common/Link', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+const HINT =
+  'Headlamp is requesting resources across the whole cluster. If you only have access to ' +
+  'some namespaces, list them under Allowed namespaces in the cluster settings.';
+
+function renderForbidden() {
+  return render(
+    <ClusterGroupErrorMessage
+      errors={[new ApiError('forbidden', { status: 403, cluster: CLUSTER })]}
+      namespacedResource
+    />
+  );
+}
+
+describe('ClusterGroupErrorMessage', () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it('offers the namespace scoping hint when nothing narrows the requests', () => {
+    renderForbidden();
+
+    expect(screen.getByText(HINT, { exact: false })).toBeInTheDocument();
+  });
+
+  it('stays quiet when the allowed namespaces are already listed', () => {
+    storeClusterSettings(CLUSTER, { allowedNamespaces: ['team-a'] });
+
+    renderForbidden();
+
+    expect(screen.queryByText(HINT, { exact: false })).not.toBeInTheDocument();
+  });
+
+  // The request layer scopes lists by the selector too, so claiming the whole cluster was
+  // asked for would be untrue, and would point at a setting that is already filled in.
+  it('stays quiet when a namespaces selector is configured', () => {
+    storeClusterSettings(CLUSTER, { allowedNamespacesSelector: 'team=frontend' });
+
+    renderForbidden();
+
+    expect(screen.queryByText(HINT, { exact: false })).not.toBeInTheDocument();
+  });
+
+  it('does not offer the hint for a cluster scoped resource', () => {
+    render(<ClusterGroupErrorMessage errors={[new ApiError('forbidden', { status: 403 })]} />);
+
+    expect(screen.queryByText(HINT, { exact: false })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/cluster/ClusterGroupErrorMessage.tsx
+++ b/frontend/src/components/cluster/ClusterGroupErrorMessage.tsx
@@ -21,22 +21,72 @@ import Button from '@mui/material/Button';
 import { useTheme } from '@mui/material/styles';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSelectedClusters } from '../../lib/k8s';
+import { loadClusterSettings } from '../../helpers/clusterSettings';
+import { useCluster, useSelectedClusters } from '../../lib/k8s';
 import { ApiError } from '../../lib/k8s/api/v2/ApiError';
+import { useTypedSelector } from '../../redux/hooks';
+import Link from '../common/Link';
 
 export interface ClusterGroupErrorMessageProps {
   /**
    * Array of errors
    */
   errors?: ApiError[] | null;
+  /**
+   * Whether the failed requests were for namespaced resources, in which case a forbidden
+   * response may only mean they were asked for across the whole cluster.
+   */
+  namespacedResource?: boolean;
 }
 
-export function ClusterGroupErrorMessage({ errors }: ClusterGroupErrorMessageProps) {
+export function ClusterGroupErrorMessage({
+  errors,
+  namespacedResource,
+}: ClusterGroupErrorMessageProps) {
   if (!errors || errors?.length === 0) {
     return null;
   }
 
-  return errors.map((error, i) => <ErrorMessage error={error} key={error.stack ?? i} />);
+  const forbidden = errors.find(error => error.status === 403);
+
+  return (
+    <>
+      {errors.map((error, i) => (
+        <ErrorMessage error={error} key={error.stack ?? i} />
+      ))}
+      {namespacedResource && forbidden && <NamespaceScopeHint cluster={forbidden.cluster} />}
+    </>
+  );
+}
+
+/**
+ * Points a user who cannot list a cluster's namespaces at the setting that tells Headlamp
+ * which ones to ask for. Without it every request goes cluster-wide and is refused, and
+ * Kubernetes offers no way to discover the namespaces such a user may read.
+ */
+function NamespaceScopeHint({ cluster: errorCluster }: { cluster?: string }) {
+  const { t } = useTranslation();
+  const currentCluster = useCluster();
+  const cluster = errorCluster || currentCluster;
+  const selectedNamespaces = useTypedSelector(state => state.filter.namespaces);
+  const allowedNamespaces = loadClusterSettings(cluster || '')?.allowedNamespaces ?? [];
+
+  if (selectedNamespaces.size > 0 || allowedNamespaces.length > 0) {
+    return null;
+  }
+
+  return (
+    <Alert severity="info" sx={{ mb: 1 }}>
+      {t(
+        'Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.'
+      )}{' '}
+      {cluster && (
+        <Link routeName="settingsCluster" params={{ cluster }}>
+          {t('translation|Cluster settings')}
+        </Link>
+      )}
+    </Alert>
+  );
 }
 
 function ErrorMessage({ error }: { error: ApiError }) {

--- a/frontend/src/components/cluster/ClusterGroupErrorMessage.tsx
+++ b/frontend/src/components/cluster/ClusterGroupErrorMessage.tsx
@@ -21,22 +21,75 @@ import Button from '@mui/material/Button';
 import { useTheme } from '@mui/material/styles';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSelectedClusters } from '../../lib/k8s';
+import { hasAllowedNamespacesRestriction } from '../../helpers/clusterSettings';
+import { useCluster, useSelectedClusters } from '../../lib/k8s';
 import { ApiError } from '../../lib/k8s/api/v2/ApiError';
+import { useTypedSelector } from '../../redux/hooks';
+import Link from '../common/Link';
 
 export interface ClusterGroupErrorMessageProps {
   /**
    * Array of errors
    */
   errors?: ApiError[] | null;
+  /**
+   * Whether the failed requests were for namespaced resources, in which case a forbidden
+   * response may only mean they were asked for across the whole cluster.
+   */
+  namespacedResource?: boolean;
 }
 
-export function ClusterGroupErrorMessage({ errors }: ClusterGroupErrorMessageProps) {
+export function ClusterGroupErrorMessage({
+  errors,
+  namespacedResource,
+}: ClusterGroupErrorMessageProps) {
   if (!errors || errors?.length === 0) {
     return null;
   }
 
-  return errors.map((error, i) => <ErrorMessage error={error} key={error.stack ?? i} />);
+  const forbidden = errors.find(error => error.status === 403);
+
+  return (
+    <>
+      {errors.map((error, i) => (
+        <ErrorMessage error={error} key={error.stack ?? i} />
+      ))}
+      {namespacedResource && forbidden && <NamespaceScopeHint cluster={forbidden.cluster} />}
+    </>
+  );
+}
+
+/**
+ * Points a user who cannot list a cluster's namespaces at the setting that tells Headlamp
+ * which ones to ask for. Without it every request goes cluster-wide and is refused, and
+ * Kubernetes offers no way to discover the namespaces such a user may read.
+ */
+function NamespaceScopeHint({ cluster: errorCluster }: { cluster?: string }) {
+  const { t } = useTranslation();
+  const currentCluster = useCluster();
+  const cluster = errorCluster || currentCluster;
+  const selectedNamespaces = useTypedSelector(state => state.filter.namespaces);
+  // The request layer scopes lists by the allowed namespaces and by the selector that
+  // resolves to more of them, so both count as a restriction. Claiming the whole cluster
+  // was asked for would be untrue, and would point at a setting already filled in.
+  const namespacesRestricted = hasAllowedNamespacesRestriction(cluster || '');
+
+  if (selectedNamespaces.size > 0 || namespacesRestricted) {
+    return null;
+  }
+
+  return (
+    <Alert severity="info" sx={{ mb: 1 }}>
+      {t(
+        'Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.'
+      )}{' '}
+      {cluster && (
+        <Link routeName="settingsCluster" params={{ cluster }}>
+          {t('translation|Cluster settings')}
+        </Link>
+      )}
+    </Alert>
+  );
 }
 
 function ErrorMessage({ error }: { error: ApiError }) {

--- a/frontend/src/components/cluster/Overview.test.tsx
+++ b/frontend/src/components/cluster/Overview.test.tsx
@@ -14,29 +14,31 @@
  * limitations under the License.
  */
 
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import type React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Overview from './Overview';
 
-const { chartMocks, eventUseList, nodeUseList, nodeUseMetrics, podUseList } = vi.hoisted(() => ({
-  chartMocks: {
-    CpuCircularChart: () => <div>cpu</div>,
-    MemoryCircularChart: () => <div>memory</div>,
-    NodesStatusCircleChart: () => <div>nodes</div>,
-    PodsStatusCircleChart: () => <div>pods</div>,
-  },
-  eventUseList: vi.fn(() => ({ items: [], errors: null })),
-  nodeUseList: vi.fn(() => [[]]),
-  nodeUseMetrics: vi.fn(() => [[], null]),
-  podUseList: vi.fn(() => [[]]),
-}));
+const { chartMocks, eventUseList, namespacesMock, nodeUseList, nodeUseMetrics, podUseList } =
+  vi.hoisted(() => ({
+    chartMocks: {
+      CpuCircularChart: () => <div>cpu</div>,
+      MemoryCircularChart: () => <div>memory</div>,
+      NodesStatusCircleChart: () => <div>nodes</div>,
+      PodsStatusCircleChart: () => <div>pods</div>,
+    },
+    eventUseList: vi.fn(() => ({ items: [], errors: null })),
+    namespacesMock: vi.fn((): string[] => []),
+    nodeUseList: vi.fn(() => [[]] as any),
+    nodeUseMetrics: vi.fn(() => [[], null] as any),
+    podUseList: vi.fn(() => [[]] as any),
+  }));
 
 vi.mock('react-i18next', async importOriginal => ({
   ...(await importOriginal<typeof import('react-i18next')>()),
   useTranslation: () => ({
-    t: (key: string) => key,
+    t: (key: string) => key.split('|').pop(),
   }),
 }));
 
@@ -66,7 +68,7 @@ vi.mock('../../lib/util', () => ({
 
 vi.mock('../../redux/filterSlice', async importOriginal => ({
   ...(await importOriginal<typeof import('../../redux/filterSlice')>()),
-  useNamespaces: () => [],
+  useNamespaces: namespacesMock,
 }));
 
 vi.mock('../../redux/hooks', () => ({
@@ -96,25 +98,145 @@ vi.mock('../common/SectionBox', () => ({
   ),
 }));
 
+vi.mock('./ClusterGroupErrorMessage', () => ({
+  ClusterGroupErrorMessage: ({
+    errors,
+    namespacedResource,
+  }: {
+    errors: { status?: number }[];
+    namespacedResource?: boolean;
+  }) => (
+    <div>{`error:${errors.map(error => error.status).join(',')}${
+      namespacedResource ? ':namespaced' : ''
+    }`}</div>
+  ),
+}));
+
 vi.mock('./Charts', () => chartMocks);
 vi.mock('./Charts/index', () => chartMocks);
 
+const renderOverview = () =>
+  render(
+    <MemoryRouter>
+      <Overview />
+    </MemoryRouter>
+  );
+
 describe('Overview', () => {
+  const OVERVIEW_REFETCH_INTERVAL_MS = 60_000;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    namespacesMock.mockReturnValue([]);
+    podUseList.mockReturnValue([[]]);
+    nodeUseList.mockReturnValue([[]]);
+    nodeUseMetrics.mockReturnValue([[], null]);
+  });
+
   it('polls overview resources instead of opening watch streams', () => {
-    const OVERVIEW_REFETCH_INTERVAL_MS = 60_000;
+    renderOverview();
 
-    render(
-      <MemoryRouter>
-        <Overview />
-      </MemoryRouter>
-    );
-
-    expect(podUseList).toHaveBeenCalledWith({ refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS });
+    expect(podUseList).toHaveBeenCalledWith({
+      namespace: [],
+      refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS,
+    });
     expect(nodeUseList).toHaveBeenCalledWith({ refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS });
     expect(eventUseList).toHaveBeenCalledWith({
       limit: 2000,
       namespace: [],
       refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS,
     });
+  });
+
+  // A user without cluster-wide list permissions only gets counts when the request is
+  // scoped to the namespaces they can read.
+  it('scopes the pod list to the selected namespaces', () => {
+    namespacesMock.mockReturnValue(['team-a', 'team-b']);
+
+    renderOverview();
+
+    expect(podUseList).toHaveBeenCalledWith({
+      namespace: ['team-a', 'team-b'],
+      refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS,
+    });
+  });
+
+  it('reports a forbidden pod list rather than charting it as empty', () => {
+    podUseList.mockReturnValue([null, { status: 403 }]);
+
+    renderOverview();
+
+    expect(screen.queryByText('pods')).not.toBeInTheDocument();
+    expect(screen.getByText('Unavailable')).toBeInTheDocument();
+    expect(screen.getByText('Pods')).toBeInTheDocument();
+    expect(screen.getByText('error:403:namespaced')).toBeInTheDocument();
+    expect(screen.getByText('nodes')).toBeInTheDocument();
+  });
+
+  // One failure affects the cpu, memory and nodes charts alike, and saying so three times
+  // buries the section it explains.
+  it('reports a failure once for the whole section', () => {
+    nodeUseList.mockReturnValue([null, { status: 403 }]);
+
+    renderOverview();
+
+    expect(screen.getByText('error:403')).toBeInTheDocument();
+    expect(screen.getAllByText('Unavailable')).toHaveLength(3);
+    ['CPU', 'Memory', 'Nodes'].forEach(title => {
+      expect(screen.getByText(title), title).toBeInTheDocument();
+    });
+  });
+
+  // Nodes are cluster scoped, so narrowing to namespaces would not make them readable.
+  it('does not offer namespace scoping for a forbidden node list', () => {
+    nodeUseList.mockReturnValue([null, { status: 403 }]);
+
+    renderOverview();
+
+    expect(screen.getByText('error:403')).toBeInTheDocument();
+    expect(screen.queryByText('error:403:namespaced')).not.toBeInTheDocument();
+  });
+
+  // A list spanning several namespaces reports the one that failed while still returning
+  // what the others found, so the counts must survive alongside the message.
+  it('keeps the chart when only part of the pod list failed', () => {
+    podUseList.mockReturnValue([[{}], { status: 403 }]);
+
+    renderOverview();
+
+    expect(screen.getByText('pods')).toBeInTheDocument();
+    expect(screen.queryByText('Unavailable')).not.toBeInTheDocument();
+    expect(screen.getByText('error:403:namespaced')).toBeInTheDocument();
+  });
+
+  // Nodes being readable does not make their usage readable: summing an empty metric set
+  // would read as 0 usage rather than as the missing permission it is.
+  it('does not chart usage of readable nodes when metrics are forbidden', () => {
+    nodeUseList.mockReturnValue([[{}]]);
+    nodeUseMetrics.mockReturnValue([[], { status: 403 }]);
+
+    renderOverview();
+
+    expect(screen.queryByText('cpu')).not.toBeInTheDocument();
+    expect(screen.queryByText('memory')).not.toBeInTheDocument();
+    expect(screen.getAllByText('Unavailable')).toHaveLength(2);
+    expect(screen.getByText('nodes')).toBeInTheDocument();
+  });
+
+  it('keeps the list charts when only metrics are forbidden', () => {
+    nodeUseMetrics.mockReturnValue([[], { status: 403 }]);
+
+    renderOverview();
+
+    expect(screen.getByText('pods')).toBeInTheDocument();
+    expect(screen.getByText('nodes')).toBeInTheDocument();
+
+    expect(screen.queryByText('cpu')).not.toBeInTheDocument();
+    expect(screen.queryByText('memory')).not.toBeInTheDocument();
+    expect(screen.getAllByText('Unavailable')).toHaveLength(2);
+    ['CPU', 'Memory'].forEach(title => {
+      expect(screen.getByText(title), title).toBeInTheDocument();
+    });
+    expect(screen.getByText('error:403')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/cluster/Overview.test.tsx
+++ b/frontend/src/components/cluster/Overview.test.tsx
@@ -14,29 +14,45 @@
  * limitations under the License.
  */
 
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import type React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Overview from './Overview';
 
-const { chartMocks, eventUseList, nodeUseList, nodeUseMetrics, podUseList } = vi.hoisted(() => ({
-  chartMocks: {
-    CpuCircularChart: () => <div>cpu</div>,
-    MemoryCircularChart: () => <div>memory</div>,
-    NodesStatusCircleChart: () => <div>nodes</div>,
-    PodsStatusCircleChart: () => <div>pods</div>,
-  },
-  eventUseList: vi.fn(() => ({ items: [], errors: null })),
-  nodeUseList: vi.fn(() => [[]]),
-  nodeUseMetrics: vi.fn(() => [[], null]),
-  podUseList: vi.fn(() => [[]]),
-}));
+const { chartMocks, eventUseList, namespacesMock, nodeUseList, nodeUseMetrics, podUseList } =
+  vi.hoisted(() => ({
+    chartMocks: {
+      CpuCircularChart: () => <div>cpu</div>,
+      MemoryCircularChart: () => <div>memory</div>,
+      NodesStatusCircleChart: () => <div>nodes</div>,
+      PodsStatusCircleChart: () => <div>pods</div>,
+    },
+    eventUseList: vi.fn(() => ({ items: [], errors: null })),
+    namespacesMock: vi.fn((): string[] => []),
+    nodeUseList: vi.fn(() => ({ items: [], errors: null, isSuccess: true } as any)),
+    nodeUseMetrics: vi.fn(() => [[], null] as any),
+    podUseList: vi.fn(() => ({ items: [], errors: null, isSuccess: true } as any)),
+  }));
+
+/**
+ * A list reports one error per namespace or cluster it asked, so the mocks mirror the
+ * `errors` array the real hook returns rather than a single error.
+ */
+function listResult(items: object[] | null, ...errors: { status?: number }[]) {
+  return {
+    items,
+    errors: errors.length ? errors : null,
+    isSuccess: errors.length === 0,
+    // One result per cluster that answered, so null items stand for every request failing.
+    clusterResults: items === null ? {} : { 'test-cluster': { items } },
+  };
+}
 
 vi.mock('react-i18next', async importOriginal => ({
   ...(await importOriginal<typeof import('react-i18next')>()),
   useTranslation: () => ({
-    t: (key: string) => key,
+    t: (key: string) => key.split('|').pop(),
   }),
 }));
 
@@ -66,7 +82,7 @@ vi.mock('../../lib/util', () => ({
 
 vi.mock('../../redux/filterSlice', async importOriginal => ({
   ...(await importOriginal<typeof import('../../redux/filterSlice')>()),
-  useNamespaces: () => [],
+  useNamespaces: namespacesMock,
 }));
 
 vi.mock('../../redux/hooks', () => ({
@@ -96,25 +112,171 @@ vi.mock('../common/SectionBox', () => ({
   ),
 }));
 
+vi.mock('./ClusterGroupErrorMessage', () => ({
+  ClusterGroupErrorMessage: ({
+    errors,
+    namespacedResource,
+  }: {
+    errors: { status?: number }[];
+    namespacedResource?: boolean;
+  }) => (
+    <div>{`error:${errors.map(error => error.status).join(',')}${
+      namespacedResource ? ':namespaced' : ''
+    }`}</div>
+  ),
+}));
+
 vi.mock('./Charts', () => chartMocks);
 vi.mock('./Charts/index', () => chartMocks);
 
+const renderOverview = () =>
+  render(
+    <MemoryRouter>
+      <Overview />
+    </MemoryRouter>
+  );
+
 describe('Overview', () => {
+  const OVERVIEW_REFETCH_INTERVAL_MS = 60_000;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    namespacesMock.mockReturnValue([]);
+    podUseList.mockReturnValue(listResult([]));
+    nodeUseList.mockReturnValue(listResult([]));
+    nodeUseMetrics.mockReturnValue([[], null]);
+  });
+
   it('polls overview resources instead of opening watch streams', () => {
-    const OVERVIEW_REFETCH_INTERVAL_MS = 60_000;
+    renderOverview();
 
-    render(
-      <MemoryRouter>
-        <Overview />
-      </MemoryRouter>
-    );
-
-    expect(podUseList).toHaveBeenCalledWith({ refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS });
+    expect(podUseList).toHaveBeenCalledWith({
+      namespace: [],
+      refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS,
+    });
     expect(nodeUseList).toHaveBeenCalledWith({ refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS });
     expect(eventUseList).toHaveBeenCalledWith({
       limit: 2000,
       namespace: [],
       refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS,
     });
+  });
+
+  // A user without cluster-wide list permissions only gets counts when the request is
+  // scoped to the namespaces they can read.
+  it('scopes the pod list to the selected namespaces', () => {
+    namespacesMock.mockReturnValue(['team-a', 'team-b']);
+
+    renderOverview();
+
+    expect(podUseList).toHaveBeenCalledWith({
+      namespace: ['team-a', 'team-b'],
+      refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS,
+    });
+  });
+
+  it('reports a forbidden pod list rather than charting it as empty', () => {
+    podUseList.mockReturnValue(listResult(null, { status: 403 }));
+
+    renderOverview();
+
+    expect(screen.queryByText('pods')).not.toBeInTheDocument();
+    expect(screen.getByText('Unavailable')).toBeInTheDocument();
+    expect(screen.getByText('Pods')).toBeInTheDocument();
+    expect(screen.getByText('error:403:namespaced')).toBeInTheDocument();
+    expect(screen.getByText('nodes')).toBeInTheDocument();
+  });
+
+  // One failure affects the cpu, memory and nodes charts alike, and saying so three times
+  // buries the section it explains.
+  it('reports a failure once for the whole section', () => {
+    nodeUseList.mockReturnValue(listResult(null, { status: 403 }));
+
+    renderOverview();
+
+    expect(screen.getByText('error:403')).toBeInTheDocument();
+    expect(screen.getAllByText('Unavailable')).toHaveLength(3);
+    ['CPU', 'Memory', 'Nodes'].forEach(title => {
+      expect(screen.getByText(title), title).toBeInTheDocument();
+    });
+  });
+
+  // Nodes are cluster scoped, so narrowing to namespaces would not make them readable.
+  it('does not offer namespace scoping for a forbidden node list', () => {
+    nodeUseList.mockReturnValue(listResult(null, { status: 403 }));
+
+    renderOverview();
+
+    expect(screen.getByText('error:403')).toBeInTheDocument();
+    expect(screen.queryByText('error:403:namespaced')).not.toBeInTheDocument();
+  });
+
+  // One namespace answering with nothing is still an answer: the count it contributes is a
+  // real zero, so the chart has to keep it rather than claim the pods could not be listed.
+  it('keeps the chart when a partly failed pod list answered with no pods', () => {
+    podUseList.mockReturnValue(listResult([], { status: 403 }));
+
+    renderOverview();
+
+    expect(screen.getByText('pods')).toBeInTheDocument();
+    expect(screen.queryByText('Unavailable')).not.toBeInTheDocument();
+    expect(screen.getByText('error:403:namespaced')).toBeInTheDocument();
+  });
+
+  // A list spanning several namespaces reports the one that failed while still returning
+  // what the others found, so the counts must survive alongside the message.
+  it('keeps the chart when only part of the pod list failed', () => {
+    podUseList.mockReturnValue(listResult([{}], { status: 403 }));
+
+    renderOverview();
+
+    expect(screen.getByText('pods')).toBeInTheDocument();
+    expect(screen.queryByText('Unavailable')).not.toBeInTheDocument();
+    expect(screen.getByText('error:403:namespaced')).toBeInTheDocument();
+  });
+
+  // Nodes being readable does not make their usage readable: summing an empty metric set
+  // would read as 0 usage rather than as the missing permission it is.
+  it('does not chart usage of readable nodes when metrics are forbidden', () => {
+    nodeUseList.mockReturnValue(listResult([{}]));
+    nodeUseMetrics.mockReturnValue([[], { status: 403 }]);
+
+    renderOverview();
+
+    expect(screen.queryByText('cpu')).not.toBeInTheDocument();
+    expect(screen.queryByText('memory')).not.toBeInTheDocument();
+    expect(screen.getAllByText('Unavailable')).toHaveLength(2);
+    ['CPU', 'Memory'].forEach(title => {
+      expect(screen.getByText(title), title).toBeInTheDocument();
+    });
+    expect(screen.getByText('error:403')).toBeInTheDocument();
+    expect(screen.getByText('nodes')).toBeInTheDocument();
+  });
+
+  // Every namespace of a fanned out list reports its own failure, and reading only the
+  // first one drops the rest along with the hint their status would have raised.
+  it('reports every error of a partly failed list, not only the first', () => {
+    podUseList.mockReturnValue(listResult(null, { status: 500 }, { status: 403 }));
+
+    renderOverview();
+
+    expect(screen.getByText('error:500,403:namespaced')).toBeInTheDocument();
+  });
+
+  it('keeps the list charts when only metrics are forbidden', () => {
+    nodeUseMetrics.mockReturnValue([[], { status: 403 }]);
+
+    renderOverview();
+
+    expect(screen.getByText('pods')).toBeInTheDocument();
+    expect(screen.getByText('nodes')).toBeInTheDocument();
+
+    expect(screen.queryByText('cpu')).not.toBeInTheDocument();
+    expect(screen.queryByText('memory')).not.toBeInTheDocument();
+    expect(screen.getAllByText('Unavailable')).toHaveLength(2);
+    ['CPU', 'Memory'].forEach(title => {
+      expect(screen.getByText(title), title).toBeInTheDocument();
+    });
+    expect(screen.getByText('error:403')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -18,9 +18,11 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 import Grid from '@mui/material/Grid';
 import { Theme } from '@mui/material/styles';
 import Switch from '@mui/material/Switch';
+import { uniqBy } from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
+import type { ApiError } from '../../lib/k8s/api/v2/ApiError';
 import Event from '../../lib/k8s/event';
 import Node from '../../lib/k8s/node';
 import Pod from '../../lib/k8s/pod';
@@ -36,6 +38,7 @@ import { PageGrid } from '../common/Resource';
 import ResourceListView from '../common/Resource/ResourceListView';
 import { SectionBox } from '../common/SectionBox';
 import ShowHideLabel from '../common/ShowHideLabel';
+import TileChart from '../common/TileChart';
 import { LightTooltip } from '../common/Tooltip';
 import {
   CpuCircularChart,
@@ -47,39 +50,103 @@ import { ClusterGroupErrorMessage } from './ClusterGroupErrorMessage';
 
 const OVERVIEW_REFETCH_INTERVAL_MS = 60_000;
 
-export default function Overview() {
+/**
+ * Renders a chart, or a placeholder when its resources could not be listed at all. A list
+ * spanning several namespaces or clusters reports an error while still returning what the
+ * other requests found, so the chart stays as long as it has something to count. The reason
+ * is reported once for the whole section rather than in every chart it affects.
+ */
+function ChartSlot({
+  error,
+  hasItems,
+  title,
+  children,
+}: {
+  error?: ApiError | null;
+  hasItems?: boolean;
+  title: string;
+  children: React.ReactNode;
+}) {
   const { t } = useTranslation(['translation']);
+
+  if (error && !hasItems) {
+    return <TileChart title={title} legend={t('translation|Unavailable')} />;
+  }
+
+  return <>{children}</>;
+}
+
+export default function Overview() {
+  const { t } = useTranslation(['translation', 'glossary']);
+  const namespaces = useNamespaces();
+
   // The overview only needs periodic snapshots for aggregate charts. Avoid long-lived
   // watches here because large clusters can stream enough events to exhaust the tab.
-  const [pods] = Pod.useList({ refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS });
-  const [nodes] = Node.useList({ refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS });
+  const [pods, podsError] = Pod.useList({
+    namespace: namespaces,
+    refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS,
+  });
+  const [nodes, nodesError] = Node.useList({ refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS });
   const [nodeMetrics, metricsError] = Node.useMetrics();
   const chartProcessors = useTypedSelector(state => state.overviewCharts.processors);
 
-  const noPermissions = metricsError?.status === 403;
-  const noMetrics = metricsError !== null && !noPermissions;
+  const forbiddenMetrics = metricsError?.status === 403 ? metricsError : null;
+  const noMetrics = metricsError !== null && !forbiddenMetrics;
+
+  // A forbidden metrics response leaves the usage charts with nothing to sum, and summing
+  // nothing reads as 0 usage rather than as the missing permission it is.
+  const hasNodeUsage = !!nodes?.length && (!forbiddenMetrics || !!nodeMetrics?.length);
+
+  const chartErrors = React.useMemo(
+    () =>
+      uniqBy(
+        [podsError, nodesError, forbiddenMetrics].filter((error): error is ApiError => !!error),
+        error => error.status
+      ),
+    [podsError, nodesError, forbiddenMetrics]
+  );
 
   // Process the default charts through any registered processors
   const defaultCharts: OverviewChart[] = [
     {
       id: 'cpu',
       component: () => (
-        <CpuCircularChart items={nodes} itemsMetrics={nodeMetrics} noMetrics={noMetrics} />
+        <ChartSlot
+          error={nodesError ?? forbiddenMetrics}
+          hasItems={hasNodeUsage}
+          title={t('glossary|CPU')}
+        >
+          <CpuCircularChart items={nodes} itemsMetrics={nodeMetrics} noMetrics={noMetrics} />
+        </ChartSlot>
       ),
     },
     {
       id: 'memory',
       component: () => (
-        <MemoryCircularChart items={nodes} itemsMetrics={nodeMetrics} noMetrics={noMetrics} />
+        <ChartSlot
+          error={nodesError ?? forbiddenMetrics}
+          hasItems={hasNodeUsage}
+          title={t('glossary|Memory')}
+        >
+          <MemoryCircularChart items={nodes} itemsMetrics={nodeMetrics} noMetrics={noMetrics} />
+        </ChartSlot>
       ),
     },
     {
       id: 'pods',
-      component: () => <PodsStatusCircleChart items={pods} />,
+      component: () => (
+        <ChartSlot error={podsError} hasItems={!!pods?.length} title={t('glossary|Pods')}>
+          <PodsStatusCircleChart items={pods} />
+        </ChartSlot>
+      ),
     },
     {
       id: 'nodes',
-      component: () => <NodesStatusCircleChart items={nodes} />,
+      component: () => (
+        <ChartSlot error={nodesError} hasItems={!!nodes?.length} title={t('glossary|Nodes')}>
+          <NodesStatusCircleChart items={nodes} />
+        </ChartSlot>
+      ),
     },
   ];
   const charts = chartProcessors.reduce(
@@ -90,17 +157,17 @@ export default function Overview() {
   return (
     <PageGrid>
       <SectionBox title={t('translation|Overview')} py={2} mt={[4, 0, 0]}>
-        {noPermissions ? (
-          <ClusterGroupErrorMessage errors={[metricsError]} />
-        ) : (
-          <Grid container justifyContent="flex-start" alignItems="stretch" spacing={4}>
-            {charts.map(chart => (
-              <Grid key={chart.id} item xs sx={{ maxWidth: '300px' }}>
-                <chart.component />
-              </Grid>
-            ))}
-          </Grid>
-        )}
+        <ClusterGroupErrorMessage
+          errors={chartErrors}
+          namespacedResource={podsError?.status === 403}
+        />
+        <Grid container justifyContent="flex-start" alignItems="stretch" spacing={4}>
+          {charts.map(chart => (
+            <Grid key={chart.id} item xs sx={{ maxWidth: '300px' }}>
+              <chart.component />
+            </Grid>
+          ))}
+        </Grid>
       </SectionBox>
       <EventsSection />
     </PageGrid>

--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -18,9 +18,12 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 import Grid from '@mui/material/Grid';
 import { Theme } from '@mui/material/styles';
 import Switch from '@mui/material/Switch';
+import { uniqBy } from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
+import type { ApiError } from '../../lib/k8s/api/v2/ApiError';
+import { hasListResults } from '../../lib/k8s/api/v2/useKubeObjectList';
 import Event from '../../lib/k8s/event';
 import Node from '../../lib/k8s/node';
 import Pod from '../../lib/k8s/pod';
@@ -36,6 +39,7 @@ import { PageGrid } from '../common/Resource';
 import ResourceListView from '../common/Resource/ResourceListView';
 import { SectionBox } from '../common/SectionBox';
 import ShowHideLabel from '../common/ShowHideLabel';
+import TileChart from '../common/TileChart';
 import { LightTooltip } from '../common/Tooltip';
 import {
   CpuCircularChart,
@@ -47,41 +51,113 @@ import { ClusterGroupErrorMessage } from './ClusterGroupErrorMessage';
 
 const OVERVIEW_REFETCH_INTERVAL_MS = 60_000;
 
-export default function Overview() {
+/**
+ * Renders a chart, or a placeholder when its resources could not be listed at all. A list
+ * spanning several namespaces or clusters reports an error while still returning what the
+ * other requests found, so the chart stays as long as one of them answered. A request that
+ * answered with nothing counts: an empty namespace really does hold zero of a resource. The
+ * reason is reported once for the whole section rather than in every chart it affects.
+ */
+function ChartSlot({
+  errors,
+  hasData,
+  title,
+  children,
+}: {
+  errors?: ApiError[] | null;
+  hasData?: boolean;
+  title: string;
+  children: React.ReactNode;
+}) {
   const { t } = useTranslation(['translation']);
+
+  if (!!errors?.length && !hasData) {
+    return <TileChart title={title} legend={t('translation|Unavailable')} />;
+  }
+
+  return <>{children}</>;
+}
+
+export default function Overview() {
+  const { t } = useTranslation(['translation', 'glossary']);
+  const namespaces = useNamespaces();
+
   // The overview only needs periodic snapshots for aggregate charts. Avoid long-lived
   // watches here because large clusters can stream enough events to exhaust the tab.
-  const podsQuery = Pod.useList({ refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS });
-  const [pods] = podsQuery;
-  const [nodes] = Node.useList({ refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS });
+  const podsQuery = Pod.useList({
+    namespace: namespaces,
+    refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS,
+  });
+  const nodesQuery = Node.useList({ refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS });
   const [nodeMetrics, metricsError] = Node.useMetrics();
   const chartProcessors = useTypedSelector(state => state.overviewCharts.processors);
 
-  const noPermissions = metricsError?.status === 403;
-  const noMetrics = metricsError !== null && !noPermissions;
+  // A list fans out over the namespaces and clusters it was asked for and reports an error
+  // for each request that failed. Keep every one of them: reading only the first hides a
+  // later failure with another status, and with it the hint its status would have raised.
+  const pods = podsQuery.items;
+  const podsErrors = podsQuery.errors;
+  const nodes = nodesQuery.items;
+  const nodesErrors = nodesQuery.errors;
+
+  // A namespace that answered with nothing contributes a real zero, so the charts go by
+  // whether any request answered rather than by whether the answer holds an item.
+  const hasPods = hasListResults(podsQuery);
+  const hasNodes = hasListResults(nodesQuery);
+
+  const forbiddenMetrics = metricsError?.status === 403 ? metricsError : null;
+  const noMetrics = metricsError !== null && !forbiddenMetrics;
+
+  // A forbidden metrics response leaves the usage charts with nothing to sum, and summing
+  // nothing reads as 0 usage rather than as the missing permission it is.
+  const hasNodeUsage = hasNodes && (!forbiddenMetrics || !!nodeMetrics?.length);
+
+  // The usage charts are the nodes they sum as much as the metrics they sum them with.
+  const usageErrors = React.useMemo(
+    () => [...(nodesErrors ?? []), forbiddenMetrics].filter((error): error is ApiError => !!error),
+    [nodesErrors, forbiddenMetrics]
+  );
+
+  const chartErrors = React.useMemo(
+    () => uniqBy([...(podsErrors ?? []), ...usageErrors], error => error.status),
+    [podsErrors, usageErrors]
+  );
+
+  // Only namespaced resources can be narrowed to the namespaces a restricted user may read.
+  const forbiddenPods = !!podsErrors?.some(error => error.status === 403);
 
   // Process the default charts through any registered processors
   const defaultCharts: OverviewChart[] = [
     {
       id: 'cpu',
       component: () => (
-        <CpuCircularChart items={nodes} itemsMetrics={nodeMetrics} noMetrics={noMetrics} />
+        <ChartSlot errors={usageErrors} hasData={hasNodeUsage} title={t('glossary|CPU')}>
+          <CpuCircularChart items={nodes} itemsMetrics={nodeMetrics} noMetrics={noMetrics} />
+        </ChartSlot>
       ),
     },
     {
       id: 'memory',
       component: () => (
-        <MemoryCircularChart items={nodes} itemsMetrics={nodeMetrics} noMetrics={noMetrics} />
+        <ChartSlot errors={usageErrors} hasData={hasNodeUsage} title={t('glossary|Memory')}>
+          <MemoryCircularChart items={nodes} itemsMetrics={nodeMetrics} noMetrics={noMetrics} />
+        </ChartSlot>
       ),
     },
     {
       id: 'pods',
-      component: () => <PodsStatusCircleChart items={pods} />,
+      component: () => (
+        <ChartSlot errors={podsErrors} hasData={hasPods} title={t('glossary|Pods')}>
+          <PodsStatusCircleChart items={pods} />
+        </ChartSlot>
+      ),
     },
     {
       id: 'nodes',
       component: () => (
-        <NodesStatusCircleChart items={nodes} pods={pods} podsLoaded={podsQuery.isSuccess} />
+        <ChartSlot errors={nodesErrors} hasData={hasNodes} title={t('glossary|Nodes')}>
+          <NodesStatusCircleChart items={nodes} pods={pods} podsLoaded={podsQuery.isSuccess} />
+        </ChartSlot>
       ),
     },
   ];
@@ -93,17 +169,14 @@ export default function Overview() {
   return (
     <PageGrid>
       <SectionBox title={t('translation|Overview')} py={2} mt={[4, 0, 0]}>
-        {noPermissions ? (
-          <ClusterGroupErrorMessage errors={[metricsError]} />
-        ) : (
-          <Grid container justifyContent="flex-start" alignItems="stretch" spacing={4}>
-            {charts.map(chart => (
-              <Grid key={chart.id} item xs sx={{ maxWidth: '300px' }}>
-                <chart.component />
-              </Grid>
-            ))}
-          </Grid>
-        )}
+        <ClusterGroupErrorMessage errors={chartErrors} namespacedResource={forbiddenPods} />
+        <Grid container justifyContent="flex-start" alignItems="stretch" spacing={4}>
+          {charts.map(chart => (
+            <Grid key={chart.id} item xs sx={{ maxWidth: '300px' }}>
+              <chart.component />
+            </Grid>
+          ))}
+        </Grid>
       </SectionBox>
       <EventsSection />
     </PageGrid>

--- a/frontend/src/components/cluster/__snapshots__/Overview.ErrorState.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Overview.ErrorState.stories.storyshot
@@ -39,6 +39,49 @@
                 class="MuiBox-root css-lpikod"
               >
                 <div
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard css-rme5zz-MuiPaper-root-MuiAlert-root"
+                  role="alert"
+                >
+                  <div
+                    class="MuiAlert-icon css-1ytlwq5-MuiAlert-icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
+                      data-testid="ReportProblemOutlinedIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="MuiAlert-message css-1pxa9xg-MuiAlert-message"
+                  >
+                    <div
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom MuiAlertTitle-root css-1mny8mx-MuiTypography-root-MuiAlertTitle-root"
+                    >
+                      Failed to load resources
+                    </div>
+                  </div>
+                  <div
+                    class="MuiAlert-action css-ki1hdl-MuiAlert-action"
+                  >
+                    <button
+                      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textWarning MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorWarning MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textWarning MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorWarning MuiButton-disableElevation css-1s9cj53-MuiButtonBase-root-MuiButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      Show details
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
+                </div>
+                <div
                   class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-4 css-13cu5dn-MuiGrid-root"
                 >
                   <div
@@ -297,101 +340,12 @@
                           <p
                             class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
                           >
-                            0 / 0 Requested
+                            Unavailable
                           </p>
                         </div>
                         <div
                           class="MuiBox-root css-0"
-                        >
-                          <div
-                            aria-busy="false"
-                            aria-live="polite"
-                            class="MuiBox-root css-2esbmj"
-                          >
-                            <div
-                              class="recharts-wrapper"
-                              style="position: relative; cursor: default; width: 112px; height: 112px; margin-left: auto; margin-right: auto;"
-                            >
-                              <svg
-                                class="recharts-surface"
-                                cx="70"
-                                cy="70"
-                                height="112"
-                                style="width: 100%; height: 100%;"
-                                viewBox="0 0 112 112"
-                                width="112"
-                              >
-                                <title />
-                                <desc />
-                                <defs>
-                                  <clippath
-                                    id="recharts-id"
-                                  >
-                                    <rect
-                                      height="102"
-                                      width="102"
-                                      x="5"
-                                      y="5"
-                                    />
-                                  </clippath>
-                                </defs>
-                                <g
-                                  class="recharts-layer recharts-pie"
-                                  tabindex="0"
-                                >
-                                  <g
-                                    class="recharts-layer recharts-pie-sector"
-                                    tabindex="-1"
-                                  />
-                                  <g
-                                    class="recharts-layer recharts-pie-sector"
-                                    tabindex="-1"
-                                  />
-                                  <g
-                                    class="recharts-layer recharts-pie-sector"
-                                    tabindex="-1"
-                                  >
-                                    <path
-                                      aria-label="0 %"
-                                      class="recharts-sector"
-                                      cx="61"
-                                      cy="61"
-                                      d="M 61,16.199999999999996
-    A 44.800000000000004,44.800000000000004,0,
-    1,1,
-    60.99921809249515,16.20000000682343
-  L 60.999410078712856,27.200000005148027
-            A 33.800000000000004,33.800000000000004,0,
-            1,0,
-            61,27.199999999999996 Z"
-                                      fill="#e0e0e0"
-                                      name="total"
-                                      role="img"
-                                      stroke="#e0e0e0"
-                                      tabindex="-1"
-                                    />
-                                  </g>
-                                  <text
-                                    class="recharts-text recharts-label"
-                                    fill="#808080"
-                                    offset="5"
-                                    style="font-size: 16.8px; fill: #000;"
-                                    text-anchor="middle"
-                                    x="61"
-                                    y="61"
-                                  >
-                                    <tspan
-                                      dy="0.355em"
-                                      x="61"
-                                    >
-                                      0 %
-                                    </tspan>
-                                  </text>
-                                </g>
-                              </svg>
-                            </div>
-                          </div>
-                        </div>
+                        />
                       </div>
                     </div>
                   </div>

--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -171,12 +171,14 @@ export interface ResourceTableProps<RowItem> {
   errorMessage?: string | null;
   /** Display an errors */
   errors?: ApiError[] | null;
+  /** Whether the listed resource is namespaced, which decides how a forbidden list is explained */
+  namespacedResource?: boolean;
   /** State of the Table (page, rows per page) is reflected in the url */
   reflectInURL?: string | boolean;
 }
 
 export interface ResourceTableFromResourceClassProps<KubeClass extends KubeObjectClass>
-  extends Omit<ResourceTableProps<InstanceType<KubeClass>>, 'data'> {
+  extends Omit<ResourceTableProps<InstanceType<KubeClass>>, 'data' | 'namespacedResource'> {
   resourceClass: KubeClass;
   namespaces?: string[];
 }
@@ -226,6 +228,10 @@ function TableFromResourceClass<KubeClass extends KubeObjectClass>(
       errors={errors}
       id={id || `headlamp-${resourceClass.pluralName}`}
       {...otherProps}
+      // The scope comes from the resource class, so it is set after the spread: a caller
+      // could otherwise make a cluster-scoped table offer the namespace hint, or hide it
+      // on a namespaced one.
+      namespacedResource={resourceClass.isNamespaced}
       data={throttledItems}
     />
   );
@@ -330,6 +336,7 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
     enableRowActions = false,
     enableRowSelection = false,
     errors,
+    namespacedResource,
   } = props;
   const { t } = useTranslation(['glossary', 'translation']);
   const theme = useTheme();
@@ -727,7 +734,7 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
 
   return (
     <>
-      <ClusterGroupErrorMessage errors={errors} />
+      <ClusterGroupErrorMessage errors={errors} namespacedResource={namespacedResource} />
       <Table<RowItem>
         enableFullScreenToggle={false}
         enableFacetedValues={enableFacetedValues}

--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -161,6 +161,8 @@ export interface ResourceTableProps<RowItem> {
   errorMessage?: string | null;
   /** Display an errors */
   errors?: ApiError[] | null;
+  /** Whether the listed resource is namespaced, which decides how a forbidden list is explained */
+  namespacedResource?: boolean;
   /** State of the Table (page, rows per page) is reflected in the url */
   reflectInURL?: string | boolean;
 }
@@ -214,6 +216,7 @@ function TableFromResourceClass<KubeClass extends KubeObjectClass>(
   return (
     <ResourceTableContent
       errors={errors}
+      namespacedResource={resourceClass.isNamespaced}
       id={id || `headlamp-${resourceClass.pluralName}`}
       {...otherProps}
       data={throttledItems}
@@ -320,6 +323,7 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
     enableRowActions = false,
     enableRowSelection = false,
     errors,
+    namespacedResource,
   } = props;
   const { t } = useTranslation(['glossary', 'translation']);
   const theme = useTheme();
@@ -693,7 +697,7 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
 
   return (
     <>
-      <ClusterGroupErrorMessage errors={errors} />
+      <ClusterGroupErrorMessage errors={errors} namespacedResource={namespacedResource} />
       <Table<RowItem>
         enableFullScreenToggle={false}
         enableFacetedValues={enableFacetedValues}

--- a/frontend/src/components/workload/Overview.test.tsx
+++ b/frontend/src/components/workload/Overview.test.tsx
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import type React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Overview from './Overview';
+
+const { namespacesMock, workloadMocks } = vi.hoisted(() => {
+  const kinds = [
+    'cronJob',
+    'daemonSet',
+    'deployment',
+    'job',
+    'jobSet',
+    'pod',
+    'replicaSet',
+    'statefulSet',
+  ];
+
+  return {
+    namespacesMock: vi.fn((): string[] => []),
+    workloadMocks: Object.fromEntries(
+      kinds.map(kind => [kind, vi.fn(() => [[]] as any)])
+    ) as Record<string, ReturnType<typeof vi.fn>>,
+  };
+});
+
+vi.mock('react-i18next', async importOriginal => ({
+  ...(await importOriginal<typeof import('react-i18next')>()),
+  useTranslation: () => ({ t: (key: string) => key.split('|').pop() }),
+}));
+
+vi.mock('../../lib/k8s/cronJob', () => ({
+  default: { className: 'CronJob', pluralName: 'cronjobs', useList: workloadMocks.cronJob },
+}));
+vi.mock('../../lib/k8s/daemonSet', () => ({
+  default: { className: 'DaemonSet', pluralName: 'daemonsets', useList: workloadMocks.daemonSet },
+}));
+vi.mock('../../lib/k8s/deployment', () => ({
+  default: {
+    className: 'Deployment',
+    pluralName: 'deployments',
+    useList: workloadMocks.deployment,
+  },
+}));
+vi.mock('../../lib/k8s/job', () => ({
+  default: { className: 'Job', pluralName: 'jobs', useList: workloadMocks.job },
+}));
+vi.mock('../../lib/k8s/jobSet', () => ({
+  default: { className: 'JobSet', pluralName: 'jobsets', useList: workloadMocks.jobSet },
+}));
+vi.mock('../../lib/k8s/pod', () => ({
+  default: { className: 'Pod', pluralName: 'pods', useList: workloadMocks.pod },
+}));
+vi.mock('../../lib/k8s/replicaSet', () => ({
+  default: {
+    className: 'ReplicaSet',
+    pluralName: 'replicasets',
+    useList: workloadMocks.replicaSet,
+  },
+}));
+vi.mock('../../lib/k8s/statefulSet', () => ({
+  default: {
+    className: 'StatefulSet',
+    pluralName: 'statefulsets',
+    useList: workloadMocks.statefulSet,
+  },
+}));
+
+vi.mock('../../lib/util', () => ({
+  getReadyReplicas: () => 0,
+  getTotalReplicas: () => 0,
+}));
+
+vi.mock('../../redux/filterSlice', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../redux/filterSlice')>()),
+  useNamespaces: namespacesMock,
+}));
+
+vi.mock('../cluster/ClusterGroupErrorMessage', () => ({
+  ClusterGroupErrorMessage: ({ errors }: { errors: { status?: number }[] }) => (
+    <div>{`errors:${errors.map(error => error.status).join(',')}`}</div>
+  ),
+}));
+
+vi.mock('../common/Link', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock('../common/Resource', () => ({
+  PageGrid: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('../common/Resource/ResourceListView', () => ({
+  default: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+
+vi.mock('../common/SectionBox', () => ({
+  SectionBox: ({ children }: { children: React.ReactNode }) => <section>{children}</section>,
+}));
+
+vi.mock('./Charts', () => ({
+  WorkloadCircleChart: () => <div>chart</div>,
+}));
+
+vi.mock('../common/TileChart', () => ({
+  default: ({ title, legend }: { title: string; legend: string }) => (
+    <div>{`${title}:${legend}`}</div>
+  ),
+}));
+
+const renderOverview = () =>
+  render(
+    <MemoryRouter>
+      <Overview />
+    </MemoryRouter>
+  );
+
+describe('Workload Overview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    namespacesMock.mockReturnValue([]);
+    Object.values(workloadMocks).forEach(useList => useList.mockReturnValue([[]]));
+  });
+
+  // Without the namespaces a restricted user's charts count nothing, since the cluster-wide
+  // list they fall back to is forbidden.
+  it('scopes every workload list to the selected namespaces', () => {
+    namespacesMock.mockReturnValue(['team-a']);
+
+    renderOverview();
+
+    Object.entries(workloadMocks).forEach(([kind, useList]) => {
+      expect(useList, kind).toHaveBeenCalledWith({ namespace: ['team-a'] });
+    });
+  });
+
+  // Charting a forbidden list as zero is the symptom this page is fixing, so the kinds that
+  // could not be listed say so instead.
+  it('replaces the chart of a forbidden kind rather than counting it as zero', () => {
+    workloadMocks.pod.mockReturnValue([null, { status: 403, message: 'pods is forbidden' }]);
+
+    renderOverview();
+
+    expect(screen.getByText('Pods:Unavailable')).toBeInTheDocument();
+    expect(screen.getAllByText('chart')).toHaveLength(7);
+  });
+
+  // One namespace being forbidden does not make the others uncountable, so a list that
+  // returned something keeps its chart.
+  it('keeps the chart of a kind whose list only partly failed', () => {
+    workloadMocks.pod.mockReturnValue([[{}], { status: 403, message: 'pods is forbidden' }]);
+
+    renderOverview();
+
+    expect(screen.getAllByText('chart')).toHaveLength(8);
+    expect(screen.queryByText('Pods:Unavailable')).not.toBeInTheDocument();
+    expect(screen.getByText('errors:403')).toBeInTheDocument();
+  });
+
+  it('reports failures once rather than per workload kind', () => {
+    workloadMocks.pod.mockReturnValue([null, { status: 403, message: 'pods is forbidden' }]);
+    workloadMocks.job.mockReturnValue([null, { status: 403, message: 'jobs is forbidden' }]);
+    workloadMocks.deployment.mockReturnValue([null, { status: 500, message: 'boom' }]);
+
+    renderOverview();
+
+    expect(screen.getByText('errors:403,500')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/workload/Overview.test.tsx
+++ b/frontend/src/components/workload/Overview.test.tsx
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import type React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Overview from './Overview';
+
+const { namespacesMock, workloadMocks } = vi.hoisted(() => {
+  const kinds = [
+    'cronJob',
+    'daemonSet',
+    'deployment',
+    'job',
+    'jobSet',
+    'leaderWorkerSet',
+    'pod',
+    'replicaSet',
+    'statefulSet',
+  ];
+
+  return {
+    namespacesMock: vi.fn((): string[] => []),
+    workloadMocks: Object.fromEntries(
+      kinds.map(kind => [kind, vi.fn(() => ({ items: [], errors: null } as any))])
+    ) as Record<string, ReturnType<typeof vi.fn>>,
+  };
+});
+
+/**
+ * A list reports one error per namespace or cluster it asked, so the mocks mirror the
+ * `errors` array the real hook returns rather than a single error.
+ */
+function listResult(items: object[] | null, ...errors: { status?: number; message?: string }[]) {
+  return {
+    items,
+    errors: errors.length ? errors : null,
+    isSuccess: errors.length === 0,
+    // One result per cluster that answered, so null items stand for every request failing.
+    clusterResults: items === null ? {} : { 'test-cluster': { items } },
+  };
+}
+
+vi.mock('react-i18next', async importOriginal => ({
+  ...(await importOriginal<typeof import('react-i18next')>()),
+  useTranslation: () => ({ t: (key: string) => key.split('|').pop() }),
+}));
+
+vi.mock('../../lib/k8s/cronJob', () => ({
+  default: { className: 'CronJob', pluralName: 'cronjobs', useList: workloadMocks.cronJob },
+}));
+vi.mock('../../lib/k8s/daemonSet', () => ({
+  default: { className: 'DaemonSet', pluralName: 'daemonsets', useList: workloadMocks.daemonSet },
+}));
+vi.mock('../../lib/k8s/deployment', () => ({
+  default: {
+    className: 'Deployment',
+    pluralName: 'deployments',
+    useList: workloadMocks.deployment,
+  },
+}));
+vi.mock('../../lib/k8s/job', () => ({
+  default: { className: 'Job', pluralName: 'jobs', useList: workloadMocks.job },
+}));
+vi.mock('../../lib/k8s/jobSet', () => ({
+  default: { className: 'JobSet', pluralName: 'jobsets', useList: workloadMocks.jobSet },
+}));
+vi.mock('../../lib/k8s/leaderWorkerSet', () => ({
+  default: {
+    className: 'LeaderWorkerSet',
+    pluralName: 'leaderworkersets',
+    useList: workloadMocks.leaderWorkerSet,
+  },
+}));
+vi.mock('../../lib/k8s/pod', () => ({
+  default: { className: 'Pod', pluralName: 'pods', useList: workloadMocks.pod },
+}));
+vi.mock('../../lib/k8s/replicaSet', () => ({
+  default: {
+    className: 'ReplicaSet',
+    pluralName: 'replicasets',
+    useList: workloadMocks.replicaSet,
+  },
+}));
+vi.mock('../../lib/k8s/statefulSet', () => ({
+  default: {
+    className: 'StatefulSet',
+    pluralName: 'statefulsets',
+    useList: workloadMocks.statefulSet,
+  },
+}));
+
+vi.mock('../../lib/util', () => ({
+  getReadyReplicas: () => 0,
+  getTotalReplicas: () => 0,
+}));
+
+vi.mock('../../redux/filterSlice', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../redux/filterSlice')>()),
+  useNamespaces: namespacesMock,
+}));
+
+vi.mock('../cluster/ClusterGroupErrorMessage', () => ({
+  ClusterGroupErrorMessage: ({ errors }: { errors: { status?: number }[] }) => (
+    <div>{`errors:${errors.map(error => error.status).join(',')}`}</div>
+  ),
+}));
+
+vi.mock('../common/Link', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock('../common/Resource', () => ({
+  PageGrid: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('../common/Resource/ResourceListView', () => ({
+  default: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+
+vi.mock('../common/SectionBox', () => ({
+  SectionBox: ({ children }: { children: React.ReactNode }) => <section>{children}</section>,
+}));
+
+vi.mock('./Charts', () => ({
+  WorkloadCircleChart: () => <div>chart</div>,
+}));
+
+vi.mock('../common/TileChart', () => ({
+  default: ({ title, legend }: { title: string; legend: string }) => (
+    <div>{`${title}:${legend}`}</div>
+  ),
+}));
+
+const renderOverview = () =>
+  render(
+    <MemoryRouter>
+      <Overview />
+    </MemoryRouter>
+  );
+
+describe('Workload Overview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    namespacesMock.mockReturnValue([]);
+    Object.values(workloadMocks).forEach(useList => useList.mockReturnValue(listResult([])));
+  });
+
+  // Without the namespaces a restricted user's charts count nothing, since the cluster-wide
+  // list they fall back to is forbidden.
+  it('scopes every workload list to the selected namespaces', () => {
+    namespacesMock.mockReturnValue(['team-a']);
+
+    renderOverview();
+
+    Object.entries(workloadMocks).forEach(([kind, useList]) => {
+      expect(useList, kind).toHaveBeenCalledWith({ namespace: ['team-a'] });
+    });
+  });
+
+  // Charting a forbidden list as zero is the symptom this page is fixing, so the kinds that
+  // could not be listed say so instead.
+  it('replaces the chart of a forbidden kind rather than counting it as zero', () => {
+    workloadMocks.pod.mockReturnValue(
+      listResult(null, { status: 403, message: 'pods is forbidden' })
+    );
+
+    renderOverview();
+
+    expect(screen.getByText('Pods:Unavailable')).toBeInTheDocument();
+    expect(screen.getAllByText('chart')).toHaveLength(8);
+  });
+
+  // One namespace answering with nothing is still an answer: the count it contributes is a
+  // real zero, so the chart has to keep it rather than claim the kind could not be listed.
+  it('keeps the chart of a kind whose partly failed list answered with no items', () => {
+    workloadMocks.pod.mockReturnValue(listResult([], { status: 403 }));
+
+    renderOverview();
+
+    expect(screen.getAllByText('chart')).toHaveLength(9);
+    expect(screen.queryByText('Pods:Unavailable')).not.toBeInTheDocument();
+    expect(screen.getByText('errors:403')).toBeInTheDocument();
+  });
+
+  // One namespace being forbidden does not make the others uncountable, so a list that
+  // returned something keeps its chart.
+  it('keeps the chart of a kind whose list only partly failed', () => {
+    workloadMocks.pod.mockReturnValue(
+      listResult([{}], { status: 403, message: 'pods is forbidden' })
+    );
+
+    renderOverview();
+
+    expect(screen.getAllByText('chart')).toHaveLength(9);
+    expect(screen.queryByText('Pods:Unavailable')).not.toBeInTheDocument();
+    expect(screen.getByText('errors:403')).toBeInTheDocument();
+  });
+
+  // Every namespace of a fanned out list reports its own failure, and reading only the
+  // first one drops the rest along with the hint their status would have raised.
+  it('reports every error of a partly failed list, not only the first', () => {
+    workloadMocks.pod.mockReturnValue(listResult([{}], { status: 500 }, { status: 403 }));
+
+    renderOverview();
+
+    expect(screen.getAllByText('chart')).toHaveLength(9);
+    expect(screen.getByText('errors:500,403')).toBeInTheDocument();
+  });
+
+  it('reports failures once rather than per workload kind', () => {
+    workloadMocks.pod.mockReturnValue(
+      listResult(null, { status: 403, message: 'pods is forbidden' })
+    );
+    workloadMocks.job.mockReturnValue(
+      listResult(null, { status: 403, message: 'jobs is forbidden' })
+    );
+    workloadMocks.deployment.mockReturnValue(listResult(null, { status: 500, message: 'boom' }));
+
+    renderOverview();
+
+    expect(screen.getByText('errors:403,500')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/workload/Overview.tsx
+++ b/frontend/src/components/workload/Overview.tsx
@@ -15,8 +15,10 @@
  */
 
 import Grid from '@mui/material/Grid';
+import { uniqBy } from 'lodash';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import type { ApiError } from '../../lib/k8s/api/v2/ApiError';
 import CronJob from '../../lib/k8s/cronJob';
 import DaemonSet from '../../lib/k8s/daemonSet';
 import Deployment from '../../lib/k8s/deployment';
@@ -27,10 +29,13 @@ import ReplicaSet from '../../lib/k8s/replicaSet';
 import StatefulSet from '../../lib/k8s/statefulSet';
 import type { Workload, WorkloadClass } from '../../lib/k8s/Workload';
 import { getReadyReplicas, getTotalReplicas } from '../../lib/util';
+import { useNamespaces } from '../../redux/filterSlice';
+import { ClusterGroupErrorMessage } from '../cluster/ClusterGroupErrorMessage';
 import Link from '../common/Link';
 import { PageGrid } from '../common/Resource';
 import ResourceListView from '../common/Resource/ResourceListView';
 import { SectionBox } from '../common/SectionBox';
+import TileChart from '../common/TileChart';
 import { WorkloadCircleChart } from './Charts';
 
 interface WorkloadDict {
@@ -38,14 +43,55 @@ interface WorkloadDict {
 }
 
 export default function Overview() {
-  const [pods] = Pod.useList();
-  const [deployments] = Deployment.useList();
-  const [statefulSets] = StatefulSet.useList();
-  const [daemonSets] = DaemonSet.useList();
-  const [replicaSets] = ReplicaSet.useList();
-  const [jobs] = Job.useList();
-  const [cronJobs] = CronJob.useList();
-  const [jobSets] = JobSet.useList();
+  const namespaces = useNamespaces();
+
+  const listOptions = { namespace: namespaces };
+  const [pods, podsError] = Pod.useList(listOptions);
+  const [deployments, deploymentsError] = Deployment.useList(listOptions);
+  const [statefulSets, statefulSetsError] = StatefulSet.useList(listOptions);
+  const [daemonSets, daemonSetsError] = DaemonSet.useList(listOptions);
+  const [replicaSets, replicaSetsError] = ReplicaSet.useList(listOptions);
+  const [jobs, jobsError] = Job.useList(listOptions);
+  const [cronJobs, cronJobsError] = CronJob.useList(listOptions);
+  const [jobSets, jobSetsError] = JobSet.useList(listOptions);
+
+  const workloadErrors: Record<string, ApiError | null> = {
+    [Pod.className]: podsError,
+    [Deployment.className]: deploymentsError,
+    [StatefulSet.className]: statefulSetsError,
+    [DaemonSet.className]: daemonSetsError,
+    [ReplicaSet.className]: replicaSetsError,
+    [Job.className]: jobsError,
+    [CronJob.className]: cronJobsError,
+    [JobSet.className]: jobSetsError,
+  };
+
+  const listErrors = useMemo(
+    () =>
+      uniqBy(
+        [
+          podsError,
+          deploymentsError,
+          statefulSetsError,
+          daemonSetsError,
+          replicaSetsError,
+          jobsError,
+          cronJobsError,
+          jobSetsError,
+        ].filter((error): error is ApiError => !!error),
+        error => error.status
+      ),
+    [
+      podsError,
+      deploymentsError,
+      statefulSetsError,
+      daemonSetsError,
+      replicaSetsError,
+      jobsError,
+      cronJobsError,
+      jobSetsError,
+    ]
+  );
 
   const workloadsData: WorkloadDict = useMemo(
     () => ({
@@ -136,26 +182,39 @@ export default function Overview() {
   return (
     <PageGrid>
       <SectionBox py={2} mt={1}>
+        <ClusterGroupErrorMessage errors={listErrors} namespacedResource />
         <Grid container justifyContent="flex-start" alignItems="flex-start" spacing={2}>
-          {workloads.map(workload => (
-            <Grid item lg={3} md={4} xs={6} key={workload.className} style={{ minWidth: 0 }}>
-              <WorkloadCircleChart
-                workloadData={workloadsData[workload.className] || null}
-                title={<ChartLink workload={workload} />}
-                partialLabel={t('translation|Failed')}
-                totalLabel={
-                  workload === Pod || jobHealth[workload.className]
-                    ? t('translation|Healthy')
-                    : t('translation|Running')
-                }
-                categorize={
-                  workload === Pod
-                    ? item => (item as Pod).getHealth()
-                    : jobHealth[workload.className]
-                }
-              />
-            </Grid>
-          ))}
+          {workloads.map(workload => {
+            const items = workloadsData[workload.className];
+            const error = workloadErrors[workload.className];
+
+            return (
+              <Grid item lg={3} md={4} xs={6} key={workload.className} style={{ minWidth: 0 }}>
+                {error && !items.length ? (
+                  <TileChart
+                    title={workloadLabel[workload.className]}
+                    legend={t('translation|Unavailable')}
+                  />
+                ) : (
+                  <WorkloadCircleChart
+                    workloadData={items || null}
+                    title={<ChartLink workload={workload} />}
+                    partialLabel={t('translation|Failed')}
+                    totalLabel={
+                      workload === Pod || jobHealth[workload.className]
+                        ? t('translation|Healthy')
+                        : t('translation|Running')
+                    }
+                    categorize={
+                      workload === Pod
+                        ? item => (item as Pod).getHealth()
+                        : jobHealth[workload.className]
+                    }
+                  />
+                )}
+              </Grid>
+            );
+          })}
         </Grid>
       </SectionBox>
       <ResourceListView

--- a/frontend/src/components/workload/Overview.tsx
+++ b/frontend/src/components/workload/Overview.tsx
@@ -15,8 +15,11 @@
  */
 
 import Grid from '@mui/material/Grid';
+import { uniqBy } from 'lodash';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import type { ApiError } from '../../lib/k8s/api/v2/ApiError';
+import { hasListResults } from '../../lib/k8s/api/v2/useKubeObjectList';
 import CronJob from '../../lib/k8s/cronJob';
 import DaemonSet from '../../lib/k8s/daemonSet';
 import Deployment from '../../lib/k8s/deployment';
@@ -28,10 +31,13 @@ import ReplicaSet from '../../lib/k8s/replicaSet';
 import StatefulSet from '../../lib/k8s/statefulSet';
 import type { Workload, WorkloadClass } from '../../lib/k8s/Workload';
 import { getReadyReplicas, getTotalReplicas } from '../../lib/util';
+import { useNamespaces } from '../../redux/filterSlice';
+import { ClusterGroupErrorMessage } from '../cluster/ClusterGroupErrorMessage';
 import Link from '../common/Link';
 import { PageGrid } from '../common/Resource';
 import ResourceListView from '../common/Resource/ResourceListView';
 import { SectionBox } from '../common/SectionBox';
+import TileChart from '../common/TileChart';
 import { WorkloadCircleChart } from './Charts';
 
 interface WorkloadDict {
@@ -39,15 +45,86 @@ interface WorkloadDict {
 }
 
 export default function Overview() {
-  const [pods] = Pod.useList();
-  const [deployments] = Deployment.useList();
-  const [statefulSets] = StatefulSet.useList();
-  const [daemonSets] = DaemonSet.useList();
-  const [replicaSets] = ReplicaSet.useList();
-  const [jobs] = Job.useList();
-  const [cronJobs] = CronJob.useList();
-  const [jobSets] = JobSet.useList();
-  const [leaderWorkerSets] = LeaderWorkerSet.useList();
+  const namespaces = useNamespaces();
+
+  const listOptions = { namespace: namespaces };
+  // A list fans out over the namespaces and clusters it was asked for and reports an error
+  // for each request that failed, so every query is kept whole. Reading only the first error
+  // hides a later failure with another status, and with it the hint its status would raise.
+  const podsQuery = Pod.useList(listOptions);
+  const deploymentsQuery = Deployment.useList(listOptions);
+  const statefulSetsQuery = StatefulSet.useList(listOptions);
+  const daemonSetsQuery = DaemonSet.useList(listOptions);
+  const replicaSetsQuery = ReplicaSet.useList(listOptions);
+  const jobsQuery = Job.useList(listOptions);
+  const cronJobsQuery = CronJob.useList(listOptions);
+  const jobSetsQuery = JobSet.useList(listOptions);
+  const leaderWorkerSetsQuery = LeaderWorkerSet.useList(listOptions);
+
+  const pods = podsQuery.items;
+  const deployments = deploymentsQuery.items;
+  const statefulSets = statefulSetsQuery.items;
+  const daemonSets = daemonSetsQuery.items;
+  const replicaSets = replicaSetsQuery.items;
+  const jobs = jobsQuery.items;
+  const cronJobs = cronJobsQuery.items;
+  const jobSets = jobSetsQuery.items;
+  const leaderWorkerSets = leaderWorkerSetsQuery.items;
+
+  // A namespace that answered with nothing contributes a real zero, so the charts go by
+  // whether any request answered rather than by whether the answer holds an item.
+  const workloadHasData: Record<string, boolean> = {
+    [Pod.className]: hasListResults(podsQuery),
+    [Deployment.className]: hasListResults(deploymentsQuery),
+    [StatefulSet.className]: hasListResults(statefulSetsQuery),
+    [DaemonSet.className]: hasListResults(daemonSetsQuery),
+    [ReplicaSet.className]: hasListResults(replicaSetsQuery),
+    [Job.className]: hasListResults(jobsQuery),
+    [CronJob.className]: hasListResults(cronJobsQuery),
+    [JobSet.className]: hasListResults(jobSetsQuery),
+    [LeaderWorkerSet.className]: hasListResults(leaderWorkerSetsQuery),
+  };
+
+  const workloadErrors: Record<string, ApiError[] | null> = {
+    [Pod.className]: podsQuery.errors,
+    [Deployment.className]: deploymentsQuery.errors,
+    [StatefulSet.className]: statefulSetsQuery.errors,
+    [DaemonSet.className]: daemonSetsQuery.errors,
+    [ReplicaSet.className]: replicaSetsQuery.errors,
+    [Job.className]: jobsQuery.errors,
+    [CronJob.className]: cronJobsQuery.errors,
+    [JobSet.className]: jobSetsQuery.errors,
+    [LeaderWorkerSet.className]: leaderWorkerSetsQuery.errors,
+  };
+
+  const listErrors = useMemo(
+    () =>
+      uniqBy(
+        [
+          podsQuery.errors,
+          deploymentsQuery.errors,
+          statefulSetsQuery.errors,
+          daemonSetsQuery.errors,
+          replicaSetsQuery.errors,
+          jobsQuery.errors,
+          cronJobsQuery.errors,
+          jobSetsQuery.errors,
+          leaderWorkerSetsQuery.errors,
+        ].flatMap(errors => errors ?? []),
+        error => error.status
+      ),
+    [
+      podsQuery.errors,
+      deploymentsQuery.errors,
+      statefulSetsQuery.errors,
+      daemonSetsQuery.errors,
+      replicaSetsQuery.errors,
+      jobsQuery.errors,
+      cronJobsQuery.errors,
+      jobSetsQuery.errors,
+      leaderWorkerSetsQuery.errors,
+    ]
+  );
 
   const workloadsData: WorkloadDict = useMemo(
     () => ({
@@ -156,26 +233,39 @@ export default function Overview() {
   return (
     <PageGrid>
       <SectionBox py={2} mt={1}>
+        <ClusterGroupErrorMessage errors={listErrors} namespacedResource />
         <Grid container justifyContent="flex-start" alignItems="flex-start" spacing={2}>
-          {workloads.map(workload => (
-            <Grid item lg={3} md={4} xs={6} key={workload.className} style={{ minWidth: 0 }}>
-              <WorkloadCircleChart
-                workloadData={workloadsData[workload.className] || null}
-                title={<ChartLink workload={workload} />}
-                partialLabel={t('translation|Failed')}
-                totalLabel={
-                  workload === Pod || perItemHealth[workload.className]
-                    ? t('translation|Healthy')
-                    : t('translation|Running')
-                }
-                categorize={
-                  workload === Pod
-                    ? item => (item as Pod).getHealth()
-                    : perItemHealth[workload.className]
-                }
-              />
-            </Grid>
-          ))}
+          {workloads.map(workload => {
+            const items = workloadsData[workload.className];
+            const errors = workloadErrors[workload.className];
+
+            return (
+              <Grid item lg={3} md={4} xs={6} key={workload.className} style={{ minWidth: 0 }}>
+                {!!errors?.length && !workloadHasData[workload.className] ? (
+                  <TileChart
+                    title={workloadLabel[workload.className]}
+                    legend={t('translation|Unavailable')}
+                  />
+                ) : (
+                  <WorkloadCircleChart
+                    workloadData={items || null}
+                    title={<ChartLink workload={workload} />}
+                    partialLabel={t('translation|Failed')}
+                    totalLabel={
+                      workload === Pod || perItemHealth[workload.className]
+                        ? t('translation|Healthy')
+                        : t('translation|Running')
+                    }
+                    categorize={
+                      workload === Pod
+                        ? item => (item as Pod).getHealth()
+                        : perItemHealth[workload.className]
+                    }
+                  />
+                )}
+              </Grid>
+            );
+          })}
         </Grid>
       </SectionBox>
       <ResourceListView

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -264,6 +264,7 @@
   "{{count}} clusters_other": "{{count}} كتل",
   "Current//context:cluster": "الحالي",
   "Choose cluster": "اختر كتلة",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "فشل تحميل الموارد",
   "You don't have permissions to view this resource": "ليس لديك صلاحية لعرض هذا المورد",
   "Resource not found": "المورد غير موجود",

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -249,6 +249,7 @@
   "{{count}} clusters_other": "{{count}} كتل",
   "Current//context:cluster": "الحالي",
   "Choose cluster": "اختر كتلة",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "فشل تحميل الموارد",
   "You don't have permissions to view this resource": "ليس لديك صلاحية لعرض هذا المورد",
   "Resource not found": "المورد غير موجود",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -260,6 +260,7 @@
   "{{count}} clusters_other": "{{count}} Cluster",
   "Current//context:cluster": "কারেন্ট",
   "Choose cluster": "Cluster চয়ন করুন",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "resources লোড করতে Failed",
   "You don't have permissions to view this resource": "এই resourcesটি দেখার জন্য আপনার অনুমতি নেই",
   "Resource not found": "Resource পাওয়া যায় নি",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -245,6 +245,7 @@
   "{{count}} clusters_other": "{{count}} Cluster",
   "Current//context:cluster": "কারেন্ট",
   "Choose cluster": "Cluster চয়ন করুন",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "resources লোড করতে Failed",
   "You don't have permissions to view this resource": "এই resourcesটি দেখার জন্য আপনার অনুমতি নেই",
   "Resource not found": "Resource পাওয়া যায় নি",

--- a/frontend/src/i18n/locales/cs/translation.json
+++ b/frontend/src/i18n/locales/cs/translation.json
@@ -262,6 +262,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "Aktuální",
   "Choose cluster": "Zvolte cluster.",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "Nepovedlo se načíst prostředky.",
   "You don't have permissions to view this resource": "Nemáte oprávnění k zobrazení tohoto prostředku.",
   "Resource not found": "Prostředek se nenašel",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -245,6 +245,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "",
   "Choose cluster": "",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "",
   "You don't have permissions to view this resource": "",
   "Resource not found": "",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -260,6 +260,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "Aktuell",
   "Choose cluster": "Cluster auswählen",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "",
   "You don't have permissions to view this resource": "",
   "Resource not found": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -245,6 +245,7 @@
   "{{count}} clusters_other": "{{count}} clusters",
   "Current//context:cluster": "Current",
   "Choose cluster": "Choose cluster",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.",
   "Failed to load resources": "Failed to load resources",
   "You don't have permissions to view this resource": "You don't have permissions to view this resource",
   "Resource not found": "Resource not found",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -260,6 +260,7 @@
   "{{count}} clusters_other": "{{count}} clusters",
   "Current//context:cluster": "Current",
   "Choose cluster": "Choose cluster",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.",
   "Failed to load resources": "Failed to load resources",
   "You don't have permissions to view this resource": "You don't have permissions to view this resource",
   "Resource not found": "Resource not found",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -246,6 +246,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "",
   "Choose cluster": "",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "",
   "You don't have permissions to view this resource": "",
   "Resource not found": "",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -261,6 +261,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "Actuales",
   "Choose cluster": "Elegir cluster",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "Fallo al cargar recursos",
   "You don't have permissions to view this resource": "No tiene permisos para ver este recurso",
   "Resource not found": "Recurso no encontrado",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -261,6 +261,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "Actuel",
   "Choose cluster": "Choisir un cluster",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "Échec du chargement des ressources",
   "You don't have permissions to view this resource": "Vous n'avez pas les permissions pour voir cette ressource",
   "Resource not found": "Ressource non trouvée",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -246,6 +246,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "",
   "Choose cluster": "",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "",
   "You don't have permissions to view this resource": "",
   "Resource not found": "",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -246,6 +246,7 @@
   "{{count}} clusters_other": "{{count}} clusters",
   "Current//context:cluster": "Current",
   "Choose cluster": "Choose cluster",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "Failed to load resources",
   "You don't have permissions to view this resource": "You don't have permissions to view this resource",
   "Resource not found": "Resource not found",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -261,6 +261,7 @@
   "{{count}} clusters_other": "{{count}} clusters",
   "Current//context:cluster": "Current",
   "Choose cluster": "Choose cluster",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "Failed to load resources",
   "You don't have permissions to view this resource": "You don't have permissions to view this resource",
   "Resource not found": "Resource not found",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -245,6 +245,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "",
   "Choose cluster": "",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "",
   "You don't have permissions to view this resource": "",
   "Resource not found": "",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -260,6 +260,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "",
   "Choose cluster": "",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "",
   "You don't have permissions to view this resource": "",
   "Resource not found": "",

--- a/frontend/src/i18n/locales/hu/translation.json
+++ b/frontend/src/i18n/locales/hu/translation.json
@@ -260,6 +260,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "Aktuális",
   "Choose cluster": "Fürt kiválasztása",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "Nem sikerült betölteni az erőforrásokat",
   "You don't have permissions to view this resource": "Nem jogosult az erőforrás megtekintésére",
   "Resource not found": "Az erőforrás nem található",

--- a/frontend/src/i18n/locales/id/translation.json
+++ b/frontend/src/i18n/locales/id/translation.json
@@ -259,6 +259,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "Saat ini",
   "Choose cluster": "Pilih kluster",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "Gagal memuat sumber daya",
   "You don't have permissions to view this resource": "Anda tidak memiliki izin untuk melihat sumber daya ini",
   "Resource not found": "Sumber daya tidak ditemukan",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -246,6 +246,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "",
   "Choose cluster": "",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "",
   "You don't have permissions to view this resource": "",
   "Resource not found": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -261,6 +261,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "Corrente//context:cluster",
   "Choose cluster": "Scegli cluster",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "Impossibile caricare le risorse",
   "You don't have permissions to view this resource": "Non hai i permessi per visualizzare questa risorsa",
   "Resource not found": "Risorsa non trovata",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -244,6 +244,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "",
   "Choose cluster": "",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "",
   "You don't have permissions to view this resource": "",
   "Resource not found": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -259,6 +259,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "現在",
   "Choose cluster": "クラスターを選択",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "リソースの読み込みに失敗しました",
   "You don't have permissions to view this resource": "このリソースを表示する権限がありません",
   "Resource not found": "リソースが見つかりません",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -244,6 +244,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "",
   "Choose cluster": "",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "",
   "You don't have permissions to view this resource": "",
   "Resource not found": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -259,6 +259,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "Current",
   "Choose cluster": "클러스터 선택",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "리소스를 불러오는 데 실패했습니다",
   "You don't have permissions to view this resource": "이 리소스를 볼 권한이 없습니다",
   "Resource not found": "리소스를 찾을 수 없습니다",

--- a/frontend/src/i18n/locales/nl/translation.json
+++ b/frontend/src/i18n/locales/nl/translation.json
@@ -260,6 +260,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "Huidig",
   "Choose cluster": "Een cluster kiezen",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "Kan de resources niet laden.",
   "You don't have permissions to view this resource": "U bent niet gemachtigd om deze resource weer te geven",
   "Resource not found": "Resource niet gevonden",

--- a/frontend/src/i18n/locales/pl/translation.json
+++ b/frontend/src/i18n/locales/pl/translation.json
@@ -262,6 +262,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "Bieżący",
   "Choose cluster": "Wybierz klaster",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "Nie można załadować zasobów",
   "You don't have permissions to view this resource": "Nie masz uprawnień do wyświetlania tego zasobu",
   "Resource not found": "Nie znaleziono zasobu",

--- a/frontend/src/i18n/locales/pt-br/translation.json
+++ b/frontend/src/i18n/locales/pt-br/translation.json
@@ -261,6 +261,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "Actual",
   "Choose cluster": "Escolha o cluster",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "Falha ao carregar recursos",
   "You don't have permissions to view this resource": "Não tem permissões para ver este recurso",
   "Resource not found": "Recurso não encontrado",

--- a/frontend/src/i18n/locales/pt-pt/translation.json
+++ b/frontend/src/i18n/locales/pt-pt/translation.json
@@ -261,6 +261,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "",
   "Choose cluster": "",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "",
   "You don't have permissions to view this resource": "",
   "Resource not found": "",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -246,6 +246,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "",
   "Choose cluster": "",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "",
   "You don't have permissions to view this resource": "",
   "Resource not found": "",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -247,6 +247,7 @@
   "{{count}} clusters_other": "{{count}} кластеров",
   "Current//context:cluster": "Текущий",
   "Choose cluster": "Выберите кластер",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "Не удалось загрузить ресурсы",
   "You don't have permissions to view this resource": "У вас нет разрешений для просмотра этого ресурса",
   "Resource not found": "Ресурс не найден",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -262,6 +262,7 @@
   "{{count}} clusters_other": "{{count}} кластеров",
   "Current//context:cluster": "Текущий",
   "Choose cluster": "Выберите кластер",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "Не удалось загрузить ресурсы",
   "You don't have permissions to view this resource": "У вас нет разрешений для просмотра этого ресурса",
   "Resource not found": "Ресурс не найден",

--- a/frontend/src/i18n/locales/sv/translation.json
+++ b/frontend/src/i18n/locales/sv/translation.json
@@ -260,6 +260,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "Nuvarande",
   "Choose cluster": "Välj kluster",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "Det gick inte att läsa in resurserna",
   "You don't have permissions to view this resource": "Du har inte behörighet att visa den här resursen",
   "Resource not found": "Det gick inte att hitta resursen",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -260,6 +260,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "தற்போதைய",
   "Choose cluster": "க்ளஸ்டர் தேர்ந்தெடுக்கவும்",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "ரிசோர்ஸ்களை ஏற்றுவதில் தோல்வி",
   "You don't have permissions to view this resource": "இந்த ரிசோர்ஸைப் பார்க்க உங்களுக்கு அனுமதிகள் இல்லை",
   "Resource not found": "ரிசோர்ஸ் கிடைக்கவில்லை",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -245,6 +245,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "",
   "Choose cluster": "",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "",
   "You don't have permissions to view this resource": "",
   "Resource not found": "",

--- a/frontend/src/i18n/locales/tr/translation.json
+++ b/frontend/src/i18n/locales/tr/translation.json
@@ -260,6 +260,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "Geçerli",
   "Choose cluster": "Küme seçin",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "Kaynaklar yüklenemedi",
   "You don't have permissions to view this resource": "Bu kaynağı görüntüleme izniniz yok",
   "Resource not found": "Kaynak bulunamadı",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -245,6 +245,7 @@
   "{{count}} clusters_other": "{{count}} کلسٹرز",
   "Current//context:cluster": "موجودہ",
   "Choose cluster": "کلسٹر منتخب کریں",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "وسائل لوڈ نہیں ہو سکے",
   "You don't have permissions to view this resource": "آپ کو یہ وسیلہ دیکھنے کی اجازت نہیں ہے",
   "Resource not found": "وسیلہ نہیں ملا",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -260,6 +260,7 @@
   "{{count}} clusters_other": "{{count}} کلسٹرز",
   "Current//context:cluster": "موجودہ",
   "Choose cluster": "کلسٹر منتخب کریں",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "وسائل لوڈ نہیں ہو سکے",
   "You don't have permissions to view this resource": "آپ کو یہ وسیلہ دیکھنے کی اجازت نہیں ہے",
   "Resource not found": "وسیلہ نہیں ملا",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -244,6 +244,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "",
   "Choose cluster": "",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "",
   "You don't have permissions to view this resource": "",
   "Resource not found": "",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -259,6 +259,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "當前",
   "Choose cluster": "選擇叢集",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "無法讀取資源",
   "You don't have permissions to view this resource": "您沒有許可權檢視此資源",
   "Resource not found": "資源未找到",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -244,6 +244,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "",
   "Choose cluster": "",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "",
   "You don't have permissions to view this resource": "",
   "Resource not found": "",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -259,6 +259,7 @@
   "{{count}} clusters_other": "",
   "Current//context:cluster": "当前",
   "Choose cluster": "选择集群",
+  "Headlamp is requesting resources across the whole cluster. If you only have access to some namespaces, list them under Allowed namespaces in the cluster settings.": "",
   "Failed to load resources": "无法读取资源",
   "You don't have permissions to view this resource": "您没有权限查看此资源",
   "Resource not found": "资源未找到",

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -185,6 +185,22 @@ function allowedNamespaceListQuery<K extends KubeObject>(
  * @param queryParams - query parameters
  * @returns query options for getting a single list of kube resources
  */
+/**
+ * Whether any of the requests a list fanned out over answered.
+ *
+ * A list keeps a result for every cluster that responded, so an empty set of them means
+ * each request failed. An empty item list means something else: the requests that did
+ * answer found nothing, and a count of zero is then the answer rather than the lack of one.
+ *
+ * @param query - The list query to inspect.
+ * @returns Whether at least one request returned data.
+ */
+export function hasListResults(
+  query: Pick<QueryListResponse<any, any, any>, 'clusterResults'>
+): boolean {
+  return Object.keys(query.clusterResults ?? {}).length > 0;
+}
+
 export function kubeObjectListQuery<K extends KubeObject>(
   kubeObjectClass: KubeObjectClass,
   endpoint: KubeObjectEndpoint,


### PR DESCRIPTION
## Summary

This PR fixes the overview charts showing `0` for users whose RBAC is limited to specific namespaces. The cluster and workload overviews called `useList()` without a namespace, so every chart issued a cluster-wide LIST that such users are refused — and the empty result was drawn as a confident zero. The charts now use the same namespace filter the list pages already pass, stop charting failures as zero, and point the user at the one setting that can fix a request nothing scopes.

## Related Issue

Fixes #6897

## Changes

- **Scoped the overview lists to the selected namespaces** in `cluster/Overview.tsx` (pods) and `workload/Overview.tsx` (all eight workload kinds). `makeListRequests` then fans out per namespace; an empty selection still falls back to Allowed namespaces and finally to one cluster-wide request, so nothing changes for users who can list the cluster.
- **Stopped charting a failed list as zero.** A list that returned nothing and an error is replaced by a tile carrying the chart's own title and "Unavailable". A list that partly succeeded keeps its chart — one forbidden namespace does not make the others uncountable.
- **Reported failures once per section** instead of once per affected chart. On the cluster overview a single node failure used to mean three identical alerts (CPU, Memory, Nodes); it is now one, above the grid.
- **Narrowed the metrics-403 handling**: a forbidden node-metrics response no longer blanks the whole overview section, which would have hidden the pods chart this fix repairs.
- **Added an actionable hint** to `ClusterGroupErrorMessage`: when a namespaced list is forbidden and no namespaces are selected or configured, it links to *Settings → Cluster → Allowed namespaces*. Wired through `ResourceTable` (`namespacedResource={resourceClass.isNamespaced}`), so every list page gets it too, and never for cluster-scoped resources where namespaces would not help.
- **Tests**: new `workload/Overview.test.tsx`, extended `cluster/Overview.test.tsx` — namespace scoping on both pages, placeholder instead of zero, one report per section, no namespace hint for a cluster-scoped failure, and partial results surviving alongside the error.

## Steps to Test

1. Create a namespace-restricted user and point a context at it:

   ```bash
   kubectl create ns team-a
   kubectl create rolebinding team-a-admin --clusterrole=admin --user=restricted -n team-a
   kubectl config set-context restricted --cluster=kind-kind --user=restricted --namespace=team-a
   ```

2. Open Headlamp with that context and go to **Cluster → Overview**. Before this PR the Pods chart reads `0`; with it, the chart counts the pods in `team-a`, while CPU/Memory/Nodes show *Unavailable* with one explanation above them.
3. Go to **Workloads**. Every chart is scoped the same way; kinds that cannot be listed show *Unavailable* rather than `0`.
4. Clear the namespace filter and remove any Allowed namespaces so nothing scopes the request. The charts report the permission failure and offer a link to *Cluster settings*, instead of silently showing zeros.
5. Run the unit tests:

   ```bash
   cd frontend && npx vitest run src/components/cluster src/components/workload src/components/common/Resource
   ```

   116 tests pass, including the new namespace-scoping and placeholder cases.

## Notes for the Reviewer

- **This does not discover namespaces.** Kubernetes has no API that enumerates the namespaces a user may read — `SelfSubjectAccessReview` and `SelfSubjectRulesReview` both require the namespace up front. So counts appear only once Headlamp knows the namespaces: the filter, the kubeconfig context's namespace, or Allowed namespaces. Auto-discovery is #6015; this PR makes the gap legible rather than silent.
- **Behaviour change worth your judgement:** a forbidden list now renders a labelled "Unavailable" tile instead of a zeroed chart. I think a wrong number is worse than an absent one, but say the word if you would rather keep the chart.
- **i18n:** one new key across the 17 `translation.json` files. The chart titles and "Unavailable" reuse existing keys. I reverted the unrelated `glossary.json` churn that `npm run i18n` produces so the diff stays reviewable — worth a separate cleanup PR.
- `ResourceTable` gains one optional prop (`namespacedResource`), defaulted off, so plugin tables are unaffected.
- Verified with `eslint`, `prettier` and `tsc --noEmit`; snapshot suites under `components/cluster` pass unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Namespace selections now apply consistently across cluster and workload overviews.
  - Added guidance and a direct link to cluster settings when namespace access is restricted.
  - Overview charts show when data is unavailable instead of displaying misleading zero values.
  - Partial chart data remains visible when only some requests fail.
  - Pod and node information refreshes periodically.

- **Bug Fixes**
  - Improved error reporting by separating, grouping, and deduplicating resource access errors.
  - Metrics charts remain visible when related permissions are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->