### PR TITLE
0054: frontend: Support secondary theme contrast

### DIFF
--- a/e2e-tests/tests/themeContrast.spec.ts
+++ b/e2e-tests/tests/themeContrast.spec.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+
+test.use({ locale: 'en-US' });
+
+test('secondary button uses contrasting theme colors', async ({ page }) => {
+  await page.goto('/settings/general');
+  await page.evaluate(() => {
+    (window as any).pluginLib.registerAppTheme({
+      name: 'E2E Secondary Contrast',
+      base: 'light',
+      primary: '#414141',
+      secondary: '#eff2f5',
+      secondaryContrastText: '#44444f',
+    });
+  });
+
+  await page.getByRole('button', { name: 'E2E Secondary Contrast' }).click();
+  await page.evaluate(() => {
+    history.pushState({}, '', '/settings/cluster?c=test');
+    dispatchEvent(new PopStateEvent('popstate'));
+  });
+  await page.locator('#color-picker-button').click();
+
+  const cancelButton = page.getByRole('button', { name: 'Cancel' });
+  await expect(cancelButton).toHaveCSS('background-color', 'rgb(239, 242, 245)');
+  await expect(cancelButton).toHaveCSS('color', 'rgb(68, 68, 79)');
+});

--- a/frontend/src/lib/AppTheme.ts
+++ b/frontend/src/lib/AppTheme.ts
@@ -25,6 +25,8 @@ export interface AppTheme {
   primary?: string;
   /** Secondary theme color */
   secondary?: string;
+  /** Text color to use against the secondary theme color */
+  secondaryContrastText?: string;
   text?: {
     /** Primary text color */
     primary?: string;

--- a/frontend/src/lib/themes.test.ts
+++ b/frontend/src/lib/themes.test.ts
@@ -67,6 +67,38 @@ describe('themes.ts', () => {
 
       expect(theme.palette.navbar.searchHint).toBe('#123456');
     });
+
+    it('should allow secondary contrast text override from AppTheme', () => {
+      const theme = createMuiTheme({
+        base: 'light',
+        name: 'Custom Theme',
+        secondary: '#123456',
+        secondaryContrastText: '#ffffff',
+      });
+
+      expect(theme.palette.secondary.contrastText).toBe('#ffffff');
+    });
+
+    it('should allow secondary contrast text override for dark themes', () => {
+      const theme = createMuiTheme({
+        base: 'dark',
+        name: 'Custom Dark Theme',
+        secondary: '#123456',
+        secondaryContrastText: '#ffffff',
+      });
+
+      expect(theme.palette.secondary.contrastText).toBe('#ffffff');
+    });
+
+    it('should use black contrast text by default for custom secondary colors', () => {
+      const theme = createMuiTheme({
+        base: 'light',
+        name: 'Custom Theme',
+        secondary: '#123456',
+      });
+
+      expect(theme.palette.secondary.contrastText).toBe('#000');
+    });
   });
 
   describe('getThemeName', () => {

--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -223,7 +223,10 @@ export function createMuiTheme(currentTheme: AppTheme) {
         main: currentTheme.primary ?? '#0078d4',
       },
       secondary: currentTheme.secondary
-        ? { main: currentTheme.secondary, contrastText: '#000' }
+        ? {
+            main: currentTheme.secondary,
+            contrastText: currentTheme.secondaryContrastText ?? '#000',
+          }
         : {
             light: pink.A200,
             main: pink.A400,
@@ -430,9 +433,6 @@ export function createMuiTheme(currentTheme: AppTheme) {
         },
         primary: {
           main: currentTheme.primary ?? '#4B99EE',
-        },
-        secondary: {
-          main: currentTheme.secondary ?? commonRules.palette.secondary.main,
         },
         squareButton: {
           background: '#424242',


### PR DESCRIPTION
## Summary

Allow an `AppTheme` to define the text color used on its custom secondary
color. Themes that do not set `secondaryContrastText` retain the existing black
fallback.

## Related Changes

- [Original downstream PR Azure/aks-desktop__UNCLEAN#178](https://github.com/Azure/aks-desktop__UNCLEAN/pull/178)
  introduced configurable secondary button contrast text. It was auto-closed
  during a rebase.
- [Merged reupload Azure/aks-desktop__UNCLEAN#268](https://github.com/Azure/aks-desktop__UNCLEAN/pull/268)
  reapplied the original PR to `headlamp-downstream`.
- [Azure/aks-desktop@12b5795](https://github.com/Azure/aks-desktop/commit/12b579560e88c564bc640432960091099a678c00)
  is the rebased downstream implementation by tejhan-diallo.
- [Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823)
  packages the downstream Headlamp patch series that includes patch 0054.

## Changes

- Add the documented `AppTheme.secondaryContrastText` option.
- Pass the option to MUI's secondary palette while preserving the fallback.
- Cover both the override and fallback branches in `themes.test.ts`.
- Register a custom plugin theme and verify its secondary colors in Playwright.

## Steps to Test

1. Run `npm --prefix frontend test -- --run src/lib/themes.test.ts`.
2. Run `npm --prefix frontend run tsc`.
3. Run `npm --prefix frontend run build`.
4. Run the `themeContrast.spec.ts` Playwright test against Headlamp.

Focused Istanbul coverage for `frontend/src/lib/themes.ts` is 92.55% branches.

## Screenshots

![Cluster settings color picker showing the secondary Cancel button](https://raw.githubusercontent.com/illume/headlamp/41713bc427256ef6c5ff949e1bf596297a96be62/pr-screenshots/0054-secondary-theme-contrast.png)

## Notes for the Reviewer

The e2e coverage commit intentionally precedes the implementation commit. The
implementation commit preserves the original author's name, email, and authored
date, and adds René Dudfield as co-author.

Assisted by copilot.