### PR TITLE
0056: backend: Disable local static-plugin caching

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -374,6 +374,10 @@ func addPluginRoutes(config *HeadlampConfig, r *mux.Router) {
 	if config.StaticPluginDir != "" {
 		staticPluginsHandler := http.StripPrefix(config.BaseURL+"/static-plugins/",
 			spa.BrotliSidecars(config.StaticPluginDir, http.FileServer(http.Dir(config.StaticPluginDir))))
+		if !config.UseInCluster {
+			staticPluginsHandler = serveWithNoCacheHeader(staticPluginsHandler)
+		}
+
 		r.PathPrefix("/static-plugins/").Handler(staticPluginsHandler)
 	}
 }

--- a/backend/cmd/plugin_routes_test.go
+++ b/backend/cmd/plugin_routes_test.go
@@ -88,3 +88,28 @@ func TestPluginRouteCacheControl(t *testing.T) {
 		})
 	}
 }
+
+func TestLocalStaticPluginCacheControl(t *testing.T) {
+	staticPluginDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(staticPluginDir, "plugin.js"), []byte("plugin"), 0o600))
+
+	config := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				PluginDir:       t.TempDir(),
+				StaticPluginDir: staticPluginDir,
+			},
+		},
+	}
+	router := mux.NewRouter()
+	addPluginRoutes(config, router)
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(
+		recorder,
+		httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/static-plugins/plugin.js", nil),
+	)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Equal(t, "no-cache", recorder.Header().Get("Cache-Control"))
+}

--- a/backend/cmd/plugin_routes_test.go
+++ b/backend/cmd/plugin_routes_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPluginRouteCacheControl(t *testing.T) {
+	pluginDir := t.TempDir()
+	userPluginDir := t.TempDir()
+	staticPluginDir := t.TempDir()
+
+	for _, directory := range []string{pluginDir, userPluginDir, staticPluginDir} {
+		require.NoError(t, os.WriteFile(filepath.Join(directory, "plugin.js"), []byte("plugin"), 0o600))
+	}
+
+	for _, test := range []struct {
+		name          string
+		path          string
+		useInCluster  bool
+		userPluginDir string
+		staticDir     string
+		status        int
+		cacheControl  string
+	}{
+		{name: "local development plugin", path: "/plugins/plugin.js", status: http.StatusOK, cacheControl: "no-cache"},
+		{name: "in-cluster development plugin", path: "/plugins/plugin.js", useInCluster: true, status: http.StatusOK},
+		{
+			name: "local user plugin", path: "/user-plugins/plugin.js", userPluginDir: userPluginDir,
+			status: http.StatusOK, cacheControl: "no-cache",
+		},
+		{
+			name: "in-cluster user plugin", path: "/user-plugins/plugin.js", useInCluster: true,
+			userPluginDir: userPluginDir, status: http.StatusOK,
+		},
+		{name: "missing user plugin route", path: "/user-plugins/plugin.js", status: http.StatusNotFound},
+		{
+			name: "in-cluster static plugin", path: "/static-plugins/plugin.js", useInCluster: true,
+			staticDir: staticPluginDir, status: http.StatusOK,
+		},
+		{name: "missing static plugin route", path: "/static-plugins/plugin.js", status: http.StatusNotFound},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			config := &HeadlampConfig{
+				HeadlampConfig: &headlampconfig.HeadlampConfig{
+					HeadlampCFG: &headlampconfig.HeadlampCFG{
+						UseInCluster:    test.useInCluster,
+						PluginDir:       pluginDir,
+						UserPluginDir:   test.userPluginDir,
+						StaticPluginDir: test.staticDir,
+					},
+				},
+			}
+			router := mux.NewRouter()
+			addPluginRoutes(config, router)
+
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(
+				recorder,
+				httptest.NewRequestWithContext(t.Context(), http.MethodGet, test.path, nil),
+			)
+
+			require.Equal(t, test.status, recorder.Code)
+			require.Equal(t, test.cacheControl, recorder.Header().Get("Cache-Control"))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- serve local shipped plugin assets with `Cache-Control: no-cache`
- preserve existing cache behavior for in-cluster static plugins
- cover development, user-installed, and shipped plugin routes directly

## Improvements over existing

Compared with the downstream change, this PR:

- adds a test-only commit before the behavior change so the existing route
  contract is independently reviewable and passing
- expands unit coverage across `/plugins/`, `/user-plugins/`, and
  `/static-plugins/` in local and in-cluster modes
- covers optional route registration, missing routes, successful file serving,
  and existing cache headers
- keeps a dedicated local static-plugin regression test in the upstreamed
  commit, so the new branch is covered by the commit that introduces it
- retains the current `spa.BrotliSidecars` serving path while adding the existing
  no-cache wrapper only for local static plugins

Headlamp PR
[#6740](https://github.com/kubernetes-sigs/headlamp/pull/6740) is
related but not equivalent. It changes development and user-installed plugin
caching for in-cluster plugin watching; this PR changes shipped static-plugin
caching only for local mode.

## Coverage

Focused coverage reports:

- `addPluginRoutes`: 100% statements
- `serveWithNoCacheHeader`: 100% statements

The first commit passes independently before the implementation commit.

An existing Playwright test,
`e2e-tests/tests/prometheusPlugin.spec.ts`, verifies that the Prometheus static
plugin is bundled and that its settings UI loads. No new browser e2e test is
needed for this HTTP response-header change; the focused `httptest` regression
uses the real router, file server, sidecar wrapper, and response headers.

## Source

This ports patch **0056**,
`patches/0056-headlamp-upstream-static-plugin-no-cache.patch`, retained by
[Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823), the
patch-series PR.

Original PR:
[Azure/aks-desktop#359](https://github.com/Azure/aks-desktop/pull/359).

The behavior originated there as
[commit `4e914814`](https://github.com/Azure/aks-desktop/commit/4e91481401f53acc005e48d21e255c6c3482ab2c),
authored by Oleksandr Dubenko on 2026-03-03. Patch 0056 was later reconstructed
as source commit `e97596dc2c8341a03da3ee369239e55ed4cb2ad8`, authored by
Oleksandr on 2026-07-31 at 13:40:14 UTC.

The upstreamed implementation commit preserves the patch author and date and
adds René Dudfield as co-author.

## Validation

- `go test ./cmd -run '^Test(PluginRouteCacheControl|LocalStaticPluginCacheControl)$' -count=1`
- `go test -p 1 ./...`
- `npm run backend:lint`

Assisted by copilot
