### PR TITLE
Add plugins-config flag for admin-set plugin defaults

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -183,6 +183,7 @@ type clientConfig struct {
 	DefaultLightTheme         string    `json:"defaultLightTheme,omitempty"`
 	DefaultDarkTheme          string    `json:"defaultDarkTheme,omitempty"`
 	ForceTheme                string    `json:"forceTheme,omitempty"`
+	Plugins                   string    `json:"plugins,omitempty"`
 }
 
 type OauthConfig struct {
@@ -2156,6 +2157,7 @@ func (c *HeadlampConfig) getConfig(w http.ResponseWriter, r *http.Request) {
 		DefaultLightTheme:         c.DefaultLightTheme,
 		DefaultDarkTheme:          c.DefaultDarkTheme,
 		ForceTheme:                c.ForceTheme,
+		Plugins:                   c.PluginsConfig,
 	}
 
 	if err := json.NewEncoder(w).Encode(&clientConfig); err != nil {

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -4169,3 +4169,46 @@ func TestExternalProxyOversizeResponseGzip(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, int(maxProxyResponseSize), rr.Body.Len())
 }
+
+func TestGetConfigIncludesPluginsConfig(t *testing.T) {
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				KubeConfigStore: kubeconfig.NewContextStore(),
+				PluginsConfig:   `{"prometheus":{"autoDetect":false}}`,
+			},
+		},
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/config", nil)
+	recorder := httptest.NewRecorder()
+
+	c.getConfig(recorder, req)
+
+	var config clientConfig
+
+	err := json.Unmarshal(recorder.Body.Bytes(), &config)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"prometheus":{"autoDetect":false}}`, config.Plugins)
+}
+
+func TestGetConfigOmitsUnsetPluginsConfig(t *testing.T) {
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				KubeConfigStore: kubeconfig.NewContextStore(),
+			},
+		},
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/config", nil)
+	recorder := httptest.NewRecorder()
+
+	c.getConfig(recorder, req)
+
+	var config clientConfig
+
+	err := json.Unmarshal(recorder.Body.Bytes(), &config)
+	require.NoError(t, err)
+	assert.Empty(t, config.Plugins)
+	assert.NotContains(t, recorder.Body.String(), "plugins")
+}

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -121,6 +121,7 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 		DefaultLightTheme:                     conf.DefaultLightTheme,
 		DefaultDarkTheme:                      conf.DefaultDarkTheme,
 		ForceTheme:                            conf.ForceTheme,
+		PluginsConfig:                         conf.PluginsConfig,
 		UnsafeUseServiceAccountToken:          conf.UnsafeUseServiceAccountToken,
 		ServiceAccountTokenPath:               conf.ServiceAccountTokenPath,
 	}

--- a/backend/cmd/server_config_test.go
+++ b/backend/cmd/server_config_test.go
@@ -39,6 +39,7 @@ func TestBuildHeadlampCFG(t *testing.T) {
 			WatchPluginsChanges:    false,
 			BaseURL:                "/headlamp",
 			ProxyURLs:              "http://proxy1,http://proxy2",
+			PluginsConfig:          `{"prometheus":{"autoDetect":false}}`,
 		}
 
 		headlampCFG := buildHeadlampCFG(conf, store)
@@ -53,6 +54,7 @@ func TestBuildHeadlampCFG(t *testing.T) {
 		assert.False(t, headlampCFG.WatchPluginsChanges)
 		assert.Equal(t, "/headlamp", headlampCFG.BaseURL)
 		assert.Equal(t, []string{"http://proxy1", "http://proxy2"}, headlampCFG.ProxyURLs)
+		assert.Equal(t, `{"prometheus":{"autoDetect":false}}`, headlampCFG.PluginsConfig)
 		assert.Equal(t, store, headlampCFG.KubeConfigStore)
 	})
 

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -111,6 +112,7 @@ type Config struct {
 	DefaultLightTheme string `koanf:"default-light-theme"`
 	DefaultDarkTheme  string `koanf:"default-dark-theme"`
 	ForceTheme        string `koanf:"force-theme"`
+	PluginsConfig     string `koanf:"plugins-config"`
 }
 
 func (c *Config) warnRedundantThemeDefaults() {
@@ -178,6 +180,19 @@ func (c *Config) Validate() error {
 
 	if err := c.validateClusterInventory(); err != nil {
 		return err
+	}
+
+	return c.validatePluginsConfig()
+}
+
+func (c *Config) validatePluginsConfig() error {
+	if c.PluginsConfig == "" {
+		return nil
+	}
+
+	var plugins map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(c.PluginsConfig), &plugins); err != nil {
+		return fmt.Errorf("plugins-config must be a JSON object keyed by plugin name: %w", err)
 	}
 
 	return nil
@@ -585,6 +600,8 @@ func addGeneralFlags(f *flag.FlagSet) {
 	f.String("default-light-theme", "", "Default theme to use when user prefers light mode")
 	f.String("default-dark-theme", "", "Default theme to use when user prefers dark mode")
 	f.String("force-theme", "", "Force a specific theme, overriding user preferences")
+	f.String("plugins-config", "",
+		"JSON object of default settings for plugins, keyed by plugin name. Users can override these in the UI")
 	f.Bool("unsafe-use-service-account-token", false,
 		"UNSAFE: use the pod's service account token to authenticate all users in-cluster. "+
 			"Disables per-user auth; only safe behind an auth proxy")

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -1006,3 +1006,54 @@ func TestGetDefaultKubeConfigPath(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(tmpDir, ".kube", "config"), path)
 }
+
+func TestValidatePluginsConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		expectError   bool
+		expectedValue string
+	}{
+		{
+			name:          "unset",
+			args:          []string{"go run ./cmd"},
+			expectError:   false,
+			expectedValue: "",
+		},
+		{
+			name:          "valid object",
+			args:          []string{"go run ./cmd", `--plugins-config={"prometheus":{"autoDetect":false}}`},
+			expectError:   false,
+			expectedValue: `{"prometheus":{"autoDetect":false}}`,
+		},
+		{
+			name:          "malformed json",
+			args:          []string{"go run ./cmd", `--plugins-config={"prometheus":`},
+			expectError:   true,
+			expectedValue: "",
+		},
+		{
+			name:          "json but not an object",
+			args:          []string{"go run ./cmd", `--plugins-config=["prometheus"]`},
+			expectError:   true,
+			expectedValue: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf, err := config.Parse(tt.args)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "plugins-config must be a JSON object keyed by plugin name")
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, conf)
+			assert.Equal(t, tt.expectedValue, conf.PluginsConfig)
+		})
+	}
+}

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -80,6 +80,7 @@ type HeadlampCFG struct {
 	DefaultLightTheme            string
 	DefaultDarkTheme             string
 	ForceTheme                   string
+	PluginsConfig                string
 	UnsafeUseServiceAccountToken bool
 	ServiceAccountTokenPath      string
 

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -138,6 +138,7 @@ config:
 | config.podDebugImage | string | `""`                | Default image to use when creating pod debug containers                    |
 | config.nodeShellImage | string | `""`               | Default image to use when creating node shell pods                         |
 | config.nodeShellNamespace | string | `""`            | Default namespace to use when creating node shell pods                      |
+| config.pluginsConfig | object | `{}`                 | Default settings for plugins, keyed by the plugin's config key. Each plugin defines its own keys and users can override them in the UI. Served unauthenticated at `/config`, so should not put secrets here                         |
 | config.clusterInventory.enabled | bool | `false` | Enable experimental/alpha Cluster Inventory discovery |
 | config.clusterInventory.accessProvidersConfig | object | `{}` | Experimental/alpha Cluster Inventory access providers config. Required when Cluster Inventory is enabled |
 | config.clusterInventory.plugins | list | `[]` | Kubernetes image volumes that provide experimental/alpha Cluster Inventory access provider binaries |

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -291,6 +291,9 @@ spec:
             {{- with .Values.config.nodeShellNamespace }}
             - "-node-shell-namespace={{ . }}"
             {{- end }}
+            {{- with .Values.config.pluginsConfig }}
+            - {{ printf "-plugins-config=%s" (mustToJson .) | quote }}
+            {{- end }}
             {{- if and .Values.config.inCluster .Values.config.unsafeUseServiceAccountToken }}
             - "-unsafe-use-service-account-token"
             {{- end }}

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -192,6 +192,10 @@
           "type": "string",
           "description": "Default namespace to use when creating node shell pods"
         },
+        "pluginsConfig": {
+          "type": "object",
+          "description": "Default settings for plugins, keyed by the plugin's config key. Each plugin defines its own keys; users can override them in the UI"
+        },
         "unsafeUseServiceAccountToken": {
           "type": "boolean",
           "description": "UNSAFE: authenticate every user as the pod's service account in-cluster mode"

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -138,6 +138,8 @@ config:
   nodeShellImage: ""
   # -- Default namespace to use when creating node shell pods. If empty, Headlamp uses its built-in default.
   nodeShellNamespace: ""
+  # -- Default settings for plugins, keyed by config key. Served unauthenticated at /config, so do not put secrets here.
+  pluginsConfig: {}
   # tlsCertPath: "/headlamp-cert/headlamp-ca.crt"
   # tlsKeyPath: "/headlamp-cert/headlamp-tls.key"
   clusterInventory:

--- a/frontend/src/components/App/Layout.tsx
+++ b/frontend/src/components/App/Layout.tsx
@@ -147,7 +147,8 @@ const fetchConfig = (dispatch: Dispatch<UnknownAction>) => {
       clustersToConfig[cluster.name] = cluster;
     });
 
-    const configToStore = { ...config, clusters: clustersToConfig };
+    const plugins = config?.plugins ? JSON.parse(config.plugins) : undefined;
+    const configToStore = { ...config, clusters: clustersToConfig, plugins };
 
     if (clusters === null) {
       dispatch(setConfig(configToStore));

--- a/frontend/src/plugin/configStore.test.ts
+++ b/frontend/src/plugin/configStore.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { setConfig } from '../redux/configSlice';
+import store from '../redux/stores/store';
+import { ConfigStore } from './configStore';
+
+function setServerDefaults(plugins: { [configKey: string]: { [key: string]: any } } | undefined) {
+  store.dispatch(setConfig({ clusters: {}, plugins }));
+}
+
+describe('ConfigStore server defaults', () => {
+  it('falls back to the user value when the server has no defaults for this plugin', () => {
+    setServerDefaults(undefined);
+
+    const configStore = new ConfigStore<{ address: string }>('user-only');
+    configStore.set({ address: 'user/prometheus:9090' });
+
+    expect(configStore.get()).toEqual({ address: 'user/prometheus:9090' });
+  });
+
+  it('merges server defaults with user overrides, user winning on shared keys', () => {
+    setServerDefaults({ merged: { address: 'monitoring/prometheus:9090', autoDetect: false } });
+
+    const configStore = new ConfigStore<{ address: string; autoDetect: boolean }>('merged');
+    configStore.update({ address: 'other/prometheus:9090' });
+
+    expect(configStore.get()).toEqual({ address: 'other/prometheus:9090', autoDetect: false });
+  });
+});

--- a/frontend/src/plugin/configStore.ts
+++ b/frontend/src/plugin/configStore.ts
@@ -14,9 +14,21 @@
  * limitations under the License.
  */
 
-import { useSelector } from 'react-redux';
+import { shallowEqual, useSelector } from 'react-redux';
 import store from '../redux/stores/store';
 import { setPluginConfig, updatePluginConfig } from './pluginConfigSlice';
+
+/** Merges backend-provided plugin defaults with the user's own settings*/
+function mergeWithServerDefaults<T>(state: any, configKey: string): T {
+  const serverDefaults = state?.config?.plugins?.[configKey];
+  const userConfig = state?.pluginConfigs?.[configKey];
+
+  if (serverDefaults === undefined) {
+    return userConfig as T;
+  }
+
+  return { ...serverDefaults, ...userConfig } as T;
+}
 
 /**
  * A class to manage the configuration state for plugins in a Redux store.
@@ -69,7 +81,7 @@ export class ConfigStore<T> {
    */
   public get(): T {
     const state: any = store.getState();
-    return state?.pluginConfigs?.[this.configKey] as T;
+    return mergeWithServerDefaults(state, this.configKey);
   }
 
   /**
@@ -82,7 +94,10 @@ export class ConfigStore<T> {
   public useConfig() {
     const configKey = this.configKey; // Capture the configKey for closure
     return function useConfigHook(): T {
-      return useSelector((state: any) => state?.pluginConfigs?.[configKey] as T);
+      return useSelector(
+        (state: any) => mergeWithServerDefaults<T>(state, configKey),
+        shallowEqual
+      );
     };
   }
 }

--- a/frontend/src/redux/configSlice.ts
+++ b/frontend/src/redux/configSlice.ts
@@ -74,6 +74,8 @@ export interface ConfigState {
   defaultLightTheme?: string;
   defaultDarkTheme?: string;
   forceTheme?: string;
+  /** Default plugin settings from the backend, keyed by config key; user settings take precedence. */
+  plugins?: { [configKey: string]: { [key: string]: any } };
   /**
    * Settings is a map of settings names to settings values.
    */
@@ -199,6 +201,7 @@ const configSlice = createSlice({
         defaultLightTheme?: string;
         defaultDarkTheme?: string;
         forceTheme?: string;
+        plugins?: ConfigState['plugins'];
       }>
     ) {
       state.clusters = action.payload.clusters;
@@ -220,6 +223,7 @@ const configSlice = createSlice({
       state.defaultLightTheme = action.payload.defaultLightTheme;
       state.defaultDarkTheme = action.payload.defaultDarkTheme;
       state.forceTheme = action.payload.forceTheme;
+      state.plugins = action.payload.plugins;
     },
     /**
      * Save the config. To both the store, and localStorage.


### PR DESCRIPTION
## Summary

Lets an admin set default plugin settings server-side (Helm value / CLI flag), merged with whatever the user's already set in the UI and user choice prevails.

## Related Issue

Fixes #3900

## Changes

- New `-plugins-config` flag (opaque JSON, keyed by plugin name), served on `/config`
- Same wiring path as the existing theme-default flags
- Matching `config.pluginsConfig` Helm value
- Frontend merges it into `ConfigStore` — server default + user override, user wins

## Steps to Test

1. Run with `-plugins-config='{"prometheus":{"autoDetect":false,"address":"monitoring/prometheus:9090"}}'`
2. Check `/config` returns it
3. Load UI with no user setting saved, see the server default
4. Set a conflicting value in the plugin's Settings UI, user value wins
5. Pass garbage JSON, server refuses to start instead of shipping a broken `/config`
