### PR TITLE
pluginctl: Add exponential backoff for artifacthub fetch

### DIFF
--- a/plugins/pluginctl/src/plugin-management.js
+++ b/plugins/pluginctl/src/plugin-management.js
@@ -34,6 +34,50 @@ const stream = require('stream');
 const semver = require('semver');
 const envPaths = require('env-paths');
 
+async function fetchWithRetry(url, options, maxRetries = 3) {
+  for (let i = 0; i <= maxRetries; i++) {
+    try {
+      const response = await fetch(url, options);
+      if (response.ok) {
+        return response;
+      }
+      const isTransient = response.status === 408 || response.status === 429 || response.status >= 500;
+      if (!isTransient || i === maxRetries) return response;
+      
+      if (response.body && typeof response.body.cancel === 'function') {
+        response.body.cancel().catch(() => {});
+      }
+    } catch (error) {
+      if (error.name === 'AbortError') throw error;
+      if (i === maxRetries) throw error;
+    }
+    
+    await new Promise((resolve, reject) => {
+      let timeout;
+      const abortHandler = () => {
+        clearTimeout(timeout);
+        const err = new Error('The operation was aborted');
+        err.name = 'AbortError';
+        reject(err);
+      };
+
+      if (options && options.signal) {
+        if (options.signal.aborted) {
+          return abortHandler();
+        }
+        options.signal.addEventListener('abort', abortHandler, { once: true });
+      }
+
+      timeout = setTimeout(() => {
+        if (options && options.signal) {
+          options.signal.removeEventListener('abort', abortHandler);
+        }
+        resolve();
+      }, Math.pow(2, i) * 1000);
+    });
+  }
+}
+
 // comment out for testing
 // function sleep(ms) {
 //   // console.log(ms)
@@ -400,7 +444,7 @@ async function downloadExtractPlugin(
   }
 
   // await sleep(4000); // comment out for testing
-  const archResponse = await fetch(archiveURL, { redirect: 'follow', follow: 10 }, { signal });
+  const archResponse = await fetchWithRetry(archiveURL, { redirect: 'follow', follow: 10, signal });
   if (!archResponse.ok) {
     throw new Error(`Failed to download tarball. Status code: ${archResponse.status}`);
   }
@@ -500,7 +544,7 @@ async function fetchPluginInfo(URL, progressCallback, signal, pluginVersion) {
     if (progressCallback) {
       progressCallback({ type: 'info', message: 'Fetching Plugin Metadata' });
     }
-    let response = await fetch(apiURL, { redirect: 'follow', follow: 10 }, { signal });
+    let response = await fetchWithRetry(apiURL, { redirect: 'follow', follow: 10, signal });
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
@@ -513,10 +557,9 @@ async function fetchPluginInfo(URL, progressCallback, signal, pluginVersion) {
       }
       // Remove trailing slash if present to avoid double slashes
       const baseURL = apiURL.endsWith('/') ? apiURL.slice(0, -1) : apiURL;
-      response = await fetch(
+      response = await fetchWithRetry(
         `${baseURL}/${pluginVersion}`,
-        { redirect: 'follow', follow: 10 },
-        { signal }
+        { redirect: 'follow', follow: 10, signal }
       );
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
@@ -574,4 +617,4 @@ function defaultPluginsDir() {
   return path.join(configDir, 'user-plugins');
 }
 
-module.exports = { PluginManager, validateArchiveURL };
+module.exports = { PluginManager, validateArchiveURL, fetchWithRetry };

--- a/plugins/pluginctl/src/plugin-management.test.js
+++ b/plugins/pluginctl/src/plugin-management.test.js
@@ -163,3 +163,98 @@ describe('validateArchiveURL', () => {
     expect(validateArchiveURL('https://gitlab.com/owner/repo/invalid/path')).toBe(false);
   });
 });
+
+const fetchWithRetry = pluginManagement.fetchWithRetry;
+
+describe('fetchWithRetry', () => {
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    global.fetch = jest.fn();
+    jest.spyOn(global, 'setTimeout').mockImplementation((cb) => cb());
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  test('recovers after transient failures and network rejections', async () => {
+    global.fetch
+      .mockResolvedValueOnce({ ok: false, status: 500 }) // 1st try fails (HTTP error)
+      .mockRejectedValueOnce(new Error('Network connection dropped')) // 2nd try fails (Network error)
+      .mockResolvedValueOnce({ ok: true, status: 200 }); // 3rd try succeeds
+
+    const response = await fetchWithRetry('https://example.com/api', {}, 3);
+
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+    expect(response.ok).toBe(true);
+    expect(response.status).toBe(200);
+  });
+
+  test('exhausts retry budget on network rejections and throws last error', async () => {
+    global.fetch.mockRejectedValue(new Error('Persistent network failure'));
+
+    await expect(fetchWithRetry('https://example.com/api', {}, 3)).rejects.toThrow('Persistent network failure');
+    expect(global.fetch).toHaveBeenCalledTimes(4);
+  });
+
+  test('returns immediately on non-transient client errors', async () => {
+    global.fetch.mockResolvedValueOnce({ ok: false, status: 404 }); // 1st try returns 404
+
+    const response = await fetchWithRetry('https://example.com/api', {}, 3);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1); // Should not retry 404
+    expect(response.ok).toBe(false);
+    expect(response.status).toBe(404);
+  });
+
+  test('exhausts retry budget and returns last failed response for transient statuses', async () => {
+    global.fetch.mockResolvedValue({ ok: false, status: 503 });
+
+    const response = await fetchWithRetry('https://example.com/api', {}, 3);
+
+    expect(global.fetch).toHaveBeenCalledTimes(4);
+    expect(response.ok).toBe(false);
+    expect(response.status).toBe(503);
+
+    expect(global.setTimeout).toHaveBeenCalledTimes(3);
+    expect(global.setTimeout).toHaveBeenNthCalledWith(1, expect.any(Function), 1000);
+    expect(global.setTimeout).toHaveBeenNthCalledWith(2, expect.any(Function), 2000);
+    expect(global.setTimeout).toHaveBeenNthCalledWith(3, expect.any(Function), 4000);
+  });
+
+  test('throws AbortError immediately during a request', async () => {
+    const abortError = new Error('The operation was aborted');
+    abortError.name = 'AbortError';
+    global.fetch.mockRejectedValue(abortError);
+
+    await expect(fetchWithRetry('https://example.com/api', {}, 3)).rejects.toThrow('The operation was aborted');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('throws AbortError immediately during backoff', async () => {
+    global.fetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    
+    // For this test, we actually want setTimeout to block so we can abort it.
+    // We'll restore setTimeout specifically for this test.
+    jest.spyOn(global, 'setTimeout').mockImplementation((cb) => {
+      // Don't call cb, let it hang so we can test cancellation.
+      return 123; // fake timeout ID
+    });
+    jest.spyOn(global, 'clearTimeout').mockImplementation(() => {});
+    
+    const controller = new AbortController();
+    const fetchPromise = fetchWithRetry('https://example.com/api', { signal: controller.signal }, 3);
+
+    await Promise.resolve(); // flush fetch promise
+    
+    // Abort while it's "waiting" in the mocked setTimeout
+    controller.abort();
+
+    await expect(fetchPromise).rejects.toThrow('The operation was aborted');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.clearTimeout).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION

## Summary

This PR improves the reliability of fetching plugins from ArtifactHub by introducing an exponential backoff retry mechanism to `pluginctl`. This ensures that transient network failures or temporary ArtifactHub rate limits do not immediately fail the plugin installation process.

## Related Issue

N/A (This was originally included in #6965 but was extracted into this focused PR based on reviewer feedback).

## Changes

- Added `fetchWithRetry` in `plugins/pluginctl/src/plugin-management.js` which implements an exponential backoff (up to 3 retries).
- Fixed a bug where `AbortError` was swallowed during retries. Now, `AbortError` is thrown immediately to ensure that plugin installation cancellation remains highly responsive.

## Steps to Test

1. Run the `pluginctl` CLI tool to fetch/install a plugin.
2. If you want to force test the retry mechanism, you can temporarily block or simulate network latency to `artifacthub.io`.
3. Cancel the installation mid-fetch to observe that the CLI remains responsive and aborts immediately.


## Notes for the Reviewer

- As requested in the review for the Reset App State feature, this `pluginctl` retry implementation was extracted into its own focused, atomic PR.
