### PR TITLE
backend: Fix cache keys for URL query parameters

### DIFF
--- a/backend/pkg/auth/auth_test.go
+++ b/backend/pkg/auth/auth_test.go
@@ -441,6 +441,10 @@ func (cacheStub) Delete(ctx context.Context, k string) error {
 	return nil
 }
 
+func (cacheStub) DeleteAll(ctx context.Context, _ cache.Matcher) error {
+	return nil
+}
+
 func (cacheStub) Get(ctx context.Context, k string) (interface{}, error) {
 	return nil, nil
 }

--- a/backend/pkg/cache/cache.go
+++ b/backend/pkg/cache/cache.go
@@ -31,6 +31,7 @@ type Cache[T any] interface {
 	Set(ctx context.Context, key string, value T) error
 	SetWithTTL(ctx context.Context, key string, value T, ttl time.Duration) error
 	Delete(ctx context.Context, key string) error
+	DeleteAll(ctx context.Context, selectFunc Matcher) error
 	Get(ctx context.Context, key string) (T, error)
 	GetAll(ctx context.Context, selectFunc Matcher) (map[string]T, error)
 	UpdateTTL(ctx context.Context, key string, ttl time.Duration) error
@@ -100,6 +101,20 @@ func (c *cache[T]) Delete(ctx context.Context, key string) error {
 	defer c.lock.Unlock()
 
 	delete(c.store, key)
+
+	return nil
+}
+
+// DeleteAll removes all values from the cache that match the given matcher function.
+func (c *cache[T]) DeleteAll(ctx context.Context, selectFunc Matcher) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	for key := range c.store {
+		if selectFunc != nil && selectFunc(key) {
+			delete(c.store, key)
+		}
+	}
 
 	return nil
 }

--- a/backend/pkg/cache/cache.go
+++ b/backend/pkg/cache/cache.go
@@ -31,6 +31,7 @@ type Cache[T any] interface {
 	Set(ctx context.Context, key string, value T) error
 	SetWithTTL(ctx context.Context, key string, value T, ttl time.Duration) error
 	Delete(ctx context.Context, key string) error
+	DeleteAll(ctx context.Context, selectFunc Matcher) error
 	Get(ctx context.Context, key string) (T, error)
 	GetAll(ctx context.Context, selectFunc Matcher) (map[string]T, error)
 	UpdateTTL(ctx context.Context, key string, ttl time.Duration) error
@@ -100,6 +101,20 @@ func (c *cache[T]) Delete(ctx context.Context, key string) error {
 	defer c.lock.Unlock()
 
 	delete(c.store, key)
+
+	return nil
+}
+
+// DeleteAll removes all values from the cache that match the given matcher function.
+func (c *cache[T]) DeleteAll(ctx context.Context, selectFunc Matcher) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	for key := range c.store {
+		if selectFunc == nil || selectFunc(key) {
+			delete(c.store, key)
+		}
+	}
 
 	return nil
 }

--- a/backend/pkg/cache/cache_test.go
+++ b/backend/pkg/cache/cache_test.go
@@ -18,6 +18,7 @@ package cache_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -107,6 +108,42 @@ func TestCacheGetAll(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(values))
+}
+
+func TestCacheDeleteAll(t *testing.T) {
+	ch := cache.New[interface{}]()
+
+	require.NoError(t, ch.Set(context.Background(), "prefix+1", "value1"))
+	require.NoError(t, ch.Set(context.Background(), "prefix+2", "value2"))
+	require.NoError(t, ch.Set(context.Background(), "prefix+1+query", "value3"))
+	require.NoError(t, ch.Set(context.Background(), "other+prefix+1", "value4"))
+
+	err := ch.DeleteAll(context.Background(), func(key string) bool {
+		return key == "prefix+1" || strings.HasPrefix(key, "prefix+1+")
+	})
+	assert.NoError(t, err)
+
+	_, err = ch.Get(context.Background(), "prefix+1")
+	assert.Error(t, err)
+
+	_, err = ch.Get(context.Background(), "prefix+1+query")
+	assert.Error(t, err)
+
+	val, err := ch.Get(context.Background(), "prefix+2")
+	assert.NoError(t, err)
+	assert.Equal(t, "value2", val)
+
+	val, err = ch.Get(context.Background(), "other+prefix+1")
+	assert.NoError(t, err)
+	assert.Equal(t, "value4", val)
+
+	// test DeleteAll with nil matcher deletes everything
+	err = ch.DeleteAll(context.Background(), nil)
+	assert.NoError(t, err)
+	_, err = ch.Get(context.Background(), "prefix+2")
+	assert.Error(t, err)
+	_, err = ch.Get(context.Background(), "other+prefix+1")
+	assert.Error(t, err)
 }
 
 func TestCacheClose(t *testing.T) {

--- a/backend/pkg/cache/cache_test.go
+++ b/backend/pkg/cache/cache_test.go
@@ -18,6 +18,7 @@ package cache_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -107,6 +108,34 @@ func TestCacheGetAll(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(values))
+}
+
+func TestCacheDeleteAll(t *testing.T) {
+	ch := cache.New[interface{}]()
+
+	require.NoError(t, ch.Set(context.Background(), "prefix+1", "value1"))
+	require.NoError(t, ch.Set(context.Background(), "prefix+2", "value2"))
+	require.NoError(t, ch.Set(context.Background(), "prefix+1+query", "value3"))
+	require.NoError(t, ch.Set(context.Background(), "other+prefix+1", "value4"))
+
+	err := ch.DeleteAll(context.Background(), func(key string) bool {
+		return key == "prefix+1" || strings.HasPrefix(key, "prefix+1+")
+	})
+	assert.NoError(t, err)
+
+	_, err = ch.Get(context.Background(), "prefix+1")
+	assert.Error(t, err)
+
+	_, err = ch.Get(context.Background(), "prefix+1+query")
+	assert.Error(t, err)
+
+	val, err := ch.Get(context.Background(), "prefix+2")
+	assert.NoError(t, err)
+	assert.Equal(t, "value2", val)
+
+	val, err = ch.Get(context.Background(), "other+prefix+1")
+	assert.NoError(t, err)
+	assert.Equal(t, "value4", val)
 }
 
 func TestCacheClose(t *testing.T) {

--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -44,16 +44,24 @@ import (
 // in cache, this delete keys having namespace non-empty and
 // also empty namespace.
 func DeleteKeys(key string, k8scache cache.Cache[string]) {
-	_ = k8scache.Delete(context.Background(), key)
-
 	keyPart := strings.Split(key, "+")
 	if len(keyPart) < 4 {
-		return // malformed key; nothing to namespace-strip
+		// Fallback to exactly delete malformed key
+		_ = k8scache.Delete(context.Background(), key)
+		return
 	}
 
+	exactKey := strings.Join(keyPart[:4], "+")
+	_ = k8scache.DeleteAll(context.Background(), func(k string) bool {
+		return k == exactKey || strings.HasPrefix(k, exactKey+"+")
+	})
+
+	// Also delete namespace-stripped version
 	keyPart[2] = ""
-	key = strings.Join(keyPart, "+")
-	_ = k8scache.Delete(context.Background(), key)
+	namespaceStrippedExactKey := strings.Join(keyPart[:4], "+")
+	_ = k8scache.DeleteAll(context.Background(), func(k string) bool {
+		return k == namespaceStrippedExactKey || strings.HasPrefix(k, namespaceStrippedExactKey+"+")
+	})
 }
 
 // handleNonGetInvalidation handle request which are modifying eg. POST/DELETE/PUT and delete keys if
@@ -377,7 +385,7 @@ func invalidateCacheKeysForResourceEvent(
 	namespace, name, contextKey string,
 	k8scache cache.Cache[string],
 ) {
-	listKey := buildCacheKey(gvr.Group, gvr.Resource, namespace, contextKey)
+	listKey := buildCacheKey(gvr.Group, gvr.Resource, namespace, contextKey, "")
 
 	logger.Log(logger.LevelInfo, nil, nil,
 		redactCacheKey(listKey)+" and related cache keys will be deleted from the cache")
@@ -388,8 +396,12 @@ func invalidateCacheKeysForResourceEvent(
 		return
 	}
 
-	namedKey := buildCacheKey(gvr.Group, name, namespace, contextKey)
-	if err := k8scache.Delete(context.Background(), namedKey); err != nil {
+	namedKey := buildCacheKey(gvr.Group, name, namespace, contextKey, "")
+	namedKeyPrefix := strings.Join(strings.Split(namedKey, "+")[:4], "+")
+
+	if err := k8scache.DeleteAll(context.Background(), func(k string) bool {
+		return k == namedKeyPrefix || strings.HasPrefix(k, namedKeyPrefix+"+")
+	}); err != nil {
 		logger.Log(logger.LevelError, nil, err, "error while deleting key")
 	}
 }

--- a/backend/pkg/k8cache/cacheInvalidation_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_test.go
@@ -130,6 +130,31 @@ func TestDeleteKeys(t *testing.T) { //nolint:funlen
 				},
 			},
 		},
+		{
+			name: "base key and all query variants are deleted, unrelated keys are kept",
+			beforemockCache: &MockCache{
+				store: map[string]string{
+					"+pods+default+test-context":                     "base-value",
+					"+pods+default+test-context+labelSelector=app=a": "variant-1",
+					"+pods+default+test-context+limit=50":            "variant-2",
+					"+pods++test-context":                            "namespace-stripped-base",
+					"+pods++test-context+limit=50":                   "namespace-stripped-variant",
+					"+pods2+default+test-context":                    "unrelated-kind",
+					"+pods+default2+test-context":                    "unrelated-namespace",
+					"+pods+default+test-context-2":                   "unrelated-context",
+					"apps+deployments+default+test-context":          "unrelated-group",
+				},
+			},
+			key: "+pods+default+test-context+limit=50", // Invalidation can be triggered by any variant
+			aftermockCache: &MockCache{
+				store: map[string]string{
+					"+pods2+default+test-context":           "unrelated-kind",
+					"+pods+default2+test-context":           "unrelated-namespace",
+					"+pods+default+test-context-2":          "unrelated-context",
+					"apps+deployments+default+test-context": "unrelated-group",
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -193,11 +193,16 @@ func unescapeCacheKeySegment(s string) string {
 // Any code that parses or otherwise manipulates the key format (e.g. the
 // namespace stripping in cache invalidation) must stay consistent with this
 // encoding to avoid the two sides silently drifting out of sync.
-func buildCacheKey(apiGroup, kind, namespace, contextID string) string {
-	return escapeCacheKeySegment(apiGroup) + "+" +
+func buildCacheKey(apiGroup, kind, namespace, contextID, query string) string {
+	key := escapeCacheKeySegment(apiGroup) + "+" +
 		escapeCacheKeySegment(kind) + "+" +
 		escapeCacheKeySegment(namespace) + "+" +
 		escapeCacheKeySegment(contextID)
+	if query != "" {
+		key += "+" + escapeCacheKeySegment(query)
+	}
+
+	return key
 }
 
 // GenerateKey function helps to generate a unique key based on the request from the client
@@ -215,9 +220,10 @@ func GenerateKey(url *url.URL, contextID string) (string, error) {
 		Kind:      kind,
 		Namespace: namespace,
 		Context:   contextID,
+		Query:     url.Query().Encode(),
 	}
 
-	return buildCacheKey(apiGroup, k.Kind, k.Namespace, k.Context), nil
+	return buildCacheKey(apiGroup, k.Kind, k.Namespace, k.Context, k.Query), nil
 }
 
 // SetHeader function help to serve response from cache to ensure the client
@@ -345,7 +351,7 @@ func redactContextKey(key string) string {
 
 // redactCacheKey returns a redacted version of the cache key (which contains the context key as its last segment).
 func redactCacheKey(key string) string {
-	parts := strings.SplitN(key, "+", 4)
+	parts := strings.SplitN(key, "+", 5)
 
 	if len(parts) >= 4 {
 		parts[3] = redactContextKey(parts[3])

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -193,31 +193,48 @@ func unescapeCacheKeySegment(s string) string {
 // Any code that parses or otherwise manipulates the key format (e.g. the
 // namespace stripping in cache invalidation) must stay consistent with this
 // encoding to avoid the two sides silently drifting out of sync.
-func buildCacheKey(apiGroup, kind, namespace, contextID string) string {
-	return escapeCacheKeySegment(apiGroup) + "+" +
+func buildCacheKey(apiGroup, kind, namespace, contextID, query string) string {
+	key := escapeCacheKeySegment(apiGroup) + "+" +
 		escapeCacheKeySegment(kind) + "+" +
 		escapeCacheKeySegment(namespace) + "+" +
 		escapeCacheKeySegment(contextID)
+	if query != "" {
+		key += "+" + escapeCacheKeySegment(query)
+	}
+
+	return key
 }
 
 // GenerateKey function helps to generate a unique key based on the request from the client
 // The function accepts url( which includes all the information of request ) and contextID which
 // helps to differentiate in multiple contexts.
-func GenerateKey(url *url.URL, contextID string) (string, error) {
-	namespace, kind := ExtractNamespace(url.Path)
+func GenerateKey(reqURL *url.URL, contextID string) (string, error) {
+	namespace, kind := ExtractNamespace(reqURL.Path)
 
-	apiGroup, _, err := GetAPIGroup(url.Path)
+	apiGroup, _, err := GetAPIGroup(reqURL.Path)
 	if err != nil {
 		return "", err
+	}
+
+	query := ""
+
+	if reqURL.RawQuery != "" {
+		parsedQuery, err := url.ParseQuery(reqURL.RawQuery)
+		if err != nil {
+			return "", fmt.Errorf("invalid query parameters: %w", err)
+		}
+
+		query = parsedQuery.Encode()
 	}
 
 	k := CacheKey{
 		Kind:      kind,
 		Namespace: namespace,
 		Context:   contextID,
+		Query:     query,
 	}
 
-	return buildCacheKey(apiGroup, k.Kind, k.Namespace, k.Context), nil
+	return buildCacheKey(apiGroup, k.Kind, k.Namespace, k.Context, k.Query), nil
 }
 
 // SetHeader function help to serve response from cache to ensure the client
@@ -343,15 +360,19 @@ func redactContextKey(key string) string {
 	return key[:3] + "...[redacted]"
 }
 
-// redactCacheKey returns a redacted version of the cache key (which contains the context key as its last segment).
+// redactCacheKey returns a redacted version of the cache key. It redacts the context key
+// (the 4th segment) and the query parameters (the 5th segment, if present) to avoid
+// leaking sensitive information such as cluster names or query filters in logs.
 func redactCacheKey(key string) string {
-	parts := strings.SplitN(key, "+", 4)
+	parts := strings.Split(key, "+")
 
 	if len(parts) >= 4 {
 		parts[3] = redactContextKey(parts[3])
-
-		return strings.Join(parts, "+")
 	}
 
-	return key
+	if len(parts) >= 5 {
+		parts[4] = "[redacted]"
+	}
+
+	return strings.Join(parts, "+")
 }

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -208,19 +208,30 @@ func buildCacheKey(apiGroup, kind, namespace, contextID, query string) string {
 // GenerateKey function helps to generate a unique key based on the request from the client
 // The function accepts url( which includes all the information of request ) and contextID which
 // helps to differentiate in multiple contexts.
-func GenerateKey(url *url.URL, contextID string) (string, error) {
-	namespace, kind := ExtractNamespace(url.Path)
+func GenerateKey(reqURL *url.URL, contextID string) (string, error) {
+	namespace, kind := ExtractNamespace(reqURL.Path)
 
-	apiGroup, _, err := GetAPIGroup(url.Path)
+	apiGroup, _, err := GetAPIGroup(reqURL.Path)
 	if err != nil {
 		return "", err
+	}
+
+	query := ""
+
+	if reqURL.RawQuery != "" {
+		parsedQuery, err := url.ParseQuery(reqURL.RawQuery)
+		if err != nil {
+			return "", fmt.Errorf("invalid query parameters: %w", err)
+		}
+
+		query = parsedQuery.Encode()
 	}
 
 	k := CacheKey{
 		Kind:      kind,
 		Namespace: namespace,
 		Context:   contextID,
-		Query:     url.Query().Encode(),
+		Query:     query,
 	}
 
 	return buildCacheKey(apiGroup, k.Kind, k.Namespace, k.Context, k.Query), nil
@@ -351,13 +362,15 @@ func redactContextKey(key string) string {
 
 // redactCacheKey returns a redacted version of the cache key (which contains the context key as its last segment).
 func redactCacheKey(key string) string {
-	parts := strings.SplitN(key, "+", 5)
+	parts := strings.Split(key, "+")
 
 	if len(parts) >= 4 {
 		parts[3] = redactContextKey(parts[3])
-
-		return strings.Join(parts, "+")
 	}
 
-	return key
+	if len(parts) >= 5 {
+		parts[4] = "[redacted]"
+	}
+
+	return strings.Join(parts, "+")
 }

--- a/backend/pkg/k8cache/cacheStore_test.go
+++ b/backend/pkg/k8cache/cacheStore_test.go
@@ -98,6 +98,20 @@ func (m *MockCache) GetAll(ctx context.Context, selectFunc cache.Matcher) (map[s
 	return nil, nil
 }
 
+// DeleteAll Mocks deleting all values that match the selectFunc.
+func (m *MockCache) DeleteAll(ctx context.Context, selectFunc cache.Matcher) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for key := range m.store {
+		if selectFunc != nil && selectFunc(key) {
+			delete(m.store, key)
+		}
+	}
+
+	return nil
+}
+
 // UpdateTTL Mocks updating of time-to-live with the help of its corresponding key string.
 func (m *MockCache) UpdateTTL(ctx context.Context, key string, ttl time.Duration) error {
 	return nil
@@ -512,6 +526,46 @@ func TestGenerateKey(t *testing.T) {
 			urlPath:     url.URL{Path: "/clusters/kind-kind/apis/apps/v1/namespaces/default/deployments"},
 			contextKey:  "prod%2Bcluster",
 			expectedKey: "apps+deployments+default+prod%252Bcluster",
+			expectedErr: nil,
+		},
+		{
+			name: "key with query parameters",
+			urlPath: url.URL{
+				Path:     "/clusters/kind-kind/apis/k8s.metrics.io/v1beta1/namespaces/test-kube/pods",
+				RawQuery: "labelSelector=app=a",
+			},
+			contextKey:  "kind-kind",
+			expectedKey: "k8s.metrics.io+pods+test-kube+kind-kind+labelSelector=app%253Da",
+			expectedErr: nil,
+		},
+		{
+			name: "key with different query parameters produces different key",
+			urlPath: url.URL{
+				Path:     "/clusters/kind-kind/apis/k8s.metrics.io/v1beta1/namespaces/test-kube/pods",
+				RawQuery: "limit=10",
+			},
+			contextKey:  "kind-kind",
+			expectedKey: "k8s.metrics.io+pods+test-kube+kind-kind+limit=10",
+			expectedErr: nil,
+		},
+		{
+			name: "key with unordered query parameters canonicalizes identically",
+			urlPath: url.URL{
+				Path:     "/clusters/kind-kind/apis/k8s.metrics.io/v1beta1/namespaces/test-kube/pods",
+				RawQuery: "limit=10&continue=token",
+			},
+			contextKey:  "kind-kind",
+			expectedKey: "k8s.metrics.io+pods+test-kube+kind-kind+continue=token&limit=10",
+			expectedErr: nil,
+		},
+		{
+			name: "key with reverse unordered query parameters canonicalizes identically",
+			urlPath: url.URL{
+				Path:     "/clusters/kind-kind/apis/k8s.metrics.io/v1beta1/namespaces/test-kube/pods",
+				RawQuery: "continue=token&limit=10",
+			},
+			contextKey:  "kind-kind",
+			expectedKey: "k8s.metrics.io+pods+test-kube+kind-kind+continue=token&limit=10",
 			expectedErr: nil,
 		},
 	}

--- a/backend/pkg/k8cache/cacheStore_test.go
+++ b/backend/pkg/k8cache/cacheStore_test.go
@@ -98,6 +98,20 @@ func (m *MockCache) GetAll(ctx context.Context, selectFunc cache.Matcher) (map[s
 	return nil, nil
 }
 
+// DeleteAll Mocks deleting all values that match the selectFunc.
+func (m *MockCache) DeleteAll(ctx context.Context, selectFunc cache.Matcher) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for key := range m.store {
+		if selectFunc != nil && selectFunc(key) {
+			delete(m.store, key)
+		}
+	}
+
+	return nil
+}
+
 // UpdateTTL Mocks updating of time-to-live with the help of its corresponding key string.
 func (m *MockCache) UpdateTTL(ctx context.Context, key string, ttl time.Duration) error {
 	return nil
@@ -513,6 +527,56 @@ func TestGenerateKey(t *testing.T) {
 			contextKey:  "prod%2Bcluster",
 			expectedKey: "apps+deployments+default+prod%252Bcluster",
 			expectedErr: nil,
+		},
+		{
+			name: "key with query parameters",
+			urlPath: url.URL{
+				Path:     "/clusters/kind-kind/apis/k8s.metrics.io/v1beta1/namespaces/test-kube/pods",
+				RawQuery: "labelSelector=app=a",
+			},
+			contextKey:  "kind-kind",
+			expectedKey: "k8s.metrics.io+pods+test-kube+kind-kind+labelSelector=app%253Da",
+			expectedErr: nil,
+		},
+		{
+			name: "key with different query parameters produces different key",
+			urlPath: url.URL{
+				Path:     "/clusters/kind-kind/apis/k8s.metrics.io/v1beta1/namespaces/test-kube/pods",
+				RawQuery: "limit=10",
+			},
+			contextKey:  "kind-kind",
+			expectedKey: "k8s.metrics.io+pods+test-kube+kind-kind+limit=10",
+			expectedErr: nil,
+		},
+		{
+			name: "key with unordered query parameters canonicalizes identically",
+			urlPath: url.URL{
+				Path:     "/clusters/kind-kind/apis/k8s.metrics.io/v1beta1/namespaces/test-kube/pods",
+				RawQuery: "limit=10&continue=token",
+			},
+			contextKey:  "kind-kind",
+			expectedKey: "k8s.metrics.io+pods+test-kube+kind-kind+continue=token&limit=10",
+			expectedErr: nil,
+		},
+		{
+			name: "key with reverse unordered query parameters canonicalizes identically",
+			urlPath: url.URL{
+				Path:     "/clusters/kind-kind/apis/k8s.metrics.io/v1beta1/namespaces/test-kube/pods",
+				RawQuery: "continue=token&limit=10",
+			},
+			contextKey:  "kind-kind",
+			expectedKey: "k8s.metrics.io+pods+test-kube+kind-kind+continue=token&limit=10",
+			expectedErr: nil,
+		},
+		{
+			name: "malformed query parameters return error",
+			urlPath: url.URL{
+				Path:     "/clusters/kind-kind/apis/k8s.metrics.io/v1beta1/namespaces/test-kube/pods",
+				RawQuery: "foo=%zz",
+			},
+			contextKey:  "kind-kind",
+			expectedKey: "",
+			expectedErr: errors.New("invalid query parameters"),
 		},
 	}
 	for _, tc := range tests {

--- a/backend/pkg/k8cache/context_cleanup.go
+++ b/backend/pkg/k8cache/context_cleanup.go
@@ -29,7 +29,7 @@ func cacheKeyBelongsToContext(key, contextKey string) bool {
 		return false
 	}
 
-	parts := strings.SplitN(key, "+", 4)
+	parts := strings.Split(key, "+")
 	if len(parts) < 4 {
 		return false
 	}
@@ -100,8 +100,8 @@ func collectCachedContextKeys(k8scache cache.Cache[string]) map[string]struct{} 
 	}
 
 	for key := range allKeys {
-		parts := strings.SplitN(key, "+", 4)
-		if len(parts) == 4 && parts[3] != "" {
+		parts := strings.Split(key, "+")
+		if len(parts) >= 4 && parts[3] != "" {
 			keys[unescapeCacheKeySegment(parts[3])] = struct{}{}
 		}
 	}

--- a/backend/pkg/k8cache/context_cleanup_test.go
+++ b/backend/pkg/k8cache/context_cleanup_test.go
@@ -42,6 +42,8 @@ func TestCacheKeyBelongsToContext(t *testing.T) {
 		{"+pods+default+other", "minikube", false},
 		{"malformed", "minikube", false},
 		{"+pods+default+minikube", "", false},
+		{"+pods+default+minikube+limit%3D50", "minikube", true},
+		{"+pods+default+other+limit%3D50", "minikube", false},
 	}
 
 	for _, tt := range tests {
@@ -56,12 +58,17 @@ func TestPurgeCacheForContext(t *testing.T) {
 	ctx := context.Background()
 
 	require.NoError(t, k8scache.Set(ctx, "+pods+default+minikube", "pods-data"))
+	require.NoError(t, k8scache.Set(ctx, "+pods+default+minikube+limit%3D50", "pods-data-query"))
 	require.NoError(t, k8scache.Set(ctx, "apps+deployments+default+minikube", "deploy-data"))
 	require.NoError(t, k8scache.Set(ctx, "+pods+default+other-cluster", "other-data"))
+	require.NoError(t, k8scache.Set(ctx, "+pods+default+other-cluster+limit%3D50", "other-data-query"))
 
 	k8cache.PurgeCacheForContext(k8scache, "minikube")
 
 	_, err := k8scache.Get(ctx, "+pods+default+minikube")
+	assert.Error(t, err)
+
+	_, err = k8scache.Get(ctx, "+pods+default+minikube+limit%3D50")
 	assert.Error(t, err)
 
 	_, err = k8scache.Get(ctx, "apps+deployments+default+minikube")
@@ -70,6 +77,10 @@ func TestPurgeCacheForContext(t *testing.T) {
 	val, err := k8scache.Get(ctx, "+pods+default+other-cluster")
 	assert.NoError(t, err)
 	assert.Equal(t, "other-data", val)
+
+	val, err = k8scache.Get(ctx, "+pods+default+other-cluster+limit%3D50")
+	assert.NoError(t, err)
+	assert.Equal(t, "other-data-query", val)
 }
 
 func TestPurgeCacheForContext_EscapedContextKey(t *testing.T) {

--- a/backend/pkg/k8cache/key.go
+++ b/backend/pkg/k8cache/key.go
@@ -18,4 +18,5 @@ type CacheKey struct {
 	Kind      string // Kind is the string object which is the user is requesting
 	Namespace string // Namespace is string object which tells what Namespace is the user trying to access
 	Context   string // Context is the unique Id which helps to differentiate multi-context
+	Query     string // Query parameters from the URL
 }


### PR DESCRIPTION
## Summary

Fixes the Headlamp backend response cache so URL query parameters are included in cache keys. This prevents requests with different query parameters from incorrectly sharing the same cached response.

## Related Issue

Fixes #7004

## Changes

* Include canonicalized URL query parameters in cache keys using `url.Query().Encode()`.
* Ensure different selectors and pagination parameters such as `labelSelector`, `limit`, and `continue` produce distinct cache entries.
* Invalidate the base cache entry and all query variants when the underlying Kubernetes resource changes.
* Add regression tests for query-based cache keys and cache invalidation.
* Preserve existing cache-key behavior for requests without query parameters.

## Steps to Test

1. Enable the experimental backend cache with `--cache-enabled=true`.
2. Make a request with a query parameter, such as:
   `GET /api/v1/namespaces/default/pods?labelSelector=app=frontend`
3. Make another request with a different selector:
   `GET /api/v1/namespaces/default/pods?labelSelector=app=backend`
4. Verify that the requests do not share the same cache entry.
5. Verify that pagination parameters such as `limit` and `continue` also produce distinct cache keys.
6. Run the backend tests and lint checks.

## Screenshots (if applicable)

Not applicable — this is a backend caching fix.

## Notes for the Reviewer

* Query parameters are canonicalized using `url.Query().Encode()` so equivalent parameter orderings produce the same cache key.
* Cache invalidation removes all query variants associated with the affected resource while preserving unrelated cache entries.
* No frontend changes are required for this backend-only fix.
