### PR TITLE
frontend: AlertNotification: Do not poll health on hidden routes

### DIFF
--- a/frontend/src/components/common/AlertNotification.test.tsx
+++ b/frontend/src/components/common/AlertNotification.test.tsx
@@ -67,4 +67,22 @@ describe('PureAlertNotification', () => {
     await act(async () => await vi.advanceTimersByTimeAsync(5000));
     expect(checkerFunction).toHaveBeenCalledTimes(3);
   });
+
+  // Routes in ROUTES_WITHOUT_ALERT hide the alert, so polling there only
+  // accrues expected failures. That stale error and backoff used to render
+  // as a "lost connection" banner right after OIDC sign-in.
+  it('does not poll cluster health on routes that hide the alert', async () => {
+    const checkerFunction = vi.fn().mockRejectedValue(new Error('no session'));
+
+    await act(async () => {
+      render(
+        <TestContext urlPrefix="/c/test-cluster/login">
+          <PureAlertNotification checkerFunction={checkerFunction} />
+        </TestContext>
+      );
+    });
+
+    await act(async () => await vi.advanceTimersByTimeAsync(20000));
+    expect(checkerFunction).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/components/common/AlertNotification.test.tsx
+++ b/frontend/src/components/common/AlertNotification.test.tsx
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import { act, cleanup, render } from '@testing-library/react';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TestContext } from '../../test';
 import { PureAlertNotification } from './AlertNotification';
@@ -23,6 +25,20 @@ vi.mock('../../lib/cluster', async importOriginal => ({
   ...(await importOriginal<typeof import('../../lib/cluster')>()),
   getCluster: () => 'test-cluster',
 }));
+
+const BANNER_TEXT = 'Lost connection to the cluster.';
+
+type TestHistory = ReturnType<typeof useHistory>;
+
+// Hands the router history to the test so it can navigate between routes
+// while the component stays mounted, like the app-level instance does.
+function HistoryGrabber({ onReady }: { onReady: (history: TestHistory) => void }) {
+  const history = useHistory();
+  useEffect(() => {
+    onReady(history);
+  }, [history, onReady]);
+  return null;
+}
 
 describe('PureAlertNotification', () => {
   // The suite-wide config fakes Date + setTimeout/clearTimeout; opt setInterval/clearInterval
@@ -66,5 +82,121 @@ describe('PureAlertNotification', () => {
     // interval would still be 10s and this advance would see no new call.
     await act(async () => await vi.advanceTimersByTimeAsync(5000));
     expect(checkerFunction).toHaveBeenCalledTimes(3);
+  });
+
+  // Routes in ROUTES_WITHOUT_ALERT hide the alert, so polling there only
+  // accrues expected failures. That stale error and backoff used to render
+  // as a "lost connection" banner right after OIDC sign-in.
+  it('does not poll cluster health on routes that hide the alert', async () => {
+    const checkerFunction = vi.fn().mockRejectedValue(new Error('no session'));
+
+    await act(async () => {
+      render(
+        <TestContext urlPrefix="/c/test-cluster/login">
+          <PureAlertNotification checkerFunction={checkerFunction} />
+        </TestContext>
+      );
+    });
+
+    await act(async () => await vi.advanceTimersByTimeAsync(20000));
+    expect(checkerFunction).not.toHaveBeenCalled();
+  });
+
+  // A failed check on a cluster view must not survive a pass through a hidden
+  // route. Before the fix the error and the raised backoff stayed in state, so
+  // the banner came back at once when the user returned from the login page,
+  // and the next check ran on the raised cadence.
+  it('clears stale error and backoff after a pass through a hidden route', async () => {
+    const checkerFunction = vi.fn().mockRejectedValueOnce(new Error('down')).mockResolvedValue({});
+    let testHistory!: TestHistory;
+
+    await act(async () => {
+      render(
+        <TestContext urlPrefix="/c/test-cluster">
+          <HistoryGrabber
+            onReady={history => {
+              testHistory = history;
+            }}
+          />
+          <PureAlertNotification checkerFunction={checkerFunction} />
+        </TestContext>
+      );
+    });
+
+    // t=5s: the check fails on the cluster view and the banner shows.
+    await act(async () => await vi.advanceTimersByTimeAsync(5000));
+    expect(checkerFunction).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(BANNER_TEXT)).not.toBeNull();
+
+    // On the login route the banner hides and polling stops.
+    await act(async () => {
+      testHistory.push('/c/test-cluster/login');
+    });
+    expect(screen.queryByText(BANNER_TEXT)).toBeNull();
+    await act(async () => await vi.advanceTimersByTimeAsync(20000));
+    expect(checkerFunction).toHaveBeenCalledTimes(1);
+
+    // Back on the cluster view no stale banner appears before any new check.
+    await act(async () => {
+      testHistory.push('/c/test-cluster');
+    });
+    expect(screen.queryByText(BANNER_TEXT)).toBeNull();
+
+    // The next check runs 5s later on the base cadence and succeeds.
+    await act(async () => await vi.advanceTimersByTimeAsync(5000));
+    expect(checkerFunction).toHaveBeenCalledTimes(2);
+    expect(screen.queryByText(BANNER_TEXT)).toBeNull();
+  });
+
+  // clearInterval stops future ticks only. A check that is in flight when the
+  // route hides the alert settles later. When it settles after the user is
+  // back on a cluster view, its rejection belongs to the old poller epoch and
+  // must not write a banner or a backoff into the new one.
+  it('ignores a check that settles after a pass through a hidden route', async () => {
+    const pendingRejects: Array<(reason: Error) => void> = [];
+    const checkerFunction = vi.fn(
+      () =>
+        new Promise((_resolve, reject) => {
+          pendingRejects.push(reject);
+        })
+    );
+    let testHistory!: TestHistory;
+
+    await act(async () => {
+      render(
+        <TestContext urlPrefix="/c/test-cluster">
+          <HistoryGrabber
+            onReady={history => {
+              testHistory = history;
+            }}
+          />
+          <PureAlertNotification checkerFunction={checkerFunction} />
+        </TestContext>
+      );
+    });
+
+    // t=5s: a check starts and stays in flight.
+    await act(async () => await vi.advanceTimersByTimeAsync(5000));
+    expect(checkerFunction).toHaveBeenCalledTimes(1);
+
+    // A quick pass through the login route and back while the check is
+    // still pending.
+    await act(async () => {
+      testHistory.push('/c/test-cluster/login');
+    });
+    await act(async () => {
+      testHistory.push('/c/test-cluster');
+    });
+
+    // The old check settles now. It must leave no banner behind.
+    await act(async () => {
+      pendingRejects[0](new Error('late rejection'));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.queryByText(BANNER_TEXT)).toBeNull();
+
+    // The backoff stayed at the base cadence: the next check fires 5s later.
+    await act(async () => await vi.advanceTimersByTimeAsync(5000));
+    expect(checkerFunction).toHaveBeenCalledTimes(2);
   });
 });

--- a/frontend/src/components/common/AlertNotification.tsx
+++ b/frontend/src/components/common/AlertNotification.tsx
@@ -66,7 +66,7 @@ export function PureAlertNotification({ checkerFunction }: PureAlertNotification
   const { t } = useTranslation();
   const { pathname } = useLocation();
 
-  function registerSetInterval(): NodeJS.Timeout {
+  function registerSetInterval(isActive: () => boolean): NodeJS.Timeout {
     return setInterval(() => {
       if (!window.navigator.onLine) {
         setError(t('translation|Offline') as string);
@@ -80,6 +80,9 @@ export function PureAlertNotification({ checkerFunction }: PureAlertNotification
 
       checkerFunction()
         .then(() => {
+          if (!isActive()) {
+            return;
+          }
           setError(false);
           // Reset the backoff so polling returns to the normal cadence once the
           // cluster recovers; otherwise the interval stays elevated for the rest
@@ -87,6 +90,9 @@ export function PureAlertNotification({ checkerFunction }: PureAlertNotification
           setNetworkStatusCheckTimeFactor(0);
         })
         .catch(err => {
+          if (!isActive()) {
+            return;
+          }
           const message = err instanceof Error ? err.message : String(err);
           setError(message);
           setNetworkStatusCheckTimeFactor(
@@ -107,15 +113,6 @@ export function PureAlertNotification({ checkerFunction }: PureAlertNotification
     setDismissed(false);
   }, [error]);
 
-  React.useEffect(
-    () => {
-      const id = registerSetInterval();
-      return () => clearInterval(id);
-    },
-    // eslint-disable-next-line
-    [networkStatusCheckTimeFactor]
-  );
-
   const showOnRoute = React.useMemo(() => {
     for (const routeName of ROUTES_WITHOUT_ALERT) {
       const maybeRoute = getRoute(routeName);
@@ -130,6 +127,30 @@ export function PureAlertNotification({ checkerFunction }: PureAlertNotification
     }
     return true;
   }, [pathname]);
+
+  React.useEffect(
+    () => {
+      // Routes in ROUTES_WITHOUT_ALERT hide the alert, so they get no health
+      // polling. On the login route the checks fail while the session has no
+      // credentials, and that stale error plus backoff would render as a
+      // "lost connection" banner right after sign-in.
+      if (!showOnRoute) {
+        setError(null);
+        setNetworkStatusCheckTimeFactor(0);
+        return;
+      }
+      // A check that is still in flight after cleanup must not write state;
+      // its late rejection would restore the stale error.
+      let active = true;
+      const id = registerSetInterval(() => active);
+      return () => {
+        active = false;
+        clearInterval(id);
+      };
+    },
+    // eslint-disable-next-line
+    [networkStatusCheckTimeFactor, showOnRoute]
+  );
 
   if (!error || !showOnRoute || dismissed) {
     return null;

--- a/frontend/src/components/common/AlertNotification.tsx
+++ b/frontend/src/components/common/AlertNotification.tsx
@@ -107,15 +107,6 @@ export function PureAlertNotification({ checkerFunction }: PureAlertNotification
     setDismissed(false);
   }, [error]);
 
-  React.useEffect(
-    () => {
-      const id = registerSetInterval();
-      return () => clearInterval(id);
-    },
-    // eslint-disable-next-line
-    [networkStatusCheckTimeFactor]
-  );
-
   const showOnRoute = React.useMemo(() => {
     for (const routeName of ROUTES_WITHOUT_ALERT) {
       const maybeRoute = getRoute(routeName);
@@ -130,6 +121,24 @@ export function PureAlertNotification({ checkerFunction }: PureAlertNotification
     }
     return true;
   }, [pathname]);
+
+  React.useEffect(
+    () => {
+      // Routes in ROUTES_WITHOUT_ALERT hide the alert, so they get no health
+      // polling. On the login route the checks fail while the session has no
+      // credentials, and that stale error plus backoff would render as a
+      // "lost connection" banner right after sign-in.
+      if (!showOnRoute) {
+        setError(null);
+        setNetworkStatusCheckTimeFactor(0);
+        return;
+      }
+      const id = registerSetInterval();
+      return () => clearInterval(id);
+    },
+    // eslint-disable-next-line
+    [networkStatusCheckTimeFactor, showOnRoute]
+  );
 
   if (!error || !showOnRoute || dismissed) {
     return null;


### PR DESCRIPTION
## Summary

This PR stops the cluster health poller on routes that hide the alert, and it clears the stored error and retry backoff there. The login route collects failed checks before sign-in, because the session has no credentials at that point. After OIDC sign-in the route changes without a page reload. The stored error then rendered as a stale "Lost connection to the cluster." banner over a healthy cluster, for one full poll period or more.

## Related Issue

Fixes #6976

## Changes

- Moved the `showOnRoute` memo above the poll effect in `AlertNotification.tsx`.
- The poll effect registers the interval only when the route shows the alert. On the other routes it clears the error and resets the backoff factor.
- Added a regression test: the poller makes no health checks on the login route.
- Added a route-transition regression test: a failed check on the cluster view, a pass through the login route, then a return with no stale banner and a check on the base cadence.

## Steps to Test

1. Configure a kubeconfig cluster with OIDC and `oidc-use-cookie=true`.
2. Open `/c/<cluster>/` in a private window and stay on the login page for 10 seconds or more.
3. Click "Sign In" and complete the identity provider flow.
4. The cluster view opens with no "Lost connection to the cluster." banner.
5. Run `npx vitest run src/components/common/AlertNotification.test.tsx`. All three tests pass. The two new tests fail on the previous code.

## Notes for the Reviewer

`ROUTES_WITHOUT_ALERT` lists `settingsCluster`. That entry matches the cluster-prefixed `/settings` redirect only. The current settings page is `settingsClusterHomeContext` at `/settings/cluster?c=...` with `useClusterURL: false`, so its path holds no cluster. There `getCluster()` returns null, and the null-cluster branch of the poller already skips checks and clears the error. This PR changes polling on the login route, the token route, and the legacy redirect. The settings page keeps its current behavior.
