### PR TITLE
frontend: Preserve cluster context in useKubeObject WebSocket updates

### DIFF
--- a/frontend/src/lib/k8s/api/v2/hooks.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/hooks.test.tsx
@@ -435,4 +435,93 @@ describe('useKubeObject watch wiring', () => {
       expect(lastCall.connections[0]?.url).not.toContain('metadata.name%3Dpod-a');
     });
   });
+
+  it('preserves the cluster association on WebSocket update', async () => {
+    vi.stubEnv('REACT_APP_ENABLE_WEBSOCKET_MULTIPLEXER', 'true');
+    mockClusterFetch.mockResolvedValue(
+      mockJsonResponse({
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: { name: 'my-pod', namespace: 'my-ns' },
+      })
+    );
+
+    const { result, rerender } = renderHook(
+      ({ cluster }) =>
+        useKubeObject({
+          kubeObjectClass: MockPod,
+          name: 'my-pod',
+          namespace: 'my-ns',
+          cluster,
+        }),
+      { wrapper: createWrapper(), initialProps: { cluster: 'test-cluster-a' } }
+    );
+
+    // Wait until multiplexer becomes enabled
+    let lastCall: any;
+    await waitFor(() => {
+      expect(mockUseWebSocket).toHaveBeenCalled();
+      const calls = mockUseWebSocket.mock.calls;
+      lastCall = calls[calls.length - 1][0];
+      expect(lastCall.enabled).toBe(true);
+    });
+
+    // Trigger websocket message
+    const onMessage = lastCall.onMessage;
+    expect(onMessage).toBeDefined();
+
+    onMessage({
+      type: 'MODIFIED',
+      object: {
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: { name: 'my-pod', namespace: 'my-ns', resourceVersion: '2' },
+      },
+    });
+
+    // Check that the returned data is updated, and has the correct cluster
+    await waitFor(() => {
+      expect(result.current.data).toBeDefined();
+      expect(result.current.data?.cluster).toBe('test-cluster-a');
+    });
+
+    // Since queryKey changes when cluster changes, a new fetch happens.
+    // We mock that next fetch response before rerendering to avoid a race condition:
+    mockClusterFetch.mockResolvedValue(
+      mockJsonResponse({
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: { name: 'my-pod', namespace: 'my-ns', resourceVersion: '3' },
+      })
+    );
+
+    // Rerender with a different cluster to verify the new callback dependency
+    rerender({ cluster: 'test-cluster-b' });
+
+    let lastCallAfter: any;
+    await waitFor(() => {
+      const callsAfter = mockUseWebSocket.mock.calls;
+      lastCallAfter = callsAfter[callsAfter.length - 1][0];
+      expect(lastCallAfter.cluster).toBe('test-cluster-b');
+      expect(lastCallAfter.enabled).toBe(true);
+      expect(lastCallAfter.onMessage).toBeDefined();
+    });
+
+    // Fire the onMessage callback of the new render
+    lastCallAfter.onMessage({
+      type: 'MODIFIED',
+      object: {
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: { name: 'my-pod', namespace: 'my-ns', resourceVersion: '4' },
+      },
+    });
+
+    // Check that the returned data is updated, and has the new cluster!
+    await waitFor(() => {
+      expect(result.current.data).toBeDefined();
+      expect(result.current.data?.cluster).toBe('test-cluster-b');
+      expect(result.current.data?.jsonData.metadata.resourceVersion).toBe('4');
+    });
+  });
 });

--- a/frontend/src/lib/k8s/api/v2/hooks.ts
+++ b/frontend/src/lib/k8s/api/v2/hooks.ts
@@ -168,10 +168,10 @@ export function useKubeObject<K extends KubeObject>({
   const handleMessage = useCallback(
     (update: KubeListUpdateEvent<K>) => {
       if (update.type !== 'ADDED' && update.object) {
-        client.setQueryData(queryKey, new kubeObjectClass(update.object));
+        client.setQueryData(queryKey, new kubeObjectClass(update.object, cluster));
       }
     },
-    [client, queryKey, kubeObjectClass]
+    [client, queryKey, kubeObjectClass, cluster]
   );
 
   const connectionsRequests = useMemo(() => {


### PR DESCRIPTION
## Summary

This PR fixes an issue in `useKubeObject` where resources updated through WebSocket events could lose their original cluster context. The WebSocket update handler now preserves the cluster used by the hook when creating updated resource instances, ensuring consistency between the initial query and subsequent updates.

## Related Issue

Fixes #7023

## Changes

- Updated the `useKubeObject` WebSocket update handler to preserve the current cluster when instantiating updated resources.
- Added the `cluster` dependency to the WebSocket callback to avoid stale closures.
- Kept the WebSocket update path consistent with the initial query path.

## Steps to Test

1. Configure multiple Kubernetes clusters in Headlamp.
2. Open a resource page that uses `useKubeObject`.
3. Trigger a WebSocket update for the resource (e.g. modify the resource using `kubectl`).
4. Verify that the updated resource retains the correct cluster association and continues to function as expected.

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- This is a small, targeted fix that only affects the WebSocket update path.
- The change aligns object construction during WebSocket updates with the existing initial query logic by preserving the cluster context.