### PR TITLE
frontend: SimpleTable: Correct getter return type

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -665,7 +665,7 @@ export function ConditionsTable(props: ConditionsTableProps) {
   function getColumns() {
     const cols: {
       label: string;
-      getter: (arg: KubeCondition) => void;
+      getter: (arg: KubeCondition) => React.ReactNode;
       hide?: boolean;
     }[] = [
       {

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -56,7 +56,7 @@ export interface SimpleTableDatumColumn extends SimpleTableColumn {
 }
 
 export interface SimpleTableGetterColumn extends SimpleTableColumn {
-  getter: (...args: any[]) => void;
+  getter: (...args: any[]) => React.ReactNode;
 }
 
 export interface SimpleTableProps {
@@ -259,8 +259,8 @@ export default function SimpleTable(props: SimpleTableProps) {
       if (!getterFunc && !!datum) {
         getterFunc = (item: any) => item[datum];
       }
-      const value1 = getterFunc(item1);
-      const value2 = getterFunc(item2);
+      const value1 = getterFunc(item1) as any;
+      const value2 = getterFunc(item2) as any;
 
       let compareValue = 0;
       if (value1 < value2) {


### PR DESCRIPTION
## Summary

This PR corrects the return type of `SimpleTableGetterColumn.getter` to match how it is used by `SimpleTable`.

The `getter` function is currently typed as returning `void`, even though its return value is rendered as part of the component. This change updates the type definition to better reflect the implementation and improves TypeScript type safety without changing runtime behavior.

## Related Issue

Fixes #7017

## Changes

- Updated the `SimpleTableGetterColumn` interface in `SimpleTable.tsx`
- Changed the `getter` return type from `void` to `React.ReactNode`
- Improved TypeScript type accuracy to align with the component's implementation
- No runtime behavior changes

## Steps to Test

1. Run `npm run tsc` from the `frontend` directory and verify there are no TypeScript errors.
2. Run `npm run lint` and ensure all lint checks pass.
3. Verify that all existing `SimpleTable` usages continue to compile and render correctly.

## Screenshots (if applicable)

N/A (TypeScript typing change only)

## Notes for the Reviewer

- This is a type-only change and does not modify the runtime behavior of `SimpleTable`.
- The updated return type reflects how the `getter` function is consumed by the component during rendering.