### PR TITLE
backend: oidc: Add integration tests against a real Dex instance

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -69,7 +69,8 @@ jobs:
           docker run -d --name headlamp-dex \
             -p 5556:5556 \
             -v "$GITHUB_WORKSPACE/backend/cmd/headlamp_testdata/dex-integration.yaml:/etc/dex/config.yaml:ro" \
-            ghcr.io/dexidp/dex:v2.44.0 dex serve /etc/dex/config.yaml
+            ghcr.io/dexidp/dex@sha256:5d0656fce7d453c0e3b2706abf40c0d0ce5b371fb0b73b3cf714d05f35fa5f86 \
+            dex serve /etc/dex/config.yaml # v2.44.0
 
           for i in $(seq 1 30); do
             if curl -sf http://127.0.0.1:5556/dex/.well-known/openid-configuration >/dev/null; then

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -47,6 +47,23 @@ jobs:
           minikube addons enable headlamp
           kubectl wait deployment -n headlamp headlamp --for condition=Available=True --timeout=30s
 
+      - name: setup and run golangci-lint
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
+        with:
+          version: v2.12.2
+          working-directory: backend
+          skip-cache: true
+          args: --timeout 3m
+
+      - name: Lint, Build & Check
+        run: |
+          cd $GITHUB_WORKSPACE
+          make backend
+
+      # Started after lint and build so that a Dex/registry hiccup cannot take
+      # those down for backend PRs unrelated to OIDC. It still runs before the
+      # test step and fails hard, so the integration tests can never silently
+      # skip on CI.
       - name: Start Dex for OIDC integration tests
         run: |
           docker run -d --name headlamp-dex \
@@ -65,19 +82,6 @@ jobs:
           echo "dex did not become ready" >&2
           docker logs headlamp-dex >&2
           exit 1
-
-      - name: setup and run golangci-lint
-        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
-        with:
-          version: v2.12.2
-          working-directory: backend
-          skip-cache: true
-          args: --timeout 3m
-
-      - name: Lint, Build & Check
-        run: |
-          cd $GITHUB_WORKSPACE
-          make backend
 
       - name: Run tests and calculate code coverage
         run: |

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -16,6 +16,7 @@ permissions:
 
 env:
   HEADLAMP_RUN_INTEGRATION_TESTS: true
+  HEADLAMP_TEST_OIDC_ISSUER: http://127.0.0.1:5556/dex
 
 jobs:
   build:
@@ -44,7 +45,26 @@ jobs:
         run: |
           minikube status
           minikube addons enable headlamp
-          kubectl wait deployment -n headlamp headlamp --for condition=Available=True --timeout=30s    
+          kubectl wait deployment -n headlamp headlamp --for condition=Available=True --timeout=30s
+
+      - name: Start Dex for OIDC integration tests
+        run: |
+          docker run -d --name headlamp-dex \
+            -p 5556:5556 \
+            -v "$GITHUB_WORKSPACE/backend/cmd/headlamp_testdata/dex-integration.yaml:/etc/dex/config.yaml:ro" \
+            ghcr.io/dexidp/dex:v2.44.0 dex serve /etc/dex/config.yaml
+
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:5556/dex/.well-known/openid-configuration >/dev/null; then
+              echo "dex is up"
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "dex did not become ready" >&2
+          docker logs headlamp-dex >&2
+          exit 1
 
       - name: setup and run golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1

--- a/backend/cmd/headlamp_testdata/dex-integration.yaml
+++ b/backend/cmd/headlamp_testdata/dex-integration.yaml
@@ -1,0 +1,26 @@
+# Dex configuration for backend OIDC integration tests.
+# The mockCallback connector issues an authorization code without any user
+# interaction, so the whole flow is a redirect chain a plain http.Client can
+# follow. Do not use this configuration outside tests.
+issuer: http://127.0.0.1:5556/dex
+
+storage:
+  type: memory
+
+web:
+  http: 0.0.0.0:5556
+
+oauth2:
+  skipApprovalScreen: true
+
+staticClients:
+  - id: headlamp-test
+    name: Headlamp integration test
+    secret: headlamp-test-secret
+    redirectURIs:
+      - http://127.0.0.1:18080/oidc-callback
+
+connectors:
+  - type: mockCallback
+    id: mock
+    name: Mock

--- a/backend/cmd/oidc_integration_test.go
+++ b/backend/cmd/oidc_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/auth"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
@@ -277,4 +278,60 @@ func TestOIDCIntegration_LoginSucceedsWithPKCE(t *testing.T) {
 
 	rawToken := authTokenFromJar(t, srv, jar)
 	assert.Len(t, strings.Split(rawToken, "."), 3, "ID token should be a JWT")
+}
+
+func TestOIDCIntegration_RefreshTokenExchange(t *testing.T) {
+	issuer := requireDexIssuer(t)
+
+	cfg := newOIDCIntegrationConfig(t, issuer)
+	srv := startOIDCIntegrationServer(t, cfg)
+
+	// Log in first: this is what populates the cache with a Dex-issued
+	// refresh token keyed by the raw ID token.
+	_, jar, _ := runOIDCLoginFlow(t, srv) //nolint:bodyclose // closed inside runOIDCLoginFlow via defer
+	rawToken := authTokenFromJar(t, srv, jar)
+
+	kContext, err := cfg.KubeConfigStore.GetContext(oidcTestCluster)
+	require.NoError(t, err)
+
+	oidcConf, err := kContext.OidcConfig()
+	require.NoError(t, err)
+
+	newToken, err := auth.RefreshAndCacheNewToken(
+		context.Background(),
+		oidcConf,
+		cfg.Cache,
+		"id_token",
+		rawToken,
+		issuer,
+		"", // no validator issuer override
+	)
+	require.NoError(t, err)
+	require.NotNil(t, newToken)
+
+	// Dex minted a fresh ID token.
+	refreshedID, ok := newToken.Extra("id_token").(string)
+	require.True(t, ok, "refreshed token should carry an id_token")
+
+	// RefreshAndCacheNewToken does NOT verify (auth.go:293-323): it does
+	// discovery and hits the token endpoint, then returns the new token
+	// unverified. So this test verifies the refreshed ID token itself,
+	// against Dex's live JWKS -- this is the assertion that makes the test
+	// worth running against a real IdP rather than a mock.
+	provider, err := oidc.NewProvider(context.Background(), issuer)
+	require.NoError(t, err)
+
+	verified, err := provider.Verifier(&oidc.Config{ClientID: oidcTestClientID}).
+		Verify(context.Background(), refreshedID)
+	require.NoError(t, err, "refreshed ID token failed live JWKS verification")
+	assert.Equal(t, issuer, verified.Issuer)
+
+	// CacheRefreshedToken re-keys the entry under the NEW id_token
+	// (auth.go:173), keeping the old key alive briefly on a TTL.
+	cached, err := cfg.Cache.Get(context.Background(), "oidc-token-"+refreshedID)
+	require.NoError(t, err)
+
+	cachedRefresh, ok := cached.(string)
+	require.True(t, ok)
+	assert.NotEmpty(t, cachedRefresh)
 }

--- a/backend/cmd/oidc_integration_test.go
+++ b/backend/cmd/oidc_integration_test.go
@@ -131,14 +131,26 @@ func startOIDCIntegrationServer(t *testing.T, cfg *HeadlampConfig) *httptest.Ser
 
 // runOIDCLoginFlow drives GET /oidc through Dex and back to /oidc-callback.
 // With skipApprovalScreen and a lone mockCallback connector, every hop is a
-// redirect, so the default client policy walks the entire flow.
-func runOIDCLoginFlow(t *testing.T, srv *httptest.Server) (*http.Response, *cookiejar.Jar) {
+// redirect, so the default client policy walks the entire flow. The returned
+// slice records the URL of every hop the client was redirected to (via
+// CheckRedirect), so callers can inspect query params Dex received on
+// intermediate redirects -- e.g. code_challenge on the authorize request --
+// which the final response/cookie alone cannot reveal.
+func runOIDCLoginFlow(t *testing.T, srv *httptest.Server) (*http.Response, *cookiejar.Jar, []*url.URL) {
 	t.Helper()
 
 	jar, err := cookiejar.New(nil)
 	require.NoError(t, err)
 
-	client := &http.Client{Jar: jar}
+	var redirects []*url.URL
+
+	client := &http.Client{
+		Jar: jar,
+		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+			redirects = append(redirects, req.URL)
+			return nil
+		},
+	}
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
 		fmt.Sprintf("%s/oidc?cluster=%s", srv.URL, oidcTestCluster), nil)
@@ -149,7 +161,28 @@ func runOIDCLoginFlow(t *testing.T, srv *httptest.Server) (*http.Response, *cook
 
 	defer func() { _ = resp.Body.Close() }()
 
-	return resp, jar
+	return resp, jar, redirects
+}
+
+// dexAuthorizeRequest returns the redirect hop that hit Dex's authorization
+// endpoint, where PKCE's code_challenge and code_challenge_method would
+// appear as query params. That hop is identified by response_type=code,
+// which oauth2.Config.AuthCodeURL sets and nothing else in this flow does --
+// Headlamp's own final redirect to /auth?cluster=... has no such param, so
+// matching on path alone would be ambiguous between the two. Fails the test
+// if no such hop was recorded.
+func dexAuthorizeRequest(t *testing.T, redirects []*url.URL) *url.URL {
+	t.Helper()
+
+	for _, u := range redirects {
+		if u.Query().Get("response_type") == "code" {
+			return u
+		}
+	}
+
+	require.Fail(t, "no redirect to Dex's authorization endpoint was recorded")
+
+	return nil
 }
 
 // authTokenFromJar reads the auth cookie back through the production reader,
@@ -185,12 +218,21 @@ func TestOIDCIntegration_LoginSucceeds(t *testing.T) {
 	cfg := newOIDCIntegrationConfig(t, issuer)
 	srv := startOIDCIntegrationServer(t, cfg)
 
-	resp, jar := runOIDCLoginFlow(t, srv) //nolint:bodyclose // closed inside runOIDCLoginFlow via defer
+	resp, jar, redirects := runOIDCLoginFlow(t, srv) //nolint:bodyclose // closed inside runOIDCLoginFlow via defer
 
 	// The callback ends with 303 -> /auth?cluster=<name>. The client follows
 	// it; the SPA route is not served here, so only the path is asserted.
 	require.Equal(t, oidcTestCluster, resp.Request.URL.Query().Get("cluster"))
 	assert.Equal(t, "/auth", resp.Request.URL.Path)
+
+	// Without OidcUsePKCE, /oidc must not send a code_challenge -- this is
+	// the negative half of the PKCE pair: it proves the flag in
+	// TestOIDCIntegration_LoginSucceedsWithPKCE changes observable behavior,
+	// rather than both tests passing for the same reason (Dex does not
+	// require PKCE from a client authenticating with a secret).
+	authorizeReq := dexAuthorizeRequest(t, redirects)
+	assert.Empty(t, authorizeReq.Query().Get("code_challenge"),
+		"non-PKCE login should not send a code_challenge")
 
 	// A token reached the browser, and it is a real JWT: /oidc-callback only
 	// gets this far after Verifier.Verify checks the signature against Dex's
@@ -218,12 +260,20 @@ func TestOIDCIntegration_LoginSucceedsWithPKCE(t *testing.T) {
 
 	srv := startOIDCIntegrationServer(t, cfg)
 
-	resp, jar := runOIDCLoginFlow(t, srv) //nolint:bodyclose // closed inside runOIDCLoginFlow via defer
+	resp, jar, redirects := runOIDCLoginFlow(t, srv) //nolint:bodyclose // closed inside runOIDCLoginFlow via defer
 
 	// Dex rejects a mismatched or malformed verifier at the token endpoint,
 	// which surfaces as a 500 from /oidc-callback rather than this redirect.
 	require.Equal(t, oidcTestCluster, resp.Request.URL.Query().Get("cluster"))
 	assert.Equal(t, "/auth", resp.Request.URL.Path)
+
+	// This is what makes the test prove PKCE was exercised rather than
+	// merely "setting OidcUsePKCE doesn't break login": Dex does not require
+	// PKCE from a client that authenticates with a secret, so without this,
+	// a silently dropped code_challenge would still pass.
+	authorizeReq := dexAuthorizeRequest(t, redirects)
+	assert.NotEmpty(t, authorizeReq.Query().Get("code_challenge"))
+	assert.Equal(t, "S256", authorizeReq.Query().Get("code_challenge_method"))
 
 	rawToken := authTokenFromJar(t, srv, jar)
 	assert.Len(t, strings.Split(rawToken, "."), 3, "ID token should be a JWT")

--- a/backend/cmd/oidc_integration_test.go
+++ b/backend/cmd/oidc_integration_test.go
@@ -113,7 +113,14 @@ func startOIDCIntegrationServer(t *testing.T, cfg *HeadlampConfig) *httptest.Ser
 	require.NoError(t, err, "port %d busy; another test server may still be running",
 		oidcTestCallbackPort)
 
-	srv := httptest.NewUnstartedServer(createHeadlampHandler(context.Background(), cfg))
+	// createHeadlampHandler starts a state-eviction goroutine that only stops
+	// on ctx.Done() (backend/cmd/headlamp.go:868-880). Each test builds a fresh
+	// server, so a cancelable context is required here to stop that goroutine
+	// on cleanup instead of leaking it for the life of the test binary.
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	srv := httptest.NewUnstartedServer(createHeadlampHandler(ctx, cfg))
 	require.NoError(t, srv.Listener.Close())
 	srv.Listener = ln
 	srv.Start()
@@ -200,4 +207,24 @@ func TestOIDCIntegration_LoginSucceeds(t *testing.T) {
 	refreshToken, ok := cached.(string)
 	require.True(t, ok, "cached refresh token should be a string")
 	assert.NotEmpty(t, refreshToken)
+}
+
+func TestOIDCIntegration_LoginSucceedsWithPKCE(t *testing.T) {
+	issuer := requireDexIssuer(t)
+
+	cfg := newOIDCIntegrationConfig(t, issuer)
+	// Sends code_challenge on /oidc and code_verifier on exchange.
+	cfg.OidcUsePKCE = true
+
+	srv := startOIDCIntegrationServer(t, cfg)
+
+	resp, jar := runOIDCLoginFlow(t, srv) //nolint:bodyclose // closed inside runOIDCLoginFlow via defer
+
+	// Dex rejects a mismatched or malformed verifier at the token endpoint,
+	// which surfaces as a 500 from /oidc-callback rather than this redirect.
+	require.Equal(t, oidcTestCluster, resp.Request.URL.Query().Get("cluster"))
+	assert.Equal(t, "/auth", resp.Request.URL.Path)
+
+	rawToken := authTokenFromJar(t, srv, jar)
+	assert.Len(t, strings.Split(rawToken, "."), 3, "ID token should be a JWT")
 }

--- a/backend/cmd/oidc_integration_test.go
+++ b/backend/cmd/oidc_integration_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/backend/cmd/oidc_integration_test.go
+++ b/backend/cmd/oidc_integration_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/auth"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/telemetry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+const (
+	// oidcTestCallbackPort must match the redirectURIs entry in
+	// headlamp_testdata/dex-integration.yaml. Dex matches redirect URIs
+	// exactly, so the test server cannot take an ephemeral port.
+	oidcTestCallbackPort = 18080
+	oidcTestCluster      = "oidc-test"
+	oidcTestClientID     = "headlamp-test"
+	oidcTestClientSecret = "headlamp-test-secret" // #nosec G101 -- static Dex test-fixture secret, not a real credential
+)
+
+// requireDexIssuer skips unless the integration suite is enabled and a Dex
+// issuer URL was supplied. Both are required: backend-test.yml sets
+// HEADLAMP_RUN_INTEGRATION_TESTS for the whole workflow, so gating on it
+// alone would fail every backend PR on runners without Dex.
+func requireDexIssuer(t *testing.T) string {
+	t.Helper()
+
+	if os.Getenv("HEADLAMP_RUN_INTEGRATION_TESTS") != "true" {
+		t.Skip("skipping integration test")
+	}
+
+	issuer := os.Getenv("HEADLAMP_TEST_OIDC_ISSUER")
+	if issuer == "" {
+		t.Skip("skipping OIDC integration test: HEADLAMP_TEST_OIDC_ISSUER is not set")
+	}
+
+	return issuer
+}
+
+// newOIDCIntegrationConfig builds a server config whose single cluster carries
+// an OIDC provider. OidcConf is set directly, so no kubeconfig file is needed:
+// Context.OidcConfig returns OidcConf verbatim when it is non-nil
+// (backend/pkg/kubeconfig/kubeconfig.go:342).
+func newOIDCIntegrationConfig(t *testing.T, issuer string) *HeadlampConfig {
+	t.Helper()
+
+	store := kubeconfig.NewContextStore()
+	require.NoError(t, store.AddContext(&kubeconfig.Context{
+		Name: oidcTestCluster,
+		// Never dialled: neither /oidc nor /oidc-callback contacts the API server.
+		Cluster:  &api.Cluster{Server: "https://127.0.0.1:6443"},
+		AuthInfo: &api.AuthInfo{},
+		OidcConf: &kubeconfig.OidcConfig{
+			ClientID:     oidcTestClientID,
+			ClientSecret: oidcTestClientSecret,
+			IdpIssuerURL: issuer,
+			// offline_access is what makes Dex issue a refresh token.
+			Scopes: []string{"email", "groups", "offline_access"},
+		},
+	}))
+
+	return &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				KubeConfigStore: store,
+			},
+			OidcCallbackURL: fmt.Sprintf(
+				"http://127.0.0.1:%d/oidc-callback", oidcTestCallbackPort),
+			Cache:            cache.New[interface{}](),
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	}
+}
+
+// startOIDCIntegrationServer serves the real router on the fixed callback port.
+func startOIDCIntegrationServer(t *testing.T, cfg *HeadlampConfig) *httptest.Server {
+	t.Helper()
+
+	lc := net.ListenConfig{}
+
+	ln, err := lc.Listen(context.Background(), "tcp", fmt.Sprintf("127.0.0.1:%d", oidcTestCallbackPort))
+	require.NoError(t, err, "port %d busy; another test server may still be running",
+		oidcTestCallbackPort)
+
+	srv := httptest.NewUnstartedServer(createHeadlampHandler(context.Background(), cfg))
+	require.NoError(t, srv.Listener.Close())
+	srv.Listener = ln
+	srv.Start()
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+// runOIDCLoginFlow drives GET /oidc through Dex and back to /oidc-callback.
+// With skipApprovalScreen and a lone mockCallback connector, every hop is a
+// redirect, so the default client policy walks the entire flow.
+func runOIDCLoginFlow(t *testing.T, srv *httptest.Server) (*http.Response, *cookiejar.Jar) {
+	t.Helper()
+
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+
+	client := &http.Client{Jar: jar}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		fmt.Sprintf("%s/oidc?cluster=%s", srv.URL, oidcTestCluster), nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+
+	defer func() { _ = resp.Body.Close() }()
+
+	return resp, jar
+}
+
+// authTokenFromJar reads the auth cookie back through the production reader,
+// which reassembles the chunked cookie the handler writes.
+func authTokenFromJar(t *testing.T, srv *httptest.Server, jar *cookiejar.Jar) string {
+	t.Helper()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	// The cookie is scoped to GetCookiePath("", cluster) == "/clusters/<cluster>"
+	// (backend/pkg/auth/cookies.go:33). cookiejar only hands back cookies whose
+	// path matches the request URL, so querying the jar at "/" returns nothing.
+	u.Path = "/clusters/" + oidcTestCluster
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	for _, c := range jar.Cookies(u) {
+		req.AddCookie(c)
+	}
+
+	token, err := auth.GetTokenFromCookie(req, oidcTestCluster)
+	require.NoError(t, err)
+	// GetTokenFromCookie returns ("", nil) when nothing is present
+	// (cookies.go:135), so a missing value is silent without this.
+	require.NotEmpty(t, token, "no auth cookie found in jar for %s", u.Path)
+
+	return token
+}
+
+func TestOIDCIntegration_LoginSucceeds(t *testing.T) {
+	issuer := requireDexIssuer(t)
+
+	cfg := newOIDCIntegrationConfig(t, issuer)
+	srv := startOIDCIntegrationServer(t, cfg)
+
+	resp, jar := runOIDCLoginFlow(t, srv) //nolint:bodyclose // closed inside runOIDCLoginFlow via defer
+
+	// The callback ends with 303 -> /auth?cluster=<name>. The client follows
+	// it; the SPA route is not served here, so only the path is asserted.
+	require.Equal(t, oidcTestCluster, resp.Request.URL.Query().Get("cluster"))
+	assert.Equal(t, "/auth", resp.Request.URL.Path)
+
+	// A token reached the browser, and it is a real JWT: /oidc-callback only
+	// gets this far after Verifier.Verify checks the signature against Dex's
+	// live JWKS. No test on main exercises that path.
+	rawToken := authTokenFromJar(t, srv, jar)
+	require.NotEmpty(t, rawToken)
+	assert.Len(t, strings.Split(rawToken, "."), 3, "ID token should be a JWT")
+
+	// The handler caches the refresh token under oidc-token-<raw>. Dex issues
+	// one because the config requests offline_access.
+	cached, err := cfg.Cache.Get(context.Background(), "oidc-token-"+rawToken)
+	require.NoError(t, err)
+
+	refreshToken, ok := cached.(string)
+	require.True(t, ok, "cached refresh token should be a string")
+	assert.NotEmpty(t, refreshToken)
+}

--- a/backend/cmd/oidc_integration_test.go
+++ b/backend/cmd/oidc_integration_test.go
@@ -16,6 +16,16 @@ limitations under the License.
 
 package main
 
+// NOTE: these tests exercise a real Dex instance (see
+// headlamp_testdata/dex-integration.yaml) rather than a mock, so go test's
+// result caching hides real failures -- a cached PASS survives Dex being
+// stopped or reconfigured unless a rerun is forced. Always pass -count=1
+// when running these against a live Dex, e.g.:
+//
+//	HEADLAMP_RUN_INTEGRATION_TESTS=true \
+//	HEADLAMP_TEST_OIDC_ISSUER=http://127.0.0.1:5556/dex \
+//	go test ./cmd/ -run 'TestOIDCIntegration_' -v -count=1
+
 import (
 	"context"
 	"fmt"


### PR DESCRIPTION
Adds backend OIDC integration tests that exercise the native OIDC login flow against a real [Dex](https://github.com/dexidp/dex) instance. This is the `p0.2` item from the #4057 umbrella.

No production code is changed — this is test coverage only.

## Why

Headlamp's native OIDC mode (`/oidc` + `/oidc-callback`) has no test that runs the flow end to end against a real identity provider. Existing tests cover configuration and helpers, but nothing exercises discovery, the authorization-code exchange, or ID-token verification against a live JWKS endpoint. That leaves the success path — the one every OIDC user depends on — unverified.

## What this covers

Three tests in `backend/cmd/oidc_integration_test.go`:

- **`TestOIDCIntegration_LoginSucceeds`** — walks `GET /oidc` through Dex and back to `/oidc-callback`, then asserts a token reached the browser and the refresh token was cached. Because `/oidc-callback` runs `Verifier.Verify` against Dex's live JWKS *before* setting the cookie or redirecting, these assertions cannot pass unless signature verification succeeded.
- **`TestOIDCIntegration_LoginSucceedsWithPKCE`** — same flow with `OidcUsePKCE` enabled, asserting `code_challenge` is present with `code_challenge_method=S256` on the authorization request. The non-PKCE test asserts the challenge is **absent**, so the pair proves the flag changes observable behavior rather than both passing for the same reason.
- **`TestOIDCIntegration_RefreshTokenExchange`** — seeds the cache with a real Dex-issued refresh token, calls `auth.RefreshAndCacheNewToken`, and verifies the refreshed ID token. That function returns the token *unverified*, so the test builds its own `oidc.NewProvider` + `Verifier(...).Verify(...)` rather than assuming the production path checks the signature.

No Kubernetes cluster is required: neither `/oidc` nor `/oidc-callback` contacts the API server.

## How it's gated

The tests skip unless **both** `HEADLAMP_RUN_INTEGRATION_TESTS=true` and `HEADLAMP_TEST_OIDC_ISSUER` are set. Two variables are needed because `backend-test.yml` already sets the first for the whole workflow — gating on it alone would fail every backend PR on runners without Dex, and break `npm run backend:test` locally.

CI starts Dex via `docker run` with a 30×1s readiness poll that dumps `docker logs` and fails the step if the container never becomes ready, so the tests can't silently skip.

The Dex step runs **after** golangci-lint and `make backend`. Starting it earlier meant an image-pull hiccup or slow container bind would fail lint and build for backend PRs unrelated to OIDC.

## Testing

Verified locally against Dex `v2.44.0` in three states, all with `-count=1`:

| Condition | Result |
|---|---|
| Dex up, env set | 3× PASS |
| Dex stopped, env set | 3× FAIL |
| env unset | 3× SKIP |

The middle row is the important one — it confirms the tests aren't vacuous. `go test`'s result cache will happily reuse a PASS while Dex is stopped, which is why the file documents `-count=1` as a requirement.

Also run: `golangci-lint run` (v2.12.2) → 0 issues; `gofmt -l` and `go vet ./cmd/` clean. `go.mod` and `go.sum` are untouched — `github.com/coreos/go-oidc/v3` was already a direct dependency.

## Notes for reviewers

- **Port 18080 is fixed, not ephemeral.** Dex matches `redirectURIs` exactly, so the test server binds a known port via `net.ListenConfig` rather than letting `httptest` pick one. There is no `t.Parallel()` in this package, and the listener is released on cleanup.
- **The Dex config is test-only** — in-memory storage and a `mockCallback` connector that bypasses authentication entirely. It cannot be pointed at a real identity backend.
- **No bugs were found.** Dex accepts Headlamp's S256 verifier, and refreshed ID tokens verify cleanly against live JWKS. The gap this closes was in coverage, not correctness.

Negative paths (expired tokens, tampered signatures, mismatched audiences) are deliberately out of scope here — they belong with the mock-based work in #5420, which doesn't need a live IdP. Token expiry isn't directly tested either, since Dex's minimum token lifetime is measured in minutes.

Part of #4057.
