### PR TITLE
backend: spa: Make urlToRel path assertion portable

### DIFF
--- a/backend/pkg/spa/pathSafety_internal_test.go
+++ b/backend/pkg/spa/pathSafety_internal_test.go
@@ -1,6 +1,9 @@
 package spa
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
 func TestURLToRelRejectsUnsafePaths(t *testing.T) {
 	tests := []struct {
@@ -27,7 +30,11 @@ func TestURLToRelAcceptsSafeRelativePath(t *testing.T) {
 		t.Fatalf("expected safe path to be accepted")
 	}
 
-	if rel != "headlamp/assets/main.js" {
-		t.Fatalf("unexpected relative path: got %q", rel)
+	// urlToRel returns an OS-relative path, so the expected value must use the
+	// platform separator: "headlamp/assets/main.js" on Unix and
+	// "headlamp\assets\main.js" on Windows.
+	want := filepath.FromSlash("headlamp/assets/main.js")
+	if rel != want {
+		t.Fatalf("unexpected relative path: got %q, want %q", rel, want)
 	}
 }


### PR DESCRIPTION
## Summary

`go test ./...` fails in the backend on Windows. `urlToRel` returns an OS-relative path
for use with `os.Root` - it calls `filepath.FromSlash`, and both callers pass the result
to `os.Root` - so on Windows it returns `headlamp\assets\main.js`. The expected value in
`TestURLToRelAcceptsSafeRelativePath` was hardcoded with forward slashes, so the assertion
failed there while passing on Linux.

This makes the expected path use `filepath.FromSlash` so it matches the separator of the
platform the test runs on. The production code is unchanged - only the test assertion.

Fixes #7046

## Changes

- `backend/pkg/spa/pathSafety_internal_test.go`: build the expected path with
  `filepath.FromSlash`, and report both `got` and `want` in the failure message

## Testing

On Windows 11, Go 1.26.5:

- Before: `--- FAIL: TestURLToRelAcceptsSafeRelativePath` -
  `unexpected relative path: got "headlamp\assets\main.js"`
- After: `ok github.com/kubernetes-sigs/headlamp/backend/pkg/spa`

Also verified `gofmt -l ./pkg/spa` is clean and `go vet ./pkg/spa/...` passes.

Scope of the original failure on Windows: `backend/pkg/spa` had 57 tests passing and 1
failing, and across the whole backend 14 packages passed with this being the only failing
one.

## Notes for the Reviewer

No screenshots - test-only change with no UI impact.

The backend test jobs run on `ubuntu-latest` only (`backend-test.yml`, and the
`go test ./...` step in `build-other-arch.yml`), which is why this was not caught. Adding
a Windows job to the matrix would surface this class of problem, but that felt like a
separate change to this fix.

I also checked the rest of the backend tests for the same pattern and this is the only
assertion that hardcodes a path separator.