### PR TITLE
frontend: networkpolicy: Show the pods a NetworkPolicy targets

### DIFF
--- a/frontend/src/components/networkpolicy/Details.stories.tsx
+++ b/frontend/src/components/networkpolicy/Details.stories.tsx
@@ -44,6 +44,13 @@ Default.parameters = {
   msw: {
     handlers: {
       story: [
+        // Handlers for the "Targeted Pods" section (pods matched by spec.podSelector).
+        http.get(`${API_BASE}/api/v1/namespaces/default/pods`, () =>
+          HttpResponse.json({ kind: 'PodList', items: [], metadata: {} })
+        ),
+        http.get(`${API_BASE}/apis/metrics.k8s.io/v1beta1/namespaces/default/pods`, () =>
+          HttpResponse.json({ kind: 'PodMetricsList', items: [], metadata: {} })
+        ),
         http.get(
           `${API_BASE}/apis/networking.k8s.io/v1/namespaces/default/networkpolicies/allow-frontend-traffic`,
           () => HttpResponse.json(NETWORK_POLICY_DETAIL)

--- a/frontend/src/components/networkpolicy/Details.test.tsx
+++ b/frontend/src/components/networkpolicy/Details.test.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import { TestContext } from '../../test';
+import { NetworkPolicyDetails } from './Details';
+
+const { mockTargetedPodsSection } = vi.hoisted(() => ({
+  mockTargetedPodsSection: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// '../../lib/k8s' is a large barrel that re-exports every resource class; some
+// component-level import of it triggers a pre-existing circular-init issue
+// between deployment.ts/replicaSet.ts and KubeObject.ts (unrelated to this
+// component) and crashes module loading outside of the full test run. Mock it
+// with a real, equivalent labelSelectorToQuery so this file can render
+// NetworkPolicyDetails without pulling in the barrel.
+vi.mock('../../lib/k8s', () => ({
+  labelSelectorToQuery: (selector: { matchLabels?: Record<string, string> } = {}) =>
+    Object.entries(selector.matchLabels ?? {})
+      .map(([key, value]) => `${key}=${value}`)
+      .join(','),
+  matchExpressionSimplifier: () => [],
+  matchLabelsSimplifier: () => [],
+}));
+
+// Same circular-init issue as above -- Details.tsx imports the NetworkPolicy
+// class purely to pass it as DetailsGrid's resourceType, which our mocked
+// DetailsGrid below never inspects, so a plain stub is enough.
+vi.mock('../../lib/k8s/networkpolicy', () => ({ default: class NetworkPolicy {} }));
+
+// DetailsGrid's own data fetching (resourceType.useGet) is out of scope here;
+// drive its extraSections directly with a fake NetworkPolicy item, the same
+// way workload/Details.test.tsx drives WorkloadDetails via extraSections.
+// TargetedPodsSection is replaced with a spy so the labelSelector it actually
+// receives (built from spec.podSelector) can be inspected -- an omitted or
+// wrong selector, or a mishandled empty selector, would show up here.
+let testItem: any;
+
+vi.mock('../common/Resource', () => ({
+  DetailsGrid: (props: any) => {
+    const sections = typeof props.extraSections === 'function' ? props.extraSections(testItem) : [];
+    return (
+      <>
+        {sections.map((s: any) => (
+          <React.Fragment key={s.id}>{s.section}</React.Fragment>
+        ))}
+      </>
+    );
+  },
+  TargetedPodsSection: (props: any) => {
+    mockTargetedPodsSection(props);
+    return null;
+  },
+  metadataStyles: {},
+}));
+
+function makeNetworkPolicy(podSelector: Record<string, any>) {
+  return {
+    kind: 'NetworkPolicy',
+    cluster: 'test-cluster',
+    metadata: { name: 'np1', namespace: 'default' },
+    spec: { podSelector, ingress: [], egress: [] },
+  };
+}
+
+describe('NetworkPolicyDetails targeted pods', () => {
+  beforeEach(() => {
+    mockTargetedPodsSection.mockReset();
+  });
+
+  it('builds a label query from a non-empty podSelector', () => {
+    testItem = makeNetworkPolicy({ matchLabels: { app: 'foo' } });
+
+    render(
+      <TestContext>
+        <NetworkPolicyDetails name="np1" namespace="default" />
+      </TestContext>
+    );
+
+    expect(mockTargetedPodsSection).toHaveBeenCalledWith(
+      expect.objectContaining({ namespace: 'default', labelSelector: 'app=foo' })
+    );
+  });
+
+  it('sends an unfiltered (empty) label query for an empty podSelector, so it lists all namespace pods', () => {
+    testItem = makeNetworkPolicy({});
+
+    render(
+      <TestContext>
+        <NetworkPolicyDetails name="np1" namespace="default" />
+      </TestContext>
+    );
+
+    expect(mockTargetedPodsSection).toHaveBeenCalledWith(
+      expect.objectContaining({ namespace: 'default', labelSelector: '' })
+    );
+  });
+});

--- a/frontend/src/components/networkpolicy/Details.tsx
+++ b/frontend/src/components/networkpolicy/Details.tsx
@@ -18,7 +18,11 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
-import { matchExpressionSimplifier, matchLabelsSimplifier } from '../../lib/k8s';
+import {
+  labelSelectorToQuery,
+  matchExpressionSimplifier,
+  matchLabelsSimplifier,
+} from '../../lib/k8s';
 import { LabelSelector } from '../../lib/k8s/cluster';
 import NetworkPolicy, {
   NetworkPolicyEgressRule,
@@ -26,7 +30,7 @@ import NetworkPolicy, {
   NetworkPolicyPort,
 } from '../../lib/k8s/networkpolicy';
 import NameValueTable from '../common/NameValueTable';
-import { DetailsGrid } from '../common/Resource';
+import { DetailsGrid, TargetedPodsSection } from '../common/Resource';
 import { metadataStyles } from '../common/Resource';
 import SectionBox from '../common/SectionBox';
 
@@ -252,6 +256,16 @@ export function NetworkPolicyDetails(props: {
       }
       extraSections={item =>
         item && [
+          {
+            id: 'networkpolicy-targeted-pods',
+            section: (
+              <TargetedPodsSection
+                namespace={item.metadata.namespace}
+                labelSelector={labelSelectorToQuery(item.spec?.podSelector ?? {})}
+                cluster={item.cluster}
+              />
+            ),
+          },
           {
             id: 'networkpolicy-ingress',
             section: <Ingress ingress={item.spec?.ingress ?? []} />,

--- a/frontend/src/components/networkpolicy/__snapshots__/Details.Default.stories.storyshot
+++ b/frontend/src/components/networkpolicy/__snapshots__/Details.Default.stories.storyshot
@@ -217,6 +217,67 @@
                 <div
                   class="MuiBox-root css-70qvj9"
                 >
+                  <h1
+                    class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
+                  >
+                    Pods
+                  </h1>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                class="MuiBox-root css-8atqhb"
+              >
+                <div
+                  aria-atomic="true"
+                  aria-live="polite"
+                  class="MuiBox-root css-ty8jgw"
+                  role="status"
+                >
+                  No data to be shown.
+                </div>
+                <div
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+                >
+                  <div
+                    class="MuiBox-root css-19midj6"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+                    >
+                      No data to be shown.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
                   <h2
                     class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
                   >


### PR DESCRIPTION
## Summary

A NetworkPolicy's details view showed its ingress and egress rules but not the pods it applies to, so checking whether spec.podSelector is right meant cross-referencing pods by hand. This adds a Pods section listing the pods matched by the policy's podSelector — an empty selector targets all pods in the namespace — reusing the TargetedPodsSection added for the Service details view in #6972.

## Related Issue

Fixes #6930

## Changes

- Added a "Pods" section to the NetworkPolicy details page (components/networkpolicy/Details.tsx), built from spec.podSelector via the shared TargetedPodsSection
- Added the pod/metrics MSW handlers to the NetworkPolicy story and updated the storyshot

## Steps to Test

1. Open a NetworkPolicy's details page
2. Confirm a "Pods" section appears listing the pods matched by its podSelector
3. For a NetworkPolicy with an empty podSelector ({}), confirm the section lists all pods in the namespace (which is what an empty selector targets)
4. Change the podSelector to something that matches nothing and confirm the section shows no pods (makes a wrong selector obvious)

## Screenshots (if applicable)
<img width="1458" height="695" alt="Screenshot 2026-08-09 at 2 29 38 AM" src="https://github.com/user-attachments/assets/37a1a21f-398d-44f6-b5e1-381ca97cf43e" />


## Notes for the Reviewer

- This reuses the TargetedPodsSection component added for the Service view in #6972, so it's a small change (just wiring podSelector into it).
- Unlike the Service view, the section always shows — a NetworkPolicy's podSelector is required, and an empty selector meaningfully targets all pods in the namespace.
