### PR TITLE
frontend: Add Dynamic Resource Allocation (DRA) API objects and views

### DIFF
--- a/frontend/src/components/Sidebar/useSidebarItems.tsx
+++ b/frontend/src/components/Sidebar/useSidebarItems.tsx
@@ -288,6 +288,29 @@ export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER
         ],
       },
       {
+        name: 'devices',
+        label: t('glossary|Devices'),
+        icon: 'mdi:memory',
+        subList: [
+          {
+            name: 'deviceClasses',
+            label: t('glossary|Device Classes'),
+          },
+          {
+            name: 'resourceSlices',
+            label: t('glossary|Resource Slices'),
+          },
+          {
+            name: 'resourceClaims',
+            label: t('glossary|Resource Claims'),
+          },
+          {
+            name: 'resourceClaimTemplates',
+            label: t('glossary|Resource Claim Templates'),
+          },
+        ],
+      },
+      {
         name: 'network',
         label: t('glossary|Network'),
         icon: 'mdi:folder-network-outline',

--- a/frontend/src/components/device/DeviceClassDetails.tsx
+++ b/frontend/src/components/device/DeviceClassDetails.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router';
+import DeviceClass from '../../../lib/k8s/deviceClass';
+import { DetailsGrid } from '../../common/Resource';
+import SectionBox from '../../common/SectionBox';
+import SimpleTable from '../../common/SimpleTable';
+
+export default function DeviceClassDetails() {
+  const { name } = useParams<{ name: string }>();
+  const { t } = useTranslation('glossary');
+
+  return (
+    <DetailsGrid
+      resourceType={DeviceClass}
+      name={name}
+      withEvents
+      extraInfo={item =>
+        item && [
+          {
+            name: t('Selectors'),
+            value: item.spec?.selectors?.map((s: any, i: number) => (
+              <div key={i}>{s.cel?.expression}</div>
+            )),
+          },
+        ]
+      }
+      extraSections={item =>
+        item && item.spec?.config ? (
+          <SectionBox title={t('Config')}>
+            <SimpleTable
+              data={item.spec.config}
+              columns={[
+                {
+                  label: t('Driver'),
+                  getter: (config: any) => config.opaque?.driver,
+                },
+                {
+                  label: t('Parameters'),
+                  getter: (config: any) =>
+                    config.opaque?.parameters ? JSON.stringify(config.opaque.parameters) : '',
+                },
+              ]}
+            />
+          </SectionBox>
+        ) : null
+      }
+    />
+  );
+}

--- a/frontend/src/components/device/DeviceClassList.tsx
+++ b/frontend/src/components/device/DeviceClassList.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import DeviceClass from '../../../lib/k8s/deviceClass';
+import ResourceListView from '../../common/Resource/ResourceListView';
+
+export default function DeviceClassList() {
+  const { t } = useTranslation('glossary');
+
+  return (
+    <ResourceListView
+      title={t('Device Classes')}
+      resourceClass={DeviceClass}
+      columns={['name', 'age']}
+    />
+  );
+}

--- a/frontend/src/components/device/ResourceClaimDetails.tsx
+++ b/frontend/src/components/device/ResourceClaimDetails.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router';
+import ResourceClaim from '../../../lib/k8s/resourceClaim';
+import { DetailsGrid } from '../../common/Resource';
+import SectionBox from '../../common/SectionBox';
+import SimpleTable from '../../common/SimpleTable';
+
+export default function ResourceClaimDetails() {
+  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+  const { t } = useTranslation('glossary');
+
+  return (
+    <DetailsGrid
+      resourceType={ResourceClaim}
+      name={name}
+      namespace={namespace}
+      withEvents
+      extraSections={item =>
+        item && (
+          <>
+            {item.spec?.devices?.requests && (
+              <SectionBox title={t('Requests')}>
+                <SimpleTable
+                  data={item.spec.devices.requests}
+                  columns={[
+                    {
+                      label: t('Name'),
+                      getter: (req: any) => req.name,
+                    },
+                    {
+                      label: t('Device Class'),
+                      getter: (req: any) => req.deviceClassName,
+                    },
+                    {
+                      label: t('Allocation Mode'),
+                      getter: (req: any) => req.allocationMode || '-',
+                    },
+                    {
+                      label: t('Admin Access'),
+                      getter: (req: any) => (req.adminAccess ? t('Yes') : t('No')),
+                    },
+                  ]}
+                />
+              </SectionBox>
+            )}
+            {item.status?.allocation?.devices?.results && (
+              <SectionBox title={t('Allocation Results')}>
+                <SimpleTable
+                  data={item.status.allocation.devices.results}
+                  columns={[
+                    {
+                      label: t('Request'),
+                      getter: (res: any) => res.request,
+                    },
+                    {
+                      label: t('Driver'),
+                      getter: (res: any) => res.driver,
+                    },
+                    {
+                      label: t('Pool'),
+                      getter: (res: any) => res.pool,
+                    },
+                    {
+                      label: t('Device'),
+                      getter: (res: any) => res.device,
+                    },
+                  ]}
+                />
+              </SectionBox>
+            )}
+          </>
+        )
+      }
+    />
+  );
+}

--- a/frontend/src/components/device/ResourceClaimList.tsx
+++ b/frontend/src/components/device/ResourceClaimList.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import ResourceClaim from '../../../lib/k8s/resourceClaim';
+import ResourceListView from '../../common/Resource/ResourceListView';
+
+export default function ResourceClaimList() {
+  const { t } = useTranslation('glossary');
+
+  return (
+    <ResourceListView
+      title={t('Resource Claims')}
+      resourceClass={ResourceClaim}
+      columns={[
+        'name',
+        'namespace',
+        {
+          id: 'allocationMode',
+          label: t('Allocation Mode'),
+          getter: (claim: any) => claim.spec?.devices?.requests?.[0]?.allocationMode || '-',
+        },
+        'age',
+      ]}
+    />
+  );
+}

--- a/frontend/src/components/device/ResourceClaimTemplateDetails.tsx
+++ b/frontend/src/components/device/ResourceClaimTemplateDetails.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router';
+import ResourceClaimTemplate from '../../../lib/k8s/resourceClaimTemplate';
+import { DetailsGrid } from '../../common/Resource';
+import SectionBox from '../../common/SectionBox';
+import SimpleTable from '../../common/SimpleTable';
+
+export default function ResourceClaimTemplateDetails() {
+  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+  const { t } = useTranslation('glossary');
+
+  return (
+    <DetailsGrid
+      resourceType={ResourceClaimTemplate}
+      name={name}
+      namespace={namespace}
+      withEvents
+      extraSections={item =>
+        item &&
+        item.spec?.spec?.devices?.requests && (
+          <SectionBox title={t('Requests')}>
+            <SimpleTable
+              data={item.spec.spec.devices.requests}
+              columns={[
+                {
+                  label: t('Name'),
+                  getter: (req: any) => req.name,
+                },
+                {
+                  label: t('Device Class'),
+                  getter: (req: any) => req.deviceClassName,
+                },
+                {
+                  label: t('Allocation Mode'),
+                  getter: (req: any) => req.allocationMode || '-',
+                },
+                {
+                  label: t('Admin Access'),
+                  getter: (req: any) => (req.adminAccess ? t('Yes') : t('No')),
+                },
+              ]}
+            />
+          </SectionBox>
+        )
+      }
+    />
+  );
+}

--- a/frontend/src/components/device/ResourceClaimTemplateList.tsx
+++ b/frontend/src/components/device/ResourceClaimTemplateList.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import ResourceClaimTemplate from '../../../lib/k8s/resourceClaimTemplate';
+import ResourceListView from '../../common/Resource/ResourceListView';
+
+export default function ResourceClaimTemplateList() {
+  const { t } = useTranslation('glossary');
+
+  return (
+    <ResourceListView
+      title={t('Resource Claim Templates')}
+      resourceClass={ResourceClaimTemplate}
+      columns={['name', 'namespace', 'age']}
+    />
+  );
+}

--- a/frontend/src/components/device/ResourceSliceDetails.tsx
+++ b/frontend/src/components/device/ResourceSliceDetails.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router';
+import ResourceSlice from '../../../lib/k8s/resourceSlice';
+import { DetailsGrid } from '../../common/Resource';
+import SectionBox from '../../common/SectionBox';
+import SimpleTable from '../../common/SimpleTable';
+
+export default function ResourceSliceDetails() {
+  const { name } = useParams<{ name: string }>();
+  const { t } = useTranslation('glossary');
+
+  return (
+    <DetailsGrid
+      resourceType={ResourceSlice}
+      name={name}
+      withEvents
+      extraInfo={item =>
+        item && [
+          {
+            name: t('Driver'),
+            value: item.spec?.driver,
+          },
+          {
+            name: t('Node'),
+            value: item.spec?.nodeName,
+          },
+          {
+            name: t('Pool Name'),
+            value: item.spec?.pool?.name,
+          },
+          {
+            name: t('Slice Count'),
+            value: item.spec?.pool?.resourceSliceCount,
+          },
+        ]
+      }
+      extraSections={item =>
+        item && item.spec?.devices ? (
+          <SectionBox title={t('Devices')}>
+            <SimpleTable
+              data={item.spec.devices}
+              columns={[
+                {
+                  label: t('Name'),
+                  getter: (dev: any) => dev.name,
+                },
+                {
+                  label: t('Capacity'),
+                  getter: (dev: any) =>
+                    dev.basic?.capacity
+                      ? Object.entries(dev.basic.capacity)
+                          .map(([k, v]) => `${k}: ${v}`)
+                          .join(', ')
+                      : '',
+                },
+              ]}
+            />
+          </SectionBox>
+        ) : null
+      }
+    />
+  );
+}

--- a/frontend/src/components/device/ResourceSliceList.tsx
+++ b/frontend/src/components/device/ResourceSliceList.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import ResourceSlice from '../../../lib/k8s/resourceSlice';
+import ResourceListView from '../../common/Resource/ResourceListView';
+
+export default function ResourceSliceList() {
+  const { t } = useTranslation('glossary');
+
+  return (
+    <ResourceListView
+      title={t('Resource Slices')}
+      resourceClass={ResourceSlice}
+      columns={[
+        'name',
+        {
+          id: 'driver',
+          label: t('Driver'),
+          getter: (slice: any) => slice.spec?.driver,
+        },
+        {
+          id: 'nodeName',
+          label: t('Node'),
+          getter: (slice: any) => slice.spec?.nodeName || '-',
+        },
+        'age',
+      ]}
+    />
+  );
+}

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -978,5 +978,19 @@
   "Toggle Table Filters": "Toggle Table Filters",
   "Toggle column filters in tables": "Toggle column filters in tables",
   "Log Viewer Search": "Log Viewer Search",
-  "Toggle search in log viewer": "Toggle search in log viewer"
+  "Toggle search in log viewer": "Toggle search in log viewer",
+  "Devices": "Devices",
+  "Device Classes": "Device Classes",
+  "Resource Slices": "Resource Slices",
+  "Resource Claims": "Resource Claims",
+  "Resource Claim Templates": "Resource Claim Templates",
+  "Driver": "Driver",
+  "Pool Name": "Pool Name",
+  "Slice Count": "Slice Count",
+  "Capacity": "Capacity",
+  "Allocation Mode": "Allocation Mode",
+  "Admin Access": "Admin Access",
+  "Allocation Results": "Allocation Results",
+  "Pool": "Pool",
+  "Device": "Device"
 }

--- a/frontend/src/lib/k8s/deviceClass.ts
+++ b/frontend/src/lib/k8s/deviceClass.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KubeObjectInterface } from './KubeObject';
+import { KubeObject } from './KubeObject';
+
+export interface KubeDeviceClass extends KubeObjectInterface {
+  spec: {
+    selectors?: Array<{
+      cel?: {
+        expression: string;
+      };
+    }>;
+    config?: Array<{
+      opaque?: {
+        driver: string;
+        parameters: any;
+      };
+      [key: string]: any;
+    }>;
+    [key: string]: any;
+  };
+}
+
+class DeviceClass extends KubeObject<KubeDeviceClass> {
+  static kind = 'DeviceClass';
+  static apiName = 'deviceclasses';
+  static apiVersion = 'resource.k8s.io/v1';
+  static isNamespaced = false;
+
+  static getBaseObject(): KubeDeviceClass {
+    return super.getBaseObject() as KubeDeviceClass;
+  }
+
+  static get listRoute() {
+    return 'deviceclasses';
+  }
+
+  static get pluralName() {
+    return 'deviceclasses';
+  }
+
+  get spec() {
+    return this.jsonData.spec;
+  }
+}
+
+export default DeviceClass;

--- a/frontend/src/lib/k8s/index.ts
+++ b/frontend/src/lib/k8s/index.ts
@@ -30,6 +30,7 @@ import CustomResourceDefinition from './crd';
 import CronJob from './cronJob';
 import DaemonSet from './daemonSet';
 import Deployment from './deployment';
+import DeviceClass from './deviceClass';
 import Endpoints from './endpoints';
 import EndpointSlice from './endpointSlices';
 import Gateway from './gateway';
@@ -53,7 +54,10 @@ import Pod from './pod';
 import PodDisruptionBudget from './podDisruptionBudget';
 import PriorityClass from './priorityClass';
 import ReplicaSet from './replicaSet';
+import ResourceClaim from './resourceClaim';
+import ResourceClaimTemplate from './resourceClaimTemplate';
 import ResourceQuota from './resourceQuota';
+import ResourceSlice from './resourceSlice';
 import Role from './role';
 import RoleBinding from './roleBinding';
 import { RuntimeClass } from './runtime';
@@ -107,6 +111,10 @@ export const ResourceClasses = {
   GatewayClass,
   HTTPRoute,
   GRPCRoute,
+  DeviceClass,
+  ResourceSlice,
+  ResourceClaim,
+  ResourceClaimTemplate,
 };
 
 /** Hook for getting or fetching the clusters configuration.

--- a/frontend/src/lib/k8s/resourceClaim.ts
+++ b/frontend/src/lib/k8s/resourceClaim.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KubeObjectInterface } from './KubeObject';
+import { KubeObject } from './KubeObject';
+
+export interface KubeResourceClaim extends KubeObjectInterface {
+  spec: {
+    devices?: {
+      requests?: Array<{
+        name: string;
+        deviceClassName: string;
+        selectors?: Array<{
+          cel?: {
+            expression: string;
+          };
+        }>;
+        allocationMode?: string;
+        adminAccess?: boolean;
+      }>;
+      config?: Array<{
+        requests?: string[];
+        opaque?: {
+          driver: string;
+          parameters: any;
+        };
+      }>;
+    };
+    [key: string]: any;
+  };
+  status?: {
+    allocation?: {
+      nodeSelector?: {
+        nodeSelectorTerms: Array<any>;
+      };
+      devices?: {
+        results?: Array<{
+          request: string;
+          driver: string;
+          pool: string;
+          device: string;
+        }>;
+      };
+    };
+    reservedFor?: Array<{
+      resource: string;
+      group: string;
+      name: string;
+      uid: string;
+    }>;
+    devices?: Array<any>;
+  };
+}
+
+class ResourceClaim extends KubeObject<KubeResourceClaim> {
+  static kind = 'ResourceClaim';
+  static apiName = 'resourceclaims';
+  static apiVersion = 'resource.k8s.io/v1';
+  static isNamespaced = true;
+
+  static getBaseObject(): KubeResourceClaim {
+    return super.getBaseObject() as KubeResourceClaim;
+  }
+
+  static get listRoute() {
+    return 'resourceclaims';
+  }
+
+  static get pluralName() {
+    return 'resourceclaims';
+  }
+
+  get spec() {
+    return this.jsonData.spec;
+  }
+
+  get status() {
+    return this.jsonData.status;
+  }
+}
+
+export default ResourceClaim;

--- a/frontend/src/lib/k8s/resourceClaimTemplate.ts
+++ b/frontend/src/lib/k8s/resourceClaimTemplate.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KubeObjectInterface } from './KubeObject';
+import { KubeObject } from './KubeObject';
+import type { KubeResourceClaim } from './resourceClaim';
+
+export interface KubeResourceClaimTemplate extends KubeObjectInterface {
+  spec: {
+    spec: KubeResourceClaim['spec'];
+    metadata?: Record<string, any>;
+  };
+}
+
+class ResourceClaimTemplate extends KubeObject<KubeResourceClaimTemplate> {
+  static kind = 'ResourceClaimTemplate';
+  static apiName = 'resourceclaimtemplates';
+  static apiVersion = 'resource.k8s.io/v1';
+  static isNamespaced = true;
+
+  static getBaseObject(): KubeResourceClaimTemplate {
+    return super.getBaseObject() as KubeResourceClaimTemplate;
+  }
+
+  static get listRoute() {
+    return 'resourceclaimtemplates';
+  }
+
+  static get pluralName() {
+    return 'resourceclaimtemplates';
+  }
+
+  get spec() {
+    return this.jsonData.spec;
+  }
+}
+
+export default ResourceClaimTemplate;

--- a/frontend/src/lib/k8s/resourceSlice.ts
+++ b/frontend/src/lib/k8s/resourceSlice.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KubeObjectInterface } from './KubeObject';
+import { KubeObject } from './KubeObject';
+
+export interface KubeResourceSlice extends KubeObjectInterface {
+  spec: {
+    driver: string;
+    pool: {
+      name: string;
+      resourceSliceCount: number;
+      generation: number;
+    };
+    nodeName?: string;
+    devices?: Array<{
+      name: string;
+      basic?: {
+        capacity: Record<string, string>;
+      };
+      [key: string]: any;
+    }>;
+  };
+}
+
+class ResourceSlice extends KubeObject<KubeResourceSlice> {
+  static kind = 'ResourceSlice';
+  static apiName = 'resourceslices';
+  static apiVersion = 'resource.k8s.io/v1';
+  static isNamespaced = false;
+
+  static getBaseObject(): KubeResourceSlice {
+    return super.getBaseObject() as KubeResourceSlice;
+  }
+
+  static get listRoute() {
+    return 'resourceslices';
+  }
+
+  static get pluralName() {
+    return 'resourceslices';
+  }
+
+  get spec() {
+    return this.jsonData.spec;
+  }
+}
+
+export default ResourceSlice;

--- a/frontend/src/lib/router/index.tsx
+++ b/frontend/src/lib/router/index.tsx
@@ -41,6 +41,14 @@ import CronJobDetails from '../../components/cronjob/Details';
 import CronJobList from '../../components/cronjob/List';
 import DaemonSetList from '../../components/daemonset/List';
 import DeploymentsList from '../../components/deployments/List';
+import DeviceClassDetails from '../../components/device/DeviceClassDetails';
+import DeviceClassList from '../../components/device/DeviceClassList';
+import ResourceClaimDetails from '../../components/device/ResourceClaimDetails';
+import ResourceClaimList from '../../components/device/ResourceClaimList';
+import ResourceClaimTemplateDetails from '../../components/device/ResourceClaimTemplateDetails';
+import ResourceClaimTemplateList from '../../components/device/ResourceClaimTemplateList';
+import ResourceSliceDetails from '../../components/device/ResourceSliceDetails';
+import ResourceSliceList from '../../components/device/ResourceSliceList';
 import EndpointDetails from '../../components/endpoints/Details';
 import EndpointList from '../../components/endpoints/List';
 import EndpointSliceDetails from '../../components/endpointSlices/Details';
@@ -109,11 +117,11 @@ import PersistentVolumeClaimList from '../../components/storage/ClaimList';
 import StorageClassDetails from '../../components/storage/ClassDetails';
 import StorageClassList from '../../components/storage/ClassList';
 import VolumeAttributesClassDetails from '../../components/storage/VolumeAttributesClassDetails';
-import VolumeAttributesClassList from '../../components/storage/VolumeAttributesClassList';
 import PersistentVolumeDetails from '../../components/storage/VolumeDetails';
 import PersistentVolumeList from '../../components/storage/VolumeList';
 import VpaDetails from '../../components/verticalPodAutoscaler/Details';
 import VpaList from '../../components/verticalPodAutoscaler/List';
+import VolumeAttributesClassList from '../../components/volumeAttributesClass/List';
 import MutatingWebhookConfigurationDetails from '../../components/webhookconfiguration/MutatingWebhookConfigDetails';
 import MutatingWebhookConfigList from '../../components/webhookconfiguration/MutatingWebhookConfigList';
 import ValidatingWebhookConfigurationDetails from '../../components/webhookconfiguration/ValidatingWebhookConfigDetails';
@@ -1020,6 +1028,58 @@ const defaultRoutes: { [routeName: string]: Route } = {
     sidebar: 'map',
     isFullWidth: true,
     component: () => <LazyGraphView height="100%" />,
+  },
+  deviceClasses: {
+    path: '/deviceclasses',
+    name: 'Device Classes',
+    sidebar: 'deviceClasses',
+    exact: true,
+    component: () => <DeviceClassList />,
+  },
+  deviceClass: {
+    path: '/deviceclasses/:name',
+    sidebar: 'deviceClasses',
+    exact: true,
+    component: () => <DeviceClassDetails />,
+  },
+  resourceSlices: {
+    path: '/resourceslices',
+    name: 'Resource Slices',
+    sidebar: 'resourceSlices',
+    exact: true,
+    component: () => <ResourceSliceList />,
+  },
+  resourceSlice: {
+    path: '/resourceslices/:name',
+    sidebar: 'resourceSlices',
+    exact: true,
+    component: () => <ResourceSliceDetails />,
+  },
+  resourceClaims: {
+    path: '/resourceclaims',
+    name: 'Resource Claims',
+    sidebar: 'resourceClaims',
+    exact: true,
+    component: () => <ResourceClaimList />,
+  },
+  resourceClaim: {
+    path: '/namespaces/:namespace/resourceclaims/:name',
+    sidebar: 'resourceClaims',
+    exact: true,
+    component: () => <ResourceClaimDetails />,
+  },
+  resourceClaimTemplates: {
+    path: '/resourceclaimtemplates',
+    name: 'Resource Claim Templates',
+    sidebar: 'resourceClaimTemplates',
+    exact: true,
+    component: () => <ResourceClaimTemplateList />,
+  },
+  resourceClaimTemplate: {
+    path: '/namespaces/:namespace/resourceclaimtemplates/:name',
+    sidebar: 'resourceClaimTemplates',
+    exact: true,
+    component: () => <ResourceClaimTemplateDetails />,
   },
 };
 


### PR DESCRIPTION
**Summary:** Adds UI support and API models for Dynamic Resource Allocation (DRA) objects including `DeviceClass`, `ResourceSlice`, `ResourceClaim`, and `ResourceClaimTemplate`.

**Related Issue:** Fixes #7018

**Changes:**
- Added API models for `DeviceClass`, `ResourceSlice`, `ResourceClaim`, and `ResourceClaimTemplate` in `frontend/src/lib/k8s/`
- Created List and Details views for all objects in `frontend/src/components/device/`
- Registered routing under `frontend/src/lib/router/index.tsx`
- Added a new `Devices` category to the Sidebar Navigation
- Added localization strings for new components

**Steps to Test:**
1. Start the cluster and ensure the DRA feature gate is enabled.
2. Run `npm run frontend:start`
3. Navigate to the `Devices` section in the Sidebar
4. Verify the lists and details views render correctly without errors

**Screenshots:**
*(Screenshots to be attached by author)*

**Notes for the Reviewer:**
This is an extensive implementation of the DRA objects to position Headlamp as a leading GUI for AI/ML and hardware accelerator visibility. It mimics the structure used by the Storage resources.
