### PR TITLE
frontend: electronI18n: Fix react-hooks/exhaustive-deps — add i18n to…

### DIFF
--- a/frontend/src/i18n/electronI18n.tsx
+++ b/frontend/src/i18n/electronI18n.tsx
@@ -42,6 +42,5 @@ export function useElectronI18n() {
     return () => {
       i18n.off('languageChanged', tellAppAboutLanguage);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [i18n]);
 }


### PR DESCRIPTION
## Summary

Fix missing `i18n` dependency in `useEffect` inside `electronI18n.tsx`.
The `i18n` object was used inside the effect but omitted from the
dependency array, causing the eslint rule to be suppressed instead of
fixed properly.

## Related Issue

Fixes #6986  (sub-task: electronI18n — react-hooks/exhaustive-deps)

## Changes

- Added `i18n` to the `useEffect` dependency array in `electronI18n.tsx`
- Removed the `eslint-disable-next-line` comment that was suppressing
  the lint violation

## Steps to Test

1. Run `npm run frontend:lint` — should pass with 0 warnings
2. Run `npm run frontend:tsc` — no TypeScript errors
3. Run `npm run frontend:test` — all tests pass

## Notes for the Reviewer

- `i18n` from `useTranslation()` is a stable object reference,
  so adding it to deps does not cause infinite re-renders.
- This is a focused single-file fix as part of the umbrella issue #5183.
