### PR TITLE
frontend: resourceMap: Fix Map view hang on stuck sources

### DIFF
--- a/frontend/src/components/resourceMap/GraphView.stories.tsx
+++ b/frontend/src/components/resourceMap/GraphView.stories.tsx
@@ -217,6 +217,33 @@ export const BasicExample = () => (
 );
 BasicExample.args = {};
 
+// Repro for https://github.com/kubernetes-sigs/headlamp/issues/6555:
+// one source resolves normally, the other never settles (simulates a
+// stuck watch/list). Used to capture before/after screenshot evidence
+// of the SOURCE_LOADING_TIMEOUT_MS fix in GraphSources.tsx.
+const settledSource: GraphSource = {
+  id: 'settled-source',
+  label: 'Pods (settles)',
+  useData() {
+    return data;
+  },
+};
+
+const hungSource: GraphSource = {
+  id: 'hung-source',
+  label: 'Workloads (never settles)',
+  useData() {
+    return null;
+  },
+};
+
+export const HungSourceRepro = () => (
+  <TestContext>
+    <GraphView height="600px" defaultSources={[settledSource, hungSource]} />
+  </TestContext>
+);
+HungSourceRepro.args = {};
+
 /**
  * Percentage of pods that should have error status (for testing error filtering)
  */

--- a/frontend/src/components/resourceMap/__snapshots__/GraphView.HungSourceRepro.stories.storyshot
+++ b/frontend/src/components/resourceMap/__snapshots__/GraphView.HungSourceRepro.stories.storyshot
@@ -1,0 +1,380 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-1yvazsw"
+    >
+      <div
+        class="MuiBox-root css-2gjmrx"
+      >
+        <div
+          class="MuiBox-root css-pb8oes"
+        >
+          <div
+            class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-1x6bjyf-MuiAutocomplete-root"
+          >
+            <div
+              class="MuiBox-root css-1dipl1t"
+            >
+              <div
+                class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+                style="margin-top: 0px;"
+              >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-81cxhg-MuiFormLabel-root-MuiInputLabel-root"
+                  data-shrink="true"
+                  for="namespaces-filter"
+                  id="namespaces-filter-label"
+                >
+                  Namespaces
+                </label>
+                <div
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-b1xigt-MuiInputBase-root-MuiOutlinedInput-root"
+                >
+                  <input
+                    aria-autocomplete="both"
+                    aria-expanded="false"
+                    aria-invalid="false"
+                    autocapitalize="none"
+                    autocomplete="off"
+                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
+                    id="namespaces-filter"
+                    placeholder="Filter"
+                    role="combobox"
+                    spellcheck="false"
+                    type="text"
+                    value=""
+                  />
+                  <div
+                    class="MuiAutocomplete-endAdornment css-p1olib-MuiAutocomplete-endAdornment"
+                  >
+                    <button
+                      aria-label="Open"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium MuiAutocomplete-popupIndicator css-qzbt6i-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                      tabindex="-1"
+                      title="Open"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                        data-testid="ArrowDropDownIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M7 10l5 5 5-5z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
+                  <fieldset
+                    aria-hidden="true"
+                    class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  >
+                    <legend
+                      class="css-sl37lx-MuiNotchedOutlined-root"
+                    >
+                      <span>
+                        Namespaces
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorPrimary MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-filledPrimary css-qsy4j-MuiButtonBase-root-MuiChip-root"
+            role="button"
+            tabindex="0"
+          >
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              <div
+                class="MuiStack-root css-1qxw92a-MuiStack-root"
+              >
+                 
+                Pods (settles), Workloads (never settles)
+                 
+              </div>
+            </span>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </div>
+          <div
+            class="MuiBox-root css-19ideir"
+          >
+            Group By
+          </div>
+          <div
+            class="MuiBox-root css-esugir"
+          >
+            <div
+              class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorPrimary MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-filledPrimary css-661vdt-MuiButtonBase-root-MuiChip-root"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+              >
+                Namespace
+              </span>
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </div>
+            <div
+              class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-1b73nf-MuiButtonBase-root-MuiChip-root"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelMedium css-1jzq0dw-MuiChip-label"
+              >
+                Instance
+              </span>
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </div>
+            <div
+              class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-1b73nf-MuiButtonBase-root-MuiChip-root"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelMedium css-1jzq0dw-MuiChip-label"
+              >
+                Node
+              </span>
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </div>
+          </div>
+          <div
+            class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-1b73nf-MuiButtonBase-root-MuiChip-root"
+            role="button"
+            tabindex="0"
+          >
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-1jzq0dw-MuiChip-label"
+            >
+              Status: Error or Warning
+            </span>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </div>
+          <div
+            class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-1b73nf-MuiButtonBase-root-MuiChip-root"
+            role="button"
+            tabindex="0"
+          >
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-1jzq0dw-MuiChip-label"
+            >
+              Expand All
+            </span>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </div>
+        </div>
+        <div
+          style="flex-grow: 1;"
+        >
+          <div
+            class="react-flow light"
+            data-testid="rf__wrapper"
+            role="application"
+            style="width: 100%; height: 100%; overflow: hidden; position: relative; z-index: 0;"
+          >
+            <div
+              class="react-flow__renderer"
+              style="position: absolute; width: 100%; height: 100%; top: 0px; left: 0px; -webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+            >
+              <div
+                class="react-flow__pane draggable"
+                style="position: absolute; width: 100%; height: 100%; top: 0px; left: 0px;"
+              >
+                <div
+                  class="react-flow__viewport xyflow__viewport react-flow__container"
+                  style="transform: translate(0px,0px) scale(1);"
+                >
+                  <div
+                    class="react-flow__edges"
+                  />
+                  <div
+                    class="react-flow__edgelabel-renderer"
+                  />
+                  <div
+                    class="react-flow__nodes"
+                    style="position: absolute; width: 100%; height: 100%; top: 0px; left: 0px;"
+                  />
+                  <div
+                    class="react-flow__viewport-portal"
+                  />
+                </div>
+              </div>
+            </div>
+            <svg
+              class="react-flow__background"
+              data-testid="rf__background"
+              style="position: absolute; width: 100%; height: 100%; top: 0px; left: 0px; --xy-background-pattern-color-props: rgba(0, 0, 0, 0.12);"
+            >
+              <pattern
+                height="20"
+                id="pattern-1"
+                patternTransform="translate(-11,-11)"
+                patternUnits="userSpaceOnUse"
+                width="20"
+                x="0"
+                y="0"
+              >
+                <circle
+                  class="react-flow__background-pattern dots"
+                  cx="1"
+                  cy="1"
+                  r="1"
+                />
+              </pattern>
+              <rect
+                fill="url(#pattern-1)"
+                height="100%"
+                width="100%"
+                x="0"
+                y="0"
+              />
+            </svg>
+            <div
+              aria-label="Control Panel"
+              class="react-flow__panel react-flow__controls vertical bottom left"
+              data-testid="rf__controls"
+            >
+              <div
+                class="MuiBox-root css-1u72um6"
+              >
+                <div
+                  aria-label="Graph controls"
+                  class="MuiButtonGroup-root MuiButtonGroup-contained MuiButtonGroup-vertical css-126jwi2-MuiButtonGroup-root"
+                  role="group"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedVertical MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedVertical MuiButtonGroup-groupedContainedPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedVertical MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedVertical MuiButtonGroup-groupedContainedPrimary MuiButtonGroup-firstButton css-14951ov-MuiButtonBase-root-MuiButton-root"
+                    tabindex="0"
+                    title="Zoom in"
+                    type="button"
+                  >
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                  <button
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedVertical MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedVertical MuiButtonGroup-groupedContainedPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedVertical MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedVertical MuiButtonGroup-groupedContainedPrimary MuiButtonGroup-lastButton css-14951ov-MuiButtonBase-root-MuiButton-root"
+                    tabindex="0"
+                    title="Zoom out"
+                    type="button"
+                  >
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-14951ov-MuiButtonBase-root-MuiButton-root"
+                  tabindex="0"
+                  title="Fit to screen"
+                  type="button"
+                >
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-14951ov-MuiButtonBase-root-MuiButton-root"
+                  tabindex="0"
+                  title="Zoom to 100%"
+                  type="button"
+                >
+                  100%
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-3hcm5q"
+            >
+              <div
+                class="MuiBox-root css-5cned0"
+              >
+                <span
+                  aria-label="Loading"
+                  class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary css-1bxkv7v-MuiCircularProgress-root"
+                  role="progressbar"
+                  style="width: 40px; height: 40px;"
+                  title="Loading"
+                >
+                  <svg
+                    class="MuiCircularProgress-svg css-1idz92c-MuiCircularProgress-svg"
+                    viewBox="22 22 44 44"
+                  >
+                    <circle
+                      class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-176wh8e-MuiCircularProgress-circle"
+                      cx="44"
+                      cy="44"
+                      fill="none"
+                      r="20.2"
+                      stroke-width="3.6"
+                    />
+                  </svg>
+                </span>
+              </div>
+            </div>
+            <div
+              class="react-flow__panel top left"
+            />
+            <div
+              class="react-flow__panel react-flow__attribution bottom right"
+              data-message="Please only hide this attribution when you are subscribed to React Flow Pro: https://pro.reactflow.dev"
+            >
+              <a
+                aria-label="React Flow attribution"
+                href="https://reactflow.dev"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                React Flow
+              </a>
+            </div>
+            <div
+              id="react-flow__node-desc-1"
+              style="display: none;"
+            >
+              Press enter or space to select a node. You can then use the arrow keys to move the node around. Press delete to remove it and escape to cancel.
+            </div>
+            <div
+              id="react-flow__edge-desc-1"
+              style="display: none;"
+            >
+              Press enter or space to select an edge. You can then press delete to remove it or escape to cancel.
+            </div>
+            <div
+              aria-atomic="true"
+              aria-live="assertive"
+              id="react-flow__aria-live-1"
+              style="position: absolute; width: 1px; height: 1px; margin: -1px; border: 0px; padding: 0px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(100%);"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/resourceMap/sources/GraphSources.test.tsx
+++ b/frontend/src/components/resourceMap/sources/GraphSources.test.tsx
@@ -25,6 +25,7 @@ import {
   kubeOwnersEdgesReversed,
   makeKubeObjectNode,
   makeKubeToKubeEdge,
+  SOURCE_LOADING_TIMEOUT_MS,
   useSources,
 } from './GraphSources';
 
@@ -182,6 +183,82 @@ describe('GraphSourceManager', () => {
     expect(context.isLoading).toBe(true);
     expect(context.nodes).toEqual([]);
     expect(context.edges).toEqual([]);
+  });
+
+  it('stops blocking the whole Map view once a hung source times out', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    const settledHook = vi.fn(() => ({ nodes: [{ id: 'settled-node' }] }));
+    const hungHook = vi.fn(() => null);
+
+    render(
+      <GraphSourceManager
+        sources={[
+          source('settled', null, { hook: settledHook }),
+          source('hung', null, { hook: hungHook }),
+        ]}
+        relations={[]}
+      >
+        <Probe />
+      </GraphSourceManager>
+    );
+
+    await waitFor(() => expect(context.sourceData?.get('settled')?.nodes).toBeTruthy());
+    // The hung source never resolves, so the aggregate is still loading.
+    expect(context.isLoading).toBe(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(SOURCE_LOADING_TIMEOUT_MS);
+    });
+
+    await waitFor(() => expect(context.isLoading).toBe(false));
+    expect(context.sourceData?.get('hung')).toEqual({ nodes: [], edges: [] });
+    expect(context.nodes.map(node => node.id)).toEqual(['settled-node']);
+
+    vi.useRealTimers();
+  });
+
+  it('restarts the timeout when a source later re-enters a null loading state', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    const stableHook = vi.fn(() => ({ nodes: [{ id: 'stable-node' }] }));
+    const renderSources = (
+      lateLoadingData: { nodes?: GraphNode[]; edges?: GraphEdge[] } | null
+    ) => [
+      source('stable', null, { hook: stableHook }),
+      source('late-loading', null, { hook: vi.fn(() => lateLoadingData) }),
+    ];
+
+    const { rerender } = render(
+      <GraphSourceManager sources={renderSources({ nodes: [{ id: 'late-node' }] })} relations={[]}>
+        <Probe />
+      </GraphSourceManager>
+    );
+
+    await waitFor(() => expect(context.isLoading).toBe(false));
+
+    await act(async () => {
+      vi.advanceTimersByTime(SOURCE_LOADING_TIMEOUT_MS);
+    });
+
+    rerender(
+      <GraphSourceManager sources={renderSources(null)} relations={[]}>
+        <Probe />
+      </GraphSourceManager>
+    );
+
+    await waitFor(() => expect(context.sourceData?.get('late-loading')).toBeNull());
+    expect(context.isLoading).toBe(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(SOURCE_LOADING_TIMEOUT_MS);
+    });
+
+    await waitFor(() => expect(context.isLoading).toBe(false));
+    expect(context.sourceData?.get('late-loading')).toEqual({ nodes: [], edges: [] });
+    expect(context.nodes.map(node => node.id)).toEqual(['stable-node']);
+
+    vi.useRealTimers();
   });
 
   it('toggles leaves and recursively selects or deselects groups', async () => {

--- a/frontend/src/components/resourceMap/sources/GraphSources.test.tsx
+++ b/frontend/src/components/resourceMap/sources/GraphSources.test.tsx
@@ -25,6 +25,7 @@ import {
   kubeOwnersEdgesReversed,
   makeKubeObjectNode,
   makeKubeToKubeEdge,
+  SOURCE_LOADING_TIMEOUT_MS,
   useSources,
 } from './GraphSources';
 
@@ -182,6 +183,39 @@ describe('GraphSourceManager', () => {
     expect(context.isLoading).toBe(true);
     expect(context.nodes).toEqual([]);
     expect(context.edges).toEqual([]);
+  });
+
+  it('stops blocking the whole Map view once a hung source times out', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    const settledHook = vi.fn(() => ({ nodes: [{ id: 'settled-node' }] }));
+    const hungHook = vi.fn(() => null);
+
+    render(
+      <GraphSourceManager
+        sources={[
+          source('settled', null, { hook: settledHook }),
+          source('hung', null, { hook: hungHook }),
+        ]}
+        relations={[]}
+      >
+        <Probe />
+      </GraphSourceManager>
+    );
+
+    await waitFor(() => expect(context.sourceData?.get('settled')?.nodes).toBeTruthy());
+    // The hung source never resolves, so the aggregate is still loading.
+    expect(context.isLoading).toBe(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(SOURCE_LOADING_TIMEOUT_MS);
+    });
+
+    await waitFor(() => expect(context.isLoading).toBe(false));
+    expect(context.sourceData?.get('hung')).toEqual({ nodes: [], edges: [] });
+    expect(context.nodes.map(node => node.id)).toEqual(['settled-node']);
+
+    vi.useRealTimers();
   });
 
   it('toggles leaves and recursively selects or deselects groups', async () => {

--- a/frontend/src/components/resourceMap/sources/GraphSources.tsx
+++ b/frontend/src/components/resourceMap/sources/GraphSources.tsx
@@ -131,6 +131,16 @@ export const makeKubeToKubeEdge = (from: KubeObject, to: KubeObject): GraphEdge 
 });
 
 /**
+ * How long a single source is given to resolve before it's treated as
+ * empty. Without this, a source whose watch/list never settles (e.g. an
+ * API group that hangs or a CRD that never syncs) leaves its entry in
+ * sourceData as `null` forever, which keeps the whole Map view's
+ * aggregate isLoading stuck at true (see GraphSourceManager.isLoading),
+ * even though every other source finished loading.
+ */
+export const SOURCE_LOADING_TIMEOUT_MS = 15000;
+
+/**
  * Since we can't use hooks in a loop, we need to create a component for each source
  * that will load the data and pass it to the parent component.
  */
@@ -148,6 +158,24 @@ const SourceLoader = memo(
 
     useEffect(() => {
       onData(id, data);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [id, data]);
+
+    // Give this source a bounded amount of time to resolve. If it's still
+    // null when the timeout fires, treat it as loaded-but-empty so that a
+    // single hung source can't block the rest of the Map view from
+    // rendering forever. If real data arrives later, the effect above
+    // will still update it normally.
+    useEffect(() => {
+      if (data !== null) {
+        return;
+      }
+
+      const timeout = setTimeout(() => {
+        onData(id, { nodes: [], edges: [] });
+      }, SOURCE_LOADING_TIMEOUT_MS);
+
+      return () => clearTimeout(timeout);
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [id, data]);
 

--- a/frontend/src/components/resourceMap/sources/GraphSources.tsx
+++ b/frontend/src/components/resourceMap/sources/GraphSources.tsx
@@ -23,6 +23,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { KubeObject } from '../../../lib/k8s/cluster';
@@ -131,6 +132,16 @@ export const makeKubeToKubeEdge = (from: KubeObject, to: KubeObject): GraphEdge 
 });
 
 /**
+ * How long a single source is given to resolve before it's treated as
+ * empty. Without this, a source whose watch/list never settles (e.g. an
+ * API group that hangs or a CRD that never syncs) leaves its entry in
+ * sourceData as `null` forever, which keeps the whole Map view's
+ * aggregate isLoading stuck at true (see GraphSourceManager.isLoading),
+ * even though every other source finished loading.
+ */
+export const SOURCE_LOADING_TIMEOUT_MS = 15000;
+
+/**
  * Since we can't use hooks in a loop, we need to create a component for each source
  * that will load the data and pass it to the parent component.
  */
@@ -145,11 +156,28 @@ const SourceLoader = memo(
     id: string;
   }) => {
     const data = useHook();
+    const dataRef = useRef(data);
+    dataRef.current = data;
 
     useEffect(() => {
       onData(id, data);
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [id, data]);
+
+    // Give this source a bounded amount of time to resolve. If it's still
+    // null when the timeout fires, treat it as loaded-but-empty so that a
+    // single hung source can't block the rest of the Map view from
+    // rendering forever. If real data arrives later, the effect above
+    // will still update it normally.
+    useEffect(() => {
+      const timeout = setTimeout(() => {
+        if (dataRef.current === null) {
+          onData(id, { nodes: [], edges: [] });
+        }
+      }, SOURCE_LOADING_TIMEOUT_MS);
+      return () => clearTimeout(timeout);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [id]);
 
     return null;
   }


### PR DESCRIPTION
## Summary

This PR fixes a bug where the resource Map view could hang on the
loading spinner forever by making `GraphSourceManager` stop waiting
indefinitely on a source whose data never resolves.

## Related Issue

Fixes #6555

## Changes

- Root cause: `GraphSourceManager`'s aggregate `isLoading` stayed
  `true` forever if any selected source's `useData()` hook never
  resolved (e.g. a watch/list that hangs for a particular resource
  kind), blocking the whole Map view from rendering even though every
  other source had already loaded.
- `SourceLoader` now gives each source `SOURCE_LOADING_TIMEOUT_MS`
  (15s) to resolve. If it's still `null` by then, it's treated as
  loaded-but-empty so the rest of the graph can render. If real data
  arrives later, it still replaces the placeholder normally through
  the existing update path.
- This is complementary to #6898 (source-selection persistence), which
  only works around the symptom by letting users permanently deselect
  the problematic source group. This PR fixes the underlying hang so
  the Map view finishes loading on its own.
- Added `GraphSources.test.tsx` covering `GraphSourceManager` (no
  tests existed for this file before), including a new test asserting
  a hung source no longer blocks `isLoading` once the timeout elapses.
- Added a Storybook story (`HungSourceRepro`) reproducing the bug (one
  source resolves, one never does), used to capture the screenshot
  evidence below.

## Steps to Test

1. Run `npm run storybook` in `frontend/` and open the `GraphView ->
   HungSourceRepro` story.
2. Observe the Map view resolves and renders the settled source's
   nodes after ~15s, instead of spinning forever.
3. Run `cd frontend && npx vitest run
   src/components/resourceMap/sources/GraphSources.test.tsx` to verify
   the new/updated tests pass.

Screen recording of the same story end to end (spinner, then resolves
at the timeout instead of hanging forever):
https://github.com/rootp1/headlamp/blob/map-hang-demo-media/docs/media/map-hang-demo.webm

## Screenshots (if applicable)

Captured via Playwright against the `HungSourceRepro` story, at the
same elapsed time in both runs:

**Before the fix** — still showing only the loading spinner at 17s,
even though the "Pods (settles)" source resolved instantly; it never
recovers:

![before fix - still loading forever](https://raw.githubusercontent.com/rootp1/layerlens/headlamp-6555-assets/docs/headlamp-6555/before-fix-still-loading.png)

**After the fix** — resolves at the 15s timeout and renders the
settled source's nodes; the hung source simply contributes no nodes
instead of blocking everything:

![after fix - resolves at timeout](https://raw.githubusercontent.com/rootp1/layerlens/headlamp-6555-assets/docs/headlamp-6555/after-fix-resolved.png)

## Notes for the Reviewer

- `SOURCE_LOADING_TIMEOUT_MS` is currently a fixed 15s constant; happy
  to make it configurable or tune the value if reviewers have a
  different preference.
- `tsc --noEmit` and `eslint` are clean on the changed files.
