### PR TITLE
frontend: Advanced Search: Match resources by API identity

### DIFF
--- a/frontend/src/components/advancedSearch/ResourceSearch.stories.tsx
+++ b/frontend/src/components/advancedSearch/ResourceSearch.stories.tsx
@@ -132,7 +132,7 @@ Default.args = {
       isNamespaced: true,
     },
     {
-      apiVersion: 'v1',
+      apiVersion: 'apps/v1',
       version: 'v1',
       singularName: 'deployment',
       kind: 'Deployment',

--- a/frontend/src/components/advancedSearch/utils/useKubeLists.test.ts
+++ b/frontend/src/components/advancedSearch/utils/useKubeLists.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useKubeLists } from './useKubeLists';
+
+const mockRegisteredUseList = vi.hoisted(() =>
+  vi.fn(() => ({
+    items: [],
+    isError: false,
+    errors: undefined,
+  }))
+);
+
+const mockGenericUseList = vi.hoisted(() =>
+  vi.fn(() => ({
+    items: [],
+    isError: false,
+    errors: undefined,
+  }))
+);
+
+vi.mock('../../../lib/k8s', () => {
+  class Deployment {
+    static apiVersion = 'apps/v1';
+    static apiName = 'deployments';
+    static isNamespaced = true;
+    static useList = mockRegisteredUseList;
+  }
+
+  return {
+    ResourceClasses: {
+      Deployment,
+    },
+  };
+});
+
+vi.mock('../../../lib/k8s/cluster', () => {
+  class KubeObject {
+    static useList = mockGenericUseList;
+  }
+
+  return {
+    KubeObject,
+  };
+});
+
+const mockUseNamespaces = vi.hoisted(() => vi.fn(() => []));
+
+vi.mock('../../../redux/filterSlice', () => ({
+  useNamespaces: mockUseNamespaces,
+}));
+
+describe('useKubeLists', () => {
+  it('does not reuse a registered ResourceClass when the API identity does not match', () => {
+    const resources = [
+      {
+        kind: 'Deployment',
+        apiVersion: 'apps/v1beta1',
+        version: 'v1beta1',
+        singularName: 'deployment',
+        pluralName: 'deployments',
+        isNamespaced: true,
+      },
+    ];
+
+    renderHook(() => useKubeLists(resources, ['cluster'], 10));
+
+    expect(mockRegisteredUseList).not.toHaveBeenCalled();
+    expect(mockGenericUseList).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/advancedSearch/utils/useKubeLists.ts
+++ b/frontend/src/components/advancedSearch/utils/useKubeLists.ts
@@ -21,6 +21,34 @@ import { ApiResource } from '../../../lib/k8s/api/v2/ApiResource';
 import { KubeObject, KubeObjectClass } from '../../../lib/k8s/cluster';
 import { useNamespaces } from '../../../redux/filterSlice';
 
+export const matchesApiIdentity = (
+  registeredClass: KubeObjectClass,
+  resource: ApiResource
+): boolean => {
+  return (
+    (Array.isArray(registeredClass.apiVersion)
+      ? registeredClass.apiVersion.includes(resource.apiVersion)
+      : registeredClass.apiVersion === resource.apiVersion) &&
+    registeredClass.apiName === resource.pluralName &&
+    registeredClass.isNamespaced === resource.isNamespaced
+  );
+};
+
+const getKubeObjectClass = (resource: ApiResource): KubeObjectClass => {
+  const registeredClass = (ResourceClasses as Record<string, KubeObjectClass>)[resource.kind];
+
+  if (registeredClass && matchesApiIdentity(registeredClass, resource)) {
+    return registeredClass;
+  }
+
+  return class extends KubeObject {
+    static kind = resource.kind;
+    static apiVersion = resource.apiVersion;
+    static apiName = resource.pluralName;
+    static isNamespaced = resource.isNamespaced;
+  };
+};
+
 /**
  * A hook that fetches and returns a list of Kubernetes objects for the specified resources.
  *
@@ -38,22 +66,7 @@ export const useKubeLists = (
   namespaces?: string[]
 ) => {
   const defaultNamespaces = useNamespaces();
-  const classes = useMemo(
-    () =>
-      resources
-        .map(
-          it =>
-            (ResourceClasses as Record<string, KubeObjectClass>)[it.kind] ??
-            class extends KubeObject {
-              static kind = it.kind;
-              static apiVersion = it.apiVersion;
-              static apiName = it.pluralName;
-              static isNamespaced = it.isNamespaced;
-            }
-        )
-        .filter(Boolean) as KubeObjectClass[],
-    [resources]
-  );
+  const classes = useMemo(() => resources.map(getKubeObjectClass), [resources]);
 
   const data = classes.map(it =>
     it.useList({


### PR DESCRIPTION
## Summary

This PR fixes Advanced Search resolving discovered Kubernetes resources using only their `kind`.

A registered `ResourceClass` is now reused only when its API identity matches the discovered resource's `apiVersion`, resource name, and namespace scope. Otherwise, Advanced Search falls back to a generic `KubeObject` class for the discovered resource.

## Related Issue

Fixes #7007
## Changes

* Updated `useKubeLists` to validate registered resource classes against the discovered API resource identity.
* Prevented resources with matching `kind` but different API identity from incorrectly using a built-in `ResourceClass`.
* Corrected the `AdvancedSearch/ResourceSearch` Storybook fixture to use the correct `apps/v1` API version for Deployments.

## Steps to Test

1. Run the TypeScript check with `npm run tsc`.
2. Run the Storybook test suite with `npx vitest run src/storybook.test.tsx`.
3. Open Advanced Search and select discovered Kubernetes resources.
4. Verify that resources are queried using their discovered API identity.

## Screenshots (if applicable)

Not applicable.

## Notes for the Reviewer

* The resource lookup previously relied on `kind` alone, which can be insufficient for distinguishing Kubernetes API resources.
* The fix preserves existing registered resource classes when their `apiVersion`, resource name, and namespace scope match the discovered resource.
* Existing built-in resources such as Deployments continue to use their specialized `KubeObject` implementations.
