### PR TITLE
Backend/serviceproxy optional port tests

### DIFF
--- a/backend/pkg/serviceproxy/handler.go
+++ b/backend/pkg/serviceproxy/handler.go
@@ -21,7 +21,7 @@ func RequestHandler(
 	w http.ResponseWriter,
 	r *http.Request,
 ) {
-	clusterName, namespace, name, requestURI := parseInfoFromRequest(r)
+	clusterName, namespace, name, requestURI, portSelector := parseInfoFromRequest(r)
 
 	defer disableResponseCaching(w)
 	// Get the context
@@ -57,7 +57,7 @@ func RequestHandler(
 	}
 
 	// Get the service
-	ps, status, err := getServiceFromCluster(r.Context(), cs, namespace, name)
+	ps, status, err := getServiceFromCluster(r.Context(), cs, namespace, name, portSelector)
 	if err != nil {
 		w.WriteHeader(status)
 		return
@@ -73,13 +73,14 @@ func shouldUseUnsafeServiceAccountToken(ctx *kubeconfig.Context, unsafeUseServic
 	return unsafeUseServiceAccountToken && ctx.UsesInClusterServiceAccountToken()
 }
 
-func parseInfoFromRequest(r *http.Request) (string, string, string, string) {
+func parseInfoFromRequest(r *http.Request) (string, string, string, string, string) {
 	clusterName := mux.Vars(r)["clusterName"]
 	namespace := mux.Vars(r)["namespace"]
 	name := mux.Vars(r)["name"]
 	requestURI := r.URL.Query().Get("request")
+	portSelector := r.URL.Query().Get("port")
 
-	return clusterName, namespace, name, requestURI
+	return clusterName, namespace, name, requestURI, portSelector
 }
 
 func getAuthToken(r *http.Request, clusterName string) (string, error) {
@@ -104,9 +105,9 @@ func getAuthToken(r *http.Request, clusterName string) (string, error) {
 }
 
 func getServiceFromCluster(
-	ctx context.Context, cs kubernetes.Interface, namespace string, name string,
+	ctx context.Context, cs kubernetes.Interface, namespace string, name string, portSelector string,
 ) (*proxyService, int, error) {
-	ps, err := GetService(ctx, cs, namespace, name)
+	ps, err := GetServiceWithPort(ctx, cs, namespace, name, portSelector)
 	if err != nil {
 		if errors.IsUnauthorized(err) {
 			return nil, http.StatusUnauthorized, err

--- a/backend/pkg/serviceproxy/handler_test.go
+++ b/backend/pkg/serviceproxy/handler_test.go
@@ -489,7 +489,7 @@ func TestGetServiceFromCluster(t *testing.T) {
 				cs = fake.NewClientset()
 			}
 
-			ps, status, err := getServiceFromCluster(context.Background(), cs, tt.namespace, tt.serviceName)
+			ps, status, err := getServiceFromCluster(context.Background(), cs, tt.namespace, tt.serviceName, "")
 
 			assert.Equal(t, tt.expectedStatus, status)
 
@@ -661,11 +661,12 @@ func TestParseInfoFromRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := tt.setupRequest()
-			clusterName, namespace, name, requestURI := parseInfoFromRequest(req)
+			clusterName, namespace, name, requestURI, portSelector := parseInfoFromRequest(req)
 			assert.Equal(t, tt.expectedClusterName, clusterName)
 			assert.Equal(t, tt.expectedNamespace, namespace)
 			assert.Equal(t, tt.expectedName, name)
 			assert.Equal(t, tt.expectedRequestURI, requestURI)
+			assert.Equal(t, "", portSelector)
 		})
 	}
 }

--- a/backend/pkg/serviceproxy/handler_test.go
+++ b/backend/pkg/serviceproxy/handler_test.go
@@ -409,14 +409,18 @@ func TestGetAuthToken(t *testing.T) {
 
 //nolint:funlen
 func TestGetServiceFromCluster(t *testing.T) {
+	metricsPort := []corev1.ServicePort{{Name: "metrics", Port: 9090}}
 	tests := []struct {
 		name           string
 		namespace      string
 		serviceName    string
 		setupService   bool
+		ports          []corev1.ServicePort
+		portSelector   string
 		mockError      error
 		expectedStatus int
 		expectError    bool
+		expectedPort   int32
 	}{
 		{
 			name:           "service not found",
@@ -467,6 +471,36 @@ func TestGetServiceFromCluster(t *testing.T) {
 			expectedStatus: http.StatusNotFound,
 			expectError:    true,
 		},
+		{
+			name:           "select metrics port by name",
+			namespace:      "default",
+			serviceName:    "metrics-service",
+			setupService:   true,
+			ports:          metricsPort,
+			portSelector:   "metrics",
+			expectedStatus: http.StatusOK,
+			expectedPort:   9090,
+		},
+		{
+			name:           "select metrics port by number",
+			namespace:      "default",
+			serviceName:    "metrics-service",
+			setupService:   true,
+			ports:          metricsPort,
+			portSelector:   "9090",
+			expectedStatus: http.StatusOK,
+			expectedPort:   9090,
+		},
+		{
+			name:           "unknown port selector returns not found",
+			namespace:      "default",
+			serviceName:    "metrics-service",
+			setupService:   true,
+			ports:          metricsPort,
+			portSelector:   "web",
+			expectedStatus: http.StatusNotFound,
+			expectError:    true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -481,15 +515,20 @@ func TestGetServiceFromCluster(t *testing.T) {
 					return true, nil, tt.mockError
 				})
 			case tt.setupService:
-				// Setup a mock service
 				service := createMockService(tt.namespace, tt.serviceName)
+				if tt.ports != nil {
+					service.Spec.Ports = tt.ports
+				}
+
 				cs = fake.NewClientset(service)
 			default:
 				// Empty clientset (service not found)
 				cs = fake.NewClientset()
 			}
 
-			ps, status, err := getServiceFromCluster(context.Background(), cs, tt.namespace, tt.serviceName, "")
+			ps, status, err := getServiceFromCluster(
+				context.Background(), cs, tt.namespace, tt.serviceName, tt.portSelector,
+			)
 
 			assert.Equal(t, tt.expectedStatus, status)
 
@@ -501,6 +540,10 @@ func TestGetServiceFromCluster(t *testing.T) {
 				assert.NotNil(t, ps)
 				assert.Equal(t, tt.serviceName, ps.Name)
 				assert.Equal(t, tt.namespace, ps.Namespace)
+
+				if tt.expectedPort != 0 {
+					assert.Equal(t, tt.expectedPort, ps.Port)
+				}
 			}
 		})
 	}
@@ -515,6 +558,7 @@ func TestParseInfoFromRequest(t *testing.T) {
 		expectedNamespace   string
 		expectedName        string
 		expectedRequestURI  string
+		expectedPort        string
 	}{
 		{
 			name: "standard case with all parameters",
@@ -656,6 +700,44 @@ func TestParseInfoFromRequest(t *testing.T) {
 			expectedName:        "search-service",
 			expectedRequestURI:  "/api/v2/search?q=test&limit=10&offset=0",
 		},
+		{
+			name: "optional port selector by name",
+			setupRequest: func() *http.Request {
+				req := httptest.NewRequestWithContext(context.Background(), "GET",
+					"/proxy?request=/metrics&port=metrics", nil)
+				req = mux.SetURLVars(req, map[string]string{
+					"clusterName": "cluster",
+					"namespace":   "monitoring",
+					"name":        "prometheus",
+				})
+
+				return req
+			},
+			expectedClusterName: "cluster",
+			expectedNamespace:   "monitoring",
+			expectedName:        "prometheus",
+			expectedRequestURI:  "/metrics",
+			expectedPort:        "metrics",
+		},
+		{
+			name: "optional port selector by number",
+			setupRequest: func() *http.Request {
+				req := httptest.NewRequestWithContext(context.Background(), "GET",
+					"/proxy?request=/&port=8080", nil)
+				req = mux.SetURLVars(req, map[string]string{
+					"clusterName": "cluster",
+					"namespace":   "default",
+					"name":        "web",
+				})
+
+				return req
+			},
+			expectedClusterName: "cluster",
+			expectedNamespace:   "default",
+			expectedName:        "web",
+			expectedRequestURI:  "/",
+			expectedPort:        "8080",
+		},
 	}
 
 	for _, tt := range tests {
@@ -666,7 +748,7 @@ func TestParseInfoFromRequest(t *testing.T) {
 			assert.Equal(t, tt.expectedNamespace, namespace)
 			assert.Equal(t, tt.expectedName, name)
 			assert.Equal(t, tt.expectedRequestURI, requestURI)
-			assert.Equal(t, "", portSelector)
+			assert.Equal(t, tt.expectedPort, portSelector)
 		})
 	}
 }

--- a/backend/pkg/serviceproxy/service.go
+++ b/backend/pkg/serviceproxy/service.go
@@ -3,6 +3,8 @@ package serviceproxy
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 
@@ -26,7 +28,21 @@ type proxyService struct {
 }
 
 // GetService returns the requested service based on the provided name and namespace.
+// It keeps the historical default of selecting a port named "http" or "https".
 func GetService(ctx context.Context, cs kubernetes.Interface, namespace string, name string) (*proxyService, error) {
+	return GetServiceWithPort(ctx, cs, namespace, name, "")
+}
+
+// GetServiceWithPort returns the requested service and resolves the Service port.
+// When portSelector is empty, behavior matches GetService (http/https named ports).
+// Otherwise portSelector may be a Service port name or port number that exists on the Service.
+func GetServiceWithPort(
+	ctx context.Context,
+	cs kubernetes.Interface,
+	namespace string,
+	name string,
+	portSelector string,
+) (*proxyService, error) {
 	service, err := cs.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -38,7 +54,7 @@ func GetService(ctx context.Context, cs kubernetes.Interface, namespace string, 
 		IsExternal: len(service.Spec.ExternalName) > 0,
 	}
 
-	port, err := GetPort(service.Spec.Ports)
+	port, err := ResolvePort(service.Spec.Ports, portSelector)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "service port not found")
 
@@ -46,14 +62,7 @@ func GetService(ctx context.Context, cs kubernetes.Interface, namespace string, 
 	}
 
 	ps.Port = port.Port
-
-	// Determine scheme - always use https for external
-	if port.Name == HTTPSchemeName {
-		ps.Scheme = HTTPSchemeName
-	} else {
-		ps.Scheme = HTTPSSchemeName
-	}
-
+	ps.Scheme = schemeForPort(port)
 	ps.URIPrefix = getServiceURLPrefix(ps, service)
 
 	return ps, nil
@@ -75,6 +84,52 @@ func GetPort(ports []corev1.ServicePort) (*corev1.ServicePort, error) {
 	}
 
 	return nil, fmt.Errorf("no port found with the name http or https")
+}
+
+// ResolvePort selects a Service port.
+// An empty portSelector preserves GetPort behavior.
+// A non-empty selector matches a port by name, or by port number when the selector is numeric.
+// Only ports declared on the Service are accepted.
+func ResolvePort(ports []corev1.ServicePort, portSelector string) (*corev1.ServicePort, error) {
+	selector := strings.TrimSpace(portSelector)
+	if selector == "" {
+		return GetPort(ports)
+	}
+
+	if portNum, err := strconv.ParseInt(selector, 10, 32); err == nil {
+		for i, port := range ports {
+			if port.Port == int32(portNum) {
+				return &ports[i], nil
+			}
+		}
+
+		return nil, fmt.Errorf("no service port with number %s", selector)
+	}
+
+	for i, port := range ports {
+		if port.Name == selector {
+			return &ports[i], nil
+		}
+	}
+
+	return nil, fmt.Errorf("no service port with name %q", selector)
+}
+
+// schemeForPort keeps existing scheme choice for ports named http/https.
+// Explicitly selected other ports default to http, except port 443 which uses https.
+func schemeForPort(port *corev1.ServicePort) string {
+	switch port.Name {
+	case HTTPSchemeName:
+		return HTTPSchemeName
+	case HTTPSSchemeName:
+		return HTTPSSchemeName
+	default:
+		if port.Port == 443 {
+			return HTTPSSchemeName
+		}
+
+		return HTTPSchemeName
+	}
 }
 
 // getServiceURLPrefix generates a URL prefix for a Kubernetes service based on the provided proxyService and service

--- a/backend/pkg/serviceproxy/service_test.go
+++ b/backend/pkg/serviceproxy/service_test.go
@@ -87,6 +87,70 @@ func TestGetServiceNonExistent(t *testing.T) {
 	}
 }
 
+func TestGetServiceWithPortByName(t *testing.T) {
+	cs := fake.NewClientset()
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "metrics-service",
+			Namespace: "default",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "metrics", Port: 9090},
+				{Name: "http", Port: 80},
+			},
+		},
+	}
+
+	_, err := cs.CoreV1().Services("default").Create(context.Background(), service, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create test service: %v", err)
+	}
+
+	ps, err := serviceproxy.GetServiceWithPort(context.Background(), cs, "default", "metrics-service", "metrics")
+	if err != nil {
+		t.Fatalf("GetServiceWithPort() error = %v", err)
+	}
+
+	if ps.URIPrefix != "http://metrics-service.default:9090" {
+		t.Errorf("GetServiceWithPort() URIPrefix = %s, want http://metrics-service.default:9090", ps.URIPrefix)
+	}
+}
+
+func TestGetServiceWithPortByNumber(t *testing.T) {
+	cs := fake.NewClientset()
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "web-service",
+			Namespace: "default",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "web", Port: 8080},
+			},
+		},
+	}
+
+	_, err := cs.CoreV1().Services("default").Create(context.Background(), service, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create test service: %v", err)
+	}
+
+	// Default GetService still fails without http/https named ports.
+	if _, err := serviceproxy.GetService(context.Background(), cs, "default", "web-service"); err == nil {
+		t.Fatal("GetService() expected error for service without http/https ports")
+	}
+
+	ps, err := serviceproxy.GetServiceWithPort(context.Background(), cs, "default", "web-service", "8080")
+	if err != nil {
+		t.Fatalf("GetServiceWithPort() error = %v", err)
+	}
+
+	if ps.URIPrefix != "http://web-service.default:8080" {
+		t.Errorf("GetServiceWithPort() URIPrefix = %s, want http://web-service.default:8080", ps.URIPrefix)
+	}
+}
+
 func TestGetPort(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -136,6 +200,60 @@ func TestGetPort(t *testing.T) {
 
 			if !tt.wantErr && port.Port != tt.wantPort {
 				t.Errorf("GetPort() port = %d, wantPort %d", port.Port, tt.wantPort)
+			}
+		})
+	}
+}
+
+func TestResolvePort(t *testing.T) {
+	ports := []corev1.ServicePort{
+		{Name: "https", Port: 443},
+		{Name: "http", Port: 80},
+		{Name: "metrics", Port: 9090},
+	}
+
+	tests := []struct {
+		name         string
+		portSelector string
+		wantPort     int32
+		wantErr      bool
+	}{
+		{
+			name:         "empty selector keeps http/https default",
+			portSelector: "",
+			wantPort:     443,
+		},
+		{
+			name:         "select by name",
+			portSelector: "metrics",
+			wantPort:     9090,
+		},
+		{
+			name:         "select by number",
+			portSelector: "80",
+			wantPort:     80,
+		},
+		{
+			name:         "unknown name",
+			portSelector: "web",
+			wantErr:      true,
+		},
+		{
+			name:         "unknown number",
+			portSelector: "1234",
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			port, err := serviceproxy.ResolvePort(ports, tt.portSelector)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ResolvePort() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if !tt.wantErr && port.Port != tt.wantPort {
+				t.Fatalf("ResolvePort() port = %d, wantPort %d", port.Port, tt.wantPort)
 			}
 		})
 	}


### PR DESCRIPTION


## Summary

This PR adds regression tests for optional serviceproxy port selection (`?port=<name|number>`), including default `http`/`https` behavior and request parsing.

## Related Issue

Related to #7057 
Depends on / stacked on: PR_FEATURE_NUMBER (`backend/serviceproxy-optional-port`)

## Changes

- Added `TestResolvePort` coverage for empty selector, name match, number match, and unknown values
- Added `TestGetServiceWithPortByName` and `TestGetServiceWithPortByNumber`
- Extended `TestParseInfoFromRequest` for `port=metrics` and `port=8080`

## Steps to Test

1. Checkout this branch (includes the feature commit + this tests commit).
2. From `backend/`, run:
   ```bash
   go test ./pkg/serviceproxy/ -count=1
3. Or run focused tests:
   go test ./pkg/serviceproxy/ -count=1 -run 'ResolvePort|WithPort|ParseInfoFromRequest'
4. Confirm all new cases pass and existing serviceproxy tests remain green.