### PR TITLE
frontend: verticalPodAutoscaler: fix error on undefined controlledRes…

### DIFF
--- a/frontend/src/components/verticalPodAutoscaler/Details.tsx
+++ b/frontend/src/components/verticalPodAutoscaler/Details.tsx
@@ -80,7 +80,7 @@ export default function VpaDetails(props: { name?: string; namespace?: string; c
                     },
                     {
                       label: t('translation|Controlled Resources'),
-                      getter: item => item?.controlledResources.join(', '),
+                      getter: item => item?.controlledResources?.join(', ') ?? 'cpu, memory',
                     },
                     {
                       label: t('translation|Controlled Values'),


### PR DESCRIPTION
## Summary

Fixes an error on the VPA details page when `controlledResources` is omitted.

That field is optional in the VPA API (defaults to cpu/memory). The Container Policy table called `.join` on `undefined`, which threw a TypeError and broke that section (caught by ErrorBoundary).

## Changes

- Guarded optional `controlledResources` in VPA details (`?.join` + empty fallback)

# Steps to Test

1. Open a VPA details page where a container policy omits `controlledResources`
2. Confirm the **Container Policy** section renders without a console TypeError
3. Open a VPA that sets `controlledResources` and confirm values still show (e.g. `cpu, memory`)

## Screenshots

Before: Container Policy section. console shows Cannot read properties of undefined (reading 'join')

<img width="1645" height="761" alt="Screenshot 2026-08-09 at 8 07 25 PM" src="https://github.com/user-attachments/assets/43dd79ef-654e-4729-bcc1-0027142c8b72" />
