### PR TITLE
dev: Add LF normalisation for yaml, css and markdown

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,7 @@
 *.mjs  text eol=lf
 *.cjs  text eol=lf
 *.json text eol=lf
+*.yaml text eol=lf
+*.yml  text eol=lf
+*.css  text eol=lf
+*.md   text eol=lf


### PR DESCRIPTION
## Summary

`.gitattributes` normalised line endings only for Go, TypeScript, JavaScript and JSON.
Prettier also checks `.yaml`, `.yml`, `.css` and `.md`, which were not listed, so on
Windows those files are checked out with CRLF and `npm run frontend:lint` fails on 14
files the contributor has not modified.

This adds the four missing extensions, following the approach taken in #6184 which added
`eol=lf` for TypeScript, JavaScript and JSON.

Fixes #7038

## Changes

- `.gitattributes`: add `*.yaml`, `*.yml`, `*.css`, `*.md` with `text eol=lf`

## Testing

On Windows 11 with `core.autocrlf=true`:

- Before: `npm run frontend:lint` fails with "Code style issues found in 14 files"
- After re-checking out those files with the new attributes: `npm run frontend:lint` passes,
  "All matched files use Prettier code style!"

The affected files are already stored with LF in the repository, so this changes only how
they are checked out. `git status` reports no content changes to any file other than
`.gitattributes`.

## Notes for the Reviewer

No screenshots - this is a repository configuration change with no UI impact.

This PR was written in part with the assistance of generative AI.