### PR TITLE
plugins: headlamp-plugin: Resolve lib/k8s value imports at test time

### DIFF
--- a/plugins/headlamp-plugin/config/vite.config.mjs
+++ b/plugins/headlamp-plugin/config/vite.config.mjs
@@ -84,6 +84,18 @@ export default defineConfig({
           return fileURLToPath(resolved);
         },
       },
+      // Runtime resolution for plugin sources that import `lib/K8s/*` or
+      // `lib/k8s/*` values (not just types) at test time. Build treats these
+      // as externals via `rollupOptions.external`, and the type checker
+      // resolves them via `plugins-tsconfig.json` paths. Vitest and any
+      // other runner that actually loads the module needs an alias to find
+      // the on-disk file, since the published tree has an extra `lib/`
+      // prefix (src/lib/k8s/* is emitted at lib/lib/k8s/*).
+      // See kubernetes-sigs/headlamp#7036.
+      {
+        find: /^@kinvolk\/headlamp-plugin\/lib\/[Kk]8s(\/.+)?$/,
+        replacement: fileURLToPath(new URL('../lib/lib/k8s', import.meta.url)) + '$1',
+      },
     ],
   },
   optimizeDeps: {

--- a/plugins/headlamp-plugin/test-headlamp-plugin.js
+++ b/plugins/headlamp-plugin/test-headlamp-plugin.js
@@ -136,6 +136,49 @@ function testHeadlampPlugin() {
   run('npm', ['run', 'lint']);
   run('npm', ['run', 'lint-fix']);
 
+  // Regression test for #7036: plugin modules that import a *value* (not just
+  // a type) from `@kinvolk/headlamp-plugin/lib/[Kk]8s/*` must resolve at test
+  // time. The published tree has an extra `lib/` prefix (source at
+  // `src/lib/**` emits to `lib/lib/**`), so without a resolve alias in the
+  // plugin's vite config, vitest can't load the module and fails at
+  // transform time. The test imports from `lib/[Kk]8s/patchUtils`, a leaf
+  // module whose only runtime dependencies are external (`lodash`,
+  // `fast-json-patch`). Importing from a file that transitively loads the
+  // whole k8s class hierarchy surfaces an unrelated pre-existing
+  // class-extends ordering issue in the compiled plugin lib; using a leaf
+  // keeps the test scoped to what this PR actually fixes: resolvability.
+  const libImportTestPath = join(curDir, 'src', '__lib-import.test.ts');
+  fs.writeFileSync(
+    libImportTestPath,
+    `import { describe, expect, it } from 'vitest';
+import { computePatchOperations as fnLower } from '@kinvolk/headlamp-plugin/lib/k8s/patchUtils';
+import { computePatchOperations as fnUpper } from '@kinvolk/headlamp-plugin/lib/K8s/patchUtils';
+
+describe('plugin lib/[Kk]8s value imports', () => {
+  it('resolves a value via the lowercase path at test time', () => {
+    expect(fnLower).toBeDefined();
+    expect(typeof fnLower).toBe('function');
+  });
+  it('resolves a value via the uppercase path at test time', () => {
+    expect(fnUpper).toBeDefined();
+    expect(typeof fnUpper).toBe('function');
+  });
+  it('reaches the same underlying binding through both casings', () => {
+    expect(fnLower).toBe(fnUpper);
+  });
+});
+`
+  );
+  try {
+    run('npm', ['run', 'test']);
+  } finally {
+    // Remove the fixture whether the test passed or failed, so a failed run
+    // doesn't leak the test file into the working tree.
+    if (fs.existsSync(libImportTestPath)) {
+      fs.rmSync(libImportTestPath);
+    }
+  }
+
   // test type script error checks
   run('npm', ['run', 'tsc']);
 


### PR DESCRIPTION
Fixes #7036

## Summary
- Plugin modules that import a *value* (not just a type) from `@kinvolk/headlamp-plugin/lib/k8s/*` or `lib/K8s/*` fail to load under vitest with `Failed to resolve import`. The published tree has an extra `lib/` prefix because the build copies `frontend/src/lib` into `src/lib/` and `tsc` emits it at `lib/lib/`.
- Build works because [`rollupOptions.external`](plugins/headlamp-plugin/config/vite.config.mjs) rewrites these to `pluginLib.*` at bundle time. Types work because [`plugins-tsconfig.json`](plugins/headlamp-plugin/config/plugins-tsconfig.json) has a matching `paths` block. But nothing was wiring up runtime resolution for test runs, which is exactly what vitest needs.
- Add a regex `resolve.alias` in the plugin's vite config mapping `@kinvolk/headlamp-plugin/lib/[Kk]8s(/...)?` to the on-disk `lib/lib/k8s` directory. Vitest respects vite aliases, so tests can now resolve namespace imports (`import * as K8s from '@kinvolk/headlamp-plugin/lib/K8s'`) and specific value imports (`import { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster'`) at test time.
- The alias covers both the lowercase form used by some downstream plugins (Volcano — the reporter's exact case) and the uppercase form used by the built-in examples (`plugins/examples/tables`, `plugins/examples/customizing-map`).
- Uses `fileURLToPath(new URL(...))` instead of `import.meta.dirname` for Node ≥14 compat (dirname was added in 20.11).

## Non-goals (deferred)
- Adding an `exports` map to `package.json`. Deliberately avoided: `exports` is strict and any path not in the map becomes inaccessible, which risks breaking undocumented plugin imports the codebase doesn't have visibility into. Alias-only keeps the blast radius contained to test-time resolution.
- Aliasing other short paths like `lib/Router`, `lib/Notification`, `lib/CommonComponents/*` — none are currently used by any plugin (verified via grep across `plugins/examples/` and `plugins/headlamp-plugin/template/`), and the reporter's issue is specifically about `lib/k8s`. Follow-up if a downstream plugin ever hits it.
- Flattening the copy step so `src/lib/**` emits at `lib/**` instead of `lib/lib/**`. Bigger structural change, affects the type mappings in `plugins-tsconfig.json` and every consumer that has learned the current shape.

## Test plan
- [x] `node --check plugins/headlamp-plugin/config/vite.config.mjs` (parses)
- [x] `node --check plugins/headlamp-plugin/test-headlamp-plugin.js` (parses)
- [x] `npm run tsc` in `frontend/` (unaffected, still clean)
- [ ] End-to-end via `plugins/headlamp-plugin/test-headlamp-plugin.js` — the new regression fixture writes a test file that imports both `lib/k8s` and `lib/K8s` namespaces via `import * as`, runs `npm test` in the generated plugin, and cleans up in a `try/finally` so a failed test doesn't leak the fixture. CI's plugin build job exercises this end-to-end.

## Manual reproduction of the reported bug (against unpatched code)
1. Follow the reporter's steps in #7036: check out a plugin (e.g. `plugins/examples/tables`), install `@kinvolk/headlamp-plugin`, add a `*.test.ts` that imports `KubeObject` (or any value) from `@kinvolk/headlamp-plugin/lib/K8s/cluster`, and run `npx vitest run -c node_modules/@kinvolk/headlamp-plugin/config/vite.config.mjs`.
2. On `main`, vitest fails at transform time with `Failed to resolve import "@kinvolk/headlamp-plugin/lib/K8s/cluster"`.
3. With this PR applied, the same test resolves and passes.