### PR TITLE
frontend: Clarify port-forward delete intent

### DIFF
--- a/docs/development/api/modules/lib_k8s_apiProxy.md
+++ b/docs/development/api/modules/lib_k8s_apiProxy.md
@@ -584,7 +584,7 @@ ___
 
 ### stopOrDeletePortForward
 
-▸ **stopOrDeletePortForward**(`cluster`, `id`, `stopOrDelete?`): `Promise`<`string`\>
+▸ **stopOrDeletePortForward**(`cluster`, `id`, `stopOnly?`): `Promise`<`string`\>
 
 Stops or deletes a portforward with the specified details.
 
@@ -596,7 +596,7 @@ Stops or deletes a portforward with the specified details.
 | :------ | :------ | :------ | :------ |
 | `cluster` | `string` | `undefined` | The cluster to portforward for. |
 | `id` | `string` | `undefined` | The id to portforward for. |
-| `stopOrDelete` | `boolean` | `true` | Whether to stop or delete the portforward. True for stop, false for delete. |
+| `stopOnly` | `boolean` | `true` | Whether to only stop the portforward without deleting. True for stop, false for delete. |
 
 #### Returns
 

--- a/frontend/src/components/common/Resource/PortForward.tsx
+++ b/frontend/src/components/common/Resource/PortForward.tsx
@@ -367,7 +367,7 @@ function PortForwardContent(props: PortForwardProps) {
       return;
     }
     setLoading(true);
-    stopOrDeletePortForward(cluster, portForward.id, true)
+    stopOrDeletePortForward(cluster, portForward.id, /* stopOnly */ true)
       .then(() => {
         setPortForward({ ...portForward, status: PORT_FORWARD_STOP_STATUS });
       })
@@ -387,7 +387,7 @@ function PortForwardContent(props: PortForwardProps) {
       return;
     }
     setLoading(true);
-    stopOrDeletePortForward(cluster, id, false)
+    stopOrDeletePortForward(cluster, id, /* stopOnly */ false)
       .then(() => {
         const parsedPortForwards = getPortForwardsFromStorage();
         const index = parsedPortForwards.findIndex((pf: PortForwardState) => pf.id === id);

--- a/frontend/src/components/portforward/index.tsx
+++ b/frontend/src/components/portforward/index.tsx
@@ -198,7 +198,7 @@ export default function PortForwardingList() {
     if (option === PortForwardAction.Stop) {
       setPortForwardInActionSafely({ ...portforward, loading: true });
       // stop portforward
-      stopOrDeletePortForward(cluster, id, true).finally(() => {
+      stopOrDeletePortForward(cluster, id, /* stopOnly */ true).finally(() => {
         setPortForwardInActionSafely(null);
         // Always refresh the backend-backed port-forward list so localStorage
         // stays in sync even if the component unmounts before the request settles.
@@ -208,7 +208,7 @@ export default function PortForwardingList() {
     if (option === PortForwardAction.Delete) {
       setPortForwardInActionSafely({ ...portforward, loading: true });
       // delete portforward
-      stopOrDeletePortForward(cluster, id, false).finally(() => {
+      stopOrDeletePortForward(cluster, id, /* stopOnly */ false).finally(() => {
         setPortForwardInActionSafely(null);
 
         // remove portforward from storage too

--- a/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
+++ b/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
@@ -1070,7 +1070,11 @@ describe('apiProxy', () => {
 
     describe('stopOrDeletePortForward', () => {
       it('Successfully deletes a port forward', async () => {
-        const response = await apiProxy.stopOrDeletePortForward(clusterName, mockId);
+        const response = await apiProxy.stopOrDeletePortForward(
+          clusterName,
+          mockId,
+          /* stopOnly */ true
+        );
         const data = JSON.parse(response);
         expect(data).toEqual(mockStopResponse);
       });

--- a/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
+++ b/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
@@ -1073,7 +1073,7 @@ describe('apiProxy', () => {
         const response = await apiProxy.stopOrDeletePortForward(
           clusterName,
           mockId,
-          /* stopOnly */ true
+          /* stopOnly */ false
         );
         const data = JSON.parse(response);
         expect(data).toEqual(mockStopResponse);

--- a/frontend/src/lib/k8s/api/v1/portForward.ts
+++ b/frontend/src/lib/k8s/api/v1/portForward.ts
@@ -119,13 +119,12 @@ export async function startPortForward(
   });
 }
 
-// @todo: stopOrDelete true is confusing, rename this param to justStop?
 /**
  * Stops or deletes a portforward with the specified details.
  *
  * @param cluster - The cluster to portforward for.
  * @param id - The id to portforward for.
- * @param stopOrDelete - Whether to stop or delete the portforward. True for stop, false for delete.
+ * @param stopOnly - Whether to only stop the portforward without deleting. True for stop, false for delete.
  *
  * @returns The response from the API.
  * @throws {Error} if the request fails.
@@ -133,7 +132,7 @@ export async function startPortForward(
 export async function stopOrDeletePortForward(
   cluster: string,
   id: string,
-  stopOrDelete: boolean = true
+  stopOnly: boolean = true
 ): Promise<string> {
   const kubeconfig = await findKubeconfigByClusterName(cluster);
   const headers = new Headers(addBackstageAuthHeaders(JSON_HEADERS));
@@ -148,7 +147,7 @@ export async function stopOrDeletePortForward(
     headers: headers,
     body: JSON.stringify({
       id,
-      stopOrDelete,
+      stopOrDelete: stopOnly,
     }),
     cluster,
   }).then(async response => {


### PR DESCRIPTION
**Description:**
This PR addresses a minor readability issue regarding the `stopOrDelete` parameter in the port-forward API. The boolean parameter was confusing since `true` could imply either stopping or deleting.
**Changes Made:**
- Renamed the `stopOrDelete` parameter to `stopOnly` in the `stopOrDeletePortForward` function.
- Updated all function calls across the codebase to use an inline comment (`/* stopOnly */`) before the boolean value, making the intent unambiguously clear to anyone reading the code.
Fixes #ISSUE_NUMBER <!-- Replace with the actual issue number if applicable -->
## Labels
`enhancement`, `cleanup`