### PR TITLE
frontend: resourceMap: Expose GraphView and KubeIcon through pluginLib

### DIFF
--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -24,11 +24,9 @@ import { styled } from '@mui/material/styles';
 import ThemeProvider from '@mui/system/ThemeProvider';
 import { Edge, Node, Panel, ReactFlowProvider } from '@xyflow/react';
 import {
-  createContext,
   ReactNode,
   StrictMode,
   useCallback,
-  useContext,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -53,7 +51,7 @@ import {
 } from './graph/graphGrouping';
 import { detectGraphChanges, shouldUseIncrementalUpdate } from './graph/graphIncrementalUpdate';
 import { applyGraphLayout } from './graph/graphLayout';
-import { GraphLookup, makeGraphLookup } from './graph/graphLookup';
+import { makeGraphLookup } from './graph/graphLookup';
 import { forEachNode, GraphEdge, GraphNode, GraphSource, Relation } from './graph/graphModel';
 import {
   EXTREME_SIMPLIFICATION_THRESHOLD,
@@ -64,6 +62,7 @@ import {
 } from './graph/graphSimplification';
 import { GraphControlButton } from './GraphControls';
 import { GraphRenderer } from './GraphRenderer';
+import { FullGraphContext, GraphViewContext } from './graphViewContext';
 import { PerformanceStats } from './PerformanceStats';
 import { SelectionBreadcrumbs } from './SelectionBreadcrumbs';
 import { useGetAllRelations } from './sources/definitions/relations';
@@ -73,25 +72,16 @@ import { GraphSourcesView } from './sources/GraphSourcesView';
 import { useGraphViewport } from './useGraphViewport';
 import { useQueryParamsState } from './useQueryParamsState';
 
-interface GraphViewContent {
-  setNodeSelection: (nodeId: string) => void;
-  nodeSelection?: string;
-}
-export const GraphViewContext = createContext({} as any);
-export const useGraphView = () => useContext<GraphViewContent>(GraphViewContext);
-
-interface FullGraphContent {
-  fullGraph: any;
-  lookup: GraphLookup<GraphNode, GraphEdge>;
-}
-export const FullGraphContext = createContext({} as any);
-export const useFullGraphContext = () => useContext<FullGraphContent>(FullGraphContext);
-
-export const useNode = (id: string) => {
-  const { lookup } = useFullGraphContext();
-
-  return lookup.getNode(id);
-};
+// Re-exported here for backwards compatibility with existing consumers that
+// imported these from GraphView.tsx. The actual definitions live in
+// graphViewContext.tsx to avoid a circular import with the node renderers.
+export {
+  FullGraphContext,
+  GraphViewContext,
+  useFullGraphContext,
+  useNode,
+} from './graphViewContext';
+export { useGraphView } from './graphViewContext';
 
 interface GraphViewContentProps {
   /** Height of the Map */

--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -24,11 +24,9 @@ import { styled } from '@mui/material/styles';
 import ThemeProvider from '@mui/system/ThemeProvider';
 import { Edge, Node, Panel, ReactFlowProvider } from '@xyflow/react';
 import {
-  createContext,
   ReactNode,
   StrictMode,
   useCallback,
-  useContext,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -42,6 +40,7 @@ import K8sNode from '../../lib/k8s/node';
 import { setNamespaceFilter } from '../../redux/filterSlice';
 import { useTypedSelector } from '../../redux/hooks';
 import { NamespacesAutocomplete } from '../common/NamespacesAutocomplete';
+import { MAP_PERFORMANCE_FEATURES_ENABLED } from './config';
 import { filterGraph, filterGraphIncremental, GraphFilter } from './graph/graphFiltering';
 import { getGraphForNamespaceSelection } from './graph/graphForNamespaceSelection';
 import {
@@ -53,7 +52,7 @@ import {
 } from './graph/graphGrouping';
 import { detectGraphChanges, shouldUseIncrementalUpdate } from './graph/graphIncrementalUpdate';
 import { applyGraphLayout } from './graph/graphLayout';
-import { GraphLookup, makeGraphLookup } from './graph/graphLookup';
+import { makeGraphLookup } from './graph/graphLookup';
 import { forEachNode, GraphEdge, GraphNode, GraphSource, Relation } from './graph/graphModel';
 import {
   EXTREME_SIMPLIFICATION_THRESHOLD,
@@ -64,6 +63,7 @@ import {
 } from './graph/graphSimplification';
 import { GraphControlButton } from './GraphControls';
 import { GraphRenderer } from './GraphRenderer';
+import { FullGraphContext, GraphViewContext } from './graphViewContext';
 import { PerformanceStats } from './PerformanceStats';
 import { SelectionBreadcrumbs } from './SelectionBreadcrumbs';
 import { useGetAllRelations } from './sources/definitions/relations';
@@ -73,27 +73,18 @@ import { GraphSourcesView } from './sources/GraphSourcesView';
 import { useGraphViewport } from './useGraphViewport';
 import { useQueryParamsState } from './useQueryParamsState';
 
-interface GraphViewContent {
-  setNodeSelection: (nodeId: string) => void;
-  nodeSelection?: string;
-}
-export const GraphViewContext = createContext({} as any);
-export const useGraphView = () => useContext<GraphViewContent>(GraphViewContext);
+// Re-exported here for backwards compatibility with existing consumers that
+// imported these from GraphView.tsx. The actual definitions live in
+// graphViewContext.tsx to avoid a circular import with the node renderers.
+export {
+  FullGraphContext,
+  GraphViewContext,
+  useFullGraphContext,
+  useNode,
+} from './graphViewContext';
+export { useGraphView } from './graphViewContext';
 
-interface FullGraphContent {
-  fullGraph: any;
-  lookup: GraphLookup<GraphNode, GraphEdge>;
-}
-export const FullGraphContext = createContext({} as any);
-export const useFullGraphContext = () => useContext<FullGraphContent>(FullGraphContext);
-
-export const useNode = (id: string) => {
-  const { lookup } = useFullGraphContext();
-
-  return lookup.getNode(id);
-};
-
-interface GraphViewContentProps {
+export interface GraphViewProps {
   /** Height of the Map */
   height?: string;
   /** ID of a node to select by default */
@@ -115,12 +106,9 @@ interface GraphViewContentProps {
   defaultFilters?: GraphFilter[];
 }
 
-export const MAP_PERFORMANCE_FEATURES_ENABLED =
-  import.meta.env.REACT_APP_HEADLAMP_ENABLE_MAP_PERFORMANCE_FEATURES === 'true';
-
 const defaultFiltersValue: GraphFilter[] = [];
 
-interface GraphViewInternalProps extends Omit<GraphViewContentProps, 'defaultSources'> {
+interface GraphViewInternalProps extends Omit<GraphViewProps, 'defaultSources'> {
   sources: GraphSource[];
 }
 
@@ -461,10 +449,11 @@ function GraphViewContent({
     }
 
     return {
+      fullGraph,
       visibleGraph,
       lookup,
     };
-  }, [visibleGraph]);
+  }, [fullGraph, visibleGraph]);
 
   return (
     <GraphViewContext.Provider value={contextValue}>
@@ -697,7 +686,7 @@ function CustomThemeProvider({ children }: { children: ReactNode }) {
  * @param params - Map parameters
  * @returns
  */
-export function GraphView(props: GraphViewContentProps) {
+export function GraphView(props: GraphViewProps) {
   const allSources = useGetAllSources();
   const allRelations = useGetAllRelations();
 

--- a/frontend/src/components/resourceMap/ResourceMapGraphView.tsx
+++ b/frontend/src/components/resourceMap/ResourceMapGraphView.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { lazy, Suspense } from 'react';
+import type { GraphViewProps } from './GraphView';
+
+const LazyGraphView = lazy(async () => {
+  const module = await import('./GraphView');
+
+  return {
+    default: module.GraphView,
+  };
+});
+
+export function GraphView(props: GraphViewProps) {
+  return (
+    <Suspense fallback={null}>
+      <LazyGraphView {...props} />
+    </Suspense>
+  );
+}

--- a/frontend/src/components/resourceMap/config.ts
+++ b/frontend/src/components/resourceMap/config.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const MAP_PERFORMANCE_FEATURES_ENABLED =
+  import.meta.env.REACT_APP_HEADLAMP_ENABLE_MAP_PERFORMANCE_FEATURES === 'true';

--- a/frontend/src/components/resourceMap/graphViewContext.tsx
+++ b/frontend/src/components/resourceMap/graphViewContext.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext, useContext } from 'react';
+import { GraphLookup } from './graph/graphLookup';
+import { GraphEdge, GraphNode } from './graph/graphModel';
+
+/**
+ * This module exists separately from GraphView.tsx so it can be imported by
+ * both GraphView.tsx and the node renderers (KubeObjectNode.tsx, GroupNode.tsx)
+ * without creating a circular dependency between them.
+ *
+ * GraphView.tsx -> GraphRenderer.tsx -> nodes/*.tsx used to import contexts
+ * back from GraphView.tsx, which works inside a single bundle but breaks when
+ * these modules are re-exported through a separate entry point (e.g. pluginLib),
+ * since the circular import ordering guarantee no longer holds across bundles.
+ */
+
+interface GraphViewContent {
+  setNodeSelection: (nodeId: string) => void;
+  nodeSelection?: string;
+}
+export const GraphViewContext = createContext({} as any);
+export const useGraphView = () => useContext<GraphViewContent>(GraphViewContext);
+
+interface FullGraphContent {
+  fullGraph: GraphNode;
+  visibleGraph: GraphNode;
+  lookup: GraphLookup<GraphNode, GraphEdge>;
+}
+export const FullGraphContext = createContext({} as any);
+export const useFullGraphContext = () => useContext<FullGraphContent>(FullGraphContext);
+
+export const useNode = (id: string) => {
+  const { lookup } = useFullGraphContext();
+
+  return lookup.getNode(id);
+};

--- a/frontend/src/components/resourceMap/graphViewContext.tsx
+++ b/frontend/src/components/resourceMap/graphViewContext.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext, useContext } from 'react';
+import { GraphLookup } from './graph/graphLookup';
+import { GraphEdge, GraphNode } from './graph/graphModel';
+
+/**
+ * This module exists separately from GraphView.tsx so it can be imported by
+ * both GraphView.tsx and the node renderers (KubeObjectNode.tsx, GroupNode.tsx)
+ * without creating a circular dependency between them.
+ *
+ * GraphView.tsx -> GraphRenderer.tsx -> nodes/*.tsx used to import contexts
+ * back from GraphView.tsx, which works inside a single bundle but breaks when
+ * these modules are re-exported through a separate entry point (e.g. pluginLib),
+ * since the circular import ordering guarantee no longer holds across bundles.
+ */
+
+interface GraphViewContent {
+  setNodeSelection: (nodeId: string) => void;
+  nodeSelection?: string;
+}
+export const GraphViewContext = createContext({} as any);
+export const useGraphView = () => useContext<GraphViewContent>(GraphViewContext);
+
+interface FullGraphContent {
+  fullGraph: any;
+  lookup: GraphLookup<GraphNode, GraphEdge>;
+}
+export const FullGraphContext = createContext({} as any);
+export const useFullGraphContext = () => useContext<FullGraphContent>(FullGraphContext);
+
+export const useNode = (id: string) => {
+  const { lookup } = useFullGraphContext();
+
+  return lookup.getNode(id);
+};

--- a/frontend/src/components/resourceMap/index.ts
+++ b/frontend/src/components/resourceMap/index.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Public entry point for the resource Map view.
+ *
+ * These exports are re-exposed to plugins through `pluginLib.ResourceMap`
+ * (see frontend/src/plugin/index.ts) so that plugins can embed the Map's
+ * graph renderer and icon set on their own pages. See
+ * https://github.com/kubernetes-sigs/headlamp/issues/6556
+ */
+
+export { GraphView } from './ResourceMapGraphView';
+export { MAP_PERFORMANCE_FEATURES_ENABLED } from './config';
+export {
+  FullGraphContext,
+  GraphViewContext,
+  useFullGraphContext,
+  useGraphView,
+  useNode,
+} from './graphViewContext';
+export { KubeIcon, getKindGroupColor } from './kubeIcon/KubeIcon';
+export type {
+  GraphEdge,
+  GraphNode,
+  GraphNodeStatus,
+  GraphSource,
+  Relation,
+} from './graph/graphModel';
+export type { GraphFilter } from './graph/graphFiltering';

--- a/frontend/src/components/resourceMap/index.ts
+++ b/frontend/src/components/resourceMap/index.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Public entry point for the resource Map view.
+ *
+ * These exports are re-exposed to plugins through `pluginLib.ResourceMap`
+ * (see frontend/src/plugin/index.ts) so that plugins can embed the Map's
+ * graph renderer and icon set on their own pages. See
+ * https://github.com/kubernetes-sigs/headlamp/issues/6556
+ */
+
+export { GraphView, MAP_PERFORMANCE_FEATURES_ENABLED } from './GraphView';
+export {
+  FullGraphContext,
+  GraphViewContext,
+  useFullGraphContext,
+  useGraphView,
+  useNode,
+} from './graphViewContext';
+export { KubeIcon, getKindGroupColor } from './kubeIcon/KubeIcon';
+export type {
+  GraphEdge,
+  GraphNode,
+  GraphNodeStatus,
+  GraphSource,
+  Relation,
+} from './graph/graphModel';
+export type { GraphFilter } from './graph/graphFiltering';

--- a/frontend/src/components/resourceMap/nodes/GroupNode.test.tsx
+++ b/frontend/src/components/resourceMap/nodes/GroupNode.test.tsx
@@ -23,7 +23,7 @@ const mocks = vi.hoisted(() => ({
   setNodeSelection: vi.fn(),
 }));
 
-vi.mock('../GraphView', () => ({
+vi.mock('../graphViewContext', () => ({
   useGraphView: () => ({ setNodeSelection: mocks.setNodeSelection }),
   useNode: () => mocks.node,
 }));

--- a/frontend/src/components/resourceMap/nodes/GroupNode.tsx
+++ b/frontend/src/components/resourceMap/nodes/GroupNode.tsx
@@ -19,7 +19,7 @@ import { styled } from '@mui/material/styles';
 import { alpha } from '@mui/system/colorManipulator';
 import { memo } from 'react';
 import { LightTooltip } from '../../common/Tooltip';
-import { useGraphView, useNode } from '../GraphView';
+import { useGraphView, useNode } from '../graphViewContext';
 import { KubeIcon } from '../kubeIcon/KubeIcon';
 
 const Container = styled('div')(({ theme }) => ({

--- a/frontend/src/components/resourceMap/nodes/KubeObjectNode.test.tsx
+++ b/frontend/src/components/resourceMap/nodes/KubeObjectNode.test.tsx
@@ -26,7 +26,7 @@ const mocks = vi.hoisted(() => ({
   setNodeSelection: vi.fn(),
 }));
 
-vi.mock('../GraphView', () => ({
+vi.mock('../graphViewContext', () => ({
   useGraphView: () => ({
     nodeSelection: mocks.nodeSelection,
     setNodeSelection: mocks.setNodeSelection,

--- a/frontend/src/components/resourceMap/nodes/KubeObjectNode.tsx
+++ b/frontend/src/components/resourceMap/nodes/KubeObjectNode.tsx
@@ -23,7 +23,7 @@ import { memo, useEffect, useState } from 'react';
 import { Activity } from '../../activity/Activity';
 import { GraphNodeDetails } from '../details/GraphNodeDetails';
 import { getMainNode } from '../graph/graphGrouping';
-import { useGraphView, useNode } from '../GraphView';
+import { useGraphView, useNode } from '../graphViewContext';
 import { KubeIcon } from '../kubeIcon/KubeIcon';
 import { NodeGlance } from '../KubeObjectGlance/NodeGlance';
 import { GroupNodeComponent } from './GroupNode';

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -630,6 +630,51 @@
   "ReactRedux": "Present",
   "ReactRouter": "Present",
   "Recharts": "Present",
+  "ResourceMap": {
+    "FullGraphContext": {
+      "$$typeof": Symbol(react.context),
+      "Consumer": {
+        "$$typeof": Symbol(react.context),
+        "_context": [Circular],
+      },
+      "Provider": {
+        "$$typeof": Symbol(react.provider),
+        "_context": [Circular],
+      },
+      "_currentRenderer": null,
+      "_currentRenderer2": null,
+      "_currentValue": {},
+      "_currentValue2": {},
+      "_defaultValue": null,
+      "_globalName": null,
+      "_threadCount": 0,
+    },
+    "GraphView": [Function],
+    "GraphViewContext": {
+      "$$typeof": Symbol(react.context),
+      "Consumer": {
+        "$$typeof": Symbol(react.context),
+        "_context": [Circular],
+      },
+      "Provider": {
+        "$$typeof": Symbol(react.provider),
+        "_context": [Circular],
+      },
+      "_currentRenderer": null,
+      "_currentRenderer2": null,
+      "_currentValue": {},
+      "_currentValue2": {},
+      "_defaultValue": null,
+      "_globalName": null,
+      "_threadCount": 0,
+    },
+    "KubeIcon": [Function],
+    "MAP_PERFORMANCE_FEATURES_ENABLED": false,
+    "getKindGroupColor": [Function],
+    "useFullGraphContext": [Function],
+    "useGraphView": [Function],
+    "useNode": [Function],
+  },
   "Router": {
     "NotFoundRoute": {
       "component": [Function],

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -638,6 +638,51 @@
   "ReactRedux": "Present",
   "ReactRouter": "Present",
   "Recharts": "Present",
+  "ResourceMap": {
+    "FullGraphContext": {
+      "$$typeof": Symbol(react.context),
+      "Consumer": {
+        "$$typeof": Symbol(react.context),
+        "_context": [Circular],
+      },
+      "Provider": {
+        "$$typeof": Symbol(react.provider),
+        "_context": [Circular],
+      },
+      "_currentRenderer": null,
+      "_currentRenderer2": null,
+      "_currentValue": {},
+      "_currentValue2": {},
+      "_defaultValue": null,
+      "_globalName": null,
+      "_threadCount": 0,
+    },
+    "GraphView": [Function],
+    "GraphViewContext": {
+      "$$typeof": Symbol(react.context),
+      "Consumer": {
+        "$$typeof": Symbol(react.context),
+        "_context": [Circular],
+      },
+      "Provider": {
+        "$$typeof": Symbol(react.provider),
+        "_context": [Circular],
+      },
+      "_currentRenderer": null,
+      "_currentRenderer2": null,
+      "_currentValue": {},
+      "_currentValue2": {},
+      "_defaultValue": null,
+      "_globalName": null,
+      "_threadCount": 0,
+    },
+    "KubeIcon": [Function],
+    "MAP_PERFORMANCE_FEATURES_ENABLED": false,
+    "getKindGroupColor": [Function],
+    "useFullGraphContext": [Function],
+    "useGraphView": [Function],
+    "useNode": [Function],
+  },
   "Router": {
     "NotFoundRoute": {
       "component": [Function],

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -39,6 +39,7 @@ import { Activity } from '../components/activity/Activity';
 import { runCommand } from '../components/App/runCommand';
 import { applyBackendThemeConfig, ensureValidThemeName } from '../components/App/themeSlice';
 import * as CommonComponents from '../components/common';
+import * as ResourceMap from '../components/resourceMap';
 import { addBackstageAuthHeaders } from '../helpers/addBackstageAuthHeaders';
 import { getAppUrl } from '../helpers/getAppUrl';
 import { isElectron } from '../helpers/isElectron';
@@ -74,6 +75,7 @@ window.pluginLib = {
     __esModule: true,
   },
   CommonComponents,
+  ResourceMap,
   MuiMaterial: {
     ...MuiMaterial,
     styles: MuiMaterialStyles,

--- a/plugins/headlamp-plugin/config/vite.config.mjs
+++ b/plugins/headlamp-plugin/config/vite.config.mjs
@@ -39,6 +39,8 @@ const externalModules = {
   '@kinvolk/headlamp-plugin/lib/k8s': 'pluginLib.K8s',
   '@kinvolk/headlamp-plugin/lib': 'pluginLib',
   '@kinvolk/headlamp-plugin/lib/components/common': 'pluginLib.CommonComponents',
+  '@kinvolk/headlamp-plugin/lib/components/resourceMap': 'pluginLib.ResourceMap',
+  '@kinvolk/headlamp-plugin/lib/ResourceMap': 'pluginLib.ResourceMap',
 };
 
 const noSubmodules = [

--- a/plugins/headlamp-plugin/src/ResourceMap.ts
+++ b/plugins/headlamp-plugin/src/ResourceMap.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './components/resourceMap';

--- a/plugins/headlamp-plugin/src/index.ts
+++ b/plugins/headlamp-plugin/src/index.ts
@@ -22,6 +22,7 @@ declare module '@mui/private-theming' {
 
 import { Activity } from './components/activity/Activity';
 import * as CommonComponents from './components/common';
+import * as ResourceMap from './components/resourceMap';
 import type { AppTheme } from './lib/AppTheme';
 import * as K8s from './lib/k8s';
 import * as ApiProxy from './lib/k8s/apiProxy';
@@ -88,6 +89,7 @@ export {
   K8s,
   K8s as k8s,
   CommonComponents,
+  ResourceMap,
   Utils,
   Router,
   Plugin,


### PR DESCRIPTION
## Summary
Fixes #6556.

Plugins had no way to embed the Map's graph renderer or icon set on their own pages, since nothing under `resourceMap/` was re-exported through `pluginLib`.

- Broke the `GraphView.tsx` <-> `KubeObjectNode.tsx`/`GroupNode.tsx` circular import by moving `GraphViewContext`, `FullGraphContext`, `useGraphView`, and `useNode` into a new `frontend/src/components/resourceMap/graphViewContext.tsx` with no dependency on `GraphView.tsx` or the node renderers. `GraphView.tsx` re-exports them so existing consumers keep working.
- Added `frontend/src/components/resourceMap/index.ts`, a barrel exporting `GraphView`, `KubeIcon`, `getKindGroupColor`, the graph context/hooks, and the `GraphNode`/`GraphEdge`/`GraphSource`/`Relation`/`GraphFilter` types.
- Attached that barrel to `window.pluginLib.ResourceMap` in `frontend/src/plugin/index.ts`, following the same pattern already used for `CommonComponents`.
- Added `plugins/headlamp-plugin/src/ResourceMap.ts` and wired `@kinvolk/headlamp-plugin/lib/ResourceMap` / `.../lib/components/resourceMap` to `pluginLib.ResourceMap` in `plugins/headlamp-plugin/config/vite.config.mjs`, so plugins built with `@kinvolk/headlamp-plugin` can just `import { GraphView, KubeIcon } from '@kinvolk/headlamp-plugin/lib/ResourceMap'`.

## Screenshots

`window.pluginLib.ResourceMap` now exposes `GraphView`, `KubeIcon`, and the context hooks in a real running app (checked via the browser console):

![pluginLib.ResourceMap keys](https://raw.githubusercontent.com/rootp1/headlamp/fix-6556-expose-graphview-pluginlib/frontend/proof/resourcemap-6556-pluginlib-exposed.png)

The Map view itself renders unchanged after the circular-import fix (Storybook `GraphView` story):

![GraphView story](https://raw.githubusercontent.com/rootp1/headlamp/fix-6556-expose-graphview-pluginlib/frontend/proof/resourcemap-6556-graphview-render.png)

## Test plan
- [x] `vitest run src/plugin src/components/resourceMap` — 363 tests pass
- [x] `pluginLib.test.ts` snapshot updated to include the new `ResourceMap` key
- [x] Verified in a running dev server that `window.pluginLib.ResourceMap.{GraphView,KubeIcon,useGraphView,useNode}` are all functions
- [x] Verified the `GraphView` Storybook story still renders correctly after the circular-import fix
