### PR TITLE
backend: add rate limiting to auth endpoints

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -720,26 +720,35 @@ func clientIP(r *http.Request, trustedProxyCIDRs []string) string {
 		return strings.TrimSpace(remoteHost)
 	}
 
-	for _, cidr := range trustedProxyCIDRs {
-		prefix, err := netip.ParsePrefix(strings.TrimSpace(cidr))
-		if err != nil {
-			continue
+	isTrusted := func(ip netip.Addr) bool {
+		for _, cidr := range trustedProxyCIDRs {
+			prefix, err := netip.ParsePrefix(strings.TrimSpace(cidr))
+			if err == nil && prefix.Contains(ip) {
+				return true
+			}
 		}
+		return false
+	}
 
-		if prefix.Contains(remoteIP) {
-			forwarded := strings.TrimSpace(r.Header.Get("X-Forwarded-For"))
-			if forwarded == "" {
-				break
+	if isTrusted(remoteIP) {
+		forwarded := strings.TrimSpace(r.Header.Get("X-Forwarded-For"))
+		if forwarded != "" {
+			ips := strings.Split(forwarded, ",")
+			for i := len(ips) - 1; i >= 0; i-- {
+				ipStr := strings.TrimSpace(ips[i])
+				if ipStr == "" {
+					continue
+				}
+
+				parsed, err := netip.ParseAddr(ipStr)
+				if err != nil {
+					return remoteIP.String()
+				}
+
+				if !isTrusted(parsed) {
+					return parsed.String()
+				}
 			}
-
-			// X-Forwarded-For is a comma-separated list.
-			// The first address is the original client.
-			client := strings.TrimSpace(strings.Split(forwarded, ",")[0])
-			if parsed, err := netip.ParseAddr(client); err == nil {
-				return parsed.String()
-			}
-
-			break
 		}
 	}
 
@@ -1070,8 +1079,16 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		http.HandlerFunc(config.getConfig))).Methods("GET")
 
 	// Auth token management
-	r.Handle("/auth/set-token", auth.NewBackendTokenMiddleware(config.UseInCluster)(
-		authRateLimitMiddleware(config.TrustedProxyCIDRs, config.handleSetToken))).Methods("POST")
+	setTokenHandler := auth.NewBackendTokenMiddleware(config.UseInCluster)(
+		http.HandlerFunc(config.handleSetToken),
+	)
+
+	r.Handle("/auth/set-token",
+		authRateLimitMiddleware(
+			config.TrustedProxyCIDRs,
+			setTokenHandler.ServeHTTP,
+		),
+	).Methods("POST")
 
 	// Websocket connections
 	if config.Multiplexer != nil {
@@ -2125,9 +2142,16 @@ func clusterRequestHandler(c *HeadlampConfig) http.Handler { //nolint:funlen
 // It parses the request and creates a proxy request to the cluster.
 // That proxy is saved in the cache with the context key.
 func handleClusterAPI(c *HeadlampConfig, router *mux.Router) {
+	setTokenHandler := auth.NewBackendTokenMiddleware(c.UseInCluster)(
+		http.HandlerFunc(c.handleSetToken),
+	)
+
 	router.Handle("/clusters/{clusterName}/set-token",
-		auth.NewBackendTokenMiddleware(c.UseInCluster)(
-			authRateLimitMiddleware(c.TrustedProxyCIDRs, c.handleSetToken))).Methods("POST")
+		authRateLimitMiddleware(
+			c.TrustedProxyCIDRs,
+			setTokenHandler.ServeHTTP,
+		),
+	).Methods("POST")
 
 	handler := clusterRequestHandler(c)
 	if c.CacheEnabled {

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -74,6 +74,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	"golang.org/x/oauth2"
+	"golang.org/x/time/rate"
 )
 
 type HeadlampConfig struct {
@@ -569,6 +570,41 @@ func setupInClusterContext(config *HeadlampConfig) {
 	}
 }
 
+var (
+	authLimiterMu sync.Mutex
+	authLimiters  = make(map[string]*rate.Limiter)
+)
+
+func getAuthLimiter(ip string) *rate.Limiter {
+	authLimiterMu.Lock()
+	defer authLimiterMu.Unlock()
+
+	limiter, exists := authLimiters[ip]
+	if !exists {
+		limiter = rate.NewLimiter(5, 10)
+		authLimiters[ip] = limiter
+	}
+	return limiter
+}
+
+func authRateLimitMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ip, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			ip = r.RemoteAddr
+		}
+		if forwarded := r.Header.Get("X-Forwarded-For"); forwarded != "" {
+			ip = strings.Split(forwarded, ",")[0]
+		}
+		
+		if !getAuthLimiter(strings.TrimSpace(ip)).Allow() {
+			http.Error(w, "Too many requests", http.StatusTooManyRequests)
+			return
+		}
+		next.ServeHTTP(w, r)
+	}
+}
+
 //nolint:gocognit,funlen,gocyclo
 func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Handler {
 	kubeConfigPath := config.KubeConfigPath
@@ -848,7 +884,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 	r.HandleFunc("/config", config.getConfig).Methods("GET")
 
 	// Auth token management
-	r.HandleFunc("/auth/set-token", config.handleSetToken).Methods("POST")
+	r.HandleFunc("/auth/set-token", authRateLimitMiddleware(config.handleSetToken)).Methods("POST")
 
 	// Websocket connections
 	if config.Multiplexer != nil {
@@ -879,7 +915,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		}
 	}()
 
-	r.HandleFunc("/oidc", func(w http.ResponseWriter, r *http.Request) {
+	r.HandleFunc("/oidc", authRateLimitMiddleware(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.Background()
 		cluster := r.URL.Query().Get("cluster")
 
@@ -1007,7 +1043,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 	r.HandleFunc("/drain-node-status",
 		config.handleNodeDrainStatus).Methods("GET").Queries("cluster", "{cluster}", "nodeName", "{node}")
 
-	r.HandleFunc("/oidc-callback", func(w http.ResponseWriter, r *http.Request) {
+	r.HandleFunc("/oidc-callback", authRateLimitMiddleware(func(w http.ResponseWriter, r *http.Request) {
 		// Shadow createHeadlampHandler's outer-scope err so any log call in
 		// this handler is guaranteed to reference this closure's err and
 		// never the startup kubeconfig-load error. See issue #4839.

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -30,6 +30,7 @@ import (
 	"io/fs"
 	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"os"
 	"os/signal"
@@ -75,6 +76,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	"golang.org/x/oauth2"
+	"golang.org/x/time/rate"
 )
 
 type HeadlampConfig struct {
@@ -658,6 +660,104 @@ func loadDynamicClusters(config *HeadlampConfig, path string, skipFunc func(kube
 	}
 }
 
+type authLimiterEntry struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+var (
+	authLimiterMu   sync.Mutex
+	authLimiters    = make(map[string]*authLimiterEntry)
+	authLimiterOnce sync.Once
+)
+
+func getAuthLimiter(ip string) *rate.Limiter {
+	authLimiterOnce.Do(func() {
+		go func() {
+			for {
+				time.Sleep(5 * time.Minute)
+				cleanupAuthLimiters(10 * time.Minute)
+			}
+		}()
+	})
+
+	authLimiterMu.Lock()
+	defer authLimiterMu.Unlock()
+
+	entry, exists := authLimiters[ip]
+	if !exists {
+		entry = &authLimiterEntry{
+			limiter: rate.NewLimiter(5, 10),
+		}
+		authLimiters[ip] = entry
+	}
+	entry.lastSeen = time.Now()
+	return entry.limiter
+}
+
+func cleanupAuthLimiters(ttl time.Duration) {
+	cutoff := time.Now().Add(-ttl)
+
+	authLimiterMu.Lock()
+	defer authLimiterMu.Unlock()
+
+	for ip, entry := range authLimiters {
+		if entry.lastSeen.Before(cutoff) {
+			delete(authLimiters, ip)
+		}
+	}
+}
+
+func clientIP(r *http.Request, trustedProxyCIDRs []string) string {
+	remoteHost, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		remoteHost = r.RemoteAddr
+	}
+
+	remoteIP, err := netip.ParseAddr(strings.TrimSpace(remoteHost))
+	if err != nil {
+		return strings.TrimSpace(remoteHost)
+	}
+
+	for _, cidr := range trustedProxyCIDRs {
+		prefix, err := netip.ParsePrefix(strings.TrimSpace(cidr))
+		if err != nil {
+			continue
+		}
+
+		if prefix.Contains(remoteIP) {
+			forwarded := strings.TrimSpace(r.Header.Get("X-Forwarded-For"))
+			if forwarded == "" {
+				break
+			}
+
+			// X-Forwarded-For is a comma-separated list.
+			// The first address is the original client.
+			client := strings.TrimSpace(strings.Split(forwarded, ",")[0])
+			if parsed, err := netip.ParseAddr(client); err == nil {
+				return parsed.String()
+			}
+
+			break
+		}
+	}
+
+	return remoteIP.String()
+}
+
+func authRateLimitMiddleware(trustedProxyCIDRs []string, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ip := clientIP(r, trustedProxyCIDRs)
+
+		if !getAuthLimiter(ip).Allow() {
+			http.Error(w, "Too many requests", http.StatusTooManyRequests)
+			return
+		}
+		next.ServeHTTP(w, r)
+
+	}
+}
+
 //nolint:gocognit,funlen,gocyclo
 func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Handler {
 	kubeConfigPath := config.KubeConfigPath
@@ -970,7 +1070,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 
 	// Auth token management
 	r.Handle("/auth/set-token", auth.NewBackendTokenMiddleware(config.UseInCluster)(
-		http.HandlerFunc(config.handleSetToken))).Methods("POST")
+		authRateLimitMiddleware(config.TrustedProxyCIDRs, config.handleSetToken))).Methods("POST")
 
 	// Websocket connections
 	if config.Multiplexer != nil {
@@ -1003,7 +1103,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		}
 	}()
 
-	r.HandleFunc("/oidc", func(w http.ResponseWriter, r *http.Request) {
+	r.HandleFunc("/oidc", authRateLimitMiddleware(config.TrustedProxyCIDRs, func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.Background()
 		cluster := r.URL.Query().Get("cluster")
 
@@ -1125,7 +1225,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		oauthMu.Unlock()
 
 		http.Redirect(w, r, authURL, http.StatusFound)
-	}).Queries("cluster", "{cluster}")
+	})).Queries("cluster", "{cluster}")
 
 	r.Handle("/drain-node",
 		auth.NewBackendTokenMiddleware(config.UseInCluster)(http.HandlerFunc(config.handleNodeDrain))).Methods("POST")
@@ -1133,7 +1233,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		auth.NewBackendTokenMiddleware(config.UseInCluster)(http.HandlerFunc(
 			config.handleNodeDrainStatus))).Methods("GET").Queries("cluster", "{cluster}", "nodeName", "{node}")
 
-	r.HandleFunc("/oidc-callback", func(w http.ResponseWriter, r *http.Request) {
+	r.HandleFunc("/oidc-callback", authRateLimitMiddleware(config.TrustedProxyCIDRs, func(w http.ResponseWriter, r *http.Request) {
 		// Shadow createHeadlampHandler's outer-scope err so any log call in
 		// this handler is guaranteed to reference this closure's err and
 		// never the startup kubeconfig-load error. See issue #4839.
@@ -1247,7 +1347,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		redirectURL += fmt.Sprintf("auth?cluster=%1s", oauthConfig.Cluster)
 
 		http.Redirect(w, r, redirectURL, http.StatusSeeOther)
-	})
+	}))
 
 	// Serve the frontend if needed
 	if spa.UseEmbeddedFiles {
@@ -2024,7 +2124,8 @@ func clusterRequestHandler(c *HeadlampConfig) http.Handler { //nolint:funlen
 // That proxy is saved in the cache with the context key.
 func handleClusterAPI(c *HeadlampConfig, router *mux.Router) {
 	router.Handle("/clusters/{clusterName}/set-token",
-		auth.NewBackendTokenMiddleware(c.UseInCluster)(http.HandlerFunc(c.handleSetToken))).Methods("POST")
+		auth.NewBackendTokenMiddleware(c.UseInCluster)(
+			authRateLimitMiddleware(c.TrustedProxyCIDRs, c.handleSetToken))).Methods("POST")
 
 	handler := clusterRequestHandler(c)
 	if c.CacheEnabled {

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -671,6 +671,7 @@ var (
 	authLimiterOnce sync.Once
 )
 
+//nolint:wsl_v5
 func getAuthLimiter(ip string) *rate.Limiter {
 	authLimiterOnce.Do(func() {
 		go func() {
@@ -745,6 +746,7 @@ func clientIP(r *http.Request, trustedProxyCIDRs []string) string {
 	return remoteIP.String()
 }
 
+//nolint:wsl_v5
 func authRateLimitMiddleware(trustedProxyCIDRs []string, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ip := clientIP(r, trustedProxyCIDRs)
@@ -754,7 +756,6 @@ func authRateLimitMiddleware(trustedProxyCIDRs []string, next http.HandlerFunc) 
 			return
 		}
 		next.ServeHTTP(w, r)
-
 	}
 }
 
@@ -1233,121 +1234,122 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		auth.NewBackendTokenMiddleware(config.UseInCluster)(http.HandlerFunc(
 			config.handleNodeDrainStatus))).Methods("GET").Queries("cluster", "{cluster}", "nodeName", "{node}")
 
-	r.HandleFunc("/oidc-callback", authRateLimitMiddleware(config.TrustedProxyCIDRs, func(w http.ResponseWriter, r *http.Request) {
-		// Shadow createHeadlampHandler's outer-scope err so any log call in
-		// this handler is guaranteed to reference this closure's err and
-		// never the startup kubeconfig-load error. See issue #4839.
-		var err error
+	r.HandleFunc("/oidc-callback",
+		authRateLimitMiddleware(config.TrustedProxyCIDRs, func(w http.ResponseWriter, r *http.Request) {
+			// Shadow createHeadlampHandler's outer-scope err so any log call in
+			// this handler is guaranteed to reference this closure's err and
+			// never the startup kubeconfig-load error. See issue #4839.
+			var err error
 
-		state := r.URL.Query().Get("state")
+			state := r.URL.Query().Get("state")
 
-		if state == "" {
-			logger.Log(logger.LevelError, nil, nil, "invalid request state is empty")
-			http.Error(w, "invalid request state is empty", http.StatusBadRequest)
+			if state == "" {
+				logger.Log(logger.LevelError, nil, nil, "invalid request state is empty")
+				http.Error(w, "invalid request state is empty", http.StatusBadRequest)
 
-			return
-		}
+				return
+			}
 
-		oauthMu.Lock()
+			oauthMu.Lock()
 
-		oauthConfig, ok := oauthRequestMap[state]
-		if ok {
-			// We have a copy of the oauthConfig, we can delete the map entry now
-			delete(oauthRequestMap, state)
-		}
+			oauthConfig, ok := oauthRequestMap[state]
+			if ok {
+				// We have a copy of the oauthConfig, we can delete the map entry now
+				delete(oauthRequestMap, state)
+			}
 
-		oauthMu.Unlock()
+			oauthMu.Unlock()
 
-		if !ok {
-			http.Error(w, "invalid request", http.StatusBadRequest)
-			return
-		}
+			if !ok {
+				http.Error(w, "invalid request", http.StatusBadRequest)
+				return
+			}
 
-		var oauth2Token *oauth2.Token
+			var oauth2Token *oauth2.Token
 
-		// Exchange authorization code for token, with or without PKCE
-		if config.OidcUsePKCE && oauthConfig.CodeVerifier != "" {
-			// Use PKCE code verifier for token exchange
-			oauth2Token, err = oauthConfig.Config.Exchange(
-				oauthConfig.Ctx,
-				r.URL.Query().Get("code"),
-				oauth2.SetAuthURLParam("code_verifier", oauthConfig.CodeVerifier),
-			)
-		} else {
-			// Standard token exchange without PKCE
-			oauth2Token, err = oauthConfig.Config.Exchange(
-				oauthConfig.Ctx,
-				r.URL.Query().Get("code"),
-			)
-		}
+			// Exchange authorization code for token, with or without PKCE
+			if config.OidcUsePKCE && oauthConfig.CodeVerifier != "" {
+				// Use PKCE code verifier for token exchange
+				oauth2Token, err = oauthConfig.Config.Exchange(
+					oauthConfig.Ctx,
+					r.URL.Query().Get("code"),
+					oauth2.SetAuthURLParam("code_verifier", oauthConfig.CodeVerifier),
+				)
+			} else {
+				// Standard token exchange without PKCE
+				oauth2Token, err = oauthConfig.Config.Exchange(
+					oauthConfig.Ctx,
+					r.URL.Query().Get("code"),
+				)
+			}
 
-		if err != nil {
-			logger.Log(logger.LevelError, nil, err, "failed to exchange token")
-			http.Error(w, "Failed to exchange token: "+err.Error(), http.StatusInternalServerError)
+			if err != nil {
+				logger.Log(logger.LevelError, nil, err, "failed to exchange token")
+				http.Error(w, "Failed to exchange token: "+err.Error(), http.StatusInternalServerError)
 
-			return
-		}
+				return
+			}
 
-		tokenType := "id_token"
-		if config.OidcUseAccessToken {
-			tokenType = "access_token"
-		}
+			tokenType := "id_token"
+			if config.OidcUseAccessToken {
+				tokenType = "access_token"
+			}
 
-		rawUserToken, ok := oauth2Token.Extra(tokenType).(string)
-		if !ok {
-			logger.Log(logger.LevelError, nil, err, fmt.Sprintf("no %s field in oauth2 token", tokenType))
-			http.Error(w, fmt.Sprintf("No %s field in oauth2 token.", tokenType), http.StatusInternalServerError)
+			rawUserToken, ok := oauth2Token.Extra(tokenType).(string)
+			if !ok {
+				logger.Log(logger.LevelError, nil, err, fmt.Sprintf("no %s field in oauth2 token", tokenType))
+				http.Error(w, fmt.Sprintf("No %s field in oauth2 token.", tokenType), http.StatusInternalServerError)
 
-			return
-		}
+				return
+			}
 
-		if err := config.Cache.Set(context.Background(),
-			fmt.Sprintf("oidc-token-%s", rawUserToken), oauth2Token.RefreshToken); err != nil {
-			logger.Log(logger.LevelError, nil, err, "failed to cache refresh token")
-			http.Error(w, "Failed to cache refresh token: "+err.Error(), http.StatusInternalServerError)
+			if err := config.Cache.Set(context.Background(),
+				fmt.Sprintf("oidc-token-%s", rawUserToken), oauth2Token.RefreshToken); err != nil {
+				logger.Log(logger.LevelError, nil, err, "failed to cache refresh token")
+				http.Error(w, "Failed to cache refresh token: "+err.Error(), http.StatusInternalServerError)
 
-			return
-		}
+				return
+			}
 
-		idToken, err := oauthConfig.Verifier.Verify(oauthConfig.Ctx, rawUserToken)
-		if err != nil {
-			logger.Log(logger.LevelError, nil, err, "failed to verify ID Token")
-			http.Error(w, "Failed to verify ID Token: "+err.Error(), http.StatusInternalServerError)
+			idToken, err := oauthConfig.Verifier.Verify(oauthConfig.Ctx, rawUserToken)
+			if err != nil {
+				logger.Log(logger.LevelError, nil, err, "failed to verify ID Token")
+				http.Error(w, "Failed to verify ID Token: "+err.Error(), http.StatusInternalServerError)
 
-			return
-		}
+				return
+			}
 
-		resp := struct {
-			OAuth2Token   *oauth2.Token
-			IDTokenClaims *json.RawMessage // ID Token payload is just JSON.
-		}{oauth2Token, new(json.RawMessage)}
+			resp := struct {
+				OAuth2Token   *oauth2.Token
+				IDTokenClaims *json.RawMessage // ID Token payload is just JSON.
+			}{oauth2Token, new(json.RawMessage)}
 
-		if err := idToken.Claims(&resp.IDTokenClaims); err != nil {
-			logger.Log(logger.LevelError, nil, err, "failed to get id token claims")
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			if err := idToken.Claims(&resp.IDTokenClaims); err != nil {
+				logger.Log(logger.LevelError, nil, err, "failed to get id token claims")
+				http.Error(w, err.Error(), http.StatusInternalServerError)
 
-			return
-		}
+				return
+			}
 
-		var redirectURL string
-		if config.DevMode {
-			redirectURL = "http://localhost:3000/"
-		} else {
-			redirectURL = "/"
-		}
+			var redirectURL string
+			if config.DevMode {
+				redirectURL = "http://localhost:3000/"
+			} else {
+				redirectURL = "/"
+			}
 
-		baseURL := strings.Trim(config.BaseURL, "/")
-		if baseURL != "" {
-			redirectURL += baseURL + "/"
-		}
+			baseURL := strings.Trim(config.BaseURL, "/")
+			if baseURL != "" {
+				redirectURL += baseURL + "/"
+			}
 
-		// Set auth cookie
-		auth.SetTokenCookie(w, r, oauthConfig.Cluster, rawUserToken, config.BaseURL, config.SessionTTL)
+			// Set auth cookie
+			auth.SetTokenCookie(w, r, oauthConfig.Cluster, rawUserToken, config.BaseURL, config.SessionTTL)
 
-		redirectURL += fmt.Sprintf("auth?cluster=%1s", oauthConfig.Cluster)
+			redirectURL += fmt.Sprintf("auth?cluster=%1s", oauthConfig.Cluster)
 
-		http.Redirect(w, r, redirectURL, http.StatusSeeOther)
-	}))
+			http.Redirect(w, r, redirectURL, http.StatusSeeOther)
+		}))
 
 	// Serve the frontend if needed
 	if spa.UseEmbeddedFiles {

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -4628,10 +4628,19 @@ func TestAuthLimiterCleanup(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
+
 			getAuthLimiter(fmt.Sprintf("10.0.0.%d", i%10))
 		}(i)
 	}
+
 	wg.Wait()
+}
+
+func resetAuthLimiters() {
+	authLimiterMu.Lock()
+	defer authLimiterMu.Unlock()
+
+	authLimiters = make(map[string]*authLimiterEntry)
 }
 
 func TestAuthRateLimitMiddleware_XForwardedFor(t *testing.T) {
@@ -4640,22 +4649,21 @@ func TestAuthRateLimitMiddleware_XForwardedFor(t *testing.T) {
 	})
 
 	t.Run("untrusted proxy ignores X-Forwarded-For", func(t *testing.T) {
-		authLimiterMu.Lock()
-		authLimiters = make(map[string]*authLimiterEntry)
-		authLimiterMu.Unlock()
+		resetAuthLimiters()
 
 		middleware := authRateLimitMiddleware(
 			[]string{"10.0.0.0/8"},
 			dummyHandler,
 		)
 
-		req := httptest.NewRequest("GET", "/auth", nil)
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "/auth", nil)
 		req.RemoteAddr = "192.168.1.100:12345"
 		req.Header.Set("X-Forwarded-For", "10.0.0.1")
 
 		// Exhaust the bucket for the actual remote IP.
 		for i := 0; i < 10; i++ {
 			rr := httptest.NewRecorder()
+
 			middleware.ServeHTTP(rr, req)
 			assert.Equal(t, http.StatusOK, rr.Code)
 		}
@@ -4663,6 +4671,7 @@ func TestAuthRateLimitMiddleware_XForwardedFor(t *testing.T) {
 		// The peer is not trusted, so changing X-Forwarded-For
 		// must not create a new rate-limit bucket.
 		req.Header.Set("X-Forwarded-For", "10.0.0.2")
+
 		rr := httptest.NewRecorder()
 		middleware.ServeHTTP(rr, req)
 
@@ -4670,22 +4679,21 @@ func TestAuthRateLimitMiddleware_XForwardedFor(t *testing.T) {
 	})
 
 	t.Run("trusted proxy uses X-Forwarded-For", func(t *testing.T) {
-		authLimiterMu.Lock()
-		authLimiters = make(map[string]*authLimiterEntry)
-		authLimiterMu.Unlock()
+		resetAuthLimiters()
 
 		middleware := authRateLimitMiddleware(
 			[]string{"192.168.1.0/24"},
 			dummyHandler,
 		)
 
-		req := httptest.NewRequest("GET", "/auth", nil)
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "/auth", nil)
 		req.RemoteAddr = "192.168.1.100:12345"
 		req.Header.Set("X-Forwarded-For", "10.0.0.1")
 
 		// Exhaust the bucket for client 10.0.0.1.
 		for i := 0; i < 10; i++ {
 			rr := httptest.NewRecorder()
+
 			middleware.ServeHTTP(rr, req)
 			assert.Equal(t, http.StatusOK, rr.Code)
 		}
@@ -4693,12 +4701,14 @@ func TestAuthRateLimitMiddleware_XForwardedFor(t *testing.T) {
 		// The proxy is trusted, so a different forwarded client
 		// should get a separate rate-limit bucket.
 		req.Header.Set("X-Forwarded-For", "10.0.0.2")
+
 		rr := httptest.NewRecorder()
 		middleware.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
 	})
 }
+
 func TestAuthRateLimitMiddleware_BurstAnd429(t *testing.T) {
 	// Reset state
 	authLimiterMu.Lock()
@@ -4710,7 +4720,7 @@ func TestAuthRateLimitMiddleware_BurstAnd429(t *testing.T) {
 	})
 	middleware := authRateLimitMiddleware(nil, dummyHandler)
 
-	req := httptest.NewRequest("GET", "/auth", nil)
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/auth", nil)
 	req.RemoteAddr = "10.1.1.1:12345"
 
 	// Exhaust the burst of 10
@@ -4737,7 +4747,7 @@ func TestAuthRateLimitMiddleware_Refill(t *testing.T) {
 	})
 	middleware := authRateLimitMiddleware(nil, dummyHandler)
 
-	req := httptest.NewRequest("GET", "/auth", nil)
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/auth", nil)
 	req.RemoteAddr = "10.2.2.2:12345"
 
 	// Exhaust the burst of 10
@@ -4767,21 +4777,23 @@ func TestAuthRateLimitMiddleware_Isolation(t *testing.T) {
 	})
 	middleware := authRateLimitMiddleware(nil, dummyHandler)
 
-	reqA := httptest.NewRequest("GET", "/auth", nil)
+	reqA := httptest.NewRequestWithContext(context.Background(), "GET", "/auth", nil)
 	reqA.RemoteAddr = "10.3.3.3:12345"
 
 	// Exhaust burst for Client A
 	for i := 0; i < 10; i++ {
 		rr := httptest.NewRecorder()
+
 		middleware.ServeHTTP(rr, reqA)
 		assert.Equal(t, http.StatusOK, rr.Code)
 	}
+
 	rrA := httptest.NewRecorder()
 	middleware.ServeHTTP(rrA, reqA)
 	assert.Equal(t, http.StatusTooManyRequests, rrA.Code)
 
 	// Client B should still be allowed
-	reqB := httptest.NewRequest("GET", "/auth", nil)
+	reqB := httptest.NewRequestWithContext(context.Background(), "GET", "/auth", nil)
 	reqB.RemoteAddr = "10.4.4.4:12345"
 	rrB := httptest.NewRecorder()
 	middleware.ServeHTTP(rrB, reqB)

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -1771,6 +1771,55 @@ func assertRouteRequiresBackendToken(t *testing.T, method, path string, body int
 	}
 }
 
+func TestSetTokenInvalidRequestsAreRateLimited(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "auth set-token",
+			path: "/auth/set-token",
+		},
+		{
+			name: "cluster set-token",
+			path: "/clusters/" + minikubeName + "/set-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetAuthLimiters()
+
+			const validToken = "valid-token-for-test"
+			t.Setenv("HEADLAMP_BACKEND_TOKEN", validToken)
+
+			handler := newRestrictedEndpointsHandler(t)
+
+			for i := 0; i < 10; i++ {
+				req, err := makeJSONReq(http.MethodPost, tt.path, nil)
+				require.NoError(t, err)
+
+				req.Header.Set("X-HEADLAMP-BACKEND-TOKEN", "invalid-token")
+
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+
+				assert.Equal(t, http.StatusForbidden, rr.Code)
+			}
+
+			req, err := makeJSONReq(http.MethodPost, tt.path, nil)
+			require.NoError(t, err)
+
+			req.Header.Set("X-HEADLAMP-BACKEND-TOKEN", "invalid-token")
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusTooManyRequests, rr.Code)
+		})
+	}
+}
+
 // TestRestrictedEndpointsBypassedWithoutConfiguredToken preserves standalone
 // development and test servers where backend-token enforcement is not configured.
 func TestRestrictedEndpointsBypassedWithoutConfiguredToken(t *testing.T) {
@@ -4706,6 +4755,35 @@ func TestAuthRateLimitMiddleware_XForwardedFor(t *testing.T) {
 		middleware.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("spoofed leftmost X-Forwarded-For does not bypass rate limit", func(t *testing.T) {
+		resetAuthLimiters()
+
+		middleware := authRateLimitMiddleware(
+			[]string{"192.168.1.0/24", "10.0.0.0/8"},
+			dummyHandler,
+		)
+
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "/auth", nil)
+		req.RemoteAddr = "192.168.1.100:12345"
+		req.Header.Set("X-Forwarded-For", "8.8.8.8, 203.0.113.1, 10.0.0.5")
+
+		// Exhaust the bucket for actual client 203.0.113.1
+		for i := 0; i < 10; i++ {
+			rr := httptest.NewRecorder()
+			middleware.ServeHTTP(rr, req)
+			assert.Equal(t, http.StatusOK, rr.Code)
+		}
+
+		// Changing the spoofed leftmost IP should not bypass the rate limit,
+		// because the actual client IP (first untrusted from right) is still 203.0.113.1.
+		req.Header.Set("X-Forwarded-For", "9.9.9.9, 203.0.113.1, 10.0.0.5")
+
+		rr := httptest.NewRecorder()
+		middleware.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusTooManyRequests, rr.Code)
 	})
 }
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -4584,3 +4584,206 @@ func TestExternalProxyOversizeResponseGzip(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, int(maxProxyResponseSize), rr.Body.Len())
 }
+
+func TestAuthLimiterCleanup(t *testing.T) {
+	// Reset state for test isolation
+	authLimiterMu.Lock()
+	authLimiters = make(map[string]*authLimiterEntry)
+	authLimiterMu.Unlock()
+
+	ip := "192.168.1.1"
+
+	// 1. A limiter is created for an IP.
+	limiter1 := getAuthLimiter(ip)
+	assert.NotNil(t, limiter1)
+
+	authLimiterMu.Lock()
+	assert.Contains(t, authLimiters, ip)
+	authLimiterMu.Unlock()
+
+	// 2. Repeated requests reuse the same limiter while active.
+	limiter2 := getAuthLimiter(ip)
+	assert.Equal(t, limiter1, limiter2)
+
+	// Simulate inactive entry by backdating lastSeen
+	authLimiterMu.Lock()
+	authLimiters[ip].lastSeen = time.Now().Add(-20 * time.Minute)
+	authLimiterMu.Unlock()
+
+	// 3. An inactive/expired limiter can eventually be removed.
+	cleanupAuthLimiters(10 * time.Minute)
+
+	authLimiterMu.Lock()
+	assert.NotContains(t, authLimiters, ip)
+	authLimiterMu.Unlock()
+
+	// 4. Creating a new request after cleanup creates a new limiter.
+	limiter3 := getAuthLimiter(ip)
+	assert.NotNil(t, limiter3)
+	assert.NotSame(t, limiter1, limiter3, "A new limiter should be created")
+
+	// 5. Concurrent access does not cause a race.
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			getAuthLimiter(fmt.Sprintf("10.0.0.%d", i%10))
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestAuthRateLimitMiddleware_XForwardedFor(t *testing.T) {
+	dummyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("untrusted proxy ignores X-Forwarded-For", func(t *testing.T) {
+		authLimiterMu.Lock()
+		authLimiters = make(map[string]*authLimiterEntry)
+		authLimiterMu.Unlock()
+
+		middleware := authRateLimitMiddleware(
+			[]string{"10.0.0.0/8"},
+			dummyHandler,
+		)
+
+		req := httptest.NewRequest("GET", "/auth", nil)
+		req.RemoteAddr = "192.168.1.100:12345"
+		req.Header.Set("X-Forwarded-For", "10.0.0.1")
+
+		// Exhaust the bucket for the actual remote IP.
+		for i := 0; i < 10; i++ {
+			rr := httptest.NewRecorder()
+			middleware.ServeHTTP(rr, req)
+			assert.Equal(t, http.StatusOK, rr.Code)
+		}
+
+		// The peer is not trusted, so changing X-Forwarded-For
+		// must not create a new rate-limit bucket.
+		req.Header.Set("X-Forwarded-For", "10.0.0.2")
+		rr := httptest.NewRecorder()
+		middleware.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusTooManyRequests, rr.Code)
+	})
+
+	t.Run("trusted proxy uses X-Forwarded-For", func(t *testing.T) {
+		authLimiterMu.Lock()
+		authLimiters = make(map[string]*authLimiterEntry)
+		authLimiterMu.Unlock()
+
+		middleware := authRateLimitMiddleware(
+			[]string{"192.168.1.0/24"},
+			dummyHandler,
+		)
+
+		req := httptest.NewRequest("GET", "/auth", nil)
+		req.RemoteAddr = "192.168.1.100:12345"
+		req.Header.Set("X-Forwarded-For", "10.0.0.1")
+
+		// Exhaust the bucket for client 10.0.0.1.
+		for i := 0; i < 10; i++ {
+			rr := httptest.NewRecorder()
+			middleware.ServeHTTP(rr, req)
+			assert.Equal(t, http.StatusOK, rr.Code)
+		}
+
+		// The proxy is trusted, so a different forwarded client
+		// should get a separate rate-limit bucket.
+		req.Header.Set("X-Forwarded-For", "10.0.0.2")
+		rr := httptest.NewRecorder()
+		middleware.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+}
+func TestAuthRateLimitMiddleware_BurstAnd429(t *testing.T) {
+	// Reset state
+	authLimiterMu.Lock()
+	authLimiters = make(map[string]*authLimiterEntry)
+	authLimiterMu.Unlock()
+
+	dummyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	middleware := authRateLimitMiddleware(nil, dummyHandler)
+
+	req := httptest.NewRequest("GET", "/auth", nil)
+	req.RemoteAddr = "10.1.1.1:12345"
+
+	// Exhaust the burst of 10
+	for i := 0; i < 10; i++ {
+		rr := httptest.NewRecorder()
+		middleware.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+	}
+
+	// 11th should be 429
+	rr := httptest.NewRecorder()
+	middleware.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusTooManyRequests, rr.Code)
+}
+
+func TestAuthRateLimitMiddleware_Refill(t *testing.T) {
+	// Reset state
+	authLimiterMu.Lock()
+	authLimiters = make(map[string]*authLimiterEntry)
+	authLimiterMu.Unlock()
+
+	dummyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	middleware := authRateLimitMiddleware(nil, dummyHandler)
+
+	req := httptest.NewRequest("GET", "/auth", nil)
+	req.RemoteAddr = "10.2.2.2:12345"
+
+	// Exhaust the burst of 10
+	for i := 0; i < 10; i++ {
+		rr := httptest.NewRecorder()
+		middleware.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+	}
+
+	// Wait for 1 token to refill (rate is 5/s -> 1 token every 200ms)
+	time.Sleep(250 * time.Millisecond)
+
+	// Next request should succeed
+	rr := httptest.NewRecorder()
+	middleware.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestAuthRateLimitMiddleware_Isolation(t *testing.T) {
+	// Reset state
+	authLimiterMu.Lock()
+	authLimiters = make(map[string]*authLimiterEntry)
+	authLimiterMu.Unlock()
+
+	dummyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	middleware := authRateLimitMiddleware(nil, dummyHandler)
+
+	reqA := httptest.NewRequest("GET", "/auth", nil)
+	reqA.RemoteAddr = "10.3.3.3:12345"
+
+	// Exhaust burst for Client A
+	for i := 0; i < 10; i++ {
+		rr := httptest.NewRecorder()
+		middleware.ServeHTTP(rr, reqA)
+		assert.Equal(t, http.StatusOK, rr.Code)
+	}
+	rrA := httptest.NewRecorder()
+	middleware.ServeHTTP(rrA, reqA)
+	assert.Equal(t, http.StatusTooManyRequests, rrA.Code)
+
+	// Client B should still be allowed
+	reqB := httptest.NewRequest("GET", "/auth", nil)
+	reqB.RemoteAddr = "10.4.4.4:12345"
+	rrB := httptest.NewRecorder()
+	middleware.ServeHTTP(rrB, reqB)
+	assert.Equal(t, http.StatusOK, rrB.Code)
+}

--- a/backend/cmd/oidc_handlers_test.go
+++ b/backend/cmd/oidc_handlers_test.go
@@ -259,6 +259,53 @@ func callOIDCCallback(t *testing.T, handler http.Handler, rawQuery string) *http
 	return rr
 }
 
+func TestOIDCRoutesAreRateLimited(t *testing.T) {
+	tests := []struct {
+		name string
+		path func(cluster string) string
+	}{
+		{
+			name: "oidc",
+			path: func(cluster string) string {
+				return "/oidc?cluster=" + cluster
+			},
+		},
+		{
+			name: "oidc callback",
+			path: func(string) string {
+				return "/oidc-callback"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oidcSrv := newOIDCTestServer(t, nil)
+			handler, cluster := newOIDCTestHandler(t, oidcSrv)
+
+			path := tt.path(cluster)
+
+			for i := 0; i < 10; i++ {
+				req := httptest.NewRequest(http.MethodGet, path, nil)
+				req.RemoteAddr = "192.0.2.1:1234"
+
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+
+				assert.NotEqual(t, http.StatusTooManyRequests, rr.Code)
+			}
+
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.RemoteAddr = "192.0.2.1:1234"
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusTooManyRequests, rr.Code)
+		})
+	}
+}
+
 // TestOIDCStart_StateIsRandom32Bytes covers target #1: each /oidc call
 // issues a fresh, base64-url-encoded 32-byte random state.
 func TestOIDCStart_StateIsRandom32Bytes(t *testing.T) {

--- a/backend/cmd/oidc_handlers_test.go
+++ b/backend/cmd/oidc_handlers_test.go
@@ -166,6 +166,10 @@ func withStateReader(r io.Reader) oidcTestOption {
 func newOIDCTestHandler(t *testing.T, oidcSrv *oidcTestServer, opts ...oidcTestOption) (http.Handler, string) {
 	t.Helper()
 
+	authLimiterMu.Lock()
+	authLimiters = make(map[string]*authLimiterEntry)
+	authLimiterMu.Unlock()
+
 	const clusterName = "oidc-char-test"
 
 	kubeConfigStore := kubeconfig.NewContextStore()

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -110,6 +110,13 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 
 			return strings.Split(conf.ProxyURLs, ",")
 		}(),
+		TrustedProxyCIDRs: func() []string {
+			if conf.TrustedProxyCIDRs == "" {
+				return []string{}
+			}
+
+			return strings.Split(conf.TrustedProxyCIDRs, ",")
+		}(),
 		ClusterInventoryProviderFile:          conf.ClusterInventoryProviderFile,
 		ClusterInventoryLabelSelector:         conf.ClusterInventoryLabelSelector,
 		ClusterInventoryNamespaces:            conf.ClusterInventoryNamespaces,

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -47,6 +47,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/term v0.44.0
+	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/streaming v0.36.1
@@ -160,7 +161,6 @@ require (
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/grpc v1.82.1 // indirect

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -203,7 +203,7 @@ func (c *Config) validateTrustedProxyCIDRs() error {
 	for _, cidr := range strings.Split(c.TrustedProxyCIDRs, ",") {
 		cidr = strings.TrimSpace(cidr)
 		if cidr == "" {
-			continue
+			return errors.New("trusted-proxy-cidrs cannot contain empty entries")
 		}
 		if _, err := netip.ParsePrefix(cidr); err != nil {
 			return fmt.Errorf("invalid trusted-proxy-cidrs entry %q: %w", cidr, err)

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io/fs"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -187,6 +188,27 @@ func (c *Config) Validate() error {
 		return err
 	}
 
+	if err := c.validateTrustedProxyCIDRs(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Config) validateTrustedProxyCIDRs() error {
+	if c.TrustedProxyCIDRs == "" {
+		return nil
+	}
+
+	for _, cidr := range strings.Split(c.TrustedProxyCIDRs, ",") {
+		cidr = strings.TrimSpace(cidr)
+		if cidr == "" {
+			continue
+		}
+		if _, err := netip.ParsePrefix(cidr); err != nil {
+			return fmt.Errorf("invalid trusted-proxy-cidrs entry %q: %w", cidr, err)
+		}
+	}
 	return nil
 }
 

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -67,6 +67,7 @@ type Config struct {
 	NodeShellImage         string `koanf:"node-shell-image"`
 	NodeShellNamespace     string `koanf:"node-shell-namespace"`
 	ProxyURLs              string `koanf:"proxy-urls"`
+	TrustedProxyCIDRs      string `koanf:"trusted-proxy-cidrs"`
 
 	ClusterInventoryProviderFile          string        `koanf:"cluster-inventory-provider-file"`
 	ClusterInventoryLabelSelector         string        `koanf:"cluster-inventory-label-selector"`
@@ -629,6 +630,7 @@ func addGeneralFlags(f *flag.FlagSet, appName string) {
 	f.String("listen-addr", "", "Address to listen on; default is empty, which means listening to any address")
 	f.Uint("port", defaultPort, "Port to listen from")
 	f.String("proxy-urls", "", "Allow proxy requests to specified URLs")
+	f.String("trusted-proxy-cidrs", "", "Comma-separated CIDRs of trusted proxies for client IP detection")
 	f.Bool("enable-helm", false, "Enable Helm operations")
 	f.Bool("enable-cluster-inventory", false,
 		"Enable experimental/alpha automatic discovery of clusters from ClusterProfile resources")

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -160,27 +160,39 @@ func TestValidateTrustedProxyCIDRs(t *testing.T) {
 	tests := []struct {
 		name        string
 		cidrs       string
-		expectError bool
+		expectError string
 	}{
 		{
-			name:        "empty trusted-proxy-cidrs is valid",
-			cidrs:       "",
-			expectError: false,
+			name:  "empty trusted-proxy-cidrs is valid",
+			cidrs: "",
 		},
 		{
-			name:        "valid single CIDR is valid",
-			cidrs:       "192.168.1.0/24",
-			expectError: false,
+			name:  "valid single CIDR is valid",
+			cidrs: "192.168.1.0/24",
 		},
 		{
-			name:        "valid comma-separated CIDRs are valid",
-			cidrs:       "10.0.0.0/8, 192.168.1.0/24",
-			expectError: false,
+			name:  "valid comma-separated CIDRs are valid",
+			cidrs: "10.0.0.0/8, 192.168.1.0/24",
 		},
 		{
 			name:        "invalid CIDR causes validation to fail",
 			cidrs:       "10.0.0.0/8, invalid-cidr",
-			expectError: true,
+			expectError: "invalid trusted-proxy-cidrs entry",
+		},
+		{
+			name:        "trailing empty CIDR entry causes validation to fail",
+			cidrs:       "10.0.0.0/8,",
+			expectError: "trusted-proxy-cidrs cannot contain empty entries",
+		},
+		{
+			name:        "leading empty CIDR entry causes validation to fail",
+			cidrs:       ",10.0.0.0/8",
+			expectError: "trusted-proxy-cidrs cannot contain empty entries",
+		},
+		{
+			name:        "empty CIDR entry between CIDRs causes validation to fail",
+			cidrs:       "10.0.0.0/8,,192.168.1.0/24",
+			expectError: "trusted-proxy-cidrs cannot contain empty entries",
 		},
 	}
 
@@ -190,9 +202,10 @@ func TestValidateTrustedProxyCIDRs(t *testing.T) {
 				"headlamp-server",
 				"--trusted-proxy-cidrs=" + tt.cidrs,
 			})
-			if tt.expectError {
+
+			if tt.expectError != "" {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "invalid trusted-proxy-cidrs entry")
+				assert.Contains(t, err.Error(), tt.expectError)
 			} else {
 				require.NoError(t, err)
 			}

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -156,6 +156,50 @@ func TestParseTrustedProxyCIDRs(t *testing.T) {
 	assert.Equal(t, "10.0.0.0/8,192.168.1.0/24", conf.TrustedProxyCIDRs)
 }
 
+func TestValidateTrustedProxyCIDRs(t *testing.T) {
+	tests := []struct {
+		name        string
+		cidrs       string
+		expectError bool
+	}{
+		{
+			name:        "empty trusted-proxy-cidrs is valid",
+			cidrs:       "",
+			expectError: false,
+		},
+		{
+			name:        "valid single CIDR is valid",
+			cidrs:       "192.168.1.0/24",
+			expectError: false,
+		},
+		{
+			name:        "valid comma-separated CIDRs are valid",
+			cidrs:       "10.0.0.0/8, 192.168.1.0/24",
+			expectError: false,
+		},
+		{
+			name:        "invalid CIDR causes validation to fail",
+			cidrs:       "10.0.0.0/8, invalid-cidr",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := config.Parse([]string{
+				"headlamp-server",
+				"--trusted-proxy-cidrs=" + tt.cidrs,
+			})
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid trusted-proxy-cidrs entry")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestParseAppName(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -116,6 +116,7 @@ func TestParseBasic(t *testing.T) {
 				"--pod-debug-image=registry.example.com/debug:latest",
 				"--node-shell-image=registry.example.com/shell:latest",
 				"--node-shell-namespace=custom-ns",
+				"--trusted-proxy-cidrs=10.0.0.0/8,192.168.1.0/24",
 			},
 			verify: func(t *testing.T, conf *config.Config) {
 				assert.Equal(t, uint(3456), conf.Port)
@@ -123,6 +124,7 @@ func TestParseBasic(t *testing.T) {
 				assert.Equal(t, "registry.example.com/shell:latest", conf.NodeShellImage)
 				assert.Equal(t, "custom-ns", conf.NodeShellNamespace)
 				assert.Equal(t, config.DefaultMeUsernamePath, conf.MeUsernamePath)
+				assert.Equal(t, "10.0.0.0/8,192.168.1.0/24", conf.TrustedProxyCIDRs)
 			},
 		},
 		{

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -116,7 +116,6 @@ func TestParseBasic(t *testing.T) {
 				"--pod-debug-image=registry.example.com/debug:latest",
 				"--node-shell-image=registry.example.com/shell:latest",
 				"--node-shell-namespace=custom-ns",
-				"--trusted-proxy-cidrs=10.0.0.0/8,192.168.1.0/24",
 			},
 			verify: func(t *testing.T, conf *config.Config) {
 				assert.Equal(t, uint(3456), conf.Port)
@@ -124,7 +123,6 @@ func TestParseBasic(t *testing.T) {
 				assert.Equal(t, "registry.example.com/shell:latest", conf.NodeShellImage)
 				assert.Equal(t, "custom-ns", conf.NodeShellNamespace)
 				assert.Equal(t, config.DefaultMeUsernamePath, conf.MeUsernamePath)
-				assert.Equal(t, "10.0.0.0/8,192.168.1.0/24", conf.TrustedProxyCIDRs)
 			},
 		},
 		{
@@ -146,6 +144,16 @@ func TestParseBasic(t *testing.T) {
 			tt.verify(t, conf)
 		})
 	}
+}
+
+func TestParseTrustedProxyCIDRs(t *testing.T) {
+	conf, err := config.Parse([]string{
+		"go run ./cmd",
+		"--trusted-proxy-cidrs=10.0.0.0/8,192.168.1.0/24",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "10.0.0.0/8,192.168.1.0/24", conf.TrustedProxyCIDRs)
 }
 
 func TestParseAppName(t *testing.T) {
@@ -507,6 +515,16 @@ var parseFlagTests = []parseFlagTest{
 		verify: func(t *testing.T, conf *config.Config) {
 			assert.Equal(t, true, conf.UnsafeUseServiceAccountToken)
 			assert.Equal(t, "/custom/token/path", conf.ServiceAccountTokenPath)
+		},
+	},
+	{
+		name: "trusted_proxy_cidrs_flag",
+		args: []string{
+			"go run ./cmd",
+			"--trusted-proxy-cidrs=10.0.0.0/8,192.168.1.0/24",
+		},
+		verify: func(t *testing.T, conf *config.Config) {
+			assert.Equal(t, "10.0.0.0/8,192.168.1.0/24", conf.TrustedProxyCIDRs)
 		},
 	},
 }

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -71,6 +71,7 @@ type HeadlampCFG struct {
 	Metrics                *telemetry.Metrics
 	BaseURL                string
 	ProxyURLs              []string
+	TrustedProxyCIDRs      []string
 
 	TLSCertPath                  string
 	TLSKeyPath                   string


### PR DESCRIPTION
## Summary

This PR adds IP-based rate limiting to Headlamp's authentication endpoints to protect them from brute-force attempts and request flooding.

## Changes

* Added a per-IP token bucket rate limiter using `golang.org/x/time/rate`.
* Added rate limiting to `/oidc`, `/oidc-callback`, and `/auth/set-token`.
* Configured the limiter for 5 requests per second with a burst capacity of 10 requests.
* Added thread-safe storage for per-IP limiters.
* Added support for extracting client IPs from `X-Forwarded-For`.
* Returns `429 Too Many Requests` when the rate limit is exceeded.


## Notes for the Reviewer

* The rate limiter is applied only to authentication-related endpoints.
* Rate limiting is maintained separately for each client IP.
* The implementation uses a token bucket with a rate of 5 requests/second and a burst capacity of 10.

