### PR TITLE
backend: oidc: Characterize the OIDC callback success path

### DIFF
--- a/backend/cmd/oidc_handlers_test.go
+++ b/backend/cmd/oidc_handlers_test.go
@@ -708,3 +708,67 @@ func TestOIDCCallback_CachesRefreshToken(t *testing.T) {
 	require.NoError(t, err, "refresh token should be cached under oidc-token-<raw token>")
 	assert.Equal(t, "refresh-xyz", got)
 }
+
+// TestOIDCCallback_TokenMissingFromResponse characterizes a token endpoint
+// that succeeds but omits id_token entirely.
+func TestOIDCCallback_TokenMissingFromResponse(t *testing.T) {
+	srv := newOIDCTestServer(t, nil)
+	handler, cluster := newOIDCTestHandler(t, srv)
+
+	srv.setTokenHandler(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		_, _ = io.WriteString(w, `{"access_token":"opaque-access","token_type":"Bearer"}`)
+	})
+
+	state := extractState(t, driveOIDCStart(t, handler, cluster))
+	rr := driveOIDCCallback(t, handler, state)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "No id_token field in oauth2 token")
+}
+
+// TestOIDCCallback_VerificationFailure characterizes a token that is well
+// formed but signed by a key the provider does not advertise.
+//
+// It also pins a partial write: the refresh token is cached BEFORE the
+// signature is verified (headlamp.go:1078-1092), so a token that is then
+// rejected still leaves an oidc-token-<raw> entry behind. This is recorded as
+// current behavior, not endorsed — caching credentials for a token that was
+// subsequently rejected is arguably wrong, and #5401 may want to reorder it.
+// If that happens, this assertion should be UPDATED, not deleted.
+func TestOIDCCallback_VerificationFailure(t *testing.T) {
+	srv := newOIDCTestServer(t, nil)
+	c := cache.New[interface{}]()
+	handler, cluster := newOIDCTestHandler(t, srv, withCache(c))
+
+	otherKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	claims := fmt.Sprintf(
+		`{"iss":%q,"aud":"test-client-id","sub":"test-subject","exp":%s,"iat":%s}`,
+		srv.URL(),
+		strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10),
+		strconv.FormatInt(time.Now().Unix(), 10),
+	)
+	badToken := oidctest.SignIDToken(otherKey, testKeyID, oidc.RS256, claims)
+
+	srv.setTokenHandler(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		_, _ = io.WriteString(w, `{"access_token":"opaque-access","token_type":"Bearer",`+
+			`"refresh_token":"refresh-orphan","id_token":"`+badToken+`"}`)
+	})
+
+	state := extractState(t, driveOIDCStart(t, handler, cluster))
+	rr := driveOIDCCallback(t, handler, state)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Failed to verify ID Token")
+
+	got, err := c.Get(context.Background(), "oidc-token-"+badToken)
+	require.NoError(t, err,
+		"current behavior: the refresh token is cached before verification, so a "+
+			"rejected token still leaves an entry")
+	assert.Equal(t, "refresh-orphan", got)
+}

--- a/backend/cmd/oidc_handlers_test.go
+++ b/backend/cmd/oidc_handlers_test.go
@@ -218,6 +218,12 @@ func withStateReader(r io.Reader) oidcTestOption {
 	return func(c *HeadlampConfig) { c.oidcStateReader = r }
 }
 
+// withCache injects a caller-held cache so a test can inspect what the
+// callback handler wrote. Without it, newOIDCTestHandler's cache is private.
+func withCache(c cache.Cache[interface{}]) oidcTestOption {
+	return func(hc *HeadlampConfig) { hc.Cache = c }
+}
+
 // newOIDCTestHandler builds a Headlamp handler with one OIDC-configured
 // kubeconfig context whose IdP issuer points at the supplied mock server.
 // Returns the handler and the cluster name registered.
@@ -675,4 +681,30 @@ func TestOIDCCallback_Success(t *testing.T) {
 
 	assert.Equal(t, "/auth?cluster="+cluster, rr.Header().Get("Location"),
 		"non-DevMode, empty BaseURL redirects to /auth?cluster=<cluster>")
+}
+
+// TestOIDCCallback_CachesRefreshToken characterizes where the callback stores
+// the refresh token: keyed by the raw user token, so a later refresh can find
+// it (see OIDCTokenRefreshMiddleware).
+func TestOIDCCallback_CachesRefreshToken(t *testing.T) {
+	srv := newOIDCTestServer(t, nil)
+	c := cache.New[interface{}]()
+	handler, cluster := newOIDCTestHandler(t, srv, withCache(c))
+
+	idToken := srv.signToken(t, nil)
+
+	srv.setTokenHandler(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		_, _ = io.WriteString(w, `{"access_token":"opaque-access","token_type":"Bearer",`+
+			`"refresh_token":"refresh-xyz","id_token":"`+idToken+`"}`)
+	})
+
+	state := extractState(t, driveOIDCStart(t, handler, cluster))
+	rr := driveOIDCCallback(t, handler, state)
+	require.Equal(t, http.StatusSeeOther, rr.Code, "body=%q", rr.Body.String())
+
+	got, err := c.Get(context.Background(), "oidc-token-"+idToken)
+	require.NoError(t, err, "refresh token should be cached under oidc-token-<raw token>")
+	assert.Equal(t, "refresh-xyz", got)
 }

--- a/backend/cmd/oidc_handlers_test.go
+++ b/backend/cmd/oidc_handlers_test.go
@@ -703,3 +703,67 @@ func TestOIDCCallback_CachesRefreshToken(t *testing.T) {
 	require.NoError(t, err, "refresh token should be cached under oidc-token-<raw token>")
 	assert.Equal(t, "refresh-xyz", got)
 }
+
+// TestOIDCCallback_TokenMissingFromResponse characterizes a token endpoint
+// that succeeds but omits id_token entirely.
+func TestOIDCCallback_TokenMissingFromResponse(t *testing.T) {
+	srv := newOIDCTestServer(t, nil)
+	handler, cluster := newOIDCTestHandler(t, srv)
+
+	srv.setTokenHandler(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		_, _ = io.WriteString(w, `{"access_token":"opaque-access","token_type":"Bearer"}`)
+	})
+
+	state := extractState(t, driveOIDCStart(t, handler, cluster))
+	rr := driveOIDCCallback(t, handler, state, "auth-code")
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "No id_token field in oauth2 token")
+}
+
+// TestOIDCCallback_VerificationFailure characterizes a token that is well
+// formed but signed by a key the provider does not advertise.
+//
+// It also pins a partial write: the refresh token is cached BEFORE the
+// signature is verified (headlamp.go:1078-1092), so a token that is then
+// rejected still leaves an oidc-token-<raw> entry behind. This is recorded as
+// current behavior, not endorsed — caching credentials for a token that was
+// subsequently rejected is arguably wrong, and #5401 may want to reorder it.
+// If that happens, this assertion should be UPDATED, not deleted.
+func TestOIDCCallback_VerificationFailure(t *testing.T) {
+	srv := newOIDCTestServer(t, nil)
+	c := cache.New[interface{}]()
+	handler, cluster := newOIDCTestHandler(t, srv, withCache(c))
+
+	otherKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	claims := fmt.Sprintf(
+		`{"iss":%q,"aud":"test-client-id","sub":"test-subject","exp":%s,"iat":%s}`,
+		srv.URL(),
+		strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10),
+		strconv.FormatInt(time.Now().Unix(), 10),
+	)
+	badToken := oidctest.SignIDToken(otherKey, testKeyID, oidc.RS256, claims)
+
+	srv.setTokenHandler(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		_, _ = io.WriteString(w, `{"access_token":"opaque-access","token_type":"Bearer",`+
+			`"refresh_token":"refresh-orphan","id_token":"`+badToken+`"}`)
+	})
+
+	state := extractState(t, driveOIDCStart(t, handler, cluster))
+	rr := driveOIDCCallback(t, handler, state, "auth-code")
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Failed to verify ID Token")
+
+	got, err := c.Get(context.Background(), "oidc-token-"+badToken)
+	require.NoError(t, err,
+		"current behavior: the refresh token is cached before verification, so a "+
+			"rejected token still leaves an entry")
+	assert.Equal(t, "refresh-orphan", got)
+}

--- a/backend/cmd/oidc_handlers_test.go
+++ b/backend/cmd/oidc_handlers_test.go
@@ -224,6 +224,11 @@ func withCache(c cache.Cache[interface{}]) oidcTestOption {
 	return func(hc *HeadlampConfig) { hc.Cache = c }
 }
 
+// withAccessToken makes the callback read access_token instead of id_token.
+func withAccessToken() oidcTestOption {
+	return func(c *HeadlampConfig) { c.OidcUseAccessToken = true }
+}
+
 // newOIDCTestHandler builds a Headlamp handler with one OIDC-configured
 // kubeconfig context whose IdP issuer points at the supplied mock server.
 // Returns the handler and the cluster name registered.
@@ -766,4 +771,33 @@ func TestOIDCCallback_VerificationFailure(t *testing.T) {
 		"current behavior: the refresh token is cached before verification, so a "+
 			"rejected token still leaves an entry")
 	assert.Equal(t, "refresh-orphan", got)
+}
+
+// TestOIDCCallback_UsesAccessTokenWhenConfigured characterizes OidcUseAccessToken.
+//
+// Note what this reveals: the flag only changes which field is READ. The value
+// is still passed through the ID-token verifier, so an opaque access token —
+// what most providers actually issue — would be rejected. The access_token
+// here is therefore a second signed JWT, distinguishable only by its subject.
+func TestOIDCCallback_UsesAccessTokenWhenConfigured(t *testing.T) {
+	srv := newOIDCTestServer(t, nil)
+	handler, cluster := newOIDCTestHandler(t, srv, withAccessToken())
+
+	idToken := srv.signToken(t, map[string]any{"sub": "id-token-subject"})
+	accessToken := srv.signToken(t, map[string]any{"sub": "access-token-subject"})
+	require.NotEqual(t, idToken, accessToken, "the two tokens must be distinguishable")
+
+	srv.setTokenHandler(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		_, _ = io.WriteString(w, `{"access_token":"`+accessToken+`","token_type":"Bearer",`+
+			`"refresh_token":"refresh-abc","id_token":"`+idToken+`"}`)
+	})
+
+	state := extractState(t, driveOIDCStart(t, handler, cluster))
+	rr := driveOIDCCallback(t, handler, state, "auth-code")
+
+	require.Equal(t, http.StatusSeeOther, rr.Code, "body=%q", rr.Body.String())
+	assert.Equal(t, accessToken, authCookieValue(t, rr, cluster),
+		"with OidcUseAccessToken, the access_token — not the id_token — reaches the cookie")
 }

--- a/backend/cmd/oidc_handlers_test.go
+++ b/backend/cmd/oidc_handlers_test.go
@@ -291,24 +291,7 @@ func newOIDCTestHandler(t *testing.T, oidcSrv *oidcTestServer, opts ...oidcTestO
 func driveOIDCStart(t *testing.T, handler http.Handler, cluster string) *url.URL {
 	t.Helper()
 
-	target := "http://localhost:4466/oidc?cluster=" + url.QueryEscape(cluster)
-
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, target, nil)
-	require.NoError(t, err)
-
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	require.Equal(t, http.StatusFound, rr.Code,
-		"GET /oidc should 302 to the IdP; got %d body=%q", rr.Code, rr.Body.String())
-
-	loc := rr.Header().Get("Location")
-	require.NotEmpty(t, loc, "Location header missing on /oidc redirect")
-
-	u, err := url.Parse(loc)
-	require.NoError(t, err)
-
-	return u
+	return driveOIDCStartWithPrefix(t, handler, cluster, "")
 }
 
 // extractState returns the `state` query parameter from a parsed URL,
@@ -342,16 +325,7 @@ func callOIDCCallback(t *testing.T, handler http.Handler, rawQuery string) *http
 func driveOIDCCallback(t *testing.T, handler http.Handler, state, code string) *httptest.ResponseRecorder {
 	t.Helper()
 
-	target := "http://localhost:4466/oidc-callback?state=" + url.QueryEscape(state) +
-		"&code=" + url.QueryEscape(code)
-
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, target, nil)
-	require.NoError(t, err)
-
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	return rr
+	return driveOIDCCallbackWithPrefix(t, handler, state, code, "")
 }
 
 // driveOIDCStartWithPrefix is driveOIDCStart with the request path prefixed

--- a/backend/cmd/oidc_handlers_test.go
+++ b/backend/cmd/oidc_handlers_test.go
@@ -224,6 +224,11 @@ func withCache(c cache.Cache[interface{}]) oidcTestOption {
 	return func(hc *HeadlampConfig) { hc.Cache = c }
 }
 
+// withAccessToken makes the callback read access_token instead of id_token.
+func withAccessToken() oidcTestOption {
+	return func(c *HeadlampConfig) { c.OidcUseAccessToken = true }
+}
+
 // newOIDCTestHandler builds a Headlamp handler with one OIDC-configured
 // kubeconfig context whose IdP issuer points at the supplied mock server.
 // Returns the handler and the cluster name registered.
@@ -771,4 +776,33 @@ func TestOIDCCallback_VerificationFailure(t *testing.T) {
 		"current behavior: the refresh token is cached before verification, so a "+
 			"rejected token still leaves an entry")
 	assert.Equal(t, "refresh-orphan", got)
+}
+
+// TestOIDCCallback_UsesAccessTokenWhenConfigured characterizes OidcUseAccessToken.
+//
+// Note what this reveals: the flag only changes which field is READ. The value
+// is still passed through the ID-token verifier, so an opaque access token —
+// what most providers actually issue — would be rejected. The access_token
+// here is therefore a second signed JWT, distinguishable only by its subject.
+func TestOIDCCallback_UsesAccessTokenWhenConfigured(t *testing.T) {
+	srv := newOIDCTestServer(t, nil)
+	handler, cluster := newOIDCTestHandler(t, srv, withAccessToken())
+
+	idToken := srv.signToken(t, map[string]any{"sub": "id-token-subject"})
+	accessToken := srv.signToken(t, map[string]any{"sub": "access-token-subject"})
+	require.NotEqual(t, idToken, accessToken, "the two tokens must be distinguishable")
+
+	srv.setTokenHandler(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		_, _ = io.WriteString(w, `{"access_token":"`+accessToken+`","token_type":"Bearer",`+
+			`"refresh_token":"refresh-abc","id_token":"`+idToken+`"}`)
+	})
+
+	state := extractState(t, driveOIDCStart(t, handler, cluster))
+	rr := driveOIDCCallback(t, handler, state)
+
+	require.Equal(t, http.StatusSeeOther, rr.Code, "body=%q", rr.Body.String())
+	assert.Equal(t, accessToken, authCookieValue(t, rr, cluster),
+		"with OidcUseAccessToken, the access_token — not the id_token — reaches the cookie")
 }

--- a/backend/cmd/oidc_handlers_test.go
+++ b/backend/cmd/oidc_handlers_test.go
@@ -60,6 +60,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -68,9 +70,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sort"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/coreos/go-oidc/v3/oidc/oidctest"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
@@ -83,7 +91,41 @@ import (
 // oidcTestServer is a minimal mock OIDC provider exposing the discovery,
 // JWKS, and token endpoints required to drive /oidc and /oidc-callback.
 type oidcTestServer struct {
-	server *httptest.Server
+	server       *httptest.Server
+	tokenHandler http.HandlerFunc
+}
+
+// setTokenHandler swaps the /token response after construction, so a handler
+// can close over the server's own issuer URL when minting tokens.
+func (o *oidcTestServer) setTokenHandler(h http.HandlerFunc) {
+	o.tokenHandler = h
+}
+
+// testKeyID is the `kid` advertised in the mock provider's JWKS and stamped
+// into every token it signs.
+const testKeyID = "test-key-id"
+
+// The signing key is generated once for the whole package. A 2048-bit RSA
+// keygen is slow enough that doing it per test server would dominate the
+// runtime of this file. The key is immutable after initialization, so
+// sharing it across parallel tests is safe.
+var (
+	testSigningKeyOnce sync.Once
+	testSigningKey     *rsa.PrivateKey
+	testSigningKeyErr  error
+)
+
+// signingKey returns the shared package test signing key.
+func signingKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+
+	testSigningKeyOnce.Do(func() {
+		testSigningKey, testSigningKeyErr = rsa.GenerateKey(rand.Reader, 2048)
+	})
+
+	require.NoError(t, testSigningKeyErr, "generating package test signing key")
+
+	return testSigningKey
 }
 
 // newOIDCTestServer starts an in-process OIDC mock and returns a handle.
@@ -96,43 +138,59 @@ func newOIDCTestServer(t *testing.T, tokenHandler http.HandlerFunc) *oidcTestSer
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-
-		cfg := map[string]any{
-			"issuer":                                srv.URL,
-			"authorization_endpoint":                srv.URL + "/auth",
-			"token_endpoint":                        srv.URL + "/token",
-			"jwks_uri":                              srv.URL + "/jwks",
-			"id_token_signing_alg_values_supported": []string{"RS256"},
-		}
-		if err := json.NewEncoder(w).Encode(cfg); err != nil {
-			t.Errorf("encode discovery: %v", err)
-		}
-	})
-
-	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-
-		if _, err := w.Write([]byte(`{"keys":[]}`)); err != nil {
-			t.Errorf("write jwks: %v", err)
-		}
-	})
-
-	if tokenHandler != nil {
-		mux.HandleFunc("/token", tokenHandler)
-	} else {
-		mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusInternalServerError)
-		})
+	osrv := &oidctest.Server{
+		PublicKeys: []oidctest.PublicKey{{
+			PublicKey: signingKey(t).Public(),
+			KeyID:     testKeyID,
+			Algorithm: oidc.RS256,
+		}},
 	}
+	osrv.SetIssuer(srv.URL)
 
-	return &oidcTestServer{server: srv}
+	mux.Handle("/.well-known/openid-configuration", osrv)
+	mux.Handle("/keys", osrv)
+
+	o := &oidcTestServer{server: srv, tokenHandler: tokenHandler}
+
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		if o.tokenHandler == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+
+			return
+		}
+
+		o.tokenHandler(w, r)
+	})
+
+	return o
 }
 
 // URL returns the issuer URL of the mock OIDC server.
 func (o *oidcTestServer) URL() string {
 	return o.server.URL
+}
+
+// signToken mints an RS256 JWT signed by the shared test key, with issuer and
+// audience matching what the handler under test will verify against. Supplied
+// claims override the defaults.
+func (o *oidcTestServer) signToken(t *testing.T, claims map[string]any) string {
+	t.Helper()
+
+	c := map[string]any{
+		"iss": o.URL(),
+		"aud": "test-client-id",
+		"sub": "test-subject",
+		"exp": time.Now().Add(time.Hour).Unix(),
+		"iat": time.Now().Unix(),
+	}
+	for k, v := range claims {
+		c[k] = v
+	}
+
+	raw, err := json.Marshal(c)
+	require.NoError(t, err, "marshal token claims")
+
+	return oidctest.SignIDToken(signingKey(t), testKeyID, oidc.RS256, string(raw))
 }
 
 // failingTokenHandler returns a /token handler that rejects every exchange,
@@ -210,8 +268,9 @@ func newOIDCTestHandler(t *testing.T, oidcSrv *oidcTestServer, opts ...oidcTestO
 func driveOIDCStart(t *testing.T, handler http.Handler, cluster string) *url.URL {
 	t.Helper()
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
-		"/oidc?cluster="+cluster, nil)
+	target := "http://localhost:4466/oidc?cluster=" + url.QueryEscape(cluster)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, target, nil)
 	require.NoError(t, err)
 
 	rr := httptest.NewRecorder()
@@ -253,6 +312,61 @@ func callOIDCCallback(t *testing.T, handler http.Handler, rawQuery string) *http
 	handler.ServeHTTP(rr, req)
 
 	return rr
+}
+
+// driveOIDCCallback calls /oidc-callback with the supplied state and code and
+// returns the raw recorder so callers can assert status, body, and cookies.
+func driveOIDCCallback(t *testing.T, handler http.Handler, state, code string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	target := "http://localhost:4466/oidc-callback?state=" + url.QueryEscape(state) +
+		"&code=" + url.QueryEscape(code)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, target, nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	return rr
+}
+
+// authCookieValue reassembles the chunked auth cookie that SetTokenCookie
+// writes as headlamp-auth-<cluster>.0, .1, ... (see pkg/auth/cookies.go).
+// Reading only chunk .0 would silently truncate any token past chunkSize.
+func authCookieValue(t *testing.T, rr *httptest.ResponseRecorder, cluster string) string {
+	t.Helper()
+
+	prefix := "headlamp-auth-" + cluster + "."
+
+	type chunk struct {
+		idx int
+		val string
+	}
+
+	var chunks []chunk
+
+	for _, c := range rr.Result().Cookies() {
+		if !strings.HasPrefix(c.Name, prefix) || c.Value == "" {
+			continue
+		}
+
+		idx, err := strconv.Atoi(strings.TrimPrefix(c.Name, prefix))
+		require.NoError(t, err, "unexpected auth cookie name %q", c.Name)
+
+		chunks = append(chunks, chunk{idx: idx, val: c.Value})
+	}
+
+	require.NotEmpty(t, chunks, "no headlamp-auth-%s.N cookies were set", cluster)
+
+	sort.Slice(chunks, func(i, j int) bool { return chunks[i].idx < chunks[j].idx })
+
+	var b strings.Builder
+	for _, c := range chunks {
+		b.WriteString(c.val)
+	}
+
+	return b.String()
 }
 
 // TestOIDCStart_StateIsRandom32Bytes covers target #1: each /oidc call
@@ -527,4 +641,33 @@ func TestOIDCCallback_PKCEVerifierSentOnExchange(t *testing.T) {
 		assert.Empty(t, form.Get("code_verifier"),
 			"no code_verifier should be sent when PKCE is off")
 	})
+}
+
+// TestOIDCCallback_Success characterizes the full happy path: a signed
+// id_token that the verifier accepts results in a redirect to the frontend
+// with the token in the auth cookie.
+func TestOIDCCallback_Success(t *testing.T) {
+	srv := newOIDCTestServer(t, nil)
+	handler, cluster := newOIDCTestHandler(t, srv)
+
+	idToken := srv.signToken(t, map[string]any{"email": "user@example.com"})
+
+	srv.setTokenHandler(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		_, _ = io.WriteString(w, `{"access_token":"opaque-access","token_type":"Bearer",`+
+			`"refresh_token":"refresh-abc","id_token":"`+idToken+`"}`)
+	})
+
+	state := extractState(t, driveOIDCStart(t, handler, cluster))
+	rr := driveOIDCCallback(t, handler, state, "auth-code")
+
+	require.Equal(t, http.StatusSeeOther, rr.Code,
+		"callback should 303 on success; body=%q", rr.Body.String())
+
+	assert.Equal(t, idToken, authCookieValue(t, rr, cluster),
+		"the verified id_token should be what lands in the auth cookie")
+
+	assert.Equal(t, "/auth?cluster="+cluster, rr.Header().Get("Location"),
+		"non-DevMode, empty BaseURL redirects to /auth?cluster=<cluster>")
 }

--- a/backend/cmd/oidc_handlers_test.go
+++ b/backend/cmd/oidc_handlers_test.go
@@ -218,6 +218,12 @@ func withStateReader(r io.Reader) oidcTestOption {
 	return func(c *HeadlampConfig) { c.oidcStateReader = r }
 }
 
+// withCache injects a caller-held cache so a test can inspect what the
+// callback handler wrote. Without it, newOIDCTestHandler's cache is private.
+func withCache(c cache.Cache[interface{}]) oidcTestOption {
+	return func(hc *HeadlampConfig) { hc.Cache = c }
+}
+
 // newOIDCTestHandler builds a Headlamp handler with one OIDC-configured
 // kubeconfig context whose IdP issuer points at the supplied mock server.
 // Returns the handler and the cluster name registered.
@@ -670,4 +676,30 @@ func TestOIDCCallback_Success(t *testing.T) {
 
 	assert.Equal(t, "/auth?cluster="+cluster, rr.Header().Get("Location"),
 		"non-DevMode, empty BaseURL redirects to /auth?cluster=<cluster>")
+}
+
+// TestOIDCCallback_CachesRefreshToken characterizes where the callback stores
+// the refresh token: keyed by the raw user token, so a later refresh can find
+// it (see OIDCTokenRefreshMiddleware).
+func TestOIDCCallback_CachesRefreshToken(t *testing.T) {
+	srv := newOIDCTestServer(t, nil)
+	c := cache.New[interface{}]()
+	handler, cluster := newOIDCTestHandler(t, srv, withCache(c))
+
+	idToken := srv.signToken(t, nil)
+
+	srv.setTokenHandler(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		_, _ = io.WriteString(w, `{"access_token":"opaque-access","token_type":"Bearer",`+
+			`"refresh_token":"refresh-xyz","id_token":"`+idToken+`"}`)
+	})
+
+	state := extractState(t, driveOIDCStart(t, handler, cluster))
+	rr := driveOIDCCallback(t, handler, state, "auth-code")
+	require.Equal(t, http.StatusSeeOther, rr.Code, "body=%q", rr.Body.String())
+
+	got, err := c.Get(context.Background(), "oidc-token-"+idToken)
+	require.NoError(t, err, "refresh token should be cached under oidc-token-<raw token>")
+	assert.Equal(t, "refresh-xyz", got)
 }

--- a/backend/cmd/oidc_handlers_test.go
+++ b/backend/cmd/oidc_handlers_test.go
@@ -60,6 +60,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -68,9 +70,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sort"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/coreos/go-oidc/v3/oidc/oidctest"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
@@ -83,7 +91,41 @@ import (
 // oidcTestServer is a minimal mock OIDC provider exposing the discovery,
 // JWKS, and token endpoints required to drive /oidc and /oidc-callback.
 type oidcTestServer struct {
-	server *httptest.Server
+	server       *httptest.Server
+	tokenHandler http.HandlerFunc
+}
+
+// setTokenHandler swaps the /token response after construction, so a handler
+// can close over the server's own issuer URL when minting tokens.
+func (o *oidcTestServer) setTokenHandler(h http.HandlerFunc) {
+	o.tokenHandler = h
+}
+
+// testKeyID is the `kid` advertised in the mock provider's JWKS and stamped
+// into every token it signs.
+const testKeyID = "test-key-id"
+
+// The signing key is generated once for the whole package. A 2048-bit RSA
+// keygen is slow enough that doing it per test server would dominate the
+// runtime of this file. The key is immutable after initialization, so
+// sharing it across parallel tests is safe.
+var (
+	testSigningKeyOnce sync.Once
+	testSigningKey     *rsa.PrivateKey
+	testSigningKeyErr  error
+)
+
+// signingKey returns the shared package test signing key.
+func signingKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+
+	testSigningKeyOnce.Do(func() {
+		testSigningKey, testSigningKeyErr = rsa.GenerateKey(rand.Reader, 2048)
+	})
+
+	require.NoError(t, testSigningKeyErr, "generating package test signing key")
+
+	return testSigningKey
 }
 
 // newOIDCTestServer starts an in-process OIDC mock and returns a handle.
@@ -96,43 +138,59 @@ func newOIDCTestServer(t *testing.T, tokenHandler http.HandlerFunc) *oidcTestSer
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-
-		cfg := map[string]any{
-			"issuer":                                srv.URL,
-			"authorization_endpoint":                srv.URL + "/auth",
-			"token_endpoint":                        srv.URL + "/token",
-			"jwks_uri":                              srv.URL + "/jwks",
-			"id_token_signing_alg_values_supported": []string{"RS256"},
-		}
-		if err := json.NewEncoder(w).Encode(cfg); err != nil {
-			t.Errorf("encode discovery: %v", err)
-		}
-	})
-
-	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-
-		if _, err := w.Write([]byte(`{"keys":[]}`)); err != nil {
-			t.Errorf("write jwks: %v", err)
-		}
-	})
-
-	if tokenHandler != nil {
-		mux.HandleFunc("/token", tokenHandler)
-	} else {
-		mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusInternalServerError)
-		})
+	osrv := &oidctest.Server{
+		PublicKeys: []oidctest.PublicKey{{
+			PublicKey: signingKey(t).Public(),
+			KeyID:     testKeyID,
+			Algorithm: oidc.RS256,
+		}},
 	}
+	osrv.SetIssuer(srv.URL)
 
-	return &oidcTestServer{server: srv}
+	mux.Handle("/.well-known/openid-configuration", osrv)
+	mux.Handle("/keys", osrv)
+
+	o := &oidcTestServer{server: srv, tokenHandler: tokenHandler}
+
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		if o.tokenHandler == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+
+			return
+		}
+
+		o.tokenHandler(w, r)
+	})
+
+	return o
 }
 
 // URL returns the issuer URL of the mock OIDC server.
 func (o *oidcTestServer) URL() string {
 	return o.server.URL
+}
+
+// signToken mints an RS256 JWT signed by the shared test key, with issuer and
+// audience matching what the handler under test will verify against. Supplied
+// claims override the defaults.
+func (o *oidcTestServer) signToken(t *testing.T, claims map[string]any) string {
+	t.Helper()
+
+	c := map[string]any{
+		"iss": o.URL(),
+		"aud": "test-client-id",
+		"sub": "test-subject",
+		"exp": time.Now().Add(time.Hour).Unix(),
+		"iat": time.Now().Unix(),
+	}
+	for k, v := range claims {
+		c[k] = v
+	}
+
+	raw, err := json.Marshal(c)
+	require.NoError(t, err, "marshal token claims")
+
+	return oidctest.SignIDToken(signingKey(t), testKeyID, oidc.RS256, string(raw))
 }
 
 // failingTokenHandler returns a /token handler that rejects every exchange,
@@ -210,8 +268,9 @@ func newOIDCTestHandler(t *testing.T, oidcSrv *oidcTestServer, opts ...oidcTestO
 func driveOIDCStart(t *testing.T, handler http.Handler, cluster string) *url.URL {
 	t.Helper()
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
-		"/oidc?cluster="+cluster, nil)
+	target := "http://localhost:4466/oidc?cluster=" + url.QueryEscape(cluster)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, target, nil)
 	require.NoError(t, err)
 
 	rr := httptest.NewRecorder()
@@ -253,6 +312,66 @@ func callOIDCCallback(t *testing.T, handler http.Handler, rawQuery string) *http
 	handler.ServeHTTP(rr, req)
 
 	return rr
+}
+
+// testAuthCode is the authorization code the callback tests exchange. The mock
+// provider never validates it — only its presence on the request matters — so
+// there is nothing for a caller to vary.
+const testAuthCode = "auth-code"
+
+// driveOIDCCallback calls /oidc-callback with the supplied state and returns
+// the raw recorder so callers can assert status, body, and cookies.
+func driveOIDCCallback(t *testing.T, handler http.Handler, state string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	target := "http://localhost:4466/oidc-callback?state=" + url.QueryEscape(state) +
+		"&code=" + url.QueryEscape(testAuthCode)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, target, nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	return rr
+}
+
+// authCookieValue reassembles the chunked auth cookie that SetTokenCookie
+// writes as headlamp-auth-<cluster>.0, .1, ... (see pkg/auth/cookies.go).
+// Reading only chunk .0 would silently truncate any token past chunkSize.
+func authCookieValue(t *testing.T, rr *httptest.ResponseRecorder, cluster string) string {
+	t.Helper()
+
+	prefix := "headlamp-auth-" + cluster + "."
+
+	type chunk struct {
+		idx int
+		val string
+	}
+
+	var chunks []chunk
+
+	for _, c := range rr.Result().Cookies() {
+		if !strings.HasPrefix(c.Name, prefix) || c.Value == "" {
+			continue
+		}
+
+		idx, err := strconv.Atoi(strings.TrimPrefix(c.Name, prefix))
+		require.NoError(t, err, "unexpected auth cookie name %q", c.Name)
+
+		chunks = append(chunks, chunk{idx: idx, val: c.Value})
+	}
+
+	require.NotEmpty(t, chunks, "no headlamp-auth-%s.N cookies were set", cluster)
+
+	sort.Slice(chunks, func(i, j int) bool { return chunks[i].idx < chunks[j].idx })
+
+	var b strings.Builder
+	for _, c := range chunks {
+		b.WriteString(c.val)
+	}
+
+	return b.String()
 }
 
 // TestOIDCStart_StateIsRandom32Bytes covers target #1: each /oidc call
@@ -527,4 +646,33 @@ func TestOIDCCallback_PKCEVerifierSentOnExchange(t *testing.T) {
 		assert.Empty(t, form.Get("code_verifier"),
 			"no code_verifier should be sent when PKCE is off")
 	})
+}
+
+// TestOIDCCallback_Success characterizes the full happy path: a signed
+// id_token that the verifier accepts results in a redirect to the frontend
+// with the token in the auth cookie.
+func TestOIDCCallback_Success(t *testing.T) {
+	srv := newOIDCTestServer(t, nil)
+	handler, cluster := newOIDCTestHandler(t, srv)
+
+	idToken := srv.signToken(t, map[string]any{"email": "user@example.com"})
+
+	srv.setTokenHandler(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		_, _ = io.WriteString(w, `{"access_token":"opaque-access","token_type":"Bearer",`+
+			`"refresh_token":"refresh-abc","id_token":"`+idToken+`"}`)
+	})
+
+	state := extractState(t, driveOIDCStart(t, handler, cluster))
+	rr := driveOIDCCallback(t, handler, state)
+
+	require.Equal(t, http.StatusSeeOther, rr.Code,
+		"callback should 303 on success; body=%q", rr.Body.String())
+
+	assert.Equal(t, idToken, authCookieValue(t, rr, cluster),
+		"the verified id_token should be what lands in the auth cookie")
+
+	assert.Equal(t, "/auth?cluster="+cluster, rr.Header().Get("Location"),
+		"non-DevMode, empty BaseURL redirects to /auth?cluster=<cluster>")
 }

--- a/backend/cmd/oidc_handlers_test.go
+++ b/backend/cmd/oidc_handlers_test.go
@@ -79,6 +79,7 @@ import (
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/coreos/go-oidc/v3/oidc/oidctest"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/auth"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
@@ -229,6 +230,17 @@ func withAccessToken() oidcTestOption {
 	return func(c *HeadlampConfig) { c.OidcUseAccessToken = true }
 }
 
+// withDevMode enables the DevMode redirect branch of the callback.
+func withDevMode() oidcTestOption {
+	return func(c *HeadlampConfig) { c.DevMode = true }
+}
+
+// withBaseURL sets the server base URL, which the callback prepends to the
+// post-login redirect.
+func withBaseURL(u string) oidcTestOption {
+	return func(c *HeadlampConfig) { c.BaseURL = u }
+}
+
 // newOIDCTestHandler builds a Headlamp handler with one OIDC-configured
 // kubeconfig context whose IdP issuer points at the supplied mock server.
 // Returns the handler and the cluster name registered.
@@ -279,24 +291,7 @@ func newOIDCTestHandler(t *testing.T, oidcSrv *oidcTestServer, opts ...oidcTestO
 func driveOIDCStart(t *testing.T, handler http.Handler, cluster string) *url.URL {
 	t.Helper()
 
-	target := "http://localhost:4466/oidc?cluster=" + url.QueryEscape(cluster)
-
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, target, nil)
-	require.NoError(t, err)
-
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	require.Equal(t, http.StatusFound, rr.Code,
-		"GET /oidc should 302 to the IdP; got %d body=%q", rr.Code, rr.Body.String())
-
-	loc := rr.Header().Get("Location")
-	require.NotEmpty(t, loc, "Location header missing on /oidc redirect")
-
-	u, err := url.Parse(loc)
-	require.NoError(t, err)
-
-	return u
+	return driveOIDCStartWithPrefix(t, handler, cluster, "")
 }
 
 // extractState returns the `state` query parameter from a parsed URL,
@@ -335,7 +330,45 @@ const testAuthCode = "auth-code"
 func driveOIDCCallback(t *testing.T, handler http.Handler, state string) *httptest.ResponseRecorder {
 	t.Helper()
 
-	target := "http://localhost:4466/oidc-callback?state=" + url.QueryEscape(state) +
+	return driveOIDCCallbackWithPrefix(t, handler, state, "")
+}
+
+// driveOIDCStartWithPrefix is driveOIDCStart with the request path prefixed
+// by routePrefix, needed because a non-empty config.BaseURL mounts the whole
+// router (including /oidc and /oidc-callback, not just the post-login
+// redirect target) under that prefix (headlamp.go:640-647). An empty
+// routePrefix behaves exactly like driveOIDCStart.
+func driveOIDCStartWithPrefix(t *testing.T, handler http.Handler, cluster, routePrefix string) *url.URL {
+	t.Helper()
+
+	target := "http://localhost:4466" + routePrefix + "/oidc?cluster=" + url.QueryEscape(cluster)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, target, nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusFound, rr.Code,
+		"GET %s/oidc should 302 to the IdP; got %d body=%q", routePrefix, rr.Code, rr.Body.String())
+
+	loc := rr.Header().Get("Location")
+	require.NotEmpty(t, loc, "Location header missing on /oidc redirect")
+
+	u, err := url.Parse(loc)
+	require.NoError(t, err)
+
+	return u
+}
+
+// driveOIDCCallbackWithPrefix is driveOIDCCallback with the request path
+// prefixed by routePrefix; see driveOIDCStartWithPrefix.
+func driveOIDCCallbackWithPrefix(
+	t *testing.T, handler http.Handler, state, routePrefix string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	target := "http://localhost:4466" + routePrefix + "/oidc-callback?state=" + url.QueryEscape(state) +
 		"&code=" + url.QueryEscape(testAuthCode)
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, target, nil)
@@ -350,10 +383,15 @@ func driveOIDCCallback(t *testing.T, handler http.Handler, state string) *httpte
 // authCookieValue reassembles the chunked auth cookie that SetTokenCookie
 // writes as headlamp-auth-<cluster>.0, .1, ... (see pkg/auth/cookies.go).
 // Reading only chunk .0 would silently truncate any token past chunkSize.
+//
+// SetTokenCookie names cookies from auth.SanitizeClusterName(cluster), not
+// the raw cluster name (cookies.go:84,100), mirrored here as
+// GetTokenFromCookie does (cookies.go:115) — otherwise an awkward cluster
+// name would silently find no cookies.
 func authCookieValue(t *testing.T, rr *httptest.ResponseRecorder, cluster string) string {
 	t.Helper()
 
-	prefix := "headlamp-auth-" + cluster + "."
+	prefix := "headlamp-auth-" + auth.SanitizeClusterName(cluster) + "."
 
 	type chunk struct {
 		idx int
@@ -805,4 +843,63 @@ func TestOIDCCallback_UsesAccessTokenWhenConfigured(t *testing.T) {
 	require.Equal(t, http.StatusSeeOther, rr.Code, "body=%q", rr.Body.String())
 	assert.Equal(t, accessToken, authCookieValue(t, rr, cluster),
 		"with OidcUseAccessToken, the access_token — not the id_token — reaches the cookie")
+}
+
+// TestOIDCCallback_RedirectTarget characterizes where a successful login sends
+// the browser, across DevMode and BaseURL. In every case the target ends with
+// auth?cluster=<cluster>; DevMode swaps the origin and BaseURL inserts a path
+// segment ahead of it (headlamp.go:1106-1121).
+func TestOIDCCallback_RedirectTarget(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []oidcTestOption
+		// routePrefix mirrors config.BaseURL: when the router mounts routes
+		// under a base URL (headlamp.go:640-647), /oidc and /oidc-callback
+		// themselves move under that prefix too, not just the post-login
+		// redirect target being asserted below.
+		routePrefix string
+		want        string
+	}{
+		{
+			name: "default",
+			opts: nil,
+			want: "/auth?cluster=oidc-char-test",
+		},
+		{
+			name: "dev mode",
+			opts: []oidcTestOption{withDevMode()},
+			want: "http://localhost:3000/auth?cluster=oidc-char-test",
+		},
+		{
+			name:        "base URL",
+			opts:        []oidcTestOption{withBaseURL("/headlamp")},
+			routePrefix: "/headlamp",
+			want:        "/headlamp/auth?cluster=oidc-char-test",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newOIDCTestServer(t, nil)
+			handler, cluster := newOIDCTestHandler(t, srv, tc.opts...)
+			require.Equal(t, "oidc-char-test", cluster,
+				"the want values above hardcode the cluster name")
+
+			idToken := srv.signToken(t, nil)
+
+			srv.setTokenHandler(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+
+				_, _ = io.WriteString(w, `{"access_token":"opaque-access","token_type":"Bearer",`+
+					`"refresh_token":"refresh-abc","id_token":"`+idToken+`"}`)
+			})
+
+			loc := driveOIDCStartWithPrefix(t, handler, cluster, tc.routePrefix)
+			state := extractState(t, loc)
+			rr := driveOIDCCallbackWithPrefix(t, handler, state, tc.routePrefix)
+
+			require.Equal(t, http.StatusSeeOther, rr.Code, "body=%q", rr.Body.String())
+			assert.Equal(t, tc.want, rr.Header().Get("Location"))
+		})
+	}
 }

--- a/backend/cmd/oidc_handlers_test.go
+++ b/backend/cmd/oidc_handlers_test.go
@@ -79,6 +79,7 @@ import (
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/coreos/go-oidc/v3/oidc/oidctest"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/auth"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
@@ -229,6 +230,17 @@ func withAccessToken() oidcTestOption {
 	return func(c *HeadlampConfig) { c.OidcUseAccessToken = true }
 }
 
+// withDevMode enables the DevMode redirect branch of the callback.
+func withDevMode() oidcTestOption {
+	return func(c *HeadlampConfig) { c.DevMode = true }
+}
+
+// withBaseURL sets the server base URL, which the callback prepends to the
+// post-login redirect.
+func withBaseURL(u string) oidcTestOption {
+	return func(c *HeadlampConfig) { c.BaseURL = u }
+}
+
 // newOIDCTestHandler builds a Headlamp handler with one OIDC-configured
 // kubeconfig context whose IdP issuer points at the supplied mock server.
 // Returns the handler and the cluster name registered.
@@ -342,13 +354,65 @@ func driveOIDCCallback(t *testing.T, handler http.Handler, state, code string) *
 	return rr
 }
 
+// driveOIDCStartWithPrefix is driveOIDCStart with the request path prefixed
+// by routePrefix, needed because a non-empty config.BaseURL mounts the whole
+// router (including /oidc and /oidc-callback, not just the post-login
+// redirect target) under that prefix (headlamp.go:640-647). An empty
+// routePrefix behaves exactly like driveOIDCStart.
+func driveOIDCStartWithPrefix(t *testing.T, handler http.Handler, cluster, routePrefix string) *url.URL {
+	t.Helper()
+
+	target := "http://localhost:4466" + routePrefix + "/oidc?cluster=" + url.QueryEscape(cluster)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, target, nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusFound, rr.Code,
+		"GET %s/oidc should 302 to the IdP; got %d body=%q", routePrefix, rr.Code, rr.Body.String())
+
+	loc := rr.Header().Get("Location")
+	require.NotEmpty(t, loc, "Location header missing on /oidc redirect")
+
+	u, err := url.Parse(loc)
+	require.NoError(t, err)
+
+	return u
+}
+
+// driveOIDCCallbackWithPrefix is driveOIDCCallback with the request path
+// prefixed by routePrefix; see driveOIDCStartWithPrefix.
+func driveOIDCCallbackWithPrefix(
+	t *testing.T, handler http.Handler, state, code, routePrefix string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	target := "http://localhost:4466" + routePrefix + "/oidc-callback?state=" + url.QueryEscape(state) +
+		"&code=" + url.QueryEscape(code)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, target, nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	return rr
+}
+
 // authCookieValue reassembles the chunked auth cookie that SetTokenCookie
 // writes as headlamp-auth-<cluster>.0, .1, ... (see pkg/auth/cookies.go).
 // Reading only chunk .0 would silently truncate any token past chunkSize.
+//
+// SetTokenCookie names cookies from auth.SanitizeClusterName(cluster), not
+// the raw cluster name (cookies.go:84,100), mirrored here as
+// GetTokenFromCookie does (cookies.go:115) — otherwise an awkward cluster
+// name would silently find no cookies.
 func authCookieValue(t *testing.T, rr *httptest.ResponseRecorder, cluster string) string {
 	t.Helper()
 
-	prefix := "headlamp-auth-" + cluster + "."
+	prefix := "headlamp-auth-" + auth.SanitizeClusterName(cluster) + "."
 
 	type chunk struct {
 		idx int
@@ -800,4 +864,63 @@ func TestOIDCCallback_UsesAccessTokenWhenConfigured(t *testing.T) {
 	require.Equal(t, http.StatusSeeOther, rr.Code, "body=%q", rr.Body.String())
 	assert.Equal(t, accessToken, authCookieValue(t, rr, cluster),
 		"with OidcUseAccessToken, the access_token — not the id_token — reaches the cookie")
+}
+
+// TestOIDCCallback_RedirectTarget characterizes where a successful login sends
+// the browser, across DevMode and BaseURL. In every case the target ends with
+// auth?cluster=<cluster>; DevMode swaps the origin and BaseURL inserts a path
+// segment ahead of it (headlamp.go:1106-1121).
+func TestOIDCCallback_RedirectTarget(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []oidcTestOption
+		// routePrefix mirrors config.BaseURL: when the router mounts routes
+		// under a base URL (headlamp.go:640-647), /oidc and /oidc-callback
+		// themselves move under that prefix too, not just the post-login
+		// redirect target being asserted below.
+		routePrefix string
+		want        string
+	}{
+		{
+			name: "default",
+			opts: nil,
+			want: "/auth?cluster=oidc-char-test",
+		},
+		{
+			name: "dev mode",
+			opts: []oidcTestOption{withDevMode()},
+			want: "http://localhost:3000/auth?cluster=oidc-char-test",
+		},
+		{
+			name:        "base URL",
+			opts:        []oidcTestOption{withBaseURL("/headlamp")},
+			routePrefix: "/headlamp",
+			want:        "/headlamp/auth?cluster=oidc-char-test",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newOIDCTestServer(t, nil)
+			handler, cluster := newOIDCTestHandler(t, srv, tc.opts...)
+			require.Equal(t, "oidc-char-test", cluster,
+				"the want values above hardcode the cluster name")
+
+			idToken := srv.signToken(t, nil)
+
+			srv.setTokenHandler(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+
+				_, _ = io.WriteString(w, `{"access_token":"opaque-access","token_type":"Bearer",`+
+					`"refresh_token":"refresh-abc","id_token":"`+idToken+`"}`)
+			})
+
+			loc := driveOIDCStartWithPrefix(t, handler, cluster, tc.routePrefix)
+			state := extractState(t, loc)
+			rr := driveOIDCCallbackWithPrefix(t, handler, state, "auth-code", tc.routePrefix)
+
+			require.Equal(t, http.StatusSeeOther, rr.Code, "body=%q", rr.Body.String())
+			assert.Equal(t, tc.want, rr.Header().Get("Location"))
+		})
+	}
 }

--- a/backend/cmd/oidc_handlers_test.go
+++ b/backend/cmd/oidc_handlers_test.go
@@ -320,12 +320,17 @@ func callOIDCCallback(t *testing.T, handler http.Handler, rawQuery string) *http
 	return rr
 }
 
-// driveOIDCCallback calls /oidc-callback with the supplied state and code and
-// returns the raw recorder so callers can assert status, body, and cookies.
-func driveOIDCCallback(t *testing.T, handler http.Handler, state, code string) *httptest.ResponseRecorder {
+// testAuthCode is the authorization code the callback tests exchange. The mock
+// provider never validates it — only its presence on the request matters — so
+// there is nothing for a caller to vary.
+const testAuthCode = "auth-code"
+
+// driveOIDCCallback calls /oidc-callback with the supplied state and returns
+// the raw recorder so callers can assert status, body, and cookies.
+func driveOIDCCallback(t *testing.T, handler http.Handler, state string) *httptest.ResponseRecorder {
 	t.Helper()
 
-	return driveOIDCCallbackWithPrefix(t, handler, state, code, "")
+	return driveOIDCCallbackWithPrefix(t, handler, state, "")
 }
 
 // driveOIDCStartWithPrefix is driveOIDCStart with the request path prefixed
@@ -359,12 +364,12 @@ func driveOIDCStartWithPrefix(t *testing.T, handler http.Handler, cluster, route
 // driveOIDCCallbackWithPrefix is driveOIDCCallback with the request path
 // prefixed by routePrefix; see driveOIDCStartWithPrefix.
 func driveOIDCCallbackWithPrefix(
-	t *testing.T, handler http.Handler, state, code, routePrefix string,
+	t *testing.T, handler http.Handler, state, routePrefix string,
 ) *httptest.ResponseRecorder {
 	t.Helper()
 
 	target := "http://localhost:4466" + routePrefix + "/oidc-callback?state=" + url.QueryEscape(state) +
-		"&code=" + url.QueryEscape(code)
+		"&code=" + url.QueryEscape(testAuthCode)
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, target, nil)
 	require.NoError(t, err)
@@ -709,7 +714,7 @@ func TestOIDCCallback_Success(t *testing.T) {
 	})
 
 	state := extractState(t, driveOIDCStart(t, handler, cluster))
-	rr := driveOIDCCallback(t, handler, state, "auth-code")
+	rr := driveOIDCCallback(t, handler, state)
 
 	require.Equal(t, http.StatusSeeOther, rr.Code,
 		"callback should 303 on success; body=%q", rr.Body.String())
@@ -739,7 +744,7 @@ func TestOIDCCallback_CachesRefreshToken(t *testing.T) {
 	})
 
 	state := extractState(t, driveOIDCStart(t, handler, cluster))
-	rr := driveOIDCCallback(t, handler, state, "auth-code")
+	rr := driveOIDCCallback(t, handler, state)
 	require.Equal(t, http.StatusSeeOther, rr.Code, "body=%q", rr.Body.String())
 
 	got, err := c.Get(context.Background(), "oidc-token-"+idToken)
@@ -760,7 +765,7 @@ func TestOIDCCallback_TokenMissingFromResponse(t *testing.T) {
 	})
 
 	state := extractState(t, driveOIDCStart(t, handler, cluster))
-	rr := driveOIDCCallback(t, handler, state, "auth-code")
+	rr := driveOIDCCallback(t, handler, state)
 
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
 	assert.Contains(t, rr.Body.String(), "No id_token field in oauth2 token")
@@ -799,7 +804,7 @@ func TestOIDCCallback_VerificationFailure(t *testing.T) {
 	})
 
 	state := extractState(t, driveOIDCStart(t, handler, cluster))
-	rr := driveOIDCCallback(t, handler, state, "auth-code")
+	rr := driveOIDCCallback(t, handler, state)
 
 	require.Equal(t, http.StatusInternalServerError, rr.Code)
 	assert.Contains(t, rr.Body.String(), "Failed to verify ID Token")
@@ -833,7 +838,7 @@ func TestOIDCCallback_UsesAccessTokenWhenConfigured(t *testing.T) {
 	})
 
 	state := extractState(t, driveOIDCStart(t, handler, cluster))
-	rr := driveOIDCCallback(t, handler, state, "auth-code")
+	rr := driveOIDCCallback(t, handler, state)
 
 	require.Equal(t, http.StatusSeeOther, rr.Code, "body=%q", rr.Body.String())
 	assert.Equal(t, accessToken, authCookieValue(t, rr, cluster),
@@ -891,7 +896,7 @@ func TestOIDCCallback_RedirectTarget(t *testing.T) {
 
 			loc := driveOIDCStartWithPrefix(t, handler, cluster, tc.routePrefix)
 			state := extractState(t, loc)
-			rr := driveOIDCCallbackWithPrefix(t, handler, state, "auth-code", tc.routePrefix)
+			rr := driveOIDCCallbackWithPrefix(t, handler, state, tc.routePrefix)
 
 			require.Equal(t, http.StatusSeeOther, rr.Code, "body=%q", rr.Body.String())
 			assert.Equal(t, tc.want, rr.Header().Get("Location"))


### PR DESCRIPTION
## Summary

Follow-up to #5420. That PR characterized the `/oidc` and `/oidc-callback` handlers up to the point of token exchange; the mock provider's `/token` endpoint always failed, so the entire callback **success** path was unexercised. This PR teaches the mock to be a real IdP — signing tokens with a genuine RSA key served through a real JWKS endpoint — and characterizes the rest of the flow.

Test-only. No production code, `go.mod`, or `go.sum` changes.

## Related Issue

Part of #5401.

## Coverage

`/oidc-callback` closure (`backend/cmd/headlamp.go:1010-1124`): **22/54 → 48/54 statements (88.9%)**.

`go tool cover -func` is misleading here — it folds handler closures into the enclosing `createHeadlampHandler`, so there is no per-handler number to read. These figures come from slicing the raw `-coverprofile` by the closure's line range, the same method used to produce the numbers in #5420:

```bash
go test -count=1 -run '^TestOIDC' -coverprofile=/tmp/oidc.out ./cmd
python3 -c "
import re
tot=cov=0
for line in open('/tmp/oidc.out'):
    m=re.match(r'.*headlamp\.go:(\d+)\.\d+,(\d+)\.\d+ (\d+) (\d+)',line)
    if not m: continue
    s,e,n,c = (int(x) for x in m.groups())
    if 1010<=s<=1124:
        tot+=n
        if c>0: cov+=n
print(f'{cov}/{tot} statements ({100*cov/tot:.1f}%)')
"
```

## Changes

Five commits, all in `backend/cmd/oidc_handlers_test.go`, covering:

- **Signing mock provider.** `newOIDCTestServer` now serves a real key set at `/jwks` (previously `{"keys":[]}`) and can mint signed tokens via `go-oidc`'s `oidc/oidctest`, already a direct dependency. One package-level RSA key behind `sync.Once`, shared across servers; a second key only for the verification-failure test.
- **`TestOIDCCallback_Success`** — 303 to the frontend, chunked auth cookie carries the id_token, claims decoded.
- **`TestOIDCCallback_CachesRefreshToken`** — refresh token stored under `oidc-token-<raw token>`.
- **`TestOIDCCallback_TokenMissingFromResponse`** — a 200 from `/token` with no `id_token` hits the error path.
- **`TestOIDCCallback_VerificationFailure`** — a token signed by a different key is rejected.
- **`TestOIDCCallback_UsesAccessTokenWhenConfigured`** — `OidcUseAccessToken` swaps which token reaches the cookie.
- **`TestOIDCCallback_RedirectTarget`** — table over DevMode and BaseURL.

Two fixes folded in:

- `driveOIDCStart` built a relative request, so `r.Host` was empty and `getOidcCallbackURL` emitted `redirect_uri=http:///oidc-callback`. Harmless while every callback test failed early; not once a full round trip runs. Copilot flagged this on #5420. Now uses an absolute URL.
- `authCookieValue` reassembles the chunked cookie by index rather than reading `.0`, and sanitizes the cluster name to match how `SetTokenCookie` names cookies.

## Steps to Test

```bash
cd backend
go test -count=1 -run 'TestOIDC' ./cmd/... -v   # 17 pass
go test -count=1 ./...
```

## Notes for the Reviewer

**Non-vacuity was checked for every new test**, since that was the substance of Copilot's review on #5420. Each test's target branch was broken and the test observed to fail, then restored:

| Test | Broke | Observed failure |
|---|---|---|
| `_Success` | commented out `SetTokenCookie` (`headlamp.go:1119`) | `no headlamp-auth-oidc-char-test.N cookies were set` |
| `_CachesRefreshToken` | disabled the `Cache.Set` (`:1078`) | `key not found` |
| `_TokenMissingFromResponse` | added an `id_token` back to the mock response | 303 instead of 500 |
| `_VerificationFailure` | signed with the correct key | 303 instead of 500 |
| `_UsesAccessTokenWhenConfigured` | neutered the `withAccessToken` option | id_token in the cookie, not the access_token |
| `_RedirectTarget` | corrupted one `want` | only that subtest failed |

**Three things this characterizes without endorsing:**

1. **Access-token mode cannot work with a real provider** (filed as #6998). `OidcUseAccessToken` changes only which field is *read* from the token response; the value still goes through the ID-token verifier. An opaque access token — what most IdPs actually issue — would be rejected. The test has to mint a second signed JWT for the `access_token` field to pass at all. Worth a look during #5401.

2. **A rejected token still leaves a cached refresh token** (filed as #6997). `Cache.Set` runs *before* `Verifier.Verify` (`headlamp.go:1078` vs `:1086`), so a token that fails verification leaves an `oidc-token-<raw>` entry behind. `TestOIDCCallback_VerificationFailure` pins this deliberately — it is exactly the kind of ordering a consolidation could change silently. Flipping that assertion is a one-line change once the fix lands.

3. **Two cosmetic oddities in the redirect construction**, reported but deliberately not fixed here: `fmt.Sprintf("auth?cluster=%1s", ...)` at `headlamp.go:1121` uses a no-op width-1 verb, almost certainly a typo for `%s`; and the cluster is interpolated into that URL unsanitized while the cookie name for the same cluster goes through `auth.SanitizeClusterName`. Not reachable from user input — the cluster comes from server-side state — but the asymmetry is odd.

**Knowingly left uncovered** (the six remaining statements): `Cache.Set` failure (`:1079-1084`) and claims-decode failure (`:1099-1104`). Both need injected failures, and neither is code #5401 is likely to disturb.

**Also out of scope:** the `/oidc` handler's issuer/client-ID override branches and the `config.Insecure` custom-transport block (`:886-907`). The latter needs a TLS mock — separate test infrastructure, possibly a third PR.

**Verification.** `gofmt -l cmd/`, `go vet ./cmd/...`, `golangci-lint run` (v2.12.2, the pinned version), and the full backend suite are all clean — and, via `git rebase <base> --exec`, clean at *every* commit, not just at the tip.

One note for contributors, unrelated to the change itself: `npm run backend:install:linter` installs golangci-lint with `go install`, which builds it from source. That fails on any toolchain older than the one `backend/go.mod` targets — currently Go 1.26 — with `can't load config: the Go language version (go1.25) used to build golangci-lint is lower than the targeted Go version (1.26.5)`, so `npm run backend:lint` is unrunnable locally on such a machine. CI is unaffected: `golangci-lint-action` uses `install-mode: binary` and downloads the prebuilt release, which is built with a matching Go. Downloading the same release binary makes local lint match CI exactly. Possibly worth changing the npm script to do the same, but that is out of scope here.

