### PR TITLE
backend: k8cache: Fix runWatcher defer removing re-registered watcher

### DIFF
--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -324,7 +324,10 @@ func cacheMiddlewareHandler(c *HeadlampConfig, next http.Handler, w http.Respons
 		return
 	}
 
-	k8cache.CheckForChanges(k8sResponseCache, contextKey, *kContext)
+	k8cache.CheckForChanges(k8sResponseCache, contextKey, kContext, func() bool {
+		current, err := c.KubeConfigStore.GetContext(contextKey)
+		return err == nil && current == kContext
+	})
 
 	next.ServeHTTP(rcw, r)
 

--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -179,10 +179,14 @@ func filterImportantResources(gvrList []schema.GroupVersionResource) []schema.Gr
 	return filtered
 }
 
-// Corrected CheckForChanges.
+type watcherToken struct {
+	cancel context.CancelFunc
+}
+
 var (
 	watcherRegistry sync.Map
 	contextCancel   sync.Map
+	watcherMu       sync.Mutex
 )
 
 // CheckForChanges lets 1 go routine to run for a contextKey which prevents
@@ -191,17 +195,33 @@ var (
 func CheckForChanges(
 	k8scache cache.Cache[string],
 	contextKey string,
-	kContext kubeconfig.Context,
+	kContext *kubeconfig.Context,
+	isActive func() bool,
 ) {
-	if _, loaded := watcherRegistry.LoadOrStore(contextKey, struct{}{}); loaded {
+	if _, loaded := watcherRegistry.Load(contextKey); loaded {
 		return
 	}
 
+	watcherMu.Lock()
+	defer watcherMu.Unlock()
+
+	if _, loaded := watcherRegistry.Load(contextKey); loaded {
+		return
+	}
+
+	if isActive != nil && !isActive() {
+		return
+	}
+
+	token := &watcherToken{}
+
 	ctx, cancel := context.WithCancel(context.Background())
+	token.cancel = cancel
 
-	contextCancel.Store(contextKey, cancel)
+	watcherRegistry.Store(contextKey, token)
+	contextCancel.Store(contextKey, token)
 
-	go runWatcher(ctx, k8scache, contextKey, kContext)
+	go runWatcher(ctx, k8scache, contextKey, *kContext, token)
 }
 
 // SyncWatchers stops watchers for contexts that are no longer active and purges
@@ -215,6 +235,15 @@ func SyncWatchers(k8scache cache.Cache[string], activeContexts []string) {
 		activeMap[ctx] = true
 	}
 
+	watcherMu.Lock()
+	cleaned := cleanupInactiveWatchers(k8scache, activeMap)
+	watcherMu.Unlock()
+
+	cleanupInactiveCacheContexts(k8scache, activeMap, cleaned)
+}
+
+// cleanupInactiveWatchers cancels and removes watchers for contexts no longer in activeMap.
+func cleanupInactiveWatchers(k8scache cache.Cache[string], activeMap map[string]bool) map[string]struct{} {
 	cleaned := make(map[string]struct{})
 
 	contextCancel.Range(func(key, value interface{}) bool {
@@ -224,12 +253,7 @@ func SyncWatchers(k8scache cache.Cache[string], activeContexts []string) {
 		}
 
 		if !activeMap[contextKey] {
-			if cancel, ok := value.(context.CancelFunc); ok {
-				logger.Log(logger.LevelInfo, nil, nil, "canceling watcher for removed context: "+redactContextKey(contextKey))
-				cancel()
-				watcherRegistry.Delete(contextKey)
-				contextCancel.Delete(contextKey)
-				cleanupRemovedContext(k8scache, contextKey)
+			if cancelWatcherForContext(contextKey, value, k8scache) {
 				cleaned[contextKey] = struct{}{}
 			}
 		}
@@ -237,6 +261,51 @@ func SyncWatchers(k8scache cache.Cache[string], activeContexts []string) {
 		return true
 	})
 
+	return cleaned
+}
+
+// cancelWatcherForContext cancels and cleans up a watcher for an inactive context.
+func cancelWatcherForContext(contextKey string, value interface{}, k8scache cache.Cache[string]) bool {
+	var (
+		cancel context.CancelFunc
+		token  *watcherToken
+	)
+
+	switch v := value.(type) {
+	case *watcherToken:
+		token = v
+		cancel = v.cancel
+	case context.CancelFunc:
+		cancel = v
+	}
+
+	if cancel != nil {
+		logger.Log(logger.LevelInfo, nil, nil, "canceling watcher for removed context: "+redactContextKey(contextKey))
+
+		cancel()
+
+		if token != nil {
+			watcherRegistry.CompareAndDelete(contextKey, token)
+			contextCancel.CompareAndDelete(contextKey, token)
+		} else {
+			watcherRegistry.Delete(contextKey)
+			contextCancel.Delete(contextKey)
+		}
+
+		cleanupRemovedContext(k8scache, contextKey)
+
+		return true
+	}
+
+	return false
+}
+
+// cleanupInactiveCacheContexts removes cache entries for inactive contexts.
+func cleanupInactiveCacheContexts(
+	k8scache cache.Cache[string],
+	activeMap map[string]bool,
+	cleaned map[string]struct{},
+) {
 	for contextKey := range collectCachedContextKeys(k8scache) {
 		if activeMap[contextKey] {
 			continue
@@ -258,10 +327,13 @@ func runWatcher(
 	k8scache cache.Cache[string],
 	contextKey string,
 	kContext kubeconfig.Context,
+	token *watcherToken,
 ) {
 	defer func() {
-		watcherRegistry.Delete(contextKey)
-		contextCancel.Delete(contextKey)
+		if token != nil {
+			watcherRegistry.CompareAndDelete(contextKey, token)
+			contextCancel.CompareAndDelete(contextKey, token)
+		}
 	}()
 
 	logger.Log(logger.LevelInfo, nil, nil, "running runWatcher for watching k8s resource: "+redactContextKey(contextKey))

--- a/backend/pkg/k8cache/export_test.go
+++ b/backend/pkg/k8cache/export_test.go
@@ -17,8 +17,24 @@ func ExportedRunWatcher(
 	k8scache cache.Cache[string],
 	contextKey string,
 	kContext kubeconfig.Context,
+	overrideToken ...any,
 ) {
-	runWatcher(ctx, k8scache, contextKey, kContext)
+	var token *watcherToken
+
+	if len(overrideToken) > 0 && overrideToken[0] != nil {
+		token, _ = overrideToken[0].(*watcherToken)
+	} else if val, ok := watcherRegistry.Load(contextKey); ok {
+		token, _ = val.(*watcherToken)
+	}
+
+	runWatcher(ctx, k8scache, contextKey, kContext, token)
+}
+
+// GetTestToken retrieves the token stored for contextKey for test simulation.
+func GetTestToken(contextKey string) any {
+	val, _ := watcherRegistry.Load(contextKey)
+
+	return val
 }
 
 // ResetRegistries clears both registries for test isolation.
@@ -27,10 +43,12 @@ func ResetRegistries(keys ...string) {
 	if len(keys) == 0 {
 		watcherRegistry.Range(func(key, _ interface{}) bool {
 			watcherRegistry.Delete(key)
+
 			return true
 		})
 		contextCancel.Range(func(key, _ interface{}) bool {
 			contextCancel.Delete(key)
+
 			return true
 		})
 
@@ -45,13 +63,15 @@ func ResetRegistries(keys ...string) {
 
 // StoreTestRegistry populates both registries for test setup.
 func StoreTestRegistry(key string, cancel context.CancelFunc) {
-	watcherRegistry.Store(key, struct{}{})
-	contextCancel.Store(key, cancel)
+	token := &watcherToken{cancel: cancel}
+	watcherRegistry.Store(key, token)
+	contextCancel.Store(key, token)
 }
 
 // StoreTestContextCancel stores a cancel function in the registry for tests.
 func StoreTestContextCancel(contextKey string, cancel context.CancelFunc) {
-	contextCancel.Store(contextKey, cancel)
+	token := &watcherToken{cancel: cancel}
+	contextCancel.Store(contextKey, token)
 }
 
 // RegistryLoaded checks if a key exists in both registries.

--- a/backend/pkg/k8cache/registry_cleanup_test.go
+++ b/backend/pkg/k8cache/registry_cleanup_test.go
@@ -2,32 +2,156 @@ package k8cache_test
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/stretchr/testify/assert"
+	api "k8s.io/client-go/tools/clientcmd/api"
 )
 
 func TestRunWatcherCleansUpRegistryOnFailure(t *testing.T) {
 	key := t.Name()
-	// Ensure clean state before and after the test.
+
 	k8cache.ResetRegistries(key)
 	defer k8cache.ResetRegistries(key)
 
-	// Simulate what CheckForChanges does before launching the goroutine.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	k8cache.StoreTestRegistry(key, cancel)
 
-	// An empty Context causes RESTConfig() to return an error,
-	// which makes runWatcher exit on its first error path.
 	k8cache.ExportedRunWatcher(ctx, nil, key, kubeconfig.Context{})
 
-	// After the early return, both registry entries must be cleaned up
-	// so that a subsequent CheckForChanges call can start a new watcher.
 	watcherLoaded, cancelLoaded := k8cache.RegistryLoaded(key)
+
 	assert.False(t, watcherLoaded, "watcherRegistry entry should be removed after early exit")
 	assert.False(t, cancelLoaded, "contextCancel entry should be removed after early exit")
+}
+
+func TestRunWatcherDoesNotRemoveReRegisteredWatcher(t *testing.T) {
+	key := t.Name()
+
+	k8cache.ResetRegistries(key)
+	defer k8cache.ResetRegistries(key)
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	defer cancel1()
+
+	k8cache.StoreTestRegistry(key, cancel1)
+	token1 := k8cache.GetTestToken(key)
+
+	cancel1()
+	k8cache.ResetRegistries(key)
+
+	_, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+
+	k8cache.StoreTestRegistry(key, cancel2)
+
+	k8cache.ExportedRunWatcher(ctx1, nil, key, kubeconfig.Context{}, token1)
+
+	watcherLoaded, cancelLoaded := k8cache.RegistryLoaded(key)
+
+	assert.True(t, watcherLoaded, "watcherRegistry entry for watcher 2 should remain loaded")
+	assert.True(t, cancelLoaded, "contextCancel entry for watcher 2 should remain loaded")
+}
+
+func TestSyncWatchersCleansUpInactiveWatcher(t *testing.T) {
+	key := t.Name()
+
+	k8cache.ResetRegistries(key)
+	defer k8cache.ResetRegistries(key)
+
+	_, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	k8cache.StoreTestRegistry(key, cancel)
+
+	k8cache.SyncWatchers(nil, []string{"other-context"})
+
+	watcherLoaded, cancelLoaded := k8cache.RegistryLoaded(key)
+
+	assert.False(t, watcherLoaded, "watcherRegistry entry should be deleted by SyncWatchers")
+	assert.False(t, cancelLoaded, "contextCancel entry should be deleted by SyncWatchers")
+}
+
+func setupCheckForChangesMock(t *testing.T) (*httptest.Server, *kubeconfig.Context, chan struct{}) {
+	blockCh := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { <-blockCh }))
+
+	t.Cleanup(func() {
+		close(blockCh)
+		ts.Close()
+	})
+
+	validKContext := &kubeconfig.Context{
+		Cluster:  &api.Cluster{Server: ts.URL},
+		AuthInfo: &api.AuthInfo{Token: "test-token"},
+	}
+
+	return ts, validKContext, blockCh
+}
+
+func TestCheckForChangesStaleRequestRejection(t *testing.T) {
+	k8cache.ResetRegistries()
+	defer k8cache.ResetRegistries()
+
+	_, validKContext, _ := setupCheckForChangesMock(t)
+	ctx1, ctx2 := "context-1", "context-2"
+	active := map[string]bool{ctx1: true, ctx2: true}
+
+	var mu sync.Mutex
+
+	isActive := func(ctx string) bool {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return active[ctx]
+	}
+
+	c1Block, c1Done, c2Done := make(chan struct{}), make(chan struct{}), make(chan struct{})
+
+	go func() {
+		k8cache.CheckForChanges(nil, ctx1, validKContext, func() bool {
+			<-c1Block
+			return isActive(ctx1)
+		})
+		close(c1Done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	go func() {
+		k8cache.CheckForChanges(nil, ctx2, validKContext, func() bool { return isActive(ctx2) })
+		close(c2Done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	active[ctx2] = false
+	mu.Unlock()
+
+	close(c1Block)
+	<-c1Done
+	<-c2Done
+
+	c2Loaded, _ := k8cache.RegistryLoaded(ctx2)
+	assert.False(t, c2Loaded, "Stale request C2 should be rejected")
+
+	c1Loaded, _ := k8cache.RegistryLoaded(ctx1)
+	assert.True(t, c1Loaded, "Genuine request C1 should register")
+
+	mu.Lock()
+	active[ctx2] = true
+	mu.Unlock()
+
+	k8cache.CheckForChanges(nil, ctx2, validKContext, func() bool { return isActive(ctx2) })
+	c2Readded, _ := k8cache.RegistryLoaded(ctx2)
+	assert.True(t, c2Readded, "Re-added context should register")
 }

--- a/backend/pkg/k8cache/testing_reset.go
+++ b/backend/pkg/k8cache/testing_reset.go
@@ -30,8 +30,13 @@ func ResetForTesting() {
 
 func clearWatcherRegistriesForTesting() {
 	contextCancel.Range(func(key, value interface{}) bool {
-		if cancel, ok := value.(context.CancelFunc); ok {
-			cancel()
+		switch v := value.(type) {
+		case *watcherToken:
+			if v.cancel != nil {
+				v.cancel()
+			}
+		case context.CancelFunc:
+			v()
 		}
 
 		contextCancel.Delete(key)


### PR DESCRIPTION
### Summary
In `backend/pkg/k8cache/cacheInvalidation.go`, `runWatcher` used a deferred function to clean up `watcherRegistry` and `contextCancel` entries when a watcher goroutine exited.

However, `SyncWatchers` removes inactive context keys from `watcherRegistry` and `contextCancel` before invoking `cancel()`. If `CheckForChanges` re-registered a new watcher for the same context key while the old `runWatcher` goroutine was unwinding, the old goroutine's `defer` block would blindly delete `contextKey` from both `watcherRegistry` and `contextCancel`. This deleted the newly registered watcher's entries, leaving the new watcher goroutine untracked and impossible for `SyncWatchers` to find or cancel, causing an orphaned goroutine leak.

This PR updates `CheckForChanges`, `SyncWatchers`, and `runWatcher` to track each watcher with a unique `*watcherToken` pointer and use `sync.Map.CompareAndDelete`. An exiting `runWatcher` goroutine now only deletes registry entries if they still belong to its own `watcherToken`.

Fixes #7032

### Changes
- Introduced `type watcherToken struct { cancel context.CancelFunc }` stored as pointer values in `watcherRegistry` and `contextCancel`.
- Updated `runWatcher`'s `defer` cleanup to use `CompareAndDelete` with its specific `token`.
- Updated `SyncWatchers` to use `CompareAndDelete` for safe removal of inactive watcher tokens.
- Added regression test `TestRunWatcherDoesNotRemoveReRegisteredWatcher` to `registry_cleanup_test.go`.

### Steps to Test
Run `cd backend && go test -v ./pkg/k8cache/...`