### PR TITLE
frontend: role: Link the service accounts in the binding list

### DIFF
--- a/frontend/src/components/role/BindingList.test.tsx
+++ b/frontend/src/components/role/BindingList.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { KubeRoleBinding } from '../../lib/k8s/roleBinding';
 import { TestContext } from '../../test';
@@ -62,6 +62,77 @@ describe('RoleBindingList service accounts column', () => {
     mockListView.mockReset();
   });
 
+  it('links a service account to its details page', () => {
+    const column = serviceAccountColumn();
+    const binding = makeBinding([{ kind: 'ServiceAccount', name: 'default' }], 'team-a');
+
+    render(<TestContext>{column.render(binding)}</TestContext>);
+
+    const link = screen.getByRole('link', { name: 'default' });
+    expect(link.getAttribute('href')).toContain('/serviceaccounts/team-a/default');
+    expect(link.getAttribute('href')).toContain('my-cluster');
+  });
+
+  it('prefers the namespace of the subject over the one of the binding', () => {
+    const column = serviceAccountColumn();
+    const binding = makeBinding(
+      [{ kind: 'ServiceAccount', name: 'node-viewer', namespace: 'kube-system' }],
+      'team-a'
+    );
+
+    render(<TestContext>{column.render(binding)}</TestContext>);
+
+    expect(screen.getByRole('link', { name: 'node-viewer' }).getAttribute('href')).toContain(
+      '/serviceaccounts/kube-system/node-viewer'
+    );
+  });
+
+  it('leaves a subject without any namespace as plain text', () => {
+    const column = serviceAccountColumn();
+    const binding = makeBinding([{ kind: 'ServiceAccount', name: 'orphan' }]);
+
+    render(<TestContext>{column.render(binding)}</TestContext>);
+
+    expect(screen.getByText('orphan')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'orphan' })).not.toBeInTheDocument();
+  });
+
+  it('links every service account and leaves other kinds out', () => {
+    const column = serviceAccountColumn();
+    const binding = makeBinding(
+      [
+        { apiGroup: 'rbac.authorization.k8s.io', kind: 'User', name: 'jane' },
+        { kind: 'ServiceAccount', name: 'builder', namespace: 'ci' },
+        { kind: 'ServiceAccount', name: 'deployer', namespace: 'ci' },
+      ],
+      'ci'
+    );
+
+    render(<TestContext>{column.render(binding)}</TestContext>);
+
+    expect(screen.getAllByRole('link')).toHaveLength(2);
+    expect(screen.queryByText('jane')).not.toBeInTheDocument();
+  });
+
+  it('renders a subject that is listed twice without colliding keys', () => {
+    const column = serviceAccountColumn();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const binding = makeBinding(
+      [
+        { kind: 'ServiceAccount', name: 'builder', namespace: 'ci' },
+        { kind: 'ServiceAccount', name: 'builder', namespace: 'ci' },
+      ],
+      'ci'
+    );
+
+    render(<TestContext>{column.render(binding)}</TestContext>);
+
+    expect(screen.getAllByRole('link', { name: 'builder' })).toHaveLength(2);
+    expect(consoleError.mock.calls.some(call => String(call[0]).includes('same key'))).toBe(false);
+
+    consoleError.mockRestore();
+  });
+
   it('sorts on the service account subjects and ignores the other kinds', () => {
     const column = serviceAccountColumn();
     const alpha = makeBinding(
@@ -82,5 +153,18 @@ describe('RoleBindingList service accounts column', () => {
     expect(column.sort(alpha, beta)).toBeLessThan(0);
     expect(column.sort(beta, alpha)).toBeGreaterThan(0);
     expect(column.sort(alpha, alpha)).toBe(0);
+  });
+
+  it('keeps the column value as plain names for search and export', () => {
+    const column = serviceAccountColumn();
+    const binding = makeBinding(
+      [
+        { apiGroup: 'rbac.authorization.k8s.io', kind: 'User', name: 'jane' },
+        { kind: 'ServiceAccount', name: 'builder', namespace: 'ci' },
+      ],
+      'ci'
+    );
+
+    expect(column.getValue(binding)).toBe('builder');
   });
 });

--- a/frontend/src/components/role/BindingList.test.tsx
+++ b/frontend/src/components/role/BindingList.test.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { KubeRoleBinding } from '../../lib/k8s/roleBinding';
+import { TestContext } from '../../test';
+import RoleBindingList from './BindingList';
+
+const { mockListView } = vi.hoisted(() => ({
+  mockListView: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/roleBinding', () => ({
+  default: { useList: () => ({ items: [], errors: null }) },
+}));
+
+vi.mock('../../lib/k8s/clusterRoleBinding', () => ({
+  default: { useList: () => ({ items: [], errors: null }) },
+}));
+
+vi.mock('../common/Resource/ResourceListView', () => ({
+  default: (props: any) => {
+    mockListView(props);
+    return null;
+  },
+}));
+
+function makeBinding(subjects: KubeRoleBinding['subjects'], namespace?: string) {
+  return {
+    subjects,
+    cluster: 'my-cluster',
+    getNamespace: () => namespace,
+  };
+}
+
+function serviceAccountColumn() {
+  render(
+    <TestContext>
+      <RoleBindingList />
+    </TestContext>
+  );
+
+  return mockListView.mock.calls[0][0].columns.find((c: any) => c?.id === 'serviceaccounts');
+}
+
+describe('RoleBindingList service accounts column', () => {
+  beforeEach(() => {
+    mockListView.mockReset();
+  });
+
+  it('sorts on the service account subjects and ignores the other kinds', () => {
+    const column = serviceAccountColumn();
+    const alpha = makeBinding(
+      [
+        { apiGroup: 'rbac.authorization.k8s.io', kind: 'User', name: 'zoe' },
+        { kind: 'ServiceAccount', name: 'alpha', namespace: 'ci' },
+      ],
+      'ci'
+    );
+    const beta = makeBinding(
+      [
+        { apiGroup: 'rbac.authorization.k8s.io', kind: 'User', name: 'adam' },
+        { kind: 'ServiceAccount', name: 'beta', namespace: 'ci' },
+      ],
+      'ci'
+    );
+
+    expect(column.sort(alpha, beta)).toBeLessThan(0);
+    expect(column.sort(beta, alpha)).toBeGreaterThan(0);
+    expect(column.sort(alpha, alpha)).toBe(0);
+  });
+});

--- a/frontend/src/components/role/BindingList.tsx
+++ b/frontend/src/components/role/BindingList.tsx
@@ -176,7 +176,7 @@ export default function RoleBindingList() {
               }
             />
           ),
-          sort: sortBindings('Service Accounts'),
+          sort: sortBindings('ServiceAccount'),
         },
         'labels',
         'age',

--- a/frontend/src/components/role/BindingList.tsx
+++ b/frontend/src/components/role/BindingList.tsx
@@ -22,6 +22,7 @@ import { useNamespaces } from '../../redux/filterSlice';
 import LabelListItem from '../common/LabelListItem';
 import Link from '../common/Link';
 import ResourceListView from '../common/Resource/ResourceListView';
+import { LightTooltip } from '../common/Tooltip';
 
 function RoleLink(props: { role: string; namespace?: string; cluster: string }) {
   const { role, namespace, cluster } = props;
@@ -38,6 +39,42 @@ function RoleLink(props: { role: string; namespace?: string; cluster: string }) 
     <Link routeName="clusterrole" params={{ name: role }} activeCluster={cluster} tooltip>
       {role}
     </Link>
+  );
+}
+
+function ServiceAccountList(props: { binding: RoleBinding }) {
+  const { binding } = props;
+  const subjects = binding.subjects?.filter(subject => subject.kind === 'ServiceAccount') ?? [];
+
+  if (subjects.length === 0) {
+    return null;
+  }
+
+  return (
+    <LightTooltip title={subjects.map(subject => subject.name).join('\n')} interactive>
+      <span>
+        {subjects.map((subject, index) => {
+          const namespace = subject.namespace || binding.getNamespace();
+
+          return (
+            <React.Fragment key={`${subject.name}__${index}`}>
+              {index > 0 && ', '}
+              {namespace ? (
+                <Link
+                  routeName="serviceAccount"
+                  params={{ name: subject.name, namespace }}
+                  activeCluster={binding.cluster}
+                >
+                  {subject.name}
+                </Link>
+              ) : (
+                subject.name
+              )}
+            </React.Fragment>
+          );
+        })}
+      </span>
+    </LightTooltip>
   );
 }
 
@@ -167,15 +204,7 @@ export default function RoleBindingList() {
               ?.filter(subject => subject.kind === 'ServiceAccount')
               ?.map(subject => subject.name)
               ?.join(' '),
-          render: item => (
-            <LabelListItem
-              labels={
-                item?.subjects
-                  ?.filter(subject => subject.kind === 'ServiceAccount')
-                  .map(subject => subject.name) || []
-              }
-            />
-          ),
+          render: item => <ServiceAccountList binding={item} />,
           sort: sortBindings('ServiceAccount'),
         },
         'labels',

--- a/frontend/src/components/role/__snapshots__/BindingList.RoleBindings.stories.storyshot
+++ b/frontend/src/components/role/__snapshots__/BindingList.RoleBindings.stories.storyshot
@@ -892,7 +892,12 @@
                       class=""
                       data-mui-internal-clone-element="true"
                     >
-                      default
+                      <a
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                        href="/"
+                      >
+                        default
+                      </a>
                     </span>
                   </td>
                   <td


### PR DESCRIPTION
## Summary

This PR makes service accounts clickable in the Role Bindings list view, so you can reach a service account without opening the binding first. It also fixes the sort comparator on that column, which never matched any subject and so did nothing.

## Related Issue

Fixes #6928

## Changes

- Added a `ServiceAccountList` renderer in `BindingList.tsx` that links each service account subject to its details page
- Fixed the Service Accounts column sort, which filtered for the kind `Service Accounts` instead of `ServiceAccount`
- Added a `ServiceAccount` subject to the ClusterRoleBinding story fixture, which previously only had a Group
- Added `BindingList.test.tsx` covering the link, the namespace fallback, and the plain text case

## Steps to Test

1. Go to Security, then Role Bindings
2. Find a binding that has something in the Service Accounts column
3. Click the service account name
4. You land on the service account details page, in the same cluster the binding belongs to

## Notes for the Reviewer

- The obvious approach of passing `<Link>` elements to `LabelListItem` does not work. Its prop type says `React.ReactNode[]`, but internally it does `labels.join(', ')`, so elements would render as `[object Object]`. I left that component alone rather than change something around 20 lists depend on, and rendered the links in the column instead, following the `RoleLink` helper already in this file. Happy to fix `LabelListItem` separately if you would prefer that.
- The namespace comes from `subject.namespace` and falls back to the binding's own namespace. If neither is present the name stays plain text, so no broken URL is generated.
- `activeCluster` is passed so the link stays on the binding's cluster. The details view does not need this, the list does.
- `getValue` is unchanged, so search, filtering and export still see plain names.
- The sort fix is a separate commit since it is a pre-existing bug and not part of the feature.
- No new translation strings, so the locale files are untouched.
