### PR TITLE
docs: tutorials: Improve plugin getting-started tutorial accuracy

### DIFF
--- a/docs/tutorials/plugin-development/getting-started/adding-custom-map-nodes/index.md
+++ b/docs/tutorials/plugin-development/getting-started/adding-custom-map-nodes/index.md
@@ -125,7 +125,7 @@ registerMapSource(myPodSource);
 1. Save the file and let the plugin rebuild.
 2. Open Headlamp and connect to your cluster.
 3. Click **Map** in the sidebar.
-4. In the source picker (the panel on the left), find **"My Pods"** and make sure it is enabled.
+4. Open the source picker — the filter chip above the map, labelled with the sources currently shown — and make sure **"My Pods"** is ticked in the list that drops down.
 
 You should see all pods from your cluster appear as nodes on the map under the **My Pods** source.
 

--- a/docs/tutorials/plugin-development/getting-started/adding-custom-map-nodes/index.md
+++ b/docs/tutorials/plugin-development/getting-started/adding-custom-map-nodes/index.md
@@ -125,7 +125,7 @@ registerMapSource(myPodSource);
 1. Save the file and let the plugin rebuild.
 2. Open Headlamp and connect to your cluster.
 3. Click **Map** in the sidebar.
-4. Open the source picker — the filter chip above the map, labelled with the sources currently shown — and tick **"My Pods"** in the list that drops down.
+4. Open the source picker — the filter chip above the map, labelled with the sources currently shown — and make sure **"My Pods"** is ticked in the list that drops down.
 
 You should see all pods from your cluster appear as nodes on the map under the **My Pods** source.
 

--- a/docs/tutorials/plugin-development/getting-started/adding-custom-map-nodes/index.md
+++ b/docs/tutorials/plugin-development/getting-started/adding-custom-map-nodes/index.md
@@ -125,7 +125,7 @@ registerMapSource(myPodSource);
 1. Save the file and let the plugin rebuild.
 2. Open Headlamp and connect to your cluster.
 3. Click **Map** in the sidebar.
-4. In the source picker (the panel on the left), find **"My Pods"** and make sure it is enabled.
+4. Open the source picker — the filter chip above the map, labelled with the sources currently shown — and tick **"My Pods"** in the list that drops down.
 
 You should see all pods from your cluster appear as nodes on the map under the **My Pods** source.
 

--- a/docs/tutorials/plugin-development/getting-started/building-list-and-detail-pages/index.md
+++ b/docs/tutorials/plugin-development/getting-started/building-list-and-detail-pages/index.md
@@ -81,6 +81,7 @@ function MyPodsPage() {
   return (
     <ResourceListView
       title="My Pods"
+      id="my-plugin-pods"
       resourceClass={MyPod}
       columns={[
         'name',
@@ -166,6 +167,10 @@ Now that you've seen it in action, let's look at what `ResourceListView` gave yo
 | `resourceClass={MyPod}` | Let the component fetch data — the standard approach |
 | `data={items}` | Pass pre-fetched or transformed data yourself |
 
+### The `id` prop
+
+Plugins target tables by `id`, which is how the column processors in [Tutorial 7](../extending-existing-resource-views/) find the table they want. Always pass one with your own prefix: without it, `ResourceListView` derives `headlamp-<pluralName>` from the resource class — the same ID Headlamp's own table for that resource uses — so processors aimed at the built-in table would hit yours too.
+
 ### Built-in column shortcuts
 
 `'name'`, `'namespace'`, `'age'`, and `'cluster'` can be passed as plain strings. They are fully configured columns (including `getValue`, `render`, and sorting) — and `'name'` renders a link to Headlamp's native detail page for that resource. You can always replace a shortcut with a full column object to override its behaviour.
@@ -225,10 +230,7 @@ Add a new component to your `src/index.tsx`:
 
 ```tsx
 import { useParams } from 'react-router-dom';
-import {
-  registerRoute,
-  registerSidebarEntry,
-} from '@kinvolk/headlamp-plugin/lib';
+import { registerRoute, registerSidebarEntry } from '@kinvolk/headlamp-plugin/lib';
 import { getCluster } from '@kinvolk/headlamp-plugin/lib/Utils';
 import {
   DetailsGrid,
@@ -239,75 +241,75 @@ import { Chip } from '@mui/material';
 import { MyPod } from './resources/pod';
 
 function MyPodDetailPage() {
-    const params = useParams<{ name: string; namespace?: string }>();
-    const { name, namespace } = params;
-    const cluster = getCluster();
+  const params = useParams<{ name: string; namespace?: string }>();
+  const { name, namespace } = params;
+  const cluster = getCluster();
 
-    return (
-        <DetailsGrid
-            resourceType={MyPod}
-            name={name}
-            namespace={namespace}
-            backLink={`/c/${cluster}/my-plugin/pods`}
-            extraInfo={pod => {
-                if (!pod) return [];
+  return (
+    <DetailsGrid
+      resourceType={MyPod}
+      name={name}
+      namespace={namespace}
+      backLink={`/c/${cluster}/my-plugin/pods`}
+      extraInfo={pod => {
+        if (!pod) return [];
 
-                return [
-                    {
-                        name: 'Phase',
-                        value: (
-                            <Chip
-                                label={pod.jsonData.status?.phase || 'Unknown'}
-                                color={
-                                    pod.jsonData.status?.phase === 'Running'
-                                        ? 'success'
-                                        : pod.jsonData.status?.phase === 'Failed'
-                                            ? 'error'
-                                            : pod.jsonData.status?.phase === 'Pending'
-                                                ? 'warning'
-                                                : 'default'
-                                }
-                                size="small"
-                            />
-                        ),
-                    },
-                    {
-                        name: 'Node',
-                        value: pod.jsonData.spec.nodeName || 'Not assigned',
-                    },
-                    {
-                        name: 'Pod IP',
-                        value: pod.jsonData.status?.podIP || 'Not assigned',
-                    },
-                ];
-            }}
-            extraSections={pod => {
-                if (!pod) return [];
+        return [
+          {
+            name: 'Phase',
+            value: (
+              <Chip
+                label={pod.jsonData.status?.phase || 'Unknown'}
+                color={
+                  pod.jsonData.status?.phase === 'Running'
+                    ? 'success'
+                    : pod.jsonData.status?.phase === 'Failed'
+                    ? 'error'
+                    : pod.jsonData.status?.phase === 'Pending'
+                    ? 'warning'
+                    : 'default'
+                }
+                size="small"
+              />
+            ),
+          },
+          {
+            name: 'Node',
+            value: pod.jsonData.spec.nodeName || 'Not assigned',
+          },
+          {
+            name: 'Pod IP',
+            value: pod.jsonData.status?.podIP || 'Not assigned',
+          },
+        ];
+      }}
+      extraSections={pod => {
+        if (!pod) return [];
 
-                return [
+        return [
+          {
+            id: 'my-plugin-pod-containers',
+            section: (
+              <SectionBox title="Containers">
+                <SimpleTable
+                  data={pod.jsonData.spec.containers}
+                  columns={[
+                    { label: 'Name', getter: container => container.name },
+                    { label: 'Image', getter: container => container.image },
                     {
-                        id: 'my-plugin-pod-containers',
-                        section: (
-                            <SectionBox title="Containers">
-                                <SimpleTable
-                                    data={pod.jsonData.spec.containers}
-                                    columns={[
-                                        { label: 'Name', getter: container => container.name },
-                                        { label: 'Image', getter: container => container.image },
-                                        {
-                                            label: 'Ports',
-                                            getter: container =>
-                                                container.ports?.map(p => p.containerPort).join(', ') || '-',
-                                        },
-                                    ]}
-                                />
-                            </SectionBox>
-                        ),
+                      label: 'Ports',
+                      getter: container =>
+                        container.ports?.map(p => p.containerPort).join(', ') || '-',
                     },
-                ];
-            }}
-        />
-    );
+                  ]}
+                />
+              </SectionBox>
+            ),
+          },
+        ];
+      }}
+    />
+  );
 }
 ```
 
@@ -325,15 +327,18 @@ registerRoute({
 
 ### Step 3: Test It
 
+Nothing links to your detail page yet, so open it directly in the browser.
+
 1. Save the file
-2. Navigate to the Pods list page
-3. Click on a pod name (or use the context menu → View)
-4. You should see the detail page with:
+2. Append `/c/<cluster>/my-plugin/<namespace>/pods/<pod-name>` to your Headlamp URL
+3. You should see the detail page with:
    - Standard metadata (name, namespace, labels, etc.)
    - Your custom fields (Phase, Node, Pod IP)
    - Your custom Containers section
 
 ![Screenshot of the pod detail page showing DetailsGrid with standard metadata, custom Phase, Node, and Pod IP fields, and the Containers section](./pod-detail-page.png)
+
+> **Note:** Registering a route only tells Headlamp which component to render for a URL — it doesn't create a link to it. Your list page still uses the `'name'` column shortcut, which points at Headlamp's built-in Pod details (shown in a drawer by default), not at your page. You'll point it at your own detail page in [Navigation Between List and Detail](#navigation-between-list-and-detail).
 
 ---
 
@@ -686,6 +691,7 @@ function MyPodsPage() {
   return (
     <ResourceListView
       title="My Pods"
+      id="my-plugin-pods"
       resourceClass={MyPod}
       columns={[
         {
@@ -835,6 +841,7 @@ function MyPodsPage() {
   return (
     <ResourceListView
       title="My Pods"
+      id="my-plugin-pods"
       resourceClass={MyPod}
       columns={[
         {
@@ -1097,6 +1104,7 @@ You've learned how to build professional list and detail pages:
   title="My Resources"              // Page title (required)
   resourceClass={MyResource}        // Resource class — required unless using `data`
   columns={[...]}                   // Column definitions (required)
+  id="my-plugin-resources"          // Table ID for plugin processors — use your own prefix (optional)
   hideColumns={['column-id']}       // Columns to hide (optional)
   actions={[...]}                   // Row context-menu actions — plain array, not a function (optional)
   data={items}                      // Pre-fetched data — use instead of resourceClass (optional)

--- a/docs/tutorials/plugin-development/getting-started/building-list-and-detail-pages/index.md
+++ b/docs/tutorials/plugin-development/getting-started/building-list-and-detail-pages/index.md
@@ -230,10 +230,7 @@ Add a new component to your `src/index.tsx`:
 
 ```tsx
 import { useParams } from 'react-router-dom';
-import {
-  registerRoute,
-  registerSidebarEntry,
-} from '@kinvolk/headlamp-plugin/lib';
+import { registerRoute, registerSidebarEntry } from '@kinvolk/headlamp-plugin/lib';
 import { getCluster } from '@kinvolk/headlamp-plugin/lib/Utils';
 import {
   DetailsGrid,
@@ -244,75 +241,75 @@ import { Chip } from '@mui/material';
 import { MyPod } from './resources/pod';
 
 function MyPodDetailPage() {
-    const params = useParams<{ name: string; namespace?: string }>();
-    const { name, namespace } = params;
-    const cluster = getCluster();
+  const params = useParams<{ name: string; namespace?: string }>();
+  const { name, namespace } = params;
+  const cluster = getCluster();
 
-    return (
-        <DetailsGrid
-            resourceType={MyPod}
-            name={name}
-            namespace={namespace}
-            backLink={`/c/${cluster}/my-plugin/pods`}
-            extraInfo={pod => {
-                if (!pod) return [];
+  return (
+    <DetailsGrid
+      resourceType={MyPod}
+      name={name}
+      namespace={namespace}
+      backLink={`/c/${cluster}/my-plugin/pods`}
+      extraInfo={pod => {
+        if (!pod) return [];
 
-                return [
-                    {
-                        name: 'Phase',
-                        value: (
-                            <Chip
-                                label={pod.jsonData.status?.phase || 'Unknown'}
-                                color={
-                                    pod.jsonData.status?.phase === 'Running'
-                                        ? 'success'
-                                        : pod.jsonData.status?.phase === 'Failed'
-                                            ? 'error'
-                                            : pod.jsonData.status?.phase === 'Pending'
-                                                ? 'warning'
-                                                : 'default'
-                                }
-                                size="small"
-                            />
-                        ),
-                    },
-                    {
-                        name: 'Node',
-                        value: pod.jsonData.spec.nodeName || 'Not assigned',
-                    },
-                    {
-                        name: 'Pod IP',
-                        value: pod.jsonData.status?.podIP || 'Not assigned',
-                    },
-                ];
-            }}
-            extraSections={pod => {
-                if (!pod) return [];
+        return [
+          {
+            name: 'Phase',
+            value: (
+              <Chip
+                label={pod.jsonData.status?.phase || 'Unknown'}
+                color={
+                  pod.jsonData.status?.phase === 'Running'
+                    ? 'success'
+                    : pod.jsonData.status?.phase === 'Failed'
+                    ? 'error'
+                    : pod.jsonData.status?.phase === 'Pending'
+                    ? 'warning'
+                    : 'default'
+                }
+                size="small"
+              />
+            ),
+          },
+          {
+            name: 'Node',
+            value: pod.jsonData.spec.nodeName || 'Not assigned',
+          },
+          {
+            name: 'Pod IP',
+            value: pod.jsonData.status?.podIP || 'Not assigned',
+          },
+        ];
+      }}
+      extraSections={pod => {
+        if (!pod) return [];
 
-                return [
+        return [
+          {
+            id: 'my-plugin-pod-containers',
+            section: (
+              <SectionBox title="Containers">
+                <SimpleTable
+                  data={pod.jsonData.spec.containers}
+                  columns={[
+                    { label: 'Name', getter: container => container.name },
+                    { label: 'Image', getter: container => container.image },
                     {
-                        id: 'my-plugin-pod-containers',
-                        section: (
-                            <SectionBox title="Containers">
-                                <SimpleTable
-                                    data={pod.jsonData.spec.containers}
-                                    columns={[
-                                        { label: 'Name', getter: container => container.name },
-                                        { label: 'Image', getter: container => container.image },
-                                        {
-                                            label: 'Ports',
-                                            getter: container =>
-                                                container.ports?.map(p => p.containerPort).join(', ') || '-',
-                                        },
-                                    ]}
-                                />
-                            </SectionBox>
-                        ),
+                      label: 'Ports',
+                      getter: container =>
+                        container.ports?.map(p => p.containerPort).join(', ') || '-',
                     },
-                ];
-            }}
-        />
-    );
+                  ]}
+                />
+              </SectionBox>
+            ),
+          },
+        ];
+      }}
+    />
+  );
 }
 ```
 
@@ -330,15 +327,18 @@ registerRoute({
 
 ### Step 3: Test It
 
+Nothing links to your detail page yet, so open it directly in the browser.
+
 1. Save the file
-2. Navigate to the Pods list page
-3. Click on a pod name (or use the context menu → View)
-4. You should see the detail page with:
+2. Append `/c/<cluster>/my-plugin/<namespace>/pods/<pod-name>` to your Headlamp URL
+3. You should see the detail page with:
    - Standard metadata (name, namespace, labels, etc.)
    - Your custom fields (Phase, Node, Pod IP)
    - Your custom Containers section
 
 ![Screenshot of the pod detail page showing DetailsGrid with standard metadata, custom Phase, Node, and Pod IP fields, and the Containers section](./pod-detail-page.png)
+
+> **Note:** Registering a route only tells Headlamp which component to render for a URL — it doesn't create a link to it. Your list page still uses the `'name'` column shortcut, which points at Headlamp's built-in Pod details (shown in a drawer by default), not at your page. You'll point it at your own detail page in [Navigation Between List and Detail](#navigation-between-list-and-detail).
 
 ---
 

--- a/docs/tutorials/plugin-development/getting-started/building-list-and-detail-pages/index.md
+++ b/docs/tutorials/plugin-development/getting-started/building-list-and-detail-pages/index.md
@@ -81,6 +81,7 @@ function MyPodsPage() {
   return (
     <ResourceListView
       title="My Pods"
+      id="my-plugin-pods"
       resourceClass={MyPod}
       columns={[
         'name',
@@ -165,6 +166,10 @@ Now that you've seen it in action, let's look at what `ResourceListView` gave yo
 |------|-------------|
 | `resourceClass={MyPod}` | Let the component fetch data — the standard approach |
 | `data={items}` | Pass pre-fetched or transformed data yourself |
+
+### The `id` prop
+
+Plugins target tables by `id`, which is how the column processors in [Tutorial 7](../extending-existing-resource-views/) find the table they want. Always pass one with your own prefix: without it, `ResourceListView` derives `headlamp-<pluralName>` from the resource class — the same ID Headlamp's own table for that resource uses — so processors aimed at the built-in table would hit yours too.
 
 ### Built-in column shortcuts
 
@@ -686,6 +691,7 @@ function MyPodsPage() {
   return (
     <ResourceListView
       title="My Pods"
+      id="my-plugin-pods"
       resourceClass={MyPod}
       columns={[
         {
@@ -835,6 +841,7 @@ function MyPodsPage() {
   return (
     <ResourceListView
       title="My Pods"
+      id="my-plugin-pods"
       resourceClass={MyPod}
       columns={[
         {
@@ -1097,6 +1104,7 @@ You've learned how to build professional list and detail pages:
   title="My Resources"              // Page title (required)
   resourceClass={MyResource}        // Resource class — required unless using `data`
   columns={[...]}                   // Column definitions (required)
+  id="my-plugin-resources"          // Table ID for plugin processors — use your own prefix (optional)
   hideColumns={['column-id']}       // Columns to hide (optional)
   actions={[...]}                   // Row context-menu actions — plain array, not a function (optional)
   data={items}                      // Pre-fetched data — use instead of resourceClass (optional)

--- a/docs/tutorials/plugin-development/getting-started/extending-existing-resource-views/index.md
+++ b/docs/tutorials/plugin-development/getting-started/extending-existing-resource-views/index.md
@@ -108,8 +108,7 @@ registerResourceTableColumnsProcessor(function addContainerImagesColumn({ id, co
 
 ![Screenshot of the Pods list view with the custom Container Images column added, highlighted in a red box on the right side of the table](./pods-list-column.png)
 
-> **Important:** This column appears in Headlamp's **own** built-in Pods page — not the custom `MyPodsPage` you built in Tutorial 6. You are injecting into Headlamp's view.
-
+> **Important:** This column appears in Headlamp's **own** built-in Pods page — you are injecting into Headlamp's view, **not** the custom `MyPodsPage` you built in Tutorial 6. That separation depends on the two tables having different IDs. A `resourceClass`-backed table given no explicit `id` derives one as `headlamp-<pluralName>`, and `pluralName` defaults to the class's `apiName` — so `MyPod` (whose `apiName` must be `'pods'` to reach the real endpoint) would land on `headlamp-pods` too. That is why Tutorial 6 gave the table an explicit `id="my-plugin-pods"`: without it, this processor would push its column onto your own page, where `pod.spec` is undefined and reading `pod.spec.containers` would throw.
 
 ---
 
@@ -744,6 +743,8 @@ registerResourceTableColumnsProcessor(function myProcessor({ id, columns }) {
 ```
 
 **Common table IDs:** `headlamp-pods`, `headlamp-deployments`, `headlamp-nodes`, `headlamp-namespaces`, `headlamp-services`
+
+**Naming your own tables:** Give every table you create an explicit `id` with your plugin's prefix (e.g. `id="my-plugin-pods"`). If you use `resourceClass` and omit `id`, Headlamp derives `headlamp-<pluralName>`, which can collide with a built-in table. If you pass `data={items}` instead, processors receive an empty `id` unless you set one — still use an explicit plugin-scoped `id` so your table stays identifiable and safe if you change how it loads data.
 
 ### registerDetailsViewHeaderAction
 

--- a/docs/tutorials/plugin-development/getting-started/extending-existing-resource-views/index.md
+++ b/docs/tutorials/plugin-development/getting-started/extending-existing-resource-views/index.md
@@ -108,8 +108,7 @@ registerResourceTableColumnsProcessor(function addContainerImagesColumn({ id, co
 
 ![Screenshot of the Pods list view with the custom Container Images column added, highlighted in a red box on the right side of the table](./pods-list-column.png)
 
-> **Important:** This column appears in Headlamp's **own** built-in Pods page — not the custom `MyPodsPage` you built in Tutorial 6. You are injecting into Headlamp's view.
-
+> **Important:** This column appears in Headlamp's **own** built-in Pods page — you are injecting into Headlamp's view, **not** the custom `MyPodsPage` you built in Tutorial 6. That separation depends on the two tables having different IDs. A table given no explicit `id` derives one as `headlamp-<pluralName>`, and `pluralName` defaults to the class's `apiName` — so `MyPod` (whose `apiName` must be `'pods'` to reach the real endpoint) would land on `headlamp-pods` too. That is why Tutorial 6 gave the table an explicit `id="my-plugin-pods"`: without it, this processor would push its column onto your own page, where `pod.spec` is undefined and reading `pod.spec.containers` would throw.
 
 ---
 
@@ -744,6 +743,8 @@ registerResourceTableColumnsProcessor(function myProcessor({ id, columns }) {
 ```
 
 **Common table IDs:** `headlamp-pods`, `headlamp-deployments`, `headlamp-nodes`, `headlamp-namespaces`, `headlamp-services`
+
+**Naming your own tables:** Give every table you create an explicit `id` with your plugin's prefix (e.g. `id="my-plugin-pods"`). Without one, the ID is derived as `headlamp-<pluralName>` and can collide with a built-in table.
 
 ### registerDetailsViewHeaderAction
 

--- a/docs/tutorials/plugin-development/getting-started/extending-existing-resource-views/index.md
+++ b/docs/tutorials/plugin-development/getting-started/extending-existing-resource-views/index.md
@@ -108,7 +108,7 @@ registerResourceTableColumnsProcessor(function addContainerImagesColumn({ id, co
 
 ![Screenshot of the Pods list view with the custom Container Images column added, highlighted in a red box on the right side of the table](./pods-list-column.png)
 
-> **Important:** This column appears in Headlamp's **own** built-in Pods page — you are injecting into Headlamp's view, **not** the custom `MyPodsPage` you built in Tutorial 6. That separation depends on the two tables having different IDs. A table given no explicit `id` derives one as `headlamp-<pluralName>`, and `pluralName` defaults to the class's `apiName` — so `MyPod` (whose `apiName` must be `'pods'` to reach the real endpoint) would land on `headlamp-pods` too. That is why Tutorial 6 gave the table an explicit `id="my-plugin-pods"`: without it, this processor would push its column onto your own page, where `pod.spec` is undefined and reading `pod.spec.containers` would throw.
+> **Important:** This column appears in Headlamp's **own** built-in Pods page — you are injecting into Headlamp's view, **not** the custom `MyPodsPage` you built in Tutorial 6. That separation depends on the two tables having different IDs. A `resourceClass`-backed table given no explicit `id` derives one as `headlamp-<pluralName>`, and `pluralName` defaults to the class's `apiName` — so `MyPod` (whose `apiName` must be `'pods'` to reach the real endpoint) would land on `headlamp-pods` too. That is why Tutorial 6 gave the table an explicit `id="my-plugin-pods"`: without it, this processor would push its column onto your own page, where `pod.spec` is undefined and reading `pod.spec.containers` would throw.
 
 ---
 
@@ -744,7 +744,7 @@ registerResourceTableColumnsProcessor(function myProcessor({ id, columns }) {
 
 **Common table IDs:** `headlamp-pods`, `headlamp-deployments`, `headlamp-nodes`, `headlamp-namespaces`, `headlamp-services`
 
-**Naming your own tables:** Give every table you create an explicit `id` with your plugin's prefix (e.g. `id="my-plugin-pods"`). Without one, the ID is derived as `headlamp-<pluralName>` and can collide with a built-in table.
+**Naming your own tables:** Give every table you create an explicit `id` with your plugin's prefix (e.g. `id="my-plugin-pods"`). If you use `resourceClass` and omit `id`, Headlamp derives `headlamp-<pluralName>`, which can collide with a built-in table. If you pass `data={items}` instead, processors receive an empty `id` unless you set one — still use an explicit plugin-scoped `id` so your table stays identifiable and safe if you change how it loads data.
 
 ### registerDetailsViewHeaderAction
 

--- a/docs/tutorials/plugin-development/getting-started/working-with-kubernetes-data-advanced/index.md
+++ b/docs/tutorials/plugin-development/getting-started/working-with-kubernetes-data-advanced/index.md
@@ -527,6 +527,12 @@ function MyPodsPage() {
         </Table>
       </TableContainer>
 
+      {pods && pods.length > 20 && (
+        <Typography sx={{ mt: 2, color: 'text.secondary' }}>
+          Showing first 20 of {pods.length} pods
+        </Typography>
+      )}
+
       {/* Feedback Snackbar */}
       <Snackbar
         open={snackbar.open}


### PR DESCRIPTION
## Summary

Four atomic doc commits for the plugin getting-started tutorials:

1. Tutorial 5 — restore the truncated pod list notice in the advanced example.
2. Tutorials 6 & 7 — document explicit `ResourceListView` `id` values so plugin tables do not share `headlamp-pods` with built-in views; explain why column processors stay on Headlamp's Pods page.
3. Tutorial 6 — clarify detail-page testing via direct URL until list navigation is wired.
4. Tutorial 10 — fix map source picker steps to match the filter chip UI.

## Changes

- `working-with-kubernetes-data-advanced/index.md` — pod list cap message in evict example
- `building-list-and-detail-pages/index.md` — `id` prop, detail test steps, cross-links
- `extending-existing-resource-views/index.md` — expanded Important note, quick reference for custom table IDs
- `adding-custom-map-nodes/index.md` — source picker instructions

## Steps to Test

1. Open the four changed tutorial pages in the docs site or Markdown preview.
2. Confirm Tutorial 6 snippets use `id=my-plugin-pods` and the detail test step uses a full Headlamp URL path.
3. Follow Tutorial 10 map steps in a running Headlamp instance and confirm the source picker matches the filter chip description.
4. Verify Tutorial 7 prose matches `ResourceTable` ID derivation in `frontend/src/components/common/Resource/ResourceTable.tsx`.

## Screenshots (if applicable)

N/A (documentation only)

## Notes for the Reviewer

- Doc-only change; no `npm run frontend:lint` coverage for `docs/`.
- Commit messages follow contributing guidelines (atomic commits, 72-character wrapped bodies).
- Suggest label: `documentation`.