### PR TITLE
frontend: ClusterDialog: Add resizable paper with persisted dimensions

### DIFF
--- a/frontend/src/components/cluster/Chooser.tsx
+++ b/frontend/src/components/cluster/Chooser.tsx
@@ -31,6 +31,7 @@ import { useTheme } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import useMediaQuery from '@mui/material/useMediaQuery';
+import useForkRef from '@mui/material/utils/useForkRef';
 import { visuallyHidden } from '@mui/utils';
 import _ from 'lodash';
 import React, { isValidElement, PropsWithChildren } from 'react';
@@ -56,6 +57,7 @@ import Loader from '../common/Loader';
 import { LightTooltip } from '../common/Tooltip';
 import ClusterChooser from './ClusterChooser';
 import ClusterChooserPopup from './ClusterChooserPopup';
+import { useResizableDialogSize } from './useResizableDialogSize';
 
 export interface ClusterTitleProps {
   clusters?: {
@@ -292,6 +294,15 @@ interface ClusterDialogProps extends PropsWithChildren<Omit<DialogProps, 'open' 
   onClose?: (() => void) | null;
   useCover?: boolean;
   showInfoButton?: boolean;
+  /**
+   * When set, the dialog paper becomes user-resizable via the browser's
+   * native corner grip and its width/height are persisted in
+   * `localStorage[resizeStorageKey]`. Callers that don't want this
+   * behavior (auth flow, kubeconfig loader) should omit the prop so the
+   * dialog keeps its fixed default size. Passing distinct keys from
+   * different dialogs avoids cross-dialog size contamination.
+   */
+  resizeStorageKey?: string;
 }
 
 export function ClusterDialog(props: ClusterDialogProps) {
@@ -304,11 +315,23 @@ export function ClusterDialog(props: ClusterDialogProps) {
     useCover = false,
     showInfoButton = true,
     children = [],
+    PaperProps: callerPaperProps,
+    resizeStorageKey,
     ...otherProps
   } = props;
   // Only used if open is not provided
   const [show, setShow] = React.useState(true);
   const dispatch = useDispatch();
+
+  // Opt-in resize: only callers passing `resizeStorageKey` get the persistent
+  // resize handle. Small viewports go fullscreen where resizing doesn't apply.
+  const resizeEnabled = !!resizeStorageKey && !fullScreen;
+  const { paperRef, dialogSx } = useResizableDialogSize(resizeStorageKey ?? '', resizeEnabled);
+
+  // Compose the hook's ref with any caller-supplied ref so both receive the
+  // paper element. `useForkRef` handles both callback and object refs and
+  // avoids mutating the caller's ref object directly.
+  const composedPaperRef = useForkRef(paperRef, callerPaperProps?.ref ?? null);
 
   function handleClose() {
     if (onClose !== null) {
@@ -327,13 +350,11 @@ export function ClusterDialog(props: ClusterDialogProps) {
       fullScreen={fullScreen}
       open={open !== undefined ? open : show}
       onClose={handleClose}
-      sx={
-        useCover
-          ? {
-              background: theme.palette.common.black,
-            }
-          : {}
-      }
+      PaperProps={{ ...callerPaperProps, ref: composedPaperRef }}
+      sx={{
+        ...(useCover ? { background: theme.palette.common.black } : {}),
+        ...dialogSx,
+      }}
       {...otherProps}
     >
       <DialogTitle
@@ -454,6 +475,7 @@ function Chooser(props: ClusterDialogProps) {
         onClose={onClose || handleClose}
         aria-labelledby="chooser-dialog-title"
         aria-busy={clusterList.length === 0 && clusters === null}
+        resizeStorageKey="clusterChooserDialogSize"
         {...otherProps}
       >
         <DialogTitle id="chooser-dialog-title" focusTitle>

--- a/frontend/src/components/cluster/__snapshots__/Chooser.ManyClusters.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Chooser.ManyClusters.stories.storyshot
@@ -8,7 +8,7 @@
   </div>
   <div
     aria-busy="false"
-    class="MuiDialog-root MuiModal-root css-zw3mfo-MuiModal-root-MuiDialog-root"
+    class="MuiDialog-root MuiModal-root css-72j2m8-MuiModal-root-MuiDialog-root"
     role="presentation"
   >
     <div

--- a/frontend/src/components/cluster/__snapshots__/Chooser.NoClusters.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Chooser.NoClusters.stories.storyshot
@@ -8,7 +8,7 @@
   </div>
   <div
     aria-busy="false"
-    class="MuiDialog-root MuiModal-root css-zw3mfo-MuiModal-root-MuiDialog-root"
+    class="MuiDialog-root MuiModal-root css-72j2m8-MuiModal-root-MuiDialog-root"
     role="presentation"
   >
     <div

--- a/frontend/src/components/cluster/__snapshots__/Chooser.Normal.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Chooser.Normal.stories.storyshot
@@ -8,7 +8,7 @@
   </div>
   <div
     aria-busy="false"
-    class="MuiDialog-root MuiModal-root css-zw3mfo-MuiModal-root-MuiDialog-root"
+    class="MuiDialog-root MuiModal-root css-72j2m8-MuiModal-root-MuiDialog-root"
     role="presentation"
   >
     <div

--- a/frontend/src/components/cluster/__snapshots__/Chooser.SingleCluster.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Chooser.SingleCluster.stories.storyshot
@@ -8,7 +8,7 @@
   </div>
   <div
     aria-busy="false"
-    class="MuiDialog-root MuiModal-root css-zw3mfo-MuiModal-root-MuiDialog-root"
+    class="MuiDialog-root MuiModal-root css-72j2m8-MuiModal-root-MuiDialog-root"
     role="presentation"
   >
     <div

--- a/frontend/src/components/cluster/useResizableDialogSize.test.tsx
+++ b/frontend/src/components/cluster/useResizableDialogSize.test.tsx
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  RESIZABLE_DIALOG_MIN_HEIGHT,
+  RESIZABLE_DIALOG_MIN_WIDTH,
+  useResizableDialogSize,
+} from './useResizableDialogSize';
+
+const KEY = 'test-dialog-size';
+
+// A ResizeObserver stub the tests can drive. Each new instance registers with
+// this holder so the test can fire a synthetic resize entry.
+const resizeCallbacks: Array<(entries: ResizeObserverEntry[]) => void> = [];
+
+class FakeResizeObserver {
+  private cb: (entries: ResizeObserverEntry[]) => void;
+  constructor(cb: (entries: ResizeObserverEntry[]) => void) {
+    this.cb = cb;
+    resizeCallbacks.push(cb);
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {
+    const idx = resizeCallbacks.indexOf(this.cb);
+    if (idx >= 0) resizeCallbacks.splice(idx, 1);
+  }
+}
+
+function fireResize(width: number, height: number) {
+  for (const cb of resizeCallbacks) {
+    cb([{ contentRect: { width, height } } as ResizeObserverEntry]);
+  }
+}
+
+// The observer skips its first firing (browser laying out the paper at MUI
+// defaults or CSS-clamped preference). Tests that want to exercise the
+// "user drag" path need to consume that first observation before their
+// actual assertion.
+function primeObserver() {
+  fireResize(600, 400);
+}
+
+// Invoke the callback ref returned by the hook to simulate React attaching
+// the paper element after commit. Returns the created element for further
+// manipulation in the test.
+function attachPaperRef(result: { current: ReturnType<typeof useResizableDialogSize> }) {
+  const el = document.createElement('div');
+  (result.current.paperRef as unknown as (el: HTMLDivElement | null) => void)(el);
+  return el;
+}
+
+// @vitest-environment jsdom
+
+describe('useResizableDialogSize', () => {
+  let originalRO: typeof globalThis.ResizeObserver;
+  let originalInnerWidth: number;
+  let originalInnerHeight: number;
+
+  beforeEach(() => {
+    originalRO = globalThis.ResizeObserver;
+    originalInnerWidth = window.innerWidth;
+    originalInnerHeight = window.innerHeight;
+    resizeCallbacks.length = 0;
+    localStorage.clear();
+    vi.useFakeTimers();
+    globalThis.ResizeObserver = FakeResizeObserver as unknown as typeof ResizeObserver;
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1920 });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 1080 });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    globalThis.ResizeObserver = originalRO;
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: originalInnerWidth,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: originalInnerHeight,
+    });
+  });
+
+  it('returns empty sx when disabled', () => {
+    const { result } = renderHook(() => useResizableDialogSize(KEY, false));
+    expect(result.current.dialogSx).toEqual({});
+  });
+
+  it('returns default sx (no width/height override) when no size is stored', () => {
+    const { result } = renderHook(() => useResizableDialogSize(KEY, true));
+    const paperSx = (result.current.dialogSx as any)['.MuiDialog-paper'];
+    expect(paperSx.resize).toBe('both');
+    expect(paperSx.minWidth).toBe(RESIZABLE_DIALOG_MIN_WIDTH);
+    expect(paperSx.minHeight).toBe(RESIZABLE_DIALOG_MIN_HEIGHT);
+    expect(paperSx.width).toBeUndefined();
+    expect(paperSx.height).toBeUndefined();
+  });
+
+  it('hydrates width/height from localStorage on mount', () => {
+    localStorage.setItem(KEY, JSON.stringify({ width: 800, height: 600 }));
+    const { result } = renderHook(() => useResizableDialogSize(KEY, true));
+    const paperSx = (result.current.dialogSx as any)['.MuiDialog-paper'];
+    expect(paperSx.width).toBe(800);
+    expect(paperSx.height).toBe(600);
+  });
+
+  it('clamps a stored size larger than the viewport down to 95% of viewport', () => {
+    // Stored on a bigger monitor.
+    localStorage.setItem(KEY, JSON.stringify({ width: 4000, height: 3000 }));
+    const { result } = renderHook(() => useResizableDialogSize(KEY, true));
+    const paperSx = (result.current.dialogSx as any)['.MuiDialog-paper'];
+    // 95% of 1920 = 1824, of 1080 = 1026.
+    expect(paperSx.width).toBe(1824);
+    expect(paperSx.height).toBe(1026);
+  });
+
+  it('ignores a stored size below the minimum', () => {
+    localStorage.setItem(KEY, JSON.stringify({ width: 100, height: 100 }));
+    const { result } = renderHook(() => useResizableDialogSize(KEY, true));
+    const paperSx = (result.current.dialogSx as any)['.MuiDialog-paper'];
+    expect(paperSx.width).toBeUndefined();
+    expect(paperSx.height).toBeUndefined();
+  });
+
+  it('ignores unparseable JSON in localStorage', () => {
+    localStorage.setItem(KEY, 'not-json');
+    const { result } = renderHook(() => useResizableDialogSize(KEY, true));
+    const paperSx = (result.current.dialogSx as any)['.MuiDialog-paper'];
+    expect(paperSx.width).toBeUndefined();
+  });
+
+  it('persists a resize event to localStorage after debounce, not before', () => {
+    const { result } = renderHook(() => useResizableDialogSize(KEY, true));
+    act(() => {
+      attachPaperRef(result);
+    });
+    act(() => primeObserver());
+    act(() => {
+      fireResize(900, 700);
+    });
+    // Nothing written yet (still inside the debounce window).
+    expect(localStorage.getItem(KEY)).toBeNull();
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(JSON.parse(localStorage.getItem(KEY) ?? 'null')).toEqual({
+      width: 900,
+      height: 700,
+    });
+  });
+
+  it('debounces rapid resize events, writing only the last one', () => {
+    const { result } = renderHook(() => useResizableDialogSize(KEY, true));
+    act(() => {
+      attachPaperRef(result);
+    });
+    act(() => primeObserver());
+    act(() => {
+      fireResize(800, 600);
+      vi.advanceTimersByTime(100);
+      fireResize(900, 700);
+      vi.advanceTimersByTime(100);
+      fireResize(1000, 800);
+    });
+    // Still inside the debounce window after the last event.
+    expect(localStorage.getItem(KEY)).toBeNull();
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(JSON.parse(localStorage.getItem(KEY) ?? 'null')).toEqual({
+      width: 1000,
+      height: 800,
+    });
+  });
+
+  it('ignores the very first observation (avoids writing MUI defaults)', () => {
+    const { result } = renderHook(() => useResizableDialogSize(KEY, true));
+    act(() => {
+      attachPaperRef(result);
+    });
+    // First observation is the browser's initial layout; must be ignored.
+    act(() => {
+      fireResize(600, 400);
+      vi.advanceTimersByTime(300);
+    });
+    expect(localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('does not overwrite a stored preference when the viewport clamps the paper smaller', () => {
+    // Preference stored on a big monitor: 3000x2000. Current viewport is
+    // 1920x1080, so CSS clamps the paper to 1824x1026 (95% of viewport).
+    localStorage.setItem(KEY, JSON.stringify({ width: 3000, height: 2000 }));
+    const { result } = renderHook(() => useResizableDialogSize(KEY, true));
+    act(() => {
+      attachPaperRef(result);
+    });
+    // Prime, then the observer sees the CSS-clamped size — must NOT clobber.
+    act(() => {
+      primeObserver();
+      fireResize(1824, 1026);
+      vi.advanceTimersByTime(300);
+    });
+    expect(JSON.parse(localStorage.getItem(KEY) ?? 'null')).toEqual({
+      width: 3000,
+      height: 2000,
+    });
+  });
+
+  it('persists a user-drag that is different from the clamp of the current preference', () => {
+    localStorage.setItem(KEY, JSON.stringify({ width: 3000, height: 2000 }));
+    const { result } = renderHook(() => useResizableDialogSize(KEY, true));
+    act(() => {
+      attachPaperRef(result);
+    });
+    act(() => {
+      primeObserver();
+      // Clamp of stored 3000x2000 on a 1920x1080 viewport is 1824x1026. User
+      // then drags the paper to 1500x900. This differs from the clamp, so
+      // the write should happen.
+      fireResize(1500, 900);
+      vi.advanceTimersByTime(300);
+    });
+    expect(JSON.parse(localStorage.getItem(KEY) ?? 'null')).toEqual({
+      width: 1500,
+      height: 900,
+    });
+  });
+
+  it('does not silently swallow a second user-drag that lands near the initial clamp', () => {
+    // Stored 3000x2000 with mount clamp = 1824x1026. User drags to 1500,900
+    // (persists). Later user drags BACK to 1824,1026 which happens to match
+    // the *original* clamp; without keeping `appliedSizeRef` in sync with
+    // the persisted value, the guard would skip this write.
+    localStorage.setItem(KEY, JSON.stringify({ width: 3000, height: 2000 }));
+    const { result } = renderHook(() => useResizableDialogSize(KEY, true));
+    act(() => {
+      attachPaperRef(result);
+    });
+    act(() => {
+      primeObserver();
+      fireResize(1500, 900);
+      vi.advanceTimersByTime(300);
+    });
+    expect(JSON.parse(localStorage.getItem(KEY) ?? 'null')).toEqual({
+      width: 1500,
+      height: 900,
+    });
+    // Second user drag targeting a value that equals the original clamp.
+    act(() => {
+      fireResize(1824, 1026);
+      vi.advanceTimersByTime(300);
+    });
+    expect(JSON.parse(localStorage.getItem(KEY) ?? 'null')).toEqual({
+      width: 1824,
+      height: 1026,
+    });
+  });
+
+  it('does not enforce a preferred size when the viewport is too small to honor the minimum', () => {
+    // Wide-but-short window: 1920x300. maxHeight = 285, below the 300 min.
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 300 });
+    localStorage.setItem(KEY, JSON.stringify({ width: 800, height: 600 }));
+    const { result } = renderHook(() => useResizableDialogSize(KEY, true));
+    const paperSx = (result.current.dialogSx as any)['.MuiDialog-paper'];
+    // Falls back to MUI defaults: no width/height override, min still applies.
+    expect(paperSx.width).toBeUndefined();
+    expect(paperSx.height).toBeUndefined();
+  });
+
+  it('disconnects the observer when the paper ref is detached with null', () => {
+    const { result } = renderHook(() => useResizableDialogSize(KEY, true));
+    act(() => {
+      attachPaperRef(result);
+    });
+    expect(resizeCallbacks.length).toBe(1);
+    // Simulate the paper unmounting.
+    act(() => {
+      (result.current.paperRef as unknown as (el: HTMLDivElement | null) => void)(null);
+    });
+    expect(resizeCallbacks.length).toBe(0);
+  });
+
+  it('tears down and re-attaches the observer when enabled toggles', () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => useResizableDialogSize(KEY, enabled),
+      { initialProps: { enabled: true } }
+    );
+    act(() => {
+      attachPaperRef(result);
+    });
+    expect(resizeCallbacks.length).toBe(1);
+    rerender({ enabled: false });
+    expect(resizeCallbacks.length).toBe(0);
+    // Re-enable and re-attach.
+    rerender({ enabled: true });
+    act(() => {
+      attachPaperRef(result);
+    });
+    expect(resizeCallbacks.length).toBe(1);
+  });
+
+  it('re-hydrates when the storage key changes', () => {
+    localStorage.setItem('key-a', JSON.stringify({ width: 800, height: 600 }));
+    localStorage.setItem('key-b', JSON.stringify({ width: 1200, height: 900 }));
+    const { result, rerender } = renderHook(
+      ({ key }: { key: string }) => useResizableDialogSize(key, true),
+      { initialProps: { key: 'key-a' } }
+    );
+    let paperSx = (result.current.dialogSx as any)['.MuiDialog-paper'];
+    expect(paperSx.width).toBe(800);
+    rerender({ key: 'key-b' });
+    paperSx = (result.current.dialogSx as any)['.MuiDialog-paper'];
+    expect(paperSx.width).toBe(1200);
+  });
+
+  it('drops resize events below the minimum without writing', () => {
+    const { result } = renderHook(() => useResizableDialogSize(KEY, true));
+    act(() => {
+      attachPaperRef(result);
+    });
+    act(() => primeObserver());
+    act(() => {
+      fireResize(100, 100);
+      vi.advanceTimersByTime(300);
+    });
+    expect(localStorage.getItem(KEY)).toBeNull();
+  });
+});

--- a/frontend/src/components/cluster/useResizableDialogSize.ts
+++ b/frontend/src/components/cluster/useResizableDialogSize.ts
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+/**
+ * Persisted dialog dimensions (in CSS pixels).
+ */
+export interface ResizableDialogSize {
+  width: number;
+  height: number;
+}
+
+/** Minimum width the dialog is allowed to shrink to. */
+export const RESIZABLE_DIALOG_MIN_WIDTH = 500;
+/** Minimum height the dialog is allowed to shrink to. */
+export const RESIZABLE_DIALOG_MIN_HEIGHT = 300;
+/** Maximum viewport-relative bounds so the drag handle never falls off-screen. */
+const MAX_VW_PERCENT = 95;
+const MAX_VH_PERCENT = 95;
+/** Debounce for ResizeObserver to localStorage writes. */
+const DEBOUNCE_MS = 300;
+/** Tolerance in pixels when comparing observed size to computed CSS clamp. */
+const CLAMP_MATCH_TOLERANCE_PX = 2;
+
+function safeReadSize(storageKey: string): ResizableDialogSize | null {
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      typeof parsed.width === 'number' &&
+      typeof parsed.height === 'number' &&
+      Number.isFinite(parsed.width) &&
+      Number.isFinite(parsed.height) &&
+      parsed.width >= RESIZABLE_DIALOG_MIN_WIDTH &&
+      parsed.height >= RESIZABLE_DIALOG_MIN_HEIGHT
+    ) {
+      return { width: parsed.width, height: parsed.height };
+    }
+  } catch {
+    // localStorage disabled/blocked or JSON invalid. Fall back to defaults.
+  }
+  return null;
+}
+
+function safeWriteSize(storageKey: string, size: ResizableDialogSize): void {
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(size));
+  } catch {
+    // Storage full/blocked. The next resize will just re-try.
+  }
+}
+
+function clampToViewport(size: ResizableDialogSize): ResizableDialogSize | null {
+  const maxWidth = Math.floor((window.innerWidth * MAX_VW_PERCENT) / 100);
+  const maxHeight = Math.floor((window.innerHeight * MAX_VH_PERCENT) / 100);
+  // When either viewport dimension is too small to honor the minimum, don't
+  // impose a preferred size at all. The CSS `minWidth`/`minHeight` would
+  // otherwise win over `maxWidth`/`maxHeight`, leaving the drag handle
+  // offscreen on a wide-but-short (or narrow-but-tall) window.
+  if (maxWidth < RESIZABLE_DIALOG_MIN_WIDTH || maxHeight < RESIZABLE_DIALOG_MIN_HEIGHT) {
+    return null;
+  }
+  return {
+    width: Math.min(Math.max(size.width, RESIZABLE_DIALOG_MIN_WIDTH), maxWidth),
+    height: Math.min(Math.max(size.height, RESIZABLE_DIALOG_MIN_HEIGHT), maxHeight),
+  };
+}
+
+/**
+ * Makes an MUI Dialog user-resizable and persists the size in `localStorage`.
+ *
+ * Returns a `paperRef` to attach via `PaperProps={{ ref }}` and an `sx` object
+ * to spread onto the Dialog. A `ResizeObserver` on the paper element writes
+ * debounced size updates to `localStorage[storageKey]` when the user actually
+ * drags the corner handle. Observations that merely echo the CSS clamp (i.e.
+ * the paper is at `min(preferred, 95vw)` because the viewport is smaller than
+ * the stored preference) are ignored, so a session on a smaller monitor does
+ * not overwrite the user's larger preference stored on a bigger monitor.
+ *
+ * The stored size is clamped to `95vw x 95vh` before being applied so the
+ * drag handle never lands offscreen. The CSS `maxWidth/maxHeight` bounds do
+ * the same at paint time when the viewport is later resized while the dialog
+ * is open, so no window resize listener is needed.
+ *
+ * Pass `enabled = false` (e.g. when the dialog is in fullscreen mode on
+ * small viewports) to skip resize entirely: the returned `sx` is empty and
+ * no observer is attached.
+ *
+ * Accessibility note: the resize affordance is the browser's native
+ * `resize: both` corner grip and is mouse-only. Keyboard-only users cannot
+ * change the size; a future follow-up could add explicit shortcuts.
+ */
+export function useResizableDialogSize(storageKey: string, enabled: boolean = true) {
+  const [paperEl, setPaperEl] = useState<HTMLDivElement | null>(null);
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Derived, always-fresh applied size. Recomputes when `storageKey` or
+  // `enabled` change (a `useState` initializer would freeze at first mount).
+  // Returns null when the viewport can't accommodate the minimum bounds so
+  // the paper falls back to MUI defaults + CSS min without an offscreen grip.
+  const appliedSize = useMemo<ResizableDialogSize | null>(() => {
+    if (!enabled) return null;
+    const stored = safeReadSize(storageKey);
+    return stored ? clampToViewport(stored) : null;
+  }, [enabled, storageKey]);
+
+  // Kept up-to-date via effect so the observer callback closure can read the
+  // latest applied intent without re-attaching the observer on every render.
+  const appliedSizeRef = useRef<ResizableDialogSize | null>(appliedSize);
+  useEffect(() => {
+    appliedSizeRef.current = appliedSize;
+  }, [appliedSize]);
+
+  // Callback ref so effect setup runs when the paper element mounts, not
+  // when the hook first renders. Also handles the paper unmounting cleanly:
+  // React invokes the ref with `null`, triggering observer disconnect via
+  // the cleanup below.
+  const paperRef = useCallback((el: HTMLDivElement | null) => {
+    setPaperEl(el);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || !paperEl || typeof ResizeObserver === 'undefined') return undefined;
+
+    // Skip the first observation for each mount: it's the browser laying
+    // out the paper at MUI's initial size (or at the CSS-clamped stored
+    // preference), not a user-driven resize.
+    let isFirstObservation = true;
+
+    const observer = new ResizeObserver(entries => {
+      if (entries.length === 0) return;
+      const { width, height } = entries[0].contentRect;
+      if (isFirstObservation) {
+        isFirstObservation = false;
+        return;
+      }
+      if (width < RESIZABLE_DIALOG_MIN_WIDTH || height < RESIZABLE_DIALOG_MIN_HEIGHT) return;
+
+      // Ignore observations that just echo the CSS-clamped version of the
+      // current applied intent. Without this guard, opening a dialog whose
+      // stored preference is larger than the current viewport would clamp
+      // the paper to `95vw`, the observer would see that smaller value, and
+      // the debounced write would clobber the user's larger preference.
+      const current = appliedSizeRef.current;
+      if (current) {
+        const clamped = clampToViewport(current);
+        if (
+          clamped &&
+          Math.abs(width - clamped.width) < CLAMP_MATCH_TOLERANCE_PX &&
+          Math.abs(height - clamped.height) < CLAMP_MATCH_TOLERANCE_PX
+        ) {
+          return;
+        }
+      }
+
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
+      debounceTimer.current = setTimeout(() => {
+        const rounded = { width: Math.round(width), height: Math.round(height) };
+        safeWriteSize(storageKey, rounded);
+        // Keep the ref in sync with the just-persisted value so a follow-up
+        // user drag back to what looks like the *old* clamp threshold isn't
+        // silently swallowed. Without this, `appliedSizeRef` remained frozen
+        // at mount and later user drags could match the stale clamp value.
+        appliedSizeRef.current = rounded;
+      }, DEBOUNCE_MS);
+    });
+
+    observer.observe(paperEl);
+    return () => {
+      observer.disconnect();
+      if (debounceTimer.current) {
+        clearTimeout(debounceTimer.current);
+        debounceTimer.current = null;
+      }
+    };
+  }, [enabled, storageKey, paperEl]);
+
+  const dialogSx = useMemo(() => {
+    if (!enabled) return {};
+    return {
+      '.MuiDialog-paper': {
+        resize: 'both',
+        overflow: 'auto',
+        minWidth: RESIZABLE_DIALOG_MIN_WIDTH,
+        minHeight: RESIZABLE_DIALOG_MIN_HEIGHT,
+        maxWidth: `${MAX_VW_PERCENT}vw`,
+        maxHeight: `${MAX_VH_PERCENT}vh`,
+        ...(appliedSize ? { width: appliedSize.width, height: appliedSize.height } : {}),
+      },
+    };
+  }, [enabled, appliedSize]);
+
+  return { paperRef, dialogSx };
+}


### PR DESCRIPTION
Fixes #5709

## Summary
- The ClusterChooser dialog always opened at a fixed size, awkward on ultrawide monitors and multi-monitor setups. Make the dialog paper user-resizable via the browser's native corner grip and persist the chosen width/height to `localStorage` across sessions.
- New hook `useResizableDialogSize(storageKey, enabled)` attaches a `ResizeObserver` on the paper element via a callback ref, writes debounced (300ms) size updates to `localStorage[storageKey]`, and reads the stored size on mount.
- Stored sizes are clamped to `95vw × 95vh` before being applied so the drag handle never lands offscreen when the user later opens headlamp on a smaller monitor. CSS `maxWidth: 95vw` / `maxHeight: 95vh` keep the paper inside the viewport at paint time if the browser window is later resized while the dialog is open, so no runtime resize listener is needed.
- The observer skips the very first firing per mount (browser laying out the paper at MUI defaults or at the CSS-clamped stored preference) and any subsequent firing whose size is within 2px of `clampToViewport(applied)`. Without this guard, opening the dialog on a viewport smaller than the stored preference would let the CSS clamp echo into `localStorage` and clobber the user's larger preference. This preserves a big-monitor preference through smaller-monitor sessions, and only persists sizes when the user actually drags the corner handle.
- The hook is disabled when the dialog is in `fullScreen` mode (below the `sm` breakpoint), so mobile viewports get the original fullscreen behavior with no resize affordance.
- All `localStorage` reads and writes are wrapped in `try/catch` so private-browsing modes or blocked storage never crash the hook.

## Non-goals (deferred)
- Applying the hook to other dialogs in the app. The issue is specifically about the ClusterChooser; a follow-up could generalize this once maintainers signal it's desired for e.g. `EditorDialog`, `ConfirmDialog`, etc.
- Keyboard-accessible resize. The native `resize: both` corner grip is mouse-only. Documented in the hook JSDoc as an accessibility limitation with a future-follow-up note.

## Test plan
- [x] `npx vitest run src/components/cluster` (21 tests pass across 4 files; includes 15 new tests for the hook)
- [x] `npx vitest run src/storybook.test.tsx -u` (661 tests pass; 18 storyshot updates are mechanical CSS class-hash changes on cluster/authchooser dialogs)
- [x] `npm run tsc` (clean)
- [x] `npx eslint -c .eslintrc.ci.cjs --max-warnings 0` on changed files (clean)
- [ ] Manual: open the cluster chooser dialog on a normal viewport, drag the bottom-right corner to resize, close and re-open the dialog — confirm the new size is restored
- [ ] Manual: resize the browser window smaller than the stored preference, open the dialog, confirm the paper is CSS-clamped to 95% of the viewport without overflowing
- [ ] Manual: on a fullscreen-triggering viewport (below the `sm` breakpoint), confirm no resize handle appears and no localStorage write occurs
- [ ] Manual: with a stored preference on a big monitor (e.g. 3000×2000), reopen headlamp on a smaller laptop (e.g. 1920×1080), confirm the paper renders clamped and the stored preference is NOT overwritten