### PR TITLE
plugins/headlamp-plugin: Fix storybook dev command on Windows

### DIFF
--- a/plugins/headlamp-plugin/bin/headlamp-plugin.js
+++ b/plugins/headlamp-plugin/bin/headlamp-plugin.js
@@ -1452,23 +1452,8 @@ function tsc(packageFolder) {
  * @returns {0 | 1} Exit code, where 0 is success, 1 is failure.
  */
 function storybook(packageFolder) {
-  try {
-    child_process.execSync(
-      './node_modules/.bin/storybook dev -p 6007 -c node_modules/@kinvolk/headlamp-plugin/config/.storybook',
-      {
-        stdio: 'inherit',
-        cwd: packageFolder,
-        encoding: 'utf8',
-      }
-    );
-  } catch (e) {
-    console.error(
-      `Problem running storybook dev inside of "${packageFolder}" abs: "${resolve(packageFolder)}"`
-    );
-    return 1;
-  }
-
-  return 0;
+  const script = `storybook dev -p 6007 -c node_modules/@kinvolk/headlamp-plugin/config/.storybook`;
+  return runScriptOnPackages(packageFolder, 'storybook dev', script, {});
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR fixes `headlamp-plugin storybook` failing on native Windows by replacing its hand-rolled `execSync` call with the same cross-platform helper every other CLI subcommand already uses.

## Related Issue

Fixes #6994 

## Changes

- `plugins/headlamp-plugin/bin/headlamp-plugin.js`: `storybook()` previously called `child_process.execSync('./node_modules/.bin/storybook dev ...')` directly. On Windows, `execSync` spawns `cmd.exe`, which can't resolve the Unix-style `./` relative path, so the command failed immediately with `'.' is not recognized as an internal or external command`.
- Replaced it with a call to the existing `runScriptOnPackages()` helper — the same one `lint`, `tsc`, `test`, `i18n`, and the sibling `storybook_build` already use. It resolves the binary cross-platform (`.cmd` extension on Windows via `viaCmd`) and runs it with `execFileSync`, without going through a shell at all.
- Net change: removed the custom `try`/`catch`/`execSync` block, replaced with the same two-line pattern `storybook_build()` uses.

## Steps to Test

1. On Windows (native cmd.exe/PowerShell, not WSL), clone `headlamp-k8s/plugins` (or any repo with a Headlamp plugin) and `cd` into a plugin folder, e.g. `backstage/`.
2. Run `npm install`.
3. Before the fix: `npm run storybook` fails instantly with `'.' is not recognized as an internal or external command, operable program or batch file.`
4. After the fix: `npm run storybook` correctly resolves `node_modules\.bin\storybook.cmd`, Storybook starts, and webpack begins compiling — verified locally end-to-end.

## Notes for the Reviewer

- No behavior change for macOS/Linux — `runScriptOnPackages` already handled those platforms correctly; this only fixes the Windows path.
- I did not change `storybook_build()`; it already followed this pattern correctly, which is how I found the inconsistency.
