### PR TITLE
backend: serviceproxy: Allow optional Service port selection

### DIFF
--- a/backend/pkg/serviceproxy/handler.go
+++ b/backend/pkg/serviceproxy/handler.go
@@ -21,7 +21,7 @@ func RequestHandler(
 	w http.ResponseWriter,
 	r *http.Request,
 ) {
-	clusterName, namespace, name, requestURI := parseInfoFromRequest(r)
+	clusterName, namespace, name, requestURI, portSelector := parseInfoFromRequest(r)
 
 	defer disableResponseCaching(w)
 	// Get the context
@@ -57,7 +57,7 @@ func RequestHandler(
 	}
 
 	// Get the service
-	ps, status, err := getServiceFromCluster(r.Context(), cs, namespace, name)
+	ps, status, err := getServiceFromCluster(r.Context(), cs, namespace, name, portSelector)
 	if err != nil {
 		w.WriteHeader(status)
 		return
@@ -73,13 +73,14 @@ func shouldUseUnsafeServiceAccountToken(ctx *kubeconfig.Context, unsafeUseServic
 	return unsafeUseServiceAccountToken && ctx.UsesInClusterServiceAccountToken()
 }
 
-func parseInfoFromRequest(r *http.Request) (string, string, string, string) {
+func parseInfoFromRequest(r *http.Request) (string, string, string, string, string) {
 	clusterName := mux.Vars(r)["clusterName"]
 	namespace := mux.Vars(r)["namespace"]
 	name := mux.Vars(r)["name"]
 	requestURI := r.URL.Query().Get("request")
+	portSelector := r.URL.Query().Get("port")
 
-	return clusterName, namespace, name, requestURI
+	return clusterName, namespace, name, requestURI, portSelector
 }
 
 func getAuthToken(r *http.Request, clusterName string) (string, error) {
@@ -104,9 +105,9 @@ func getAuthToken(r *http.Request, clusterName string) (string, error) {
 }
 
 func getServiceFromCluster(
-	ctx context.Context, cs kubernetes.Interface, namespace string, name string,
+	ctx context.Context, cs kubernetes.Interface, namespace string, name string, portSelector string,
 ) (*proxyService, int, error) {
-	ps, err := GetService(ctx, cs, namespace, name)
+	ps, err := GetServiceWithPort(ctx, cs, namespace, name, portSelector)
 	if err != nil {
 		if errors.IsUnauthorized(err) {
 			return nil, http.StatusUnauthorized, err

--- a/backend/pkg/serviceproxy/handler_test.go
+++ b/backend/pkg/serviceproxy/handler_test.go
@@ -489,7 +489,7 @@ func TestGetServiceFromCluster(t *testing.T) {
 				cs = fake.NewClientset()
 			}
 
-			ps, status, err := getServiceFromCluster(context.Background(), cs, tt.namespace, tt.serviceName)
+			ps, status, err := getServiceFromCluster(context.Background(), cs, tt.namespace, tt.serviceName, "")
 
 			assert.Equal(t, tt.expectedStatus, status)
 
@@ -661,11 +661,12 @@ func TestParseInfoFromRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := tt.setupRequest()
-			clusterName, namespace, name, requestURI := parseInfoFromRequest(req)
+			clusterName, namespace, name, requestURI, portSelector := parseInfoFromRequest(req)
 			assert.Equal(t, tt.expectedClusterName, clusterName)
 			assert.Equal(t, tt.expectedNamespace, namespace)
 			assert.Equal(t, tt.expectedName, name)
 			assert.Equal(t, tt.expectedRequestURI, requestURI)
+			assert.Equal(t, "", portSelector)
 		})
 	}
 }

--- a/backend/pkg/serviceproxy/service.go
+++ b/backend/pkg/serviceproxy/service.go
@@ -3,6 +3,8 @@ package serviceproxy
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 
@@ -26,7 +28,21 @@ type proxyService struct {
 }
 
 // GetService returns the requested service based on the provided name and namespace.
+// It keeps the historical default of selecting a port named "http" or "https".
 func GetService(ctx context.Context, cs kubernetes.Interface, namespace string, name string) (*proxyService, error) {
+	return GetServiceWithPort(ctx, cs, namespace, name, "")
+}
+
+// GetServiceWithPort returns the requested service and resolves the Service port.
+// When portSelector is empty, behavior matches GetService (http/https named ports).
+// Otherwise portSelector may be a Service port name or port number that exists on the Service.
+func GetServiceWithPort(
+	ctx context.Context,
+	cs kubernetes.Interface,
+	namespace string,
+	name string,
+	portSelector string,
+) (*proxyService, error) {
 	service, err := cs.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -38,7 +54,7 @@ func GetService(ctx context.Context, cs kubernetes.Interface, namespace string, 
 		IsExternal: len(service.Spec.ExternalName) > 0,
 	}
 
-	port, err := GetPort(service.Spec.Ports)
+	port, err := ResolvePort(service.Spec.Ports, portSelector)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "service port not found")
 
@@ -46,14 +62,7 @@ func GetService(ctx context.Context, cs kubernetes.Interface, namespace string, 
 	}
 
 	ps.Port = port.Port
-
-	// Determine scheme - always use https for external
-	if port.Name == HTTPSchemeName {
-		ps.Scheme = HTTPSchemeName
-	} else {
-		ps.Scheme = HTTPSSchemeName
-	}
-
+	ps.Scheme = schemeForPort(port)
 	ps.URIPrefix = getServiceURLPrefix(ps, service)
 
 	return ps, nil
@@ -75,6 +84,52 @@ func GetPort(ports []corev1.ServicePort) (*corev1.ServicePort, error) {
 	}
 
 	return nil, fmt.Errorf("no port found with the name http or https")
+}
+
+// ResolvePort selects a Service port.
+// An empty portSelector preserves GetPort behavior.
+// A non-empty selector matches a port by name, or by port number when the selector is numeric.
+// Only ports declared on the Service are accepted.
+func ResolvePort(ports []corev1.ServicePort, portSelector string) (*corev1.ServicePort, error) {
+	selector := strings.TrimSpace(portSelector)
+	if selector == "" {
+		return GetPort(ports)
+	}
+
+	if portNum, err := strconv.ParseInt(selector, 10, 32); err == nil {
+		for i, port := range ports {
+			if port.Port == int32(portNum) {
+				return &ports[i], nil
+			}
+		}
+
+		return nil, fmt.Errorf("no service port with number %s", selector)
+	}
+
+	for i, port := range ports {
+		if port.Name == selector {
+			return &ports[i], nil
+		}
+	}
+
+	return nil, fmt.Errorf("no service port with name %q", selector)
+}
+
+// schemeForPort keeps existing scheme choice for ports named http/https.
+// Explicitly selected other ports default to http, except port 443 which uses https.
+func schemeForPort(port *corev1.ServicePort) string {
+	switch port.Name {
+	case HTTPSchemeName:
+		return HTTPSchemeName
+	case HTTPSSchemeName:
+		return HTTPSSchemeName
+	default:
+		if port.Port == 443 {
+			return HTTPSSchemeName
+		}
+
+		return HTTPSchemeName
+	}
 }
 
 // getServiceURLPrefix generates a URL prefix for a Kubernetes service based on the provided proxyService and service

--- a/backend/pkg/serviceproxy/service_test.go
+++ b/backend/pkg/serviceproxy/service_test.go
@@ -140,3 +140,109 @@ func TestGetPort(t *testing.T) {
 		})
 	}
 }
+
+func TestResolvePort(t *testing.T) {
+	ports := []corev1.ServicePort{
+		{Name: "https", Port: 443},
+		{Name: "http", Port: 80},
+		{Name: "metrics", Port: 9090},
+	}
+
+	tests := []struct {
+		name         string
+		portSelector string
+		wantPort     int32
+		wantErr      bool
+	}{
+		{
+			name:         "select by name",
+			portSelector: "metrics",
+			wantPort:     9090,
+		},
+		{
+			name:         "select by port number",
+			portSelector: "80",
+			wantPort:     80,
+		},
+		{
+			name:         "select port 443",
+			portSelector: "443",
+			wantPort:     443,
+		},
+		{
+			name:         "unknown port 9999 returns error",
+			portSelector: "9999",
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			port, err := serviceproxy.ResolvePort(ports, tt.portSelector)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ResolvePort() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if !tt.wantErr && port.Port != tt.wantPort {
+				t.Errorf("ResolvePort() port = %d, wantPort %d", port.Port, tt.wantPort)
+			}
+		})
+	}
+}
+
+func TestSchemeForPort(t *testing.T) {
+	tests := []struct {
+		name         string
+		ports        []corev1.ServicePort
+		portSelector string
+		wantScheme   string
+	}{
+		{
+			name:         "http named port uses http scheme",
+			ports:        []corev1.ServicePort{{Name: "http", Port: 80}},
+			portSelector: "http",
+			wantScheme:   "http",
+		},
+		{
+			name:         "https named port uses https scheme",
+			ports:        []corev1.ServicePort{{Name: "https", Port: 443}},
+			portSelector: "https",
+			wantScheme:   "https",
+		},
+		{
+			name:         "port 443 without http/https name uses https scheme",
+			ports:        []corev1.ServicePort{{Name: "web", Port: 443}},
+			portSelector: "443",
+			wantScheme:   "https",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := fake.NewClientset()
+			service := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "scheme-service",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: tt.ports,
+				},
+			}
+
+			_, err := cs.CoreV1().Services("default").Create(context.Background(), service, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to create test service: %v", err)
+			}
+
+			ps, err := serviceproxy.GetServiceWithPort(context.Background(), cs, "default", "scheme-service", tt.portSelector)
+			if err != nil {
+				t.Fatalf("GetServiceWithPort() error = %v", err)
+			}
+
+			if ps.Scheme != tt.wantScheme {
+				t.Errorf("schemeForPort() scheme = %s, want %s", ps.Scheme, tt.wantScheme)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds optional Service port selection to serviceproxy via `?port=<name|number>`, while keeping the existing `http`/`https` named-port default when `port` is omitted.

## Related Issue

Fixes #7057

## Changes

- Added `ResolvePort` and `GetServiceWithPort` in `backend/pkg/serviceproxy/service.go`
- Kept `GetService` / `GetPort` default behavior unchanged when no port is specified
- Wired optional `port` query param in `RequestHandler`
- Updated existing handler tests only as needed for the new function signatures

## Steps to Test

1. From `backend/`, run:
   ```bash
   go test ./pkg/serviceproxy/ -count=1
2. Confirm existing default behavior still works for Services with ports named http/https.
3. (Optional manual check) With Headlamp running against a cluster:
Service with port named http → GET /clusters/<cluster>/serviceproxy/<ns>/<svc>?request=/ still works without port
Service with port named web / number 8080 → GET /clusters/<cluster>/serviceproxy/<ns>/<svc>?request=/&port=web or ...&port=8080 now resolves instead of failing on port selection
