### PR TITLE
frontend: plugins: Enforce strict mode and add regression tests

### DIFF
--- a/frontend/src/plugin/runPlugin.test.ts
+++ b/frontend/src/plugin/runPlugin.test.ts
@@ -550,7 +550,10 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/ai-assistant',
       false
     );
-    expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      '@headlamp-k8s/ai-assistant': true,
+    });
   });
 
   test('should identify ai-assistant package by underscore user-plugins path', () => {
@@ -559,7 +562,10 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/ai-assistant',
       false
     );
-    expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      '@headlamp-k8s/ai-assistant': true,
+    });
   });
 
   test('should identify ai-assistant package by underscore static-plugins path', () => {
@@ -568,7 +574,10 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/ai-assistant',
       false
     );
-    expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      '@headlamp-k8s/ai-assistant': true,
+    });
   });
 
   test('should identify ai-assistant package by underscore prerelease plugins path', () => {
@@ -577,7 +586,10 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/ai-assistantprerelease',
       false
     );
-    expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      '@headlamp-k8s/ai-assistant': true,
+    });
   });
 
   test('should identify ai-assistant package by underscore prerelease user-plugins path', () => {
@@ -586,7 +598,10 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/ai-assistantprerelease',
       false
     );
-    expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      '@headlamp-k8s/ai-assistant': true,
+    });
   });
 
   test('should identify ai-assistant package by underscore prerelease static-plugins path', () => {
@@ -595,7 +610,10 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/ai-assistantprerelease',
       false
     );
-    expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      '@headlamp-k8s/ai-assistant': true,
+    });
   });
 
   test('should handle windows paths for ai-assistant underscore variant', () => {
@@ -604,7 +622,10 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/ai-assistant',
       false
     );
-    expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      '@headlamp-k8s/ai-assistant': true,
+    });
   });
 
   test('should handle windows static paths for ai-assistant underscore variant', () => {
@@ -613,7 +634,10 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/ai-assistant',
       false
     );
-    expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      '@headlamp-k8s/ai-assistant': true,
+    });
   });
 
   test('should handle windows paths for ai-assistant underscore prerelease variant', () => {
@@ -622,6 +646,134 @@ describe('identifyPackages', () => {
       '@headlamp-k8s/ai-assistantprerelease',
       false
     );
-    expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+    expect(result).toEqual({
+      '@headlamp-k8s/minikube': false,
+      '@headlamp-k8s/ai-assistant': true,
+    });
+  });
+});
+
+describe('Security & Isolation (Issue #6826)', () => {
+  test('should shadow global window and globalThis identifiers', () => {
+    let accessedWindow: unknown = 'NOT_TESTED';
+    let accessedGlobalThis: unknown = 'NOT_TESTED';
+
+    const pluginSource = `
+        setAccessedWindow(typeof window !== 'undefined' ? window : undefined);
+        setAccessedGlobalThis(typeof globalThis !== 'undefined' ? globalThis : undefined);
+      `;
+
+    const PrivateFunction = Function;
+    const info = getInfoForRunningPlugins({
+      source: pluginSource,
+      pluginPath: '/path/to/plugin',
+      packageName: 'test-sandbox-package',
+      packageVersion: '1.0.0',
+      permissionSecrets: {},
+      handleError: () => {},
+      getAllowedPermissions: () => ({}),
+      getArgValues: () => [
+        ['setAccessedWindow', 'setAccessedGlobalThis'],
+        [
+          (val: unknown) => {
+            accessedWindow = val;
+          },
+          (val: unknown) => {
+            accessedGlobalThis = val;
+          },
+        ],
+      ],
+      PrivateFunction,
+      internalRunPlugin: runPlugin,
+      consoleError: console.error,
+    });
+
+    if (info) {
+      runPluginInner(info);
+    }
+
+    expect(accessedWindow).toBeUndefined();
+    expect(accessedGlobalThis).toBeUndefined();
+  });
+
+  test('should prevent top-level this binding from resolving to global window', () => {
+    let thisBinding: unknown = 'NOT_TESTED';
+
+    const pluginSource = `
+        setThis(this);
+      `;
+
+    const PrivateFunction = Function;
+    const info = getInfoForRunningPlugins({
+      source: pluginSource,
+      pluginPath: '/path/to/plugin',
+      packageName: 'test-sandbox-this-package',
+      packageVersion: '1.0.0',
+      permissionSecrets: {},
+      handleError: () => {},
+      getAllowedPermissions: () => ({}),
+      getArgValues: () => [
+        ['setThis'],
+        [
+          (val: unknown) => {
+            thisBinding = val;
+          },
+        ],
+      ],
+      PrivateFunction,
+      internalRunPlugin: runPlugin,
+      consoleError: console.error,
+    });
+
+    if (info) {
+      runPluginInner(info);
+    }
+
+    expect(thisBinding).toBeUndefined();
+  });
+
+  test.skip('ARCHITECTURAL LIMITATION: does not block prototype-chain escapes (({}).constructor.constructor)', () => {
+    // NOTE: This test is skipped because blocking this escape requires a true separate realm
+    // (like an iframe sandbox or Web Worker) with an explicit capability bridge.
+    // The current plugin architecture evaluates plugins directly in the main app's execution context,
+    // so lexical shadowing and strict mode cannot prevent a plugin from walking the prototype chain
+    // to obtain the real global object.
+    let accessedGlobalThis: unknown = 'NOT_TESTED';
+
+    const pluginSource = `
+      try {
+        const escapeGlobal = ({}).constructor.constructor('return globalThis')();
+        setAccessedGlobalThis(escapeGlobal);
+      } catch (e) {
+        // Blocked
+      }
+    `;
+
+    const PrivateFunction = Function;
+    const info = getInfoForRunningPlugins({
+      source: pluginSource,
+      pluginPath: '/path/to/plugin',
+      packageName: 'test-sandbox-escape',
+      packageVersion: '1.0.0',
+      permissionSecrets: {},
+      handleError: () => {},
+      getAllowedPermissions: () => ({}),
+      getArgValues: () => [
+        ['setAccessedGlobalThis'],
+        [
+          (val: unknown) => {
+            accessedGlobalThis = val;
+          },
+        ],
+      ],
+      PrivateFunction,
+      internalRunPlugin: runPlugin,
+      consoleError: console.error,
+    });
+
+    if (info) {
+      runPluginInner(info);
+    }
+    expect(accessedGlobalThis).toBe('NOT_TESTED');
   });
 });

--- a/frontend/src/plugin/runPlugin.test.ts
+++ b/frontend/src/plugin/runPlugin.test.ts
@@ -60,7 +60,7 @@ describe('runPlugin', () => {
 
     const encodedSourceMap = compiledSources[0].split('base64,')[1];
     const compiledSourceMap = JSON.parse(atob(encodedSourceMap));
-    expect(compiledSourceMap.mappings).toBe(';;AAAA');
+    expect(compiledSourceMap.mappings).toBe(';;;AAAA');
     expect(executePlugin).toHaveBeenCalledOnce();
   });
 
@@ -917,7 +917,7 @@ describe('adjustSourceMapOffsetForFunction', () => {
 
     const encodedSourceMap = result.split('base64,')[1].split(/\s/)[0];
     const resultSourceMap = JSON.parse(atob(encodedSourceMap));
-    expect(resultSourceMap.mappings).toBe(';;' + originalMappings);
+    expect(resultSourceMap.mappings).toBe(';;;' + originalMappings);
     expect(result.endsWith(sourceUrl)).toBe(true);
   });
 
@@ -949,7 +949,7 @@ describe('adjustSourceMapOffsetForFunction', () => {
     const result = adjustSourceMapOffsetForFunction(jsSource);
     const encodedSourceMap = result.split('base64,')[1];
 
-    expect(JSON.parse(atob(encodedSourceMap)).mappings).toBe(';;');
+    expect(JSON.parse(atob(encodedSourceMap)).mappings).toBe(';;;');
   });
 
   test('should return source unchanged when the source map is not valid base64', () => {
@@ -976,5 +976,170 @@ describe('adjustSourceMapOffsetForFunction', () => {
       expect.any(SyntaxError)
     );
     consoleError.mockRestore();
+  });
+});
+
+describe('Security & Isolation (Issue #6826)', () => {
+  test('should prevent top-level this binding from resolving to global window', () => {
+    let thisBinding: unknown = 'NOT_TESTED';
+
+    const pluginSource = `
+        setThis(this);
+      `;
+
+    const PrivateFunction = Function;
+    const info = getInfoForRunningPlugins({
+      source: pluginSource,
+      pluginPath: '/path/to/plugin',
+      packageName: 'test-sandbox-this-package',
+      packageVersion: '1.0.0',
+      permissionSecrets: {},
+      handleError: () => {},
+      getAllowedPermissions: () => ({}),
+      getArgValues: () => [
+        ['setThis'],
+        [
+          (val: unknown) => {
+            thisBinding = val;
+          },
+        ],
+      ],
+      PrivateFunction,
+      internalRunPlugin: runPlugin,
+      consoleError: console.error,
+    });
+
+    if (info) {
+      runPluginInner(info);
+    }
+
+    expect(thisBinding).toBeUndefined();
+  });
+
+  test('should not allow a plugin to intercept plugin execution via Function.prototype.apply override', () => {
+    let errorMessage = '';
+    let theError: Error | null = null;
+    const PrivateFunction = Function;
+    const consoleError = console.error;
+    const internalRunPlugin = runPlugin;
+
+    // Spy on apply
+    const originalApply = Function.prototype.apply;
+    let intercepted = false;
+
+    // Sentinel capability to detect apply interception
+    function SENTINEL_CAPABILITY() {}
+
+    // Mock apply to detect interception
+    Function.prototype.apply = function (thisArg, args) {
+      if (
+        args &&
+        args.length > 0 &&
+        typeof args[args.length - 1] === 'string' &&
+        args[args.length - 1].includes('use strict')
+      ) {
+        intercepted = true;
+      }
+      // Check for interception of the final capability invocation
+      if (args && args.length > 0 && args[0] === SENTINEL_CAPABILITY) {
+        intercepted = true;
+      }
+      return originalApply.call(this, thisArg, args);
+    };
+
+    try {
+      const info = getInfoForRunningPlugins({
+        source: `
+          // Empty plugin
+          const x = 1;
+        `,
+        pluginPath: '/path/to/plugin',
+        packageName: 'test-sandbox-apply',
+        packageVersion: '1.0.0',
+        permissionSecrets: {},
+        handleError: (error, packageName, packageVersion) => {
+          errorMessage = `Error in plugin ${packageName} v${packageVersion}: ${error}`;
+          theError = error as Error;
+        },
+        getAllowedPermissions: () => ({}),
+        getArgValues: () => [['test_plugin_cmd'], [SENTINEL_CAPABILITY]],
+        PrivateFunction,
+        internalRunPlugin,
+        consoleError,
+      });
+
+      if (info) {
+        runPluginInner(info);
+      }
+
+      // The execution should not have routed through the mutated Function.prototype.apply
+      expect(intercepted).toBe(false);
+      expect(errorMessage).toBe('');
+      expect(theError).toBeNull();
+    } finally {
+      // Clean up the global mutation
+      Function.prototype.apply = originalApply;
+    }
+  });
+
+  test('should not allow a plugin to intercept execution via Array.prototype[Symbol.iterator] spread', () => {
+    let errorMessage = '';
+    let theError: Error | null = null;
+    const PrivateFunction = Function;
+    const consoleError = console.error;
+    const internalRunPlugin = runPlugin;
+
+    const originalIterator = Array.prototype[Symbol.iterator];
+    let intercepted = false;
+
+    // Sentinel capability to detect iterator spread interception
+    function SENTINEL_CAPABILITY() {}
+
+    // Malicious plugin mutates global iterator
+    (globalThis as any).Array.prototype[Symbol.iterator] = function* (this: any) {
+      // Check for target parameter name or sentinel capability value
+      if (
+        this &&
+        this.length > 0 &&
+        (this[0] === 'test_plugin_cmd' || this[0] === SENTINEL_CAPABILITY)
+      ) {
+        intercepted = true;
+      }
+      yield* originalIterator.call(this);
+    } as any;
+
+    try {
+      const info = getInfoForRunningPlugins({
+        source: `
+          // Empty plugin
+          const x = 1;
+        `,
+        pluginPath: '/path/to/plugin',
+        packageName: 'test-sandbox-iterator',
+        packageVersion: '1.0.0',
+        permissionSecrets: {},
+        handleError: (error, packageName, packageVersion) => {
+          errorMessage = `Error in plugin ${packageName} v${packageVersion}: ${error}`;
+          theError = error as Error;
+        },
+        getAllowedPermissions: () => ({}),
+        getArgValues: () => [['test_plugin_cmd'], [SENTINEL_CAPABILITY]],
+        PrivateFunction,
+        internalRunPlugin,
+        consoleError,
+      });
+
+      if (info) {
+        runPluginInner(info);
+      }
+
+      // Execution must not leak
+      expect(intercepted).toBe(false);
+      expect(errorMessage).toBe('');
+      expect(theError).toBeNull();
+    } finally {
+      // Clean up the global mutation
+      (globalThis as any).Array.prototype[Symbol.iterator] = originalIterator;
+    }
   });
 });

--- a/frontend/src/plugin/runPlugin.ts
+++ b/frontend/src/plugin/runPlugin.ts
@@ -151,17 +151,32 @@ export function runPlugin(
   args: string[],
   values: unknown[]
 ): void {
+  // Shadow global scope identifiers to restrict direct global object access
+  const shadowArgs = ['window', 'globalThis', 'self', 'document'];
+  const finalArgs = [...args];
+  const finalValues = [...values];
+
+  for (const shadowArg of shadowArgs) {
+    if (!finalArgs.includes(shadowArg)) {
+      finalArgs.push(shadowArg);
+      finalValues.push(undefined);
+    }
+  }
+
+  // Ensure strict mode execution so 'this' does not default to the global window
+  const strictSource =
+    source.startsWith("'use strict'") || source.startsWith('"use strict"')
+      ? source
+      : `'use strict';\n${source}`;
+
   // We use PrivateFunction here instead of global Function so people can't
   //   override Function and snoop on it.
-  const executePlugin = new PrivateFunction(...args, source);
+  const executePlugin = new PrivateFunction(...finalArgs, strictSource);
 
   try {
-    // This executes in the global scope,
-    //   so the plugin can't access variables in this scope.
-    // Meaning, it can NOT access "permissionSecrets".
-    // Each plugin gets its own "pluginPermissionSecrets" which contains only the secrets
-    //   that it is allowed to access.
-    executePlugin(...values);
+    // This executes in the bound function scope,
+    //   so the plugin can't access variables in the outer scope or global window.
+    executePlugin(...finalValues);
   } catch (e) {
     handleError(e, packageName, packageVersion);
   }

--- a/frontend/src/plugin/runPlugin.ts
+++ b/frontend/src/plugin/runPlugin.ts
@@ -143,9 +143,10 @@ export function getInfoForRunningPlugins({
  * Adjusts inline source maps for code that will be executed via `new Function()`.
  *
  * When using `new Function(args, body)`, the browser wraps the code in a function declaration,
- * adding 2 extra lines (function header and closing brace). This causes source map line numbers
- * to be off by 2. We fix this by prepending semicolons to the mappings field - each semicolon
- * represents an empty generated line, effectively shifting all mappings down.
+ * adding 2 extra lines (function header and closing brace). Along with the 1 strict mode directive line
+ * prepended by the plugin runner, this causes source map line numbers to be off by 3.
+ * We fix this by prepending semicolons to the mappings field - each semicolon represents an empty
+ * generated line, effectively shifting all mappings down.
  */
 export function adjustSourceMapOffsetForFunction(jsSource: string) {
   try {
@@ -165,7 +166,8 @@ export function adjustSourceMapOffsetForFunction(jsSource: string) {
       return jsSource;
     }
 
-    const wrapperLineCount = 2;
+    // 2 lines from Function wrapper + 1 line for 'use strict' directive
+    const wrapperLineCount = 3;
     sourceMap.mappings = ';'.repeat(wrapperLineCount) + sourceMap.mappings;
 
     const newBase64 = btoa(JSON.stringify(sourceMap));
@@ -215,7 +217,10 @@ export function runPlugin(
   for (let index = 0; index < args.length; index += 1) {
     constructorArgs[index] = args[index];
   }
-  constructorArgs[args.length] = adjustSourceMapOffsetForFunction(source);
+
+  // Ensure strict mode execution
+  const strictSource = `'use strict';\n${adjustSourceMapOffsetForFunction(source)}`;
+  constructorArgs[args.length] = strictSource;
 
   // Use the private Function reference and avoid the mutable array iterator.
   const executePlugin = privateConstruct(PrivateFunction, constructorArgs) as Function;


### PR DESCRIPTION
Relates to #6826

## Summary
Improves plugin sandbox execution defense-in-depth by enforcing strict mode execution and adding security regression tests for prototype mutation protections. Note: A full resolution for #6826 requires a genuine isolated realm (e.g. an iframe capability bridge) as lexical shadowing of window breaks existing plugins.

## Changes
- **`frontend/src/plugin/runPlugin.ts`**:
  - Enforce strict mode execution (`'use strict'`) so top-level `this` binding inside the plugin function body evaluates to `undefined` rather than the global `window`.
  - Adjust inline source map offset calculation to account for the additional strict mode directive line before plugin source.
- **`frontend/src/plugin/runPlugin.test.ts`**:
  - Added test verifying that top-level `this` binding is `undefined` during plugin execution.
  - Added test verifying that `Function.prototype.apply` mutations cannot intercept capability passing.
  - Added test verifying that `Array.prototype[Symbol.iterator]` mutations cannot intercept argument names or capability values.
  - Updated source map offset test expectations for the 3-line wrapper offset.

## Verification
- Run plugin unit tests: `npm run frontend:test`
- Run frontend linter: `npm run frontend:lint`
- Run frontend typecheck: `npm run frontend:tsc`