### PR TITLE
backend: Kubeconfig: Let the new config win when merging

### DIFF
--- a/backend/pkg/kubeconfig/file.go
+++ b/backend/pkg/kubeconfig/file.go
@@ -107,8 +107,11 @@ func mergeWithExisting(config clientcmdapi.Config, dir, configFile string) (*cli
 		return nil, fmt.Errorf("failed to close temp kubeconfig file: %w", err)
 	}
 
+	// The incoming config comes first so that it wins over the existing file:
+	// clientcmd resolves conflicts in favour of the first entry. Entries that
+	// only exist in the file on disk are still preserved by the merge.
 	load := clientcmd.ClientConfigLoadingRules{
-		Precedence: []string{configFile, tmpPath},
+		Precedence: []string{tmpPath, configFile},
 	}
 
 	merged, err := load.Load()

--- a/backend/pkg/kubeconfig/file_test.go
+++ b/backend/pkg/kubeconfig/file_test.go
@@ -107,6 +107,83 @@ users:
 	assert.True(t, hasSecond, "expected new context to be merged in")
 }
 
+// TestWriteToFileMergeUpdatesExistingEntry verifies that writing a config whose
+// entries already exist under the same names replaces the stored values instead
+// of keeping the ones already on disk.
+func TestWriteToFileMergeUpdatesExistingEntry(t *testing.T) {
+	dir := t.TempDir()
+
+	confFor := func(server, token string) string {
+		return fmt.Sprintf(`apiVersion: v1
+clusters:
+- cluster:
+    server: %s
+  name: prod
+contexts:
+- context:
+    cluster: prod
+    user: prod
+  name: prod
+kind: Config
+users:
+- name: prod
+  user:
+    token: %s`, server, token)
+	}
+
+	initial, err := clientcmd.Load([]byte(confFor("https://old.example.com:6443", "old-token")))
+	require.NoError(t, err)
+	require.NoError(t, kubeconfig.WriteToFile(*initial, dir))
+
+	// Same names, new values: the API server moved and the credentials changed.
+	updated, err := clientcmd.Load([]byte(confFor("https://new.example.com:6443", "new-token")))
+	require.NoError(t, err)
+	require.NoError(t, kubeconfig.WriteToFile(*updated, dir))
+
+	merged, err := clientcmd.LoadFromFile(filepath.Join(dir, "config"))
+	require.NoError(t, err)
+
+	require.Contains(t, merged.Clusters, "prod")
+	assert.Equal(t, "https://new.example.com:6443", merged.Clusters["prod"].Server)
+
+	require.Contains(t, merged.AuthInfos, "prod")
+	assert.Equal(t, "new-token", merged.AuthInfos["prod"].Token)
+}
+
+// TestWriteToFileMergeKeepsUnrelatedEntries verifies that updating one entry
+// does not drop entries that exist only in the file on disk.
+func TestWriteToFileMergeKeepsUnrelatedEntries(t *testing.T) {
+	dir := t.TempDir()
+
+	initial, err := clientcmd.Load([]byte(clusterConf))
+	require.NoError(t, err)
+	require.NoError(t, kubeconfig.WriteToFile(*initial, dir))
+
+	other, err := clientcmd.Load([]byte(`apiVersion: v1
+clusters:
+- cluster:
+    server: https://staging:6443
+  name: staging
+contexts:
+- context:
+    cluster: staging
+    user: staging
+  name: staging
+kind: Config
+users:
+- name: staging
+  user:
+    token: staging-token`))
+	require.NoError(t, err)
+	require.NoError(t, kubeconfig.WriteToFile(*other, dir))
+
+	merged, err := clientcmd.LoadFromFile(filepath.Join(dir, "config"))
+	require.NoError(t, err)
+
+	assert.Contains(t, merged.Contexts, "random-cluster-4", "pre-existing context must survive")
+	assert.Contains(t, merged.Contexts, "staging", "new context must be added")
+}
+
 // runConcurrentWriteConfig spawns the given number of goroutines, each writing
 // a unique kubeconfig context via WriteToFile. A barrier ensures all goroutines
 // start simultaneously to maximise contention on the file lock.


### PR DESCRIPTION
## Summary

`mergeWithExisting` merged the incoming config into the stored one with the
precedence reversed:

```go
Precedence: []string{configFile, tmpPath},
```

`clientcmd` resolves conflicts in favour of the first entry, and `configFile` is
the config already on disk, so updating an entry that already exists kept the old
values and silently dropped the new ones. Adding new entries was unaffected,
which is why it went unnoticed.

Swapping the order makes the incoming config win. Entries that exist only in the
stored file are still preserved by the merge.

Fixes: https://github.com/kubernetes-sigs/headlamp/issues/6962

## Changes

- `pkg/kubeconfig/file.go` — put the incoming config first in `Precedence`
- `pkg/kubeconfig/file_test.go` — cover updating an existing entry, and keeping
  unrelated ones

## How to test

`go test ./pkg/kubeconfig/`

`TestWriteToFileMergeUpdatesExistingEntry` fails without the fix, reporting the
old server and token:

```
expected: "https://new.example.com:6443"
actual  : "https://old.example.com:6443"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated kubeconfig entries now correctly take precedence over existing entries with matching names.
  * Existing unrelated kubeconfig contexts are preserved when adding or updating entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->