### PR TITLE
frontend: clusterApi: testAuth cookie verification for OIDC clusters

### DIFF
--- a/frontend/src/lib/k8s/api/v1/clusterApi.test.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterApi.test.ts
@@ -152,7 +152,7 @@ describe('testAuth', () => {
 
   it('OIDC cluster: an empty username is still an authenticated session', async () => {
     // HandleMe writes 200 with username "" when the JWT carries none of
-    // preferred_username/upn/username/name. The cookie was still verified,
+    // preferred_username/upn/username/name. The cookie was still accepted,
     // so rejecting here would loop the user through login forever.
     fakeState.config.clusters[clusterName] = { auth_type: 'oidc' };
 

--- a/frontend/src/lib/k8s/api/v1/clusterApi.test.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterApi.test.ts
@@ -18,8 +18,22 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { addBackstageAuthHeaders } from '../../../../helpers/addBackstageAuthHeaders';
 import { getHeadlampAPIHeaders } from '../../../../helpers/getHeadlampAPIHeaders';
 import { storeStatelessClusterKubeconfig } from '../../../../stateless';
-import { setCluster } from './clusterApi';
-import { request } from './clusterRequests';
+import { getCluster } from '../../../cluster';
+import { ApiError } from '../v2/ApiError';
+import { setCluster, testAuth } from './clusterApi';
+import { clusterRequest, post, request } from './clusterRequests';
+
+// Mirrors the slice of redux state testAuth reads:
+// state.config.clusters[name].auth_type.
+const fakeState: { config: { clusters: Record<string, { auth_type?: string }> } } = {
+  config: { clusters: {} },
+};
+
+vi.mock('../../../../redux/stores/store', () => ({
+  default: {
+    getState: () => fakeState,
+  },
+}));
 
 vi.mock('../../../../helpers/addBackstageAuthHeaders', () => ({
   addBackstageAuthHeaders: vi.fn((headers: Record<string, string>) => headers),
@@ -82,5 +96,135 @@ describe('setCluster', () => {
       false,
       false
     );
+  });
+});
+
+describe('testAuth', () => {
+  const clusterName = 'oidc-cluster';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fakeState.config.clusters = {};
+  });
+
+  it('OIDC cluster: /me returning a real identity is authenticated', async () => {
+    fakeState.config.clusters[clusterName] = { auth_type: 'oidc' };
+
+    vi.mocked(clusterRequest).mockResolvedValueOnce({ username: 'alice@example.com' });
+
+    await expect(testAuth(clusterName)).resolves.toMatchObject({ username: 'alice@example.com' });
+
+    expect(clusterRequest).toHaveBeenCalledWith(
+      '/me',
+      expect.objectContaining({
+        cluster: clusterName,
+        timeout: 5000,
+        // A probe must not log the user out from under the caller.
+        autoLogoutOnAuthError: false,
+      })
+    );
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('OIDC cluster: a 401 from /me propagates with its status intact', async () => {
+    // The real unauthenticated path: HandleMe rejects the missing/invalid
+    // cookie before it looks at any claim. This is what fixes #4721.
+    fakeState.config.clusters[clusterName] = { auth_type: 'oidc' };
+
+    const unauthorized = new ApiError('Unauthorized - unauthorized', { status: 401 });
+    vi.mocked(clusterRequest).mockRejectedValueOnce(unauthorized);
+
+    await expect(testAuth(clusterName)).rejects.toMatchObject({
+      status: 401,
+      message: 'Unauthorized - unauthorized',
+    });
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('OIDC cluster: system:anonymous identity is treated as not-authenticated', async () => {
+    fakeState.config.clusters[clusterName] = { auth_type: 'oidc' };
+
+    vi.mocked(clusterRequest).mockResolvedValueOnce({ username: 'system:anonymous' });
+
+    await expect(testAuth(clusterName)).rejects.toMatchObject({ status: 401 });
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('OIDC cluster: an empty username is still an authenticated session', async () => {
+    // HandleMe writes 200 with username "" when the JWT carries none of
+    // preferred_username/upn/username/name. The cookie was still verified,
+    // so rejecting here would loop the user through login forever.
+    fakeState.config.clusters[clusterName] = { auth_type: 'oidc' };
+
+    vi.mocked(clusterRequest).mockResolvedValueOnce({ username: '' });
+
+    await expect(testAuth(clusterName)).resolves.toMatchObject({ username: '' });
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('OIDC cluster: a username merely prefixed with system:anonymous is authenticated', async () => {
+    fakeState.config.clusters[clusterName] = { auth_type: 'oidc' };
+
+    vi.mocked(clusterRequest).mockResolvedValueOnce({ username: 'system:anonymous-reader' });
+
+    await expect(testAuth(clusterName)).resolves.toMatchObject({
+      username: 'system:anonymous-reader',
+    });
+  });
+
+  it('no cluster argument: resolves the cluster through getCluster()', async () => {
+    // This is how Auth.tsx calls it — bare testAuth().
+    fakeState.config.clusters[clusterName] = { auth_type: 'oidc' };
+    vi.mocked(getCluster).mockReturnValueOnce(clusterName);
+
+    vi.mocked(clusterRequest).mockResolvedValueOnce({ username: 'alice@example.com' });
+
+    await expect(testAuth()).resolves.toMatchObject({ username: 'alice@example.com' });
+
+    expect(clusterRequest).toHaveBeenCalledWith(
+      '/me',
+      expect.objectContaining({ cluster: clusterName })
+    );
+  });
+
+  it('no cluster at all: falls through to SSRR', async () => {
+    vi.mocked(getCluster).mockReturnValueOnce(null);
+
+    vi.mocked(post).mockResolvedValueOnce({ status: { resourceRules: [] } });
+
+    await expect(testAuth()).resolves.toBeDefined();
+    expect(clusterRequest).not.toHaveBeenCalled();
+  });
+
+  it('cluster absent from config: falls through to SSRR', async () => {
+    // fakeState.config.clusters has no entry, so the optional-chained
+    // lookup yields undefined rather than throwing.
+    vi.mocked(post).mockResolvedValueOnce({ status: { resourceRules: [] } });
+
+    await expect(testAuth('unknown-cluster')).resolves.toBeDefined();
+
+    expect(post).toHaveBeenCalledWith(
+      '/apis/authorization.k8s.io/v1/selfsubjectrulesreviews',
+      expect.any(Object),
+      false,
+      expect.objectContaining({ cluster: 'unknown-cluster' })
+    );
+    expect(clusterRequest).not.toHaveBeenCalled();
+  });
+
+  it('non-OIDC cluster: testAuth still uses SSRR (unchanged)', async () => {
+    fakeState.config.clusters[clusterName] = { auth_type: '' };
+
+    vi.mocked(post).mockResolvedValueOnce({ status: { resourceRules: [] } });
+
+    await expect(testAuth(clusterName)).resolves.toBeDefined();
+
+    expect(post).toHaveBeenCalledWith(
+      '/apis/authorization.k8s.io/v1/selfsubjectrulesreviews',
+      expect.any(Object),
+      false,
+      expect.objectContaining({ cluster: clusterName })
+    );
+    expect(clusterRequest).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/lib/k8s/api/v1/clusterApi.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterApi.ts
@@ -34,18 +34,29 @@ import { JSON_HEADERS } from './constants';
  * Will throw an error if the user is not authenticated.
  *
  * For OIDC clusters (auth_type === 'oidc'), this calls the headlamp-server
- * `/clusters/{cluster}/me` endpoint, which validates the per-cluster auth
+ * `/clusters/{cluster}/me` endpoint, which checks the per-cluster auth
  * cookie. The handler is implemented at backend/pkg/auth/auth.go HandleMe;
  * it returns 401 with `{"message": "unauthorized"}` (or "token expired")
- * when the cookie is missing, malformed, or its embedded JWT cannot be
- * verified, and otherwise returns `{"username": ..., "email": ..., ...}`
- * with the JMESPath-extracted username from the JWT payload.
+ * when the cookie is missing, malformed, or its embedded JWT has expired,
+ * and otherwise returns `{"username": ..., "email": ..., ...}` with the
+ * JMESPath-extracted username from the JWT payload.
  *
  * **The HTTP status is the auth signal, not the username.** HandleMe
- * rejects a missing/invalid/expired token before it ever looks at claims,
- * so a 2xx already means the cookie was verified. `clusterRequest` rejects
- * on any non-2xx, so a 401 from /me surfaces as a thrown error and the
- * caller routes the user to AuthChooser.
+ * rejects a missing/malformed/expired token before it ever looks at
+ * claims, so a 2xx means a cookie was present and its JWT is well-formed
+ * and unexpired. `clusterRequest` rejects on any non-2xx, so a 401 from
+ * /me surfaces as a thrown error and the caller routes the user to
+ * AuthChooser.
+ *
+ * **Limitation.** HandleMe does *not* verify the JWT signature, issuer, or
+ * audience — parseClaimsFromToken (backend/pkg/auth/auth.go) base64-decodes
+ * the payload and nothing more. A caller who plants a hand-crafted token in
+ * their own cookie therefore gets a 200 here and is routed past
+ * AuthChooser, after which every Kubernetes call fails at the API server.
+ * That is a UX gate, not a security boundary: /me is not consulted for any
+ * authorization decision, and the case #4721 is about — an anonymous
+ * browser with no cookie at all — still 401s on the `token == ""` check.
+ * Real token validation in HandleMe is tracked separately.
  *
  * In particular, an **empty username is a valid authenticated session** and
  * must not be rejected here. The default username path (see
@@ -53,7 +64,7 @@ import { JSON_HEADERS } from './constants';
  * "preferred_username,upn,username,name" — there is no `sub` or `email`
  * fallback — so an IdP issuing none of those four claims (Dex without the
  * `profile` scope, Azure AD v2 access tokens, minimal Keycloak client
- * scopes) yields a cookie-verified 200 carrying `username: ""`. Turning
+ * scopes) yields an accepted-cookie 200 carrying `username: ""`. Turning
  * that into a synthetic 401 would send the user to login, which sets a
  * perfectly good cookie, which /me again reports with an empty username —
  * an infinite redirect loop (RouteSwitcher.tsx sends OIDC errors to

--- a/frontend/src/lib/k8s/api/v1/clusterApi.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterApi.ts
@@ -24,6 +24,7 @@ import { storeStatelessClusterKubeconfig } from '../../../../stateless';
 import { deleteClusterKubeconfig } from '../../../../stateless/deleteClusterKubeconfig';
 import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
 import { getCluster, getSelectedClusters } from '../../../cluster';
+import { ApiError } from '../v2/ApiError';
 import type { ClusterRequest } from './clusterRequests';
 import { clusterRequest, post, request } from './clusterRequests';
 import { JSON_HEADERS } from './constants';
@@ -31,10 +32,76 @@ import { JSON_HEADERS } from './constants';
 /**
  * Test authentication for the given cluster.
  * Will throw an error if the user is not authenticated.
+ *
+ * For OIDC clusters (auth_type === 'oidc'), this calls the headlamp-server
+ * `/clusters/{cluster}/me` endpoint, which validates the per-cluster auth
+ * cookie. The handler is implemented at backend/pkg/auth/auth.go HandleMe;
+ * it returns 401 with `{"message": "unauthorized"}` (or "token expired")
+ * when the cookie is missing, malformed, or its embedded JWT cannot be
+ * verified, and otherwise returns `{"username": ..., "email": ..., ...}`
+ * with the JMESPath-extracted username from the JWT payload.
+ *
+ * **The HTTP status is the auth signal, not the username.** HandleMe
+ * rejects a missing/invalid/expired token before it ever looks at claims,
+ * so a 2xx already means the cookie was verified. `clusterRequest` rejects
+ * on any non-2xx, so a 401 from /me surfaces as a thrown error and the
+ * caller routes the user to AuthChooser.
+ *
+ * In particular, an **empty username is a valid authenticated session** and
+ * must not be rejected here. The default username path (see
+ * DefaultMeUsernamePath in backend/pkg/config/config.go) is
+ * "preferred_username,upn,username,name" — there is no `sub` or `email`
+ * fallback — so an IdP issuing none of those four claims (Dex without the
+ * `profile` scope, Azure AD v2 access tokens, minimal Keycloak client
+ * scopes) yields a cookie-verified 200 carrying `username: ""`. Turning
+ * that into a synthetic 401 would send the user to login, which sets a
+ * perfectly good cookie, which /me again reports with an empty username —
+ * an infinite redirect loop (RouteSwitcher.tsx sends OIDC errors to
+ * `login`). `getClusterUserInfo` below takes the same stance: an empty
+ * username means "no info", not "unauthenticated".
+ *
+ * The `system:anonymous` check is defense in depth for an operator whose
+ * JMESPath username extraction resolves to the Kubernetes anonymous user.
+ * It is an exact match on purpose: `system:anonymous-reader` and similar
+ * are legitimate usernames, and the anonymous user is exactly
+ * `system:anonymous`.
+ *
+ * This works around the SSRR false-positive reported in #4721: when
+ * `system:basic-user` is granted to `system:unauthenticated`, SSRR
+ * returns HTTP 201 for both anonymous and authenticated callers, so it
+ * cannot be used as the auth signal on those clusters.
+ *
+ * For non-OIDC clusters, behavior is unchanged: SSRR is the auth signal.
  */
 export async function testAuth(cluster = '', namespace = 'default') {
-  const spec = { namespace };
   const clusterName = cluster || getCluster();
+
+  if (clusterName) {
+    const clusterAuthType = store.getState().config?.clusters?.[clusterName]?.auth_type;
+
+    if (clusterAuthType === 'oidc') {
+      const me = await clusterRequest('/me', {
+        timeout: 5 * 1000,
+        cluster: clusterName,
+        // This is an auth *probe*: the caller decides what a 401 means and
+        // where to send the user. Letting clusterRequest log the user out
+        // from underneath it would race that logic. The SSRR call below
+        // passes false for the same reason.
+        autoLogoutOnAuthError: false,
+      });
+
+      const username: string = (me && me.username) || '';
+      // Exact match only — see the note above on why an empty username is
+      // accepted and why this is not a `startsWith`.
+      if (username === 'system:anonymous') {
+        throw new ApiError('not authenticated', { status: 401, cluster: clusterName });
+      }
+
+      return me;
+    }
+  }
+
+  const spec = { namespace };
 
   return post('/apis/authorization.k8s.io/v1/selfsubjectrulesreviews', { spec }, false, {
     timeout: 5 * 1000,


### PR DESCRIPTION
## Summary

`testAuth` calls SSRR (`selfsubjectrulesreviews`) on every cluster to decide whether the user is authenticated. On clusters where `system:basic-user` is granted to `system:unauthenticated`, SSRR returns HTTP 201 for anonymous and authenticated callers alike, so it cannot tell them apart. `testAuth` reports "authenticated" for an anonymous browser, the user skips AuthChooser, and individual API calls then fail one by one instead of the user being sent to login.

For OIDC clusters (`auth_type === 'oidc'`), `testAuth` now calls `/clusters/{cluster}/me` instead. `HandleMe` (`backend/pkg/auth/auth.go`) checks the per-cluster auth cookie and returns 401 when it is missing, malformed, or its embedded JWT has expired. `clusterRequest` rejects on any non-2xx, so that surfaces as a thrown error and the caller routes the user to AuthChooser.

For non-OIDC clusters, behavior is unchanged — SSRR is still the auth signal there, because there is no cookie to check.

No backend changes: `/clusters/{clusterName}/me` already exists on `main`.

### The HTTP status is the auth signal, not the username

`HandleMe` rejects a missing, malformed, or expired token *before* it extracts any claim, so a 2xx already means a cookie was present and its JWT is well-formed and unexpired. The username is therefore not used to decide authentication, with one defense-in-depth exception: an exact match on `system:anonymous`, for an operator whose JMESPath username extraction resolves to the Kubernetes anonymous user.

In particular an **empty username is a valid authenticated session**. `DefaultMeUsernamePath` (`backend/pkg/config/config.go`) is `preferred_username,upn,username,name` — there is no `sub` or `email` fallback — so an IdP issuing none of those four claims (Dex without the `profile` scope, Azure AD v2 access tokens, minimal Keycloak client scopes) yields an accepted-cookie 200 carrying `username: ""`. Rejecting that would send the user to login, which sets a perfectly good cookie, which `/me` again reports with an empty username — an infinite redirect loop, since `RouteSwitcher.tsx` routes OIDC errors to `login`. `getClusterUserInfo` in the same file already takes this stance: empty means "no info", not "unauthenticated".

The `system:anonymous` check is an exact match rather than a prefix match on purpose — `system:anonymous-reader` and similar are legitimate usernames.

## Provenance

This is **stage 6 extracted from #5427**, which is being split rather than finished. #5427 is 3,636 additions across 29 files and carries a signed-OIDC-state redesign that needs its own design discussion (the state map has been reworked by ~5 separate PRs on `main` since that branch was cut). This piece is independent of that work and of the rest of the stack, so it is going up on its own to unblock #4721.

The remaining stages will follow as separate PRs. #5427 will be closed.

## Test plan

- [x] `vitest run clusterApi.test.ts` — 10 passed (1 existing `setCluster` + 9 `testAuth`)
- [x] `vitest run apiProxy.test.ts` — 67 passed. It has its own `testAuth` suite that does *not* mock the store, exercising the real SSRR path end-to-end through `nock`; it stays green.
- [x] `tsc --noEmit` across the frontend — clean
- [x] `eslint` + `prettier --check` on both changed files — clean

**Mutation check.** Each behavior below was individually reverted in `clusterApi.ts` and the suite re-run, to confirm the covering test fails for the right reason and no test is vacuous:

| Mutation | Test that fails |
|---|---|
| restore `!username \|\|` in the reject condition | empty username is still an authenticated session |
| `startsWith('system:anonymous')` instead of `===` | username merely prefixed with `system:anonymous` is authenticated |
| drop `autoLogoutOnAuthError: false` | `/me` returning a real identity is authenticated |
| change `timeout` from 5000 | `/me` returning a real identity is authenticated |
| swallow the rejection from `/me` | a 401 from `/me` propagates with its status intact |
| drop the `\|\| getCluster()` fallback | no cluster argument: resolves the cluster through `getCluster()` |
| make the `config?.clusters?.[name]?` lookup non-optional | cluster absent from config: falls through to SSRR |

Coverage over (`auth_type` × outcome):

| auth_type | /me result | expected |
|---|---|---|
| `oidc` | 200, real username | authenticated; `/me` called, SSRR not called |
| `oidc` | **401 (rejects)** | error propagates with `status: 401` — the real unauthenticated path, and the one that fixes #4721 |
| `oidc` | 200, `system:anonymous` | rejected, 401 |
| `oidc` | 200, empty username | **authenticated** |
| `oidc` | 200, `system:anonymous-reader` | authenticated |
| `oidc`, no cluster arg | 200 | resolved via `getCluster()` — how `Auth.tsx` calls it |
| no cluster at all | — | falls through to SSRR |
| absent from config | — | falls through to SSRR |
| non-`oidc` | — | authenticated via SSRR (unchanged) |

## Scope notes

**`/me` is not a cryptographic verification.** `HandleMe` decodes the JWT payload and checks `exp`; it does not check signature, issuer, or audience (`parseClaimsFromToken`, `backend/pkg/auth/auth.go`). A self-forged token passes this probe and then fails at the Kubernetes API server. `/me` is still a strictly better anonymous-user signal than SSRR — no cookie means a hard 401 on the `token == ""` check, which is the case #4721 is about — but it is a routing gate, not an authorization boundary, and nothing on the backend makes an authorization decision from it. Real token validation in `HandleMe` is filed as #7225. Raised in review by Copilot; the `testAuth` docstring carries the same limitation note.

**Reverse-proxy header auth is out of scope.** `e945fb358` added reverse-proxy / header-injected auth support (`tryProxyAuth`, `backend/pkg/auth/auth.go`). Those deployments do not have `auth_type === 'oidc'`, so they keep the SSRR path — this change is a no-op for them, and **#4721 still reproduces there**. The branch could not simply be widened to cover them: `tryProxyAuth` is the first thing `HandleMe` does and returns 200 from the presence of the username header alone, before any cookie or token is consulted, so `/me` is not an auth signal for those clusters either. Fixing that case needs its own design; tracked alongside the token-validation work in #7225.

**The "Use A Token" path on an OIDC cluster now goes through `/me`.** `authchooser/index.tsx` renders that button unconditionally, and `Auth.tsx` calls bare `testAuth()`. Service-account tokens still work — they are JWTs with an `exp` claim, which is what `HandleMe` checks. An *opaque* bearer token would now 401 where SSRR previously accepted it. Falling back to SSRR on failure would reopen #4721, so this is deliberate.

Fixes #4721
Refs #5401
