### PR TITLE
frontend: useKubeObject: Preserve cluster when handling WebSocket updates

### DIFF
--- a/frontend/src/lib/k8s/api/v2/hooks.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/hooks.test.tsx
@@ -435,4 +435,97 @@ describe('useKubeObject watch wiring', () => {
       expect(lastCall.connections[0]?.url).not.toContain('metadata.name%3Dpod-a');
     });
   });
+
+  it('preserves the cluster on the instance built from a legacy WebSocket update', async () => {
+    vi.stubEnv('REACT_APP_ENABLE_WEBSOCKET_MULTIPLEXER', 'false');
+    mockClusterFetch.mockResolvedValue(
+      mockJsonResponse({
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: { name: 'my-pod', namespace: 'my-ns' },
+      })
+    );
+
+    const { result } = renderHook(
+      () =>
+        useKubeObject({
+          kubeObjectClass: MockPod,
+          name: 'my-pod',
+          namespace: 'my-ns',
+          cluster: 'non-default-cluster',
+        }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.data?.cluster).toBe('non-default-cluster');
+    });
+
+    expect(mockUseWebSockets).toHaveBeenCalled();
+    const connections = mockUseWebSockets.mock.calls.at(-1)![0].connections;
+    expect(connections).toHaveLength(1);
+
+    connections[0].onMessage({
+      type: 'MODIFIED',
+      object: {
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: { name: 'my-pod', namespace: 'my-ns', resourceVersion: 'updated-rv' },
+      },
+    });
+
+    // Wait for the update to land (a distinct resourceVersion proves the
+    // instance was actually replaced, not left over from the initial fetch),
+    // then confirm the replacement instance still carries the cluster.
+    await waitFor(() => {
+      expect(result.current.data?.jsonData?.metadata?.resourceVersion).toBe('updated-rv');
+    });
+    expect(result.current.data?.cluster).toBe('non-default-cluster');
+  });
+
+  it('preserves the cluster on the instance built from a multiplexer WebSocket update', async () => {
+    vi.stubEnv('REACT_APP_ENABLE_WEBSOCKET_MULTIPLEXER', 'true');
+    mockClusterFetch.mockResolvedValue(
+      mockJsonResponse({
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: { name: 'my-pod', namespace: 'my-ns' },
+      })
+    );
+
+    const { result } = renderHook(
+      () =>
+        useKubeObject({
+          kubeObjectClass: MockPod,
+          name: 'my-pod',
+          namespace: 'my-ns',
+          cluster: 'non-default-cluster',
+        }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.data?.cluster).toBe('non-default-cluster');
+    });
+
+    expect(mockUseWebSocket).toHaveBeenCalled();
+    const lastCall = mockUseWebSocket.mock.calls.at(-1)![0];
+
+    lastCall.onMessage({
+      type: 'MODIFIED',
+      object: {
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: { name: 'my-pod', namespace: 'my-ns', resourceVersion: 'updated-rv' },
+      },
+    });
+
+    // Wait for the update to land (a distinct resourceVersion proves the
+    // instance was actually replaced, not left over from the initial fetch),
+    // then confirm the replacement instance still carries the cluster.
+    await waitFor(() => {
+      expect(result.current.data?.jsonData?.metadata?.resourceVersion).toBe('updated-rv');
+    });
+    expect(result.current.data?.cluster).toBe('non-default-cluster');
+  });
 });

--- a/frontend/src/lib/k8s/api/v2/hooks.ts
+++ b/frontend/src/lib/k8s/api/v2/hooks.ts
@@ -168,10 +168,10 @@ export function useKubeObject<K extends KubeObject>({
   const handleMessage = useCallback(
     (update: KubeListUpdateEvent<K>) => {
       if (update.type !== 'ADDED' && update.object) {
-        client.setQueryData(queryKey, new kubeObjectClass(update.object));
+        client.setQueryData(queryKey, new kubeObjectClass(update.object, cluster));
       }
     },
-    [client, queryKey, kubeObjectClass]
+    [client, queryKey, kubeObjectClass, cluster]
   );
 
   const connectionsRequests = useMemo(() => {


### PR DESCRIPTION
Fixes #7023

## Problem

`useKubeObject`'s initial query builds the resource instance with `new kubeObjectClass(obj, cluster)`, but the WebSocket update handler (`handleMessage`) only passed the raw object through:

```ts
client.setQueryData(queryKey, new kubeObjectClass(update.object));
```

If the hook is used against a non-default cluster, the instance produced by a watch event loses its cluster association even though the rest of the query (query key, initial fetch, endpoint resolution) stays scoped to that cluster. This shows up as inconsistent resource state after a WebSocket update in multi-cluster setups.

## Fix

Pass `cluster` through in `handleMessage` the same way the initial `queryFn` already does, and add `cluster` to the callback's dependency array so it stays correct if the hook is ever re-rendered with a different cluster.

## Testing

Added two tests to `hooks.test.tsx` covering both WebSocket transports the hook can use (legacy per-resource socket and the multiplexer), each simulating an update event and asserting the resulting instance still carries the original `cluster`. Both tests fail against the pre-fix code (confirmed locally by temporarily reverting the source change) and pass with the fix.

- `npx vitest run src/lib/k8s/api/v2/hooks.test.tsx` — 14/14 passing
- `npx tsc --noEmit` — clean
- `npm run lint` (eslint) on the changed files — clean