### PR TITLE
app: e2e-tests: Run accessibility checks in axe-core legacy mode

### DIFF
--- a/app/e2e-tests/tests/headlampPage.ts
+++ b/app/e2e-tests/tests/headlampPage.ts
@@ -27,10 +27,14 @@ export class HeadlampPage {
     // context.newPage(). Electron's CDP implementation does not support
     // Target.createTarget, so that call fails with
     // "Protocol error (Target.createTarget): Not supported" when this page
-    // belongs to an Electron BrowserWindow (PLAYWRIGHT_TEST_MODE=app).
-    const accessibilityResults = await new AxeBuilder({ page: this.page })
-      .setLegacyMode(true)
-      .analyze();
+    // belongs to an Electron BrowserWindow (PLAYWRIGHT_TEST_MODE=app). Only
+    // enable it there: legacy mode disables cross-origin iframe scanning, a
+    // coverage loss this page (a plain browser tab) doesn't need to take.
+    const axeBuilder = new AxeBuilder({ page: this.page });
+    if (process.env.PLAYWRIGHT_TEST_MODE === 'app') {
+      axeBuilder.setLegacyMode(true);
+    }
+    const accessibilityResults = await axeBuilder.analyze();
     const violations = accessibilityResults.violations.filter(
       v => v.impact === 'critical' || v.impact === 'serious'
     );

--- a/app/e2e-tests/tests/headlampPage.ts
+++ b/app/e2e-tests/tests/headlampPage.ts
@@ -22,7 +22,15 @@ export class HeadlampPage {
   constructor(private page: Page) {}
 
   async a11y() {
-    const accessibilityResults = await new AxeBuilder({ page: this.page }).analyze();
+    // Legacy mode runs axe.run() directly on this page instead of the default
+    // runPartial/finishRun flow, which needs to open a blank page via
+    // context.newPage(). Electron's CDP implementation does not support
+    // Target.createTarget, so that call fails with
+    // "Protocol error (Target.createTarget): Not supported" when this page
+    // belongs to an Electron BrowserWindow (PLAYWRIGHT_TEST_MODE=app).
+    const accessibilityResults = await new AxeBuilder({ page: this.page })
+      .setLegacyMode(true)
+      .analyze();
     const violations = accessibilityResults.violations.filter(
       v => v.impact === 'critical' || v.impact === 'serious'
     );

--- a/app/e2e-tests/tests/headlampPage.ts
+++ b/app/e2e-tests/tests/headlampPage.ts
@@ -22,7 +22,19 @@ export class HeadlampPage {
   constructor(private page: Page) {}
 
   async a11y() {
-    const accessibilityResults = await new AxeBuilder({ page: this.page }).analyze();
+    // Legacy mode runs axe.run() directly on this page instead of the default
+    // runPartial/finishRun flow, which needs to open a blank page via
+    // context.newPage(). Electron's CDP implementation does not support
+    // Target.createTarget, so that call fails with
+    // "Protocol error (Target.createTarget): Not supported" when this page
+    // belongs to an Electron BrowserWindow (PLAYWRIGHT_TEST_MODE=app). Only
+    // enable it there: legacy mode disables cross-origin iframe scanning, a
+    // coverage loss this page (a plain browser tab) doesn't need to take.
+    const axeBuilder = new AxeBuilder({ page: this.page });
+    if (process.env.PLAYWRIGHT_TEST_MODE === 'app') {
+      axeBuilder.setLegacyMode(true);
+    }
+    const accessibilityResults = await axeBuilder.analyze();
     const violations = accessibilityResults.violations.filter(
       v => v.impact === 'critical' || v.impact === 'serious'
     );


### PR DESCRIPTION
## Summary

Fixes the `AxeBuilder.analyze()` failure reported in [#6639 (comment)](https://github.com/kubernetes-sigs/headlamp/issues/6639#issuecomment-5195472975):

```
browserContext.newPage: Protocol error (Target.createTarget): Not supported
```

## Root cause

`AxeBuilder.analyze()` defaults to a `runPartial`/`finishRun` flow. `finishRun()` opens a **new blank page** via `context.newPage()` to finish the accessibility scan (see `@axe-core/playwright`'s `finishRun()`). Electron's CDP implementation does not support `Target.createTarget`, so that call throws whenever the page under test belongs to an Electron `BrowserWindow` — i.e. every time `HeadlampPage.a11y()` runs in app mode (`PLAYWRIGHT_TEST_MODE=app`). This fails `clusterRename.spec.ts` and `namespaces.spec.ts` before they reach their real assertions.

I confirmed the latest stable `@axe-core/playwright` (4.12.1, vs. the currently pinned 4.10.1) has not changed this code path — `finishRun()` still unconditionally calls `context.newPage()` — so bumping the dependency does not help.

## Fix

`AxeBuilder.setLegacyMode(true)` runs `axe.run()` directly on the existing page instead, avoiding the extra page entirely. The library's own docs note the tradeoff: cross-origin iframes won't be scanned in legacy mode. That doesn't apply here — these specs only ever exercise a single Electron window.

## Verification

Reproduced the exact reported error against a real Electron dev build (`compile-electron --dev`) and confirmed `setLegacyMode(true)` resolves it:

```
--- Testing WITHOUT legacy mode (expect Target.createTarget error) ---
Got expected error: browserContext.newPage: Protocol error (Target.createTarget): Not supported
--- Testing WITH legacy mode (expect success) ---
Legacy mode succeeded. Violations found: 0
```

Note: while verifying end-to-end against a real minikube cluster, I hit two separate, pre-existing bugs (a Release Notes modal blocking clicks on every fresh Electron launch, and Electron's shared default userData directory causing a click-interception flake) that stop `clusterRename.spec.ts`/`namespaces.spec.ts` from completing regardless of this fix. Filed and fixed separately in dependent, still-open PRs, kept out of scope here to keep this PR focused on the reported `AxeBuilder` issue.

## Test plan

- [x] Reproduced the original error against a real Electron dev build
- [x] Confirmed `setLegacyMode(true)` resolves it with 0 violations
- [ ] CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved accessibility test reliability by enabling legacy analysis mode, preventing blank-page results during checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
