### PR TITLE
0057: Honor Table toolbar and selection props

### DIFF
--- a/e2e-tests/tests/tableProps.spec.ts
+++ b/e2e-tests/tests/tableProps.spec.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import { HeadlampPage } from './headlampPage';
+
+test('honors disabled Table toolbar and row selection props', async ({ page }) => {
+  const headlampPage = new HeadlampPage(page);
+  await headlampPage.navigateToCluster('test', process.env.HEADLAMP_TEST_TOKEN);
+  await headlampPage.navigateTopage('/c/test/table-props');
+
+  await expect(page.getByRole('heading', { name: 'Table Fixture' })).toBeVisible();
+  await expect.soft(page.getByRole('button', { name: 'Show/Hide search' })).toHaveCount(0);
+
+  const customCheckbox = page.getByRole('checkbox', { name: 'Custom row checkbox' });
+  await expect(customCheckbox).not.toBeChecked();
+  await customCheckbox.click();
+  await expect(customCheckbox).toBeChecked();
+});

--- a/frontend/src/components/common/Table/Table.test.tsx
+++ b/frontend/src/components/common/Table/Table.test.tsx
@@ -1,0 +1,414 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMuiTheme } from '../../../lib/themes';
+import Table, { TableProps } from './Table';
+
+const { tableMocks } = vi.hoisted(() => ({
+  tableMocks: {
+    cellContext: 'plain' as 'dialog' | 'plain' | 'switch',
+    columnVisibility: {} as Record<string, boolean>,
+    forceNoRows: false,
+    options: null as any,
+    setColumnVisibility: vi.fn(),
+    setRowSelection: vi.fn(),
+    setTablesRowsPerPage: vi.fn(),
+    setURLState: vi.fn(),
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}));
+
+vi.mock('../../../lib/useShortcut', () => ({ useShortcut: vi.fn() }));
+vi.mock('../../../lib/util', () => ({
+  useURLState: (_key: string, options: { defaultValue: number }) => [
+    options.defaultValue,
+    tableMocks.setURLState,
+  ],
+}));
+vi.mock('../../../helpers/tablesRowsPerPage', () => ({
+  getTablesRowsPerPage: () => 10,
+  setTablesRowsPerPage: tableMocks.setTablesRowsPerPage,
+}));
+vi.mock('../../App/Settings/hook', () => ({ useSettings: () => [10] }));
+vi.mock('../../resourceMap/useQueryParamsState', () => ({
+  useQueryParamsState: (_key: string, initialValue: unknown) => [initialValue, vi.fn()],
+}));
+vi.mock('./useScrollPreservation', () => ({
+  useScrollPreservationOnDataChange: () => ({ ref: { current: null }, onScroll: vi.fn() }),
+}));
+
+vi.mock('material-react-table', () => ({
+  MRT_BottomToolbar: () => <div data-testid="bottom-toolbar" />,
+  MRT_TableBodyCell: ({ cell }: any) => {
+    const checkbox = <input aria-label={`Custom selection for ${cell.row.id}`} type="checkbox" />;
+    return (
+      <td>
+        {tableMocks.cellContext === 'switch' ? (
+          <span className="MuiSwitch-root">{checkbox}</span>
+        ) : tableMocks.cellContext === 'dialog' ? (
+          <span role="dialog">{checkbox}</span>
+        ) : (
+          checkbox
+        )}
+      </td>
+    );
+  },
+  MRT_TableHeadCell: () => <th>Selection</th>,
+  MRT_TopToolbar: () => <div data-testid="top-toolbar" />,
+  useMaterialReactTable: (options: any) => {
+    tableMocks.options = options;
+    const rows = options.data.map((item: Record<string, unknown>, index: number) => {
+      const row: any = {
+        id: String(index),
+        getCanSelect: () => true,
+        getIsSelected: () => false,
+      };
+      row.getVisibleCells = () => [
+        {
+          id: `${row.id}-selection`,
+          column: { id: 'selection', columnDef: options.columns[0] },
+          getValue: () => item.selected,
+          row,
+        },
+      ];
+      return row;
+    });
+
+    return {
+      getHeaderGroups: () => [
+        {
+          headers: [
+            {
+              id: 'selection',
+              column: {
+                id: 'selection',
+                getFilterValue: () => undefined,
+                getIsFiltered: () => false,
+                getIsSorted: () => false,
+              },
+            },
+          ],
+        },
+      ],
+      getRowModel: () => ({ rows }),
+      getSelectedRowModel: () => ({ flatRows: [], rows: [] }),
+      getState: () => ({
+        columnVisibility: tableMocks.columnVisibility,
+        showColumnFilters: false,
+      }),
+      rows,
+      setColumnVisibility: tableMocks.setColumnVisibility,
+      setRowSelection: tableMocks.setRowSelection,
+      setShowColumnFilters: vi.fn(),
+    };
+  },
+  useMRT_Rows: (table: any) => (tableMocks.forceNoRows ? [] : table.rows),
+}));
+
+const theme = createMuiTheme({ base: 'light', name: 'light' });
+
+interface TestRow {
+  /** Optional name used by additional data columns. */
+  name?: string;
+  /** Value rendered by the custom selection column. */
+  selected: boolean;
+}
+
+/**
+ * Renders a one-row table with optional toolbar and row-selection settings.
+ *
+ * @param props - Table behavior settings to exercise.
+ * @returns The Testing Library render result.
+ */
+function renderTable(props: Partial<TableProps<TestRow>> = {}) {
+  return render(
+    <ThemeProvider theme={theme}>
+      <Table
+        columns={[{ accessorKey: 'selected', header: 'Selection' }]}
+        data={[{ selected: false }]}
+        {...props}
+      />
+    </ThemeProvider>
+  );
+}
+
+describe('Table toolbar and selection props', () => {
+  beforeEach(() => {
+    tableMocks.cellContext = 'plain';
+    tableMocks.columnVisibility = {};
+    tableMocks.forceNoRows = false;
+    tableMocks.options = null;
+    tableMocks.setColumnVisibility.mockClear();
+    tableMocks.setRowSelection.mockClear();
+    tableMocks.setTablesRowsPerPage.mockClear();
+    tableMocks.setURLState.mockClear();
+  });
+
+  it.each([
+    ['by default', {}],
+    ['when enabled', { enableTopToolbar: true }],
+  ])('shows the top toolbar %s', (_description: string, props: object) => {
+    renderTable(props);
+
+    expect(screen.getByTestId('top-toolbar')).toBeVisible();
+  });
+
+  it('hides the top toolbar when disabled', () => {
+    renderTable({ enableTopToolbar: false });
+
+    expect(screen.queryByTestId('top-toolbar')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['when omitted', {}],
+    ['when enabled', { enableRowSelection: true }],
+  ])('handles custom selection checkboxes %s', (_description: string, props: object) => {
+    renderTable(props);
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(tableMocks.setRowSelection).toHaveBeenCalledOnce();
+  });
+
+  it('ignores custom selection checkboxes when row selection is disabled', () => {
+    renderTable({ enableRowSelection: false });
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(tableMocks.setRowSelection).not.toHaveBeenCalled();
+  });
+
+  it.each(['switch', 'dialog'] as const)('ignores checkboxes inside a %s', context => {
+    tableMocks.cellContext = context;
+    renderTable({ enableRowSelection: true });
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(tableMocks.setRowSelection).not.toHaveBeenCalled();
+  });
+
+  it('ignores clicks outside checkboxes', () => {
+    renderTable({ enableRowSelection: true });
+
+    fireEvent.click(screen.getByRole('cell'));
+
+    expect(tableMocks.setRowSelection).not.toHaveBeenCalled();
+  });
+
+  it('selects a range when a checkbox is shift-clicked', () => {
+    renderTable({
+      data: [{ selected: false }, { selected: false }],
+      enableRowSelection: true,
+    });
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+    fireEvent.click(checkboxes[1], { shiftKey: true });
+
+    expect(tableMocks.setRowSelection).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('Table states and options', () => {
+  beforeEach(() => {
+    tableMocks.cellContext = 'plain';
+    tableMocks.columnVisibility = {};
+    tableMocks.forceNoRows = false;
+    tableMocks.options = null;
+    tableMocks.setColumnVisibility.mockClear();
+    tableMocks.setRowSelection.mockClear();
+    tableMocks.setTablesRowsPerPage.mockClear();
+    tableMocks.setURLState.mockClear();
+  });
+
+  it('renders error, loading, and empty states', () => {
+    const errorResult = renderTable({ errorMessage: 'Unable to load rows' });
+    expect(screen.getByText('Unable to load rows')).toBeVisible();
+    errorResult.unmount();
+
+    const loadingResult = renderTable({ loading: true });
+    expect(screen.getByRole('progressbar', { name: 'Loading table data' })).toBeVisible();
+    loadingResult.unmount();
+
+    renderTable({ data: [], emptyMessage: 'Nothing here' });
+    expect(screen.getByRole('status')).toHaveTextContent('Nothing here');
+  });
+
+  it('filters data before passing it to Material React Table', () => {
+    renderTable({
+      data: [
+        { name: 'keep', selected: false },
+        { name: 'remove', selected: false },
+      ],
+      filterFunction: row => row.name === 'keep',
+    });
+
+    expect(tableMocks.options.data).toEqual([{ name: 'keep', selected: false }]);
+  });
+
+  it('uses caller pagination, ordering, and initial filter options', () => {
+    renderTable({
+      columns: [
+        { accessorKey: 'selected', gridTemplate: 2, header: 'Selection' },
+        { accessorKey: 'name', gridTemplate: 'min-content', header: 'Name' },
+      ],
+      data: [
+        { name: 'first', selected: false },
+        { name: 'second', selected: false },
+      ],
+      enableRowActions: true,
+      enableRowSelection: true,
+      initialState: { globalFilter: 'first' },
+      reflectInURL: true,
+      rowsPerPage: [1, 2],
+    });
+
+    expect(tableMocks.options.enablePagination).toBe(true);
+    expect(tableMocks.options.initialState.globalFilter).toBe('first');
+    expect(tableMocks.options.state.columnOrder).toEqual([
+      'mrt-row-select',
+      '0',
+      '1',
+      'mrt-row-actions',
+    ]);
+    expect(tableMocks.options.state.showGlobalFilter).toBe(true);
+  });
+
+  it('renders a caller selection toolbar only when rows are selected', () => {
+    const renderRowSelectionToolbar = vi.fn(() => <span>Selected actions</span>);
+    renderTable({ enableRowSelection: true, renderRowSelectionToolbar });
+
+    const noSelection = tableMocks.options.renderToolbarInternalActions({
+      table: { getSelectedRowModel: () => ({ rows: [] }) },
+    });
+    const withSelection = tableMocks.options.renderToolbarInternalActions({
+      table: { getSelectedRowModel: () => ({ rows: [{}] }) },
+    });
+
+    expect(noSelection).toBeNull();
+    expect(withSelection).toEqual(<span>Selected actions</span>);
+    expect(renderRowSelectionToolbar).toHaveBeenCalledOnce();
+  });
+
+  it('returns no selection toolbar when no renderer is provided', () => {
+    renderTable({ enableRowSelection: true });
+
+    const toolbar = tableMocks.options.renderToolbarInternalActions({
+      table: { getSelectedRowModel: () => ({ rows: [{}] }) },
+    });
+
+    expect(toolbar).toBeNull();
+  });
+
+  it('provides an empty-results fallback to Material React Table', () => {
+    renderTable();
+
+    const fallback = tableMocks.options.renderEmptyRowsFallback();
+    const result = render(<ThemeProvider theme={theme}>{fallback}</ThemeProvider>);
+
+    expect(result.getByText('No results found')).toBeVisible();
+  });
+
+  it('announces when filtering leaves no rows', () => {
+    tableMocks.forceNoRows = true;
+    renderTable();
+
+    expect(screen.getByRole('status')).toHaveTextContent('No results found');
+  });
+
+  it('updates pagination and stores a changed page size', async () => {
+    renderTable();
+
+    act(() => {
+      tableMocks.options.onPaginationChange(() => ({ pageIndex: 2, pageSize: 25 }));
+    });
+
+    await waitFor(() => expect(tableMocks.setURLState).toHaveBeenCalledWith(4));
+    expect(tableMocks.setURLState).toHaveBeenCalledWith(25);
+    expect(tableMocks.setTablesRowsPerPage).toHaveBeenCalledWith(25);
+  });
+
+  it('skips pagination updates when there are no rows', () => {
+    const updater = vi.fn();
+    renderTable({ data: [] });
+
+    tableMocks.options.onPaginationChange(updater);
+
+    expect(updater).not.toHaveBeenCalled();
+  });
+
+  it('hides lower-priority columns when the container is narrow', () => {
+    const clientWidth = vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(150);
+
+    renderTable({
+      columns: [
+        { accessorKey: 'selected', header: 'Selection', responsivePriority: 10 },
+        { accessorKey: 'name', header: 'Name', responsivePriority: 1 },
+        { accessorKey: 'detail', header: 'Detail', responsivePriority: 1 },
+        { accessorKey: 'status', header: 'Status', responsivePriority: 2 },
+      ],
+      enableRowActions: true,
+      enableRowSelection: true,
+      state: { columnVisibility: { detail: false } },
+    });
+
+    expect(tableMocks.options.state.columnVisibility).toMatchObject({
+      '1': false,
+      '2': false,
+      '3': false,
+      detail: false,
+    });
+
+    clientWidth.mockRestore();
+  });
+
+  it('keeps columns visible when the container is wide enough', () => {
+    const clientWidth = vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(1000);
+
+    renderTable({
+      columns: [
+        { accessorKey: 'selected', header: 'Selection' },
+        { accessorKey: 'name', header: 'Name' },
+      ],
+    });
+
+    expect(tableMocks.options.state.columnVisibility).toEqual({});
+
+    clientWidth.mockRestore();
+  });
+
+  it('hides and restores the actions column with data-column visibility', () => {
+    tableMocks.columnVisibility = { '0': false };
+    const hiddenResult = renderTable({
+      columns: [{ accessorKey: 'selected', header: 'Selection' }],
+    });
+
+    expect(tableMocks.setColumnVisibility).toHaveBeenCalledOnce();
+    hiddenResult.unmount();
+
+    tableMocks.setColumnVisibility.mockClear();
+    tableMocks.columnVisibility = { '0': true, actions: false };
+    renderTable({ columns: [{ accessorKey: 'selected', header: 'Selection' }] });
+
+    expect(tableMocks.setColumnVisibility).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -566,7 +566,7 @@ export default function Table<RowItem extends Record<string, any>>({
 
   // Handle shift+click range selection
   const handleRowClick = (e: React.MouseEvent, clickedIndex: number) => {
-    if (!table || !table.getRowModel) {
+    if (!table || !table.getRowModel || tableProps.enableRowSelection === false) {
       return;
     }
 
@@ -637,7 +637,7 @@ export default function Table<RowItem extends Record<string, any>>({
 
     content = (
       <>
-        <MRT_TopToolbar table={table} />
+        {(tableProps.enableTopToolbar ?? true) && <MRT_TopToolbar table={table} />}
         <MuiTable
           sx={{
             display: 'grid',

--- a/plugins/examples/sidebar/src/index.tsx
+++ b/plugins/examples/sidebar/src/index.tsx
@@ -21,9 +21,64 @@ import {
   registerSidebarEntry,
   registerSidebarEntryFilter,
 } from '@kinvolk/headlamp-plugin/lib';
-import { SectionBox } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { SectionBox, Table, TableColumn } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import Checkbox from '@mui/material/Checkbox';
 import Typography from '@mui/material/Typography';
 import React from 'react';
+
+interface TablePropsTestRow {
+  /** Display name for the fixture row. */
+  name: string;
+  /** Initial value shown by the custom selection cell. */
+  selected: boolean;
+}
+
+/**
+ * Renders the checkbox used to verify that disabled row selection leaves custom cells alone.
+ *
+ * @returns An uncontrolled checkbox for the fixture row.
+ */
+function CustomSelectionCheckbox(): React.ReactElement {
+  return <Checkbox inputProps={{ 'aria-label': 'Custom row checkbox' }} />;
+}
+
+const tablePropsColumns: TableColumn<TablePropsTestRow>[] = [
+  {
+    accessorKey: 'selected',
+    header: 'Selected',
+    Cell: CustomSelectionCheckbox,
+  },
+  {
+    accessorKey: 'name',
+    header: 'Name',
+  },
+];
+
+/**
+ * Renders a table fixture with its top toolbar and MRT row selection disabled.
+ *
+ * @returns The Table props end-to-end fixture.
+ */
+function TablePropsTestPage(): React.ReactElement {
+  return (
+    <SectionBox title="Table Fixture">
+      <Table
+        columns={tablePropsColumns}
+        data={[{ name: 'Custom selection row', selected: false }]}
+        enableRowSelection={false}
+        enableTopToolbar={false}
+      />
+    </SectionBox>
+  );
+}
+
+registerRoute({
+  path: '/table-props',
+  sidebar: null,
+  name: 'table-props',
+  exact: true,
+  component: TablePropsTestPage,
+});
 
 // A non-clickable section header in the sidebar.
 registerSidebarEntry({


### PR DESCRIPTION
## Summary

- Honor `enableTopToolbar={false}` in Headlamp's custom Table rendering.
- Skip custom row-selection handling when `enableRowSelection={false}` so
  independent checkbox cells retain their native behavior.
- Add direct unit and Playwright coverage for the public Table props.

## Improvements over the existing change

- Preserves and tests the existing default and explicitly enabled behavior.
- Raises `Table.tsx` branch coverage to 84.57%, enforced with an 80% threshold.
- Adds browser coverage through the public plugin API used by downstream tables.
- Covers checkbox exclusions for switches and dialogs as well as range selection,
  rendering states, pagination, and responsive column behavior.

## Provenance

The retained patch header records the original downstream Headlamp commit
`d1611f473d66f6959e076df6df10d21bc3996e6f` by Oleksandr Dubenko, authored on
2026-07-31. The implementation commit preserves that author and date and adds
Rene Dudfield as co-author.

Original PR: [Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823).
Patch 0057 was retained there in Azure/aks-desktop commit
[`387eb27e3f586211610dda61949255e7264a9c95`](https://github.com/Azure/aks-desktop/commit/387eb27e3f586211610dda61949255e7264a9c95)
as part of the Headlamp source-package patch series. No separate Azure PR was
found for the original downstream commit.

## Testing

- `npx vitest run src/components/common/Table/Table.test.tsx --coverage ...`
  - 22 tests passed
  - 84.57% branch coverage for `Table.tsx`
- `npm --prefix frontend run tsc`
- `npm --prefix frontend run ci-lint`
- `npm --prefix frontend run build`
- Sidebar example plugin lint and production build
- Playwright test discovery for `tests/tableProps.spec.ts`

The live Playwright assertion was not run locally because the current in-cluster
Headlamp deployment does not contain this branch's rebuilt example-plugin image.
CI builds that image before running the e2e suite.

## Screenshots

Not included. The visible difference is the requested absence of a disabled
toolbar; the Playwright regression verifies it together with checkbox behavior.

Assisted by copilot.
