### PR TITLE
0055: frontend: Allow SimpleTable cell overflow

### DIFF
--- a/e2e-tests/tests/headlamp.spec.ts
+++ b/e2e-tests/tests/headlamp.spec.ts
@@ -95,7 +95,7 @@ test('headlamp service page should contain port', async ({ page }) => {
     .filter({ has: page.getByRole('columnheader', { name: 'Protocol', exact: true }) });
   await expect(portsTable.getByRole('cell', { name: 'TCP', exact: true })).toHaveCSS(
     'overflow',
-    'hidden'
+    'visible'
   );
   await headlampPage.a11y();
 });

--- a/e2e-tests/tests/headlamp.spec.ts
+++ b/e2e-tests/tests/headlamp.spec.ts
@@ -83,13 +83,20 @@ test('service page should have headlamp service', async () => {
   await servicesPage.a11y();
 });
 
-test('headlamp service page should contain port', async () => {
+test('headlamp service page should contain port', async ({ page }) => {
   await servicesPage.navigateToServices();
   await servicesPage.clickOnServicesSection();
   await servicesPage.goToParticularService('headlamp');
 
   // Check if there is text "TCP" on the page
   await headlampPage.checkPageContent('TCP');
+  const portsTable = page
+    .getByRole('table')
+    .filter({ has: page.getByRole('columnheader', { name: 'Protocol', exact: true }) });
+  await expect(portsTable.getByRole('cell', { name: 'TCP', exact: true })).toHaveCSS(
+    'overflow',
+    'hidden'
+  );
   await headlampPage.a11y();
 });
 

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.ClusterListDisplay.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.ClusterListDisplay.stories.storyshot
@@ -37,7 +37,7 @@
           tabindex="0"
         >
           <table
-            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+            class="MuiTable-root css-1ok7ihs-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.LongNamesAndURLs.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.LongNamesAndURLs.stories.storyshot
@@ -37,7 +37,7 @@
           tabindex="0"
         >
           <table
-            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+            class="MuiTable-root css-1ok7ihs-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.ManyClusters.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.ManyClusters.stories.storyshot
@@ -37,7 +37,7 @@
           tabindex="0"
         >
           <table
-            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+            class="MuiTable-root css-1ok7ihs-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.SingleCluster.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.SingleCluster.stories.storyshot
@@ -37,7 +37,7 @@
           tabindex="0"
         >
           <table
-            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+            class="MuiTable-root css-1ok7ihs-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.VariousConfigurations.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.VariousConfigurations.stories.storyshot
@@ -37,7 +37,7 @@
           tabindex="0"
         >
           <table
-            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+            class="MuiTable-root css-1ok7ihs-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/SimpleTable.test.tsx
+++ b/frontend/src/components/common/SimpleTable.test.tsx
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { createMuiTheme } from '../../lib/themes';
+import { TestContext, TestContextProps } from '../../test';
+import SimpleTable, { SimpleTableProps } from './SimpleTable';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const theme = createMuiTheme({ base: 'light', name: 'light' });
+const columns: SimpleTableProps['columns'] = [{ label: 'Value', datum: 'value' }];
+
+/**
+ * Renders a SimpleTable with Headlamp's providers and theme.
+ *
+ * @param props - Properties passed to SimpleTable.
+ * @param contextProps - Optional router properties passed to TestContext.
+ * @returns The Testing Library render result.
+ */
+function renderTable(props: SimpleTableProps, contextProps: TestContextProps = {}) {
+  return render(
+    <TestContext {...contextProps}>
+      <ThemeProvider theme={theme}>
+        <SimpleTable {...props} />
+      </ThemeProvider>
+    </TestContext>
+  );
+}
+
+/**
+ * Reads body-cell text in visual row order.
+ *
+ * @returns The text content for each body cell.
+ */
+function getBodyCellText() {
+  return screen.getAllByRole('cell').map(cell => cell.textContent);
+}
+
+describe('SimpleTable', () => {
+  it('hides overflow for body cells and column headers', () => {
+    renderTable({
+      columns,
+      data: [{ value: 'A long value that should wrap instead of being clipped' }],
+      showPagination: false,
+    });
+
+    expect(getComputedStyle(screen.getByRole('cell')).overflow).toBe('hidden');
+    expect(getComputedStyle(screen.getByRole('columnheader')).overflow).toBe('hidden');
+  });
+
+  it('renders loading, error, and custom empty states', () => {
+    const { rerender } = renderTable({ columns, data: null });
+
+    expect(screen.getByRole('progressbar', { name: 'Loading table data' })).toBeVisible();
+
+    rerender(
+      <TestContext>
+        <ThemeProvider theme={theme}>
+          <SimpleTable columns={columns} data={null} errorMessage="Unable to load values" />
+        </ThemeProvider>
+      </TestContext>
+    );
+    expect(screen.getByText('Unable to load values')).toBeVisible();
+
+    rerender(
+      <TestContext>
+        <ThemeProvider theme={theme}>
+          <SimpleTable columns={columns} data={[]} emptyMessage="No values configured" />
+        </ThemeProvider>
+      </TestContext>
+    );
+    expect(screen.getAllByText('No values configured')).toHaveLength(2);
+    expect(screen.getByRole('status')).toHaveTextContent('No values configured');
+  });
+
+  it('renders getter values, row colors, cell properties, and no header', () => {
+    renderTable({
+      columns: [
+        {
+          label: 'Value',
+          getter: row => row.value.toUpperCase(),
+          cellProps: { 'data-testid': 'value-cell' },
+        },
+      ],
+      data: [{ value: 'ready', color: 'green' }],
+      noTableHeader: true,
+      showPagination: false,
+    });
+
+    expect(screen.queryByRole('columnheader')).not.toBeInTheDocument();
+    expect(screen.getByTestId('value-cell')).toHaveTextContent('READY');
+  });
+
+  it('shows the no-match state when filtering removes every row', () => {
+    renderTable({
+      columns,
+      data: [{ value: 'visible without filtering' }],
+      filterFunction: () => false,
+      showPagination: false,
+    });
+
+    expect(screen.getByText('No data matching the filter criteria.')).toBeVisible();
+    expect(screen.getByRole('cell')).toHaveStyle({ gridColumn: 'span 1' });
+  });
+
+  it('sorts datum values in both directions', async () => {
+    renderTable({
+      columns: [{ label: 'Value', datum: 'value', sort: true }],
+      data: [{ value: 'bravo' }, { value: 'alpha' }],
+      defaultSortingColumn: 1,
+      showPagination: false,
+    });
+
+    await waitFor(() => expect(getBodyCellText()).toEqual(['alpha', 'bravo']));
+    fireEvent.click(screen.getByRole('button', { name: 'translation|Sort descending' }));
+    await waitFor(() => expect(getBodyCellText()).toEqual(['bravo', 'alpha']));
+  });
+
+  it('sorts with getter and comparator functions', async () => {
+    const { unmount } = renderTable({
+      columns: [
+        {
+          label: 'Value',
+          getter: row => row.value,
+          sort: (row: { value: string }) => row.value,
+        },
+      ],
+      data: [{ value: 'bravo' }, { value: 'alpha' }],
+      defaultSortingColumn: 1,
+      showPagination: false,
+    });
+
+    await waitFor(() => expect(getBodyCellText()).toEqual(['alpha', 'bravo']));
+    unmount();
+
+    renderTable({
+      columns: [
+        {
+          label: 'Value',
+          getter: row => row.value,
+          sort: (left, right) => left.value.length - right.value.length,
+        },
+      ],
+      data: [{ value: 'long' }, { value: 'x' }],
+      defaultSortingColumn: -1,
+      showPagination: false,
+    });
+    await waitFor(() => expect(getBodyCellText()).toEqual(['long', 'x']));
+
+    fireEvent.click(screen.getByRole('button', { name: 'translation|Sort ascending' }));
+    await waitFor(() => expect(getBodyCellText()).toEqual(['x', 'long']));
+  });
+
+  it('changes pages and rows per page', async () => {
+    renderTable({
+      columns,
+      data: [{ value: 'first' }, { value: 'second' }, { value: 'third' }],
+      rowsPerPage: [1, 2],
+      showPagination: true,
+    });
+
+    expect(getBodyCellText()).toEqual(['first']);
+    fireEvent.click(screen.getByRole('button', { name: 'next page' }));
+    await waitFor(() => expect(getBodyCellText()).toEqual(['second']));
+
+    fireEvent.mouseDown(screen.getByRole('combobox'));
+    fireEvent.click(await screen.findByRole('option', { name: '2' }));
+    await waitFor(() => expect(getBodyCellText()).toEqual(['first', 'second']));
+  });
+
+  it('returns to the first page when refreshing from a later page', async () => {
+    const initialProps: SimpleTableProps = {
+      columns,
+      data: [{ value: 'old first' }, { value: 'old second' }],
+      page: 1,
+      rowsPerPage: [1],
+      showPagination: true,
+    };
+    const { rerender } = renderTable(initialProps);
+    expect(getBodyCellText()).toEqual(['old second']);
+
+    rerender(
+      <TestContext>
+        <ThemeProvider theme={theme}>
+          <SimpleTable {...initialProps} data={[{ value: 'new first' }, { value: 'new second' }]} />
+        </ThemeProvider>
+      </TestContext>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'translation|Refresh' }));
+    await waitFor(() => expect(getBodyCellText()).toEqual(['old first']));
+    expect(screen.queryByRole('button', { name: 'translation|Refresh' })).not.toBeInTheDocument();
+  });
+
+  it('reflects prefixed page state in the URL', () => {
+    renderTable(
+      {
+        columns,
+        data: [{ value: 'first' }, { value: 'second' }],
+        reflectInURL: 'values',
+        rowsPerPage: [1],
+        showPagination: true,
+      },
+      { urlSearchParams: { 'values.p': '2' } }
+    );
+
+    const table = screen.getByRole('table');
+    expect(within(table).getByRole('cell')).toHaveTextContent('second');
+  });
+});

--- a/frontend/src/components/common/SimpleTable.test.tsx
+++ b/frontend/src/components/common/SimpleTable.test.tsx
@@ -55,14 +55,14 @@ function getBodyCellText() {
 }
 
 describe('SimpleTable', () => {
-  it('hides overflow for body cells and column headers', () => {
+  it('allows body-cell overflow while hiding column-header overflow', () => {
     renderTable({
       columns,
       data: [{ value: 'A long value that should wrap instead of being clipped' }],
       showPagination: false,
     });
 
-    expect(getComputedStyle(screen.getByRole('cell')).overflow).toBe('hidden');
+    expect(getComputedStyle(screen.getByRole('cell')).overflow).not.toBe('hidden');
     expect(getComputedStyle(screen.getByRole('columnheader')).overflow).toBe('hidden');
   });
 

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -405,7 +405,6 @@ export default function SimpleTable(props: SimpleTableProps) {
                 [theme.breakpoints.down('sm')]: {
                   padding: '15px 24px 15px 16px',
                 },
-                overflow: 'hidden',
                 width: '100%',
                 wordWrap: 'break-word',
               },

--- a/frontend/src/components/common/__snapshots__/ConditionList.Default.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ConditionList.Default.stories.storyshot
@@ -11,7 +11,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-qzmaqi-MuiTable-root"
+        class="MuiTable-root css-fekg5f-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/ConditionList.WithLastUpdate.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ConditionList.WithLastUpdate.stories.storyshot
@@ -11,7 +11,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-r7i92b-MuiTable-root"
+        class="MuiTable-root css-1f5u0uu-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/InnerTable.Default.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.Default.stories.storyshot
@@ -19,7 +19,7 @@
         tabindex="0"
       >
         <table
-          class="MuiTable-root css-qzmaqi-MuiTable-root"
+          class="MuiTable-root css-fekg5f-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/InnerTable.InsideAnotherComponent.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.InsideAnotherComponent.stories.storyshot
@@ -27,7 +27,7 @@
           tabindex="0"
         >
           <table
-            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+            class="MuiTable-root css-1ok7ihs-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/InnerTable.WithFewRows.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.WithFewRows.stories.storyshot
@@ -19,7 +19,7 @@
         tabindex="0"
       >
         <table
-          class="MuiTable-root css-qzmaqi-MuiTable-root"
+          class="MuiTable-root css-fekg5f-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/InnerTable.WithoutTableHeader.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.WithoutTableHeader.stories.storyshot
@@ -19,7 +19,7 @@
         tabindex="0"
       >
         <table
-          class="MuiTable-root css-qzmaqi-MuiTable-root"
+          class="MuiTable-root css-fekg5f-MuiTable-root"
         >
           <tbody
             class="MuiTableBody-root css-apqrd9-MuiTableBody-root"

--- a/frontend/src/components/common/__snapshots__/ObjectEventList.WithEvents.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ObjectEventList.WithEvents.stories.storyshot
@@ -49,7 +49,7 @@
           tabindex="0"
         >
           <table
-            class="MuiTable-root css-r7i92b-MuiTable-root"
+            class="MuiTable-root css-1f5u0uu-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.Datum.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.Datum.stories.storyshot
@@ -11,7 +11,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-qzmaqi-MuiTable-root"
+        class="MuiTable-root css-fekg5f-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.Getter.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.Getter.stories.storyshot
@@ -11,7 +11,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-r7i92b-MuiTable-root"
+        class="MuiTable-root css-1f5u0uu-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.LabelSearch.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.LabelSearch.stories.storyshot
@@ -120,7 +120,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-qzmaqi-MuiTable-root"
+        class="MuiTable-root css-fekg5f-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.NameSearch.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.NameSearch.stories.storyshot
@@ -120,7 +120,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-qzmaqi-MuiTable-root"
+        class="MuiTable-root css-fekg5f-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.NamespaceSearch.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.NamespaceSearch.stories.storyshot
@@ -120,7 +120,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-qzmaqi-MuiTable-root"
+        class="MuiTable-root css-fekg5f-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.NamespaceSelect.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.NamespaceSelect.stories.storyshot
@@ -158,7 +158,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-qzmaqi-MuiTable-root"
+        class="MuiTable-root css-fekg5f-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.NotFoundMessage.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.NotFoundMessage.stories.storyshot
@@ -120,7 +120,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-qzmaqi-MuiTable-root"
+        class="MuiTable-root css-fekg5f-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.NumberSearch.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.NumberSearch.stories.storyshot
@@ -120,7 +120,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-bv8t57-MuiTable-root"
+        class="MuiTable-root css-14jq1ex-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.ReflectInURL.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.ReflectInURL.stories.storyshot
@@ -28,7 +28,7 @@
         tabindex="0"
       >
         <table
-          class="MuiTable-root css-bv8t57-MuiTable-root"
+          class="MuiTable-root css-14jq1ex-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.ReflectInURLWithPrefix.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.ReflectInURLWithPrefix.stories.storyshot
@@ -28,7 +28,7 @@
         tabindex="0"
       >
         <table
-          class="MuiTable-root css-bv8t57-MuiTable-root"
+          class="MuiTable-root css-14jq1ex-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/common/__snapshots__/SimpleTable.UIDSearch.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/SimpleTable.UIDSearch.stories.storyshot
@@ -120,7 +120,7 @@
       tabindex="0"
     >
       <table
-        class="MuiTable-root css-qzmaqi-MuiTable-root"
+        class="MuiTable-root css-fekg5f-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
@@ -256,7 +256,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-qzmaqi-MuiTable-root"
+                  class="MuiTable-root css-fekg5f-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -367,7 +367,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/daemonset/__snapshots__/Details.Default.stories.storyshot
+++ b/frontend/src/components/daemonset/__snapshots__/Details.Default.stories.storyshot
@@ -398,7 +398,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-qzmaqi-MuiTable-root"
+                  class="MuiTable-root css-fekg5f-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -696,7 +696,7 @@
                       tabindex="0"
                     >
                       <table
-                        class="MuiTable-root css-bv8t57-MuiTable-root"
+                        class="MuiTable-root css-14jq1ex-MuiTable-root"
                       >
                         <thead
                           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/daemonset/__snapshots__/Details.NoTolerations.stories.storyshot
+++ b/frontend/src/components/daemonset/__snapshots__/Details.NoTolerations.stories.storyshot
@@ -582,7 +582,7 @@
                       tabindex="0"
                     >
                       <table
-                        class="MuiTable-root css-bv8t57-MuiTable-root"
+                        class="MuiTable-root css-14jq1ex-MuiTable-root"
                       >
                         <thead
                           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceDetails.Default.stories.storyshot
+++ b/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceDetails.Default.stories.storyshot
@@ -229,7 +229,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/endpoints/__snapshots__/EndpointDetails.Default.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointDetails.Default.stories.storyshot
@@ -241,7 +241,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -350,7 +350,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/gateway/__snapshots__/GRPCRouteDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GRPCRouteDetails.Basic.stories.storyshot
@@ -247,7 +247,7 @@ api.example.com"
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-qzmaqi-MuiTable-root"
+                      class="MuiTable-root css-fekg5f-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -331,7 +331,7 @@ api.example.com"
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-1t02l4h-MuiTable-root"
+                      class="MuiTable-root css-15jmevm-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -438,7 +438,7 @@ api.example.com"
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-d21jum-MuiTable-root"
+                      class="MuiTable-root css-4d0x9t-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -493,7 +493,7 @@ api.example.com"
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-1t02l4h-MuiTable-root"
+                      class="MuiTable-root css-15jmevm-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -631,7 +631,7 @@ api.example.com"
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-1t02l4h-MuiTable-root"
+                  class="MuiTable-root css-15jmevm-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/gateway/__snapshots__/HTTPRouteDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/HTTPRouteDetails.Basic.stories.storyshot
@@ -246,7 +246,7 @@
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-r7i92b-MuiTable-root"
+                      class="MuiTable-root css-1f5u0uu-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -335,7 +335,7 @@
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-d21jum-MuiTable-root"
+                      class="MuiTable-root css-4d0x9t-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -390,7 +390,7 @@
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-1t02l4h-MuiTable-root"
+                      class="MuiTable-root css-15jmevm-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -526,7 +526,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-1t02l4h-MuiTable-root"
+                  class="MuiTable-root css-15jmevm-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Default.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Default.stories.storyshot
@@ -226,7 +226,7 @@
                       tabindex="0"
                     >
                       <table
-                        class="MuiTable-root css-1ml9dpn-MuiTable-root"
+                        class="MuiTable-root css-1ok7ihs-MuiTable-root"
                       >
                         <thead
                           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -380,7 +380,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-r7i92b-MuiTable-root"
+                  class="MuiTable-root css-1f5u0uu-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/ingress/__snapshots__/Details.WithResource.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.WithResource.stories.storyshot
@@ -258,7 +258,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/ingress/__snapshots__/Details.WithTLS.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.WithTLS.stories.storyshot
@@ -266,7 +266,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/job/__snapshots__/Details.Default.stories.storyshot
+++ b/frontend/src/components/job/__snapshots__/Details.Default.stories.storyshot
@@ -416,7 +416,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-r7i92b-MuiTable-root"
+                  class="MuiTable-root css-1f5u0uu-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/node/__snapshots__/Details.Default.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/Details.Default.stories.storyshot
@@ -1310,7 +1310,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-r7i92b-MuiTable-root"
+                  class="MuiTable-root css-1f5u0uu-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/node/__snapshots__/Details.NoMetrics.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/Details.NoMetrics.stories.storyshot
@@ -1310,7 +1310,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-r7i92b-MuiTable-root"
+                  class="MuiTable-root css-1f5u0uu-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.Default.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.Default.stories.storyshot
@@ -209,7 +209,7 @@
                       tabindex="0"
                     >
                       <table
-                        class="MuiTable-root css-qzmaqi-MuiTable-root"
+                        class="MuiTable-root css-fekg5f-MuiTable-root"
                       >
                         <thead
                           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/role/__snapshots__/BindingDetails.ClusterRoleBinding.stories.storyshot
+++ b/frontend/src/components/role/__snapshots__/BindingDetails.ClusterRoleBinding.stories.storyshot
@@ -241,7 +241,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/role/__snapshots__/BindingDetails.RoleBinding.stories.storyshot
+++ b/frontend/src/components/role/__snapshots__/BindingDetails.RoleBinding.stories.storyshot
@@ -256,7 +256,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/role/__snapshots__/Details.ClusterRole.stories.storyshot
+++ b/frontend/src/components/role/__snapshots__/Details.ClusterRole.stories.storyshot
@@ -199,7 +199,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-qzmaqi-MuiTable-root"
+                  class="MuiTable-root css-fekg5f-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/role/__snapshots__/Details.Role.stories.storyshot
+++ b/frontend/src/components/role/__snapshots__/Details.Role.stories.storyshot
@@ -236,7 +236,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-qzmaqi-MuiTable-root"
+                  class="MuiTable-root css-fekg5f-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.Default.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.Default.stories.storyshot
@@ -339,7 +339,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -446,7 +446,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-1ml9dpn-MuiTable-root"
+                  class="MuiTable-root css-1ok7ihs-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -548,7 +548,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-qzmaqi-MuiTable-root"
+                  class="MuiTable-root css-fekg5f-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.ErrorWithEndpoints.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.ErrorWithEndpoints.stories.storyshot
@@ -339,7 +339,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.LoadBalancer.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.LoadBalancer.stories.storyshot
@@ -447,7 +447,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-qzmaqi-MuiTable-root"
+                  class="MuiTable-root css-fekg5f-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.NodePort.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.NodePort.stories.storyshot
@@ -395,7 +395,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-r7i92b-MuiTable-root"
+                  class="MuiTable-root css-1f5u0uu-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8RAnnotations.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8RAnnotations.stories.storyshot
@@ -679,7 +679,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8ROwnerOnly.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8ROwnerOnly.stories.storyshot
@@ -415,7 +415,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-bv8t57-MuiTable-root"
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/serviceaccount/__snapshots__/Details.WithBindings.stories.storyshot
+++ b/frontend/src/components/serviceaccount/__snapshots__/Details.WithBindings.stories.storyshot
@@ -258,7 +258,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-qzmaqi-MuiTable-root"
+                  class="MuiTable-root css-fekg5f-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Default.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Default.stories.storyshot
@@ -268,7 +268,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-1t02l4h-MuiTable-root"
+                  class="MuiTable-root css-15jmevm-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -427,7 +427,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-r7i92b-MuiTable-root"
+                  class="MuiTable-root css-1f5u0uu-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
@@ -551,7 +551,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-r7i92b-MuiTable-root"
+                  class="MuiTable-root css-1f5u0uu-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithService.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithService.stories.storyshot
@@ -455,7 +455,7 @@
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-r7i92b-MuiTable-root"
+                      class="MuiTable-root css-1f5u0uu-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithURL.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithURL.stories.storyshot
@@ -452,7 +452,7 @@
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-r7i92b-MuiTable-root"
+                      class="MuiTable-root css-1f5u0uu-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithService.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithService.stories.storyshot
@@ -441,7 +441,7 @@
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-r7i92b-MuiTable-root"
+                      class="MuiTable-root css-1f5u0uu-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithURL.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithURL.stories.storyshot
@@ -438,7 +438,7 @@
                     tabindex="0"
                   >
                     <table
-                      class="MuiTable-root css-r7i92b-MuiTable-root"
+                      class="MuiTable-root css-1f5u0uu-MuiTable-root"
                     >
                       <thead
                         class="MuiTableHead-root css-15wwp11-MuiTableHead-root"


### PR DESCRIPTION
## Summary

- Allow `SimpleTable` body-cell content to remain visible outside its grid cell instead of clipping it.
- Keep column-header overflow hidden so header layout remains constrained.
- Add focused unit coverage and a service-details Playwright regression assertion.
- Regenerate affected storyshots for the shared style change.

## Provenance

This upstreams `patches/0055-headlamp-upstream-simpletable-overflow.patch` from Azure/aks-desktop#823.

The original change was authored by Oleksandr Dubenko in Azure/aks-desktop#498 as commit [`b3f50e3b5`](https://github.com/Azure/aks-desktop/commit/b3f50e3b5b26e934393555ef7960a9d1857b5385), then retained in the downstream patch series as commit [`e87e6d6f`](https://github.com/Azure/aks-desktop/commit/e87e6d6fe78e4a7c9219755f3c409ae1f8b50952). The upstream commit preserves Oleksandr's author identity and original author date and adds René Dudfield as co-author.

Related PRs:

- https://github.com/Azure/aks-desktop/pull/498
- https://github.com/Azure/aks-desktop/pull/823

## Changes Compared With the Original Commit

Azure/aks-desktop#498 changed one source line: it removed `overflow: 'hidden'`
from the shared `SimpleTable` body-cell styles. This PR keeps that functional
change unchanged and adds the upstream-specific verification around it:

- A preceding unit-test commit covers loading, error, empty, filtering, sorting,
  pagination, refresh, URL-state, and body/header overflow behavior. It raises
  `SimpleTable.tsx` branch coverage from 44.36% to 88.72%.
- A preceding Playwright commit checks the `TCP` body cell in the service Ports
  `SimpleTable`. The patch commit changes that scoped expectation from `hidden`
  to `visible`.
- The patch commit updates the unit and browser regression expectations and
  regenerates the storyshots affected by the current upstream Emotion class
  hashes.

The original PR did not include unit tests, e2e coverage, or storyshot updates.

## Testing

- `vitest run src/components/common/SimpleTable.test.tsx --coverage --coverage.include=src/components/common/SimpleTable.tsx --coverage.reporter=text`
  - 9 tests passed
  - 88.72% branch coverage for `SimpleTable.tsx`
- `vitest run src/storybook.test.tsx -t 'SimpleTable|Service/Details'`
- `playwright test tests/headlamp.spec.ts --list`

Assisted by copilot.
