### PR TITLE
backend: lint: Install golangci-lint from a prebuilt release binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ GO111MODULE=on
 export GO111MODULE
 
 SERVER_EXE_EXT ?=
+EXE_EXT ?=
 DOCKER_CMD ?= docker
 DOCKER_BUILDX_CMD ?= buildx
 DOCKER_REPO ?= ghcr.io/headlamp-k8s
@@ -41,7 +42,12 @@ EMBED_BUILD_FLAGS := -trimpath -ldflags="-s -w -X github.com/kubernetes-sigs/hea
 
 ifeq ($(OS), Windows_NT)
 	SERVER_EXE_EXT = .exe
+	EXE_EXT = .exe
 endif
+
+# Installed as a prebuilt release binary by tools/install-golangci-lint.js,
+# which also holds the pinned version.
+GOLANGCI_LINT := backend/tools/golangci-lint$(EXE_EXT)
 
 ifeq ($(OS), Windows_NT)
 	UNIXSHELL = false
@@ -57,21 +63,17 @@ endif
 
 all: backend frontend
 
-tools/golangci-lint: backend/go.mod backend/go.sum
-ifeq ($(UNIXSHELL), true)
-	GOBIN=`pwd`/backend/tools go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
-else
-	powershell -Command "$$env:GOBIN='$(CURDIR)/backend/tools'; go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2"
-endif
+$(GOLANGCI_LINT): tools/install-golangci-lint.js
+	node tools/install-golangci-lint.js
 
-backend-lint: tools/golangci-lint
+backend-lint: $(GOLANGCI_LINT)
 ifeq ($(UNIXSHELL), true)
 	cd backend && ./tools/golangci-lint run
 else
 	cd backend && tools\golangci-lint.exe run
 endif
 
-backend-lint-fix: tools/golangci-lint
+backend-lint-fix: $(GOLANGCI_LINT)
 ifeq ($(UNIXSHELL), true)
 	cd backend && ./tools/golangci-lint run --fix
 else

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "backend:build": "cd backend && go build -o ./headlamp-server ./cmd",
     "backend:lint": "npm run backend:install:linter && cd backend && ./tools/golangci-lint run",
     "backend:lint:fix": "npm run backend:install:linter && cd backend && ./tools/golangci-lint run --fix",
-    "backend:install:linter": "GOBIN=`pwd`/backend/tools go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2",
+    "backend:install:linter": "node tools/install-golangci-lint.js",
     "backend:test": "cd backend && go test -v -p 1 ./...",
     "backend:fuzz": "cd backend && go test -run=FuzzSanitizeClusterName -fuzz=FuzzSanitizeClusterName -fuzztime=10s ./pkg/auth/ && go test -run=FuzzDecodeBase64JSON -fuzz=FuzzDecodeBase64JSON -fuzztime=10s ./pkg/auth/ && go test -run=FuzzUnmarshalKubeconfig -fuzz=FuzzUnmarshalKubeconfig -fuzztime=10s ./pkg/kubeconfig/ && go test -run=FuzzNormalizeServerURL -fuzz=FuzzNormalizeServerURL -fuzztime=10s ./pkg/clusterinventory/",
     "backend:coverage": "cd backend && go test -v -p 1 -coverprofile=coverage.out ./... && go tool cover -func=coverage.out",

--- a/tools/install-golangci-lint.js
+++ b/tools/install-golangci-lint.js
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+
+const usage = `
+Usage: node tools/install-golangci-lint.js [--help]
+
+Installs the pinned golangci-lint release binary into backend/tools/.
+
+This downloads the same prebuilt release archive that CI's golangci-lint-action
+uses (install-mode: binary). Building the linter from source with 'go install'
+instead makes it inherit the host toolchain, and golangci-lint refuses to lint a
+module whose targeted Go version is newer than the Go it was built with -- which
+breaks 'npm run backend:lint' on any machine whose Go is older than the version
+backend/go.mod targets.
+
+The archive is verified against a sha256 pinned in this file before it is
+installed, and the install aborts on any mismatch.
+
+Re-running is a no-op once the pinned version is present.
+
+To bump the version, update VERSION and regenerate DIGESTS with:
+
+  curl -sL https://github.com/golangci/golangci-lint/releases/download/v<VER>/golangci-lint-<VER>-checksums.txt
+`;
+
+// Single source of truth for the pinned linter version. Keep in sync with the
+// 'version:' input of golangci-lint-action in .github/workflows/backend-test.yml.
+const VERSION = '2.12.2';
+
+// Expected sha256 of each release asset, pinned here rather than read from the
+// release's own checksums.txt: that file ships from the same host as the
+// archive, so it detects a corrupted download but not a tampered one. Pinning
+// in-repo keeps an independent trust anchor for a binary the lint step then
+// executes, matching how this repo pins image digests and action SHAs.
+const DIGESTS = {
+  'linux-amd64': '8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553',
+  'linux-arm64': '44cd40a8c76c86755375adfeea52cfd3533cb43d7bd647771e0ae065e166df3a',
+  'darwin-amd64': 'f6f06d94b6241521c53d15450c5209b028270bf966f842afb11c030c79f5bc16',
+  'darwin-arm64': 'a9c54498731b3128f79e090be6110f3e5fffccc617b08142ed244d4126c73f29',
+  'windows-amd64': 'bd42e3ebc8cb4ececb86941983baaf1dc221bbb04d838e94ce63b49cc91e02bb',
+  'windows-arm64': '947b9a5bf762d465710b376c156f0184abb2168378b0826af1899e0ee7183742',
+};
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { execFileSync } = require('child_process');
+
+const BASE_URL = `https://github.com/golangci/golangci-lint/releases/download/v${VERSION}`;
+
+if (process.argv.includes('--help')) {
+  console.log(usage);
+  process.exit(0);
+}
+
+/**
+ * Map Node's process.platform/process.arch onto golangci-lint release asset names.
+ *
+ * @returns {{ key: string, os: string, arch: string, ext: string, exeSuffix: string }}
+ */
+function detectTarget() {
+  const osNames = { linux: 'linux', darwin: 'darwin', win32: 'windows' };
+  const archNames = { x64: 'amd64', arm64: 'arm64' };
+
+  const osName = osNames[process.platform];
+  const archName = archNames[process.arch];
+
+  if (!osName || !archName) {
+    throw new Error(
+      `No golangci-lint release asset for ${process.platform}/${process.arch}. ` +
+        `Supported: linux, darwin, windows on x64 (amd64) or arm64.`
+    );
+  }
+
+  // Guards against a platform being added above without a matching pin, which
+  // would otherwise install an unverified binary.
+  const key = `${osName}-${archName}`;
+  if (!DIGESTS[key]) {
+    throw new Error(`No pinned sha256 for ${key} in DIGESTS; refusing to install unverified.`);
+  }
+
+  return {
+    key,
+    os: osName,
+    arch: archName,
+    ext: osName === 'windows' ? 'zip' : 'tar.gz',
+    exeSuffix: osName === 'windows' ? '.exe' : '',
+  };
+}
+
+/**
+ * Report the golangci-lint version an already-installed binary claims, if any.
+ *
+ * @param {string} binPath - Path to the candidate binary.
+ * @returns {string|null} The version string, or null if absent or unrunnable.
+ */
+function installedVersion(binPath) {
+  if (!fs.existsSync(binPath)) {
+    return null;
+  }
+
+  try {
+    const out = execFileSync(binPath, ['--version'], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] });
+    const m = out.match(/version\s+v?(\d+\.\d+\.\d+)/i);
+    return m ? m[1] : null;
+  } catch {
+    // A truncated or foreign-architecture binary is treated as "not installed"
+    // so that a re-run replaces it rather than failing.
+    return null;
+  }
+}
+
+/**
+ * Fetch a URL into memory, following redirects.
+ *
+ * @param {string} url - The URL to fetch.
+ * @returns {Promise<Buffer>} The response body.
+ */
+async function download(url) {
+  // Bounded so a hung connection fails the lint step instead of stalling it.
+  // Generous, since the archive is ~40MB and this runs on developer links.
+  const res = await fetch(url, { signal: AbortSignal.timeout(300_000) });
+  if (!res.ok) {
+    throw new Error(`Failed to download ${url}: HTTP ${res.status} ${res.statusText}`);
+  }
+  return Buffer.from(await res.arrayBuffer());
+}
+
+/**
+ * Extract a release archive using the platform's native extractor.
+ *
+ * @param {string} archivePath - Path to the downloaded archive.
+ * @param {string} destDir - Directory to extract into.
+ * @param {string} ext - Archive extension, 'zip' or 'tar.gz'.
+ */
+function extract(archivePath, destDir, ext) {
+  if (ext === 'zip') {
+    // PowerShell single-quoted strings escape a quote by doubling it; repo paths
+    // on Windows can contain apostrophes (e.g. C:\Users\O'Brien\...).
+    const q = s => `'${s.replace(/'/g, "''")}'`;
+    execFileSync(
+      'powershell',
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        `Expand-Archive -LiteralPath ${q(archivePath)} -DestinationPath ${q(destDir)} -Force`,
+      ],
+      { stdio: 'inherit' }
+    );
+  } else {
+    execFileSync('tar', ['-xzf', archivePath, '-C', destDir], { stdio: 'inherit' });
+  }
+}
+
+async function main() {
+  const target = detectTarget();
+  const repoRoot = path.resolve(__dirname, '..');
+  const toolsDir = path.join(repoRoot, 'backend', 'tools');
+  const binName = `golangci-lint${target.exeSuffix}`;
+  const binPath = path.join(toolsDir, binName);
+
+  const have = installedVersion(binPath);
+  if (have === VERSION) {
+    console.log(`golangci-lint ${VERSION} already installed at ${binPath}`);
+    return;
+  }
+
+  const stem = `golangci-lint-${VERSION}-${target.os}-${target.arch}`;
+  const assetName = `${stem}.${target.ext}`;
+
+  console.log(`Downloading ${assetName} from ${BASE_URL}`);
+  const archive = await download(`${BASE_URL}/${assetName}`);
+
+  // The archive is executed by the lint step, so a mismatch must abort the
+  // install rather than warn.
+  const want = DIGESTS[target.key];
+  const got = crypto.createHash('sha256').update(archive).digest('hex');
+  if (got !== want) {
+    throw new Error(`Checksum mismatch for ${assetName}:\n  expected ${want}\n  got      ${got}`);
+  }
+  console.log(`Verified sha256 ${got}`);
+
+  // Staged inside the destination directory so the final rename stays on one
+  // filesystem; /tmp is frequently a separate mount, which would fail EXDEV.
+  fs.mkdirSync(toolsDir, { recursive: true });
+  const tmpDir = fs.mkdtempSync(path.join(toolsDir, '.tmp-golangci-lint-'));
+  try {
+    const archivePath = path.join(tmpDir, assetName);
+    fs.writeFileSync(archivePath, archive);
+    extract(archivePath, tmpDir, target.ext);
+
+    const extracted = path.join(tmpDir, stem, binName);
+    if (!fs.existsSync(extracted)) {
+      throw new Error(`Expected ${binName} at ${extracted} after extracting ${assetName}`);
+    }
+    fs.chmodSync(extracted, 0o755);
+
+    // Move into place only after a successful verify+extract, so an interrupted
+    // run never leaves a half-written binary behind.
+    fs.rmSync(binPath, { force: true });
+    fs.renameSync(extracted, binPath);
+
+    // The archive carries the release's own build time, which would leave the
+    // binary permanently older than make's prerequisites and re-trigger the
+    // install target on every run.
+    const now = new Date();
+    fs.utimesSync(binPath, now, now);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+
+  console.log(`Installed golangci-lint ${VERSION} to ${binPath}`);
+}
+
+main().catch(err => {
+  console.error(`error: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Problem

`npm run backend:lint` is unrunnable on any machine whose system Go is older than the version `backend/go.mod` targets:

```
can't load config: the Go language version (go1.25) used to build golangci-lint
is lower than the targeted Go version (1.26.5)
```

The linter was installed by building it from source:

```
"backend:install:linter": "GOBIN=`pwd`/backend/tools go install .../golangci-lint@v2.12.2",
```

`go install` compiles golangci-lint with whatever toolchain the local `go` resolves to, and golangci-lint's own `go.mod` caps that. On a host with Go 1.24 the resulting binary is built with Go 1.25, and golangci-lint then refuses to lint a module targeting a newer language version than the one it was built with — `backend/go.mod` declares `go 1.26.0` / `toolchain go1.26.5`.

`GOTOOLCHAIN=local` doesn't help: it pins to the system Go, which is below golangci-lint's own build floor, so the install fails outright instead.

**CI has never been affected.** `golangci-lint-action` defaults to `install-mode: binary` and downloads the prebuilt release, which is built with a matching Go. So local and CI have been using two different builds of the same version, and only the local one is broken.

## Fix

Install the same prebuilt release binary CI uses, via a new `tools/install-golangci-lint.js`. The version stays pinned at **v2.12.2** — bumping the linter is a separate change, and this one introduces no new findings.

The installer:

- detects OS and arch (linux/darwin/windows × amd64/arm64) and picks the matching release asset;
- verifies the archive against a pinned sha256 and aborts on mismatch;
- is idempotent — re-running is a no-op once the pinned version is present, where `go install` previously re-ran on every lint;
- installs into `backend/tools/` (already gitignored), extracting with each platform's native tool (`tar` / `Expand-Archive`) and renaming into place only after verification succeeds.

It's plain Node with no dependencies, matching the existing `tools/verify-image-digests.js`. Node is already required (`engines.node >= 22`), so one implementation covers all three platforms rather than a shell script plus a PowerShell twin.

### On checksum verification

The digests are pinned in the repo rather than read from the release's own `checksums.txt`. That file ships from the same host as the archive, so it detects a corrupted download but not a tampered one — and the binary it guards is then executed by the lint step. Pinning keeps an independent trust anchor, consistent with how this repo already pins image digests (`tools/verify-image-digests.js`) and action SHAs. Worth noting the previous `go install` path verified through `sum.golang.org`, so trusting a co-hosted checksums file would have been a step down.

Bumping the version means updating `VERSION` and the digest table together; both sit adjacent in one file, and the regeneration command is in the script's `--help`.

## Also fixed

The Makefile target was `tools/golangci-lint` while the binary lands at `backend/tools/golangci-lint`, so `make` never saw it and reinstalled every time. The target now points at the real path.

That alone wasn't enough: `tar` preserves the archive's mtime (the release build date), which left the binary permanently older than its prerequisites and still re-triggered the target. The installer stamps mtime after install.

## Out of scope

No changes to `.github/workflows/backend-test.yml` (the action is already correct and is what this converges toward), `.golangci.yml`, Go source, `go.mod`, or `go.sum`. Command names are unchanged, so no docs needed updating.

## Verification

| Check | Result |
|---|---|
| Clean install → `npm run backend:lint` | `0 issues.` |
| `golangci-lint --version` | `2.12.2 built with go1.26.2` — ≥ the `go 1.26.0` target |
| Second run | no re-download, ~0.2s |
| `make backend-lint` twice | installs once, then skips the target |
| `npm run backend:lint:fix` | `0 issues.`, no source modified |
| Corrupted archive | aborts with a digest diff, exit 1, nothing installed |

Exercised end-to-end on **linux/amd64**. macOS and Windows, and both arm64 variants, were not executed — for those I verified that every asset name the script constructs exists in the published release, and downloaded the windows-amd64 `.zip` and darwin-arm64 `.tar.gz` to confirm the internal layout matches the path the script expects. The `Expand-Archive` call is reasoned about rather than run; that's the main residual risk and the place to look hardest in review.
