### PR TITLE
0060: Open View button in split-right

### DIFF
--- a/e2e-tests/tests/podsPage.spec.ts
+++ b/e2e-tests/tests/podsPage.spec.ts
@@ -272,7 +272,7 @@ test('warns and preserves edits when a pod is modified externally', async ({ pag
   }
 });
 
-test('opens resource YAML in a floating window', async ({ page }) => {
+test('opens resource YAML beside the current content', async ({ page }) => {
   test.setTimeout(60000);
   const name = `headlamp-view-yaml-${Date.now()}`;
   const tempDirectory = await mkdtemp(join(tmpdir(), 'headlamp-e2e-'));
@@ -329,17 +329,18 @@ test('opens resource YAML in a floating window', async ({ page }) => {
     await expect(activity).toBeVisible({ timeout: 15000 });
     await expect
       .poll(async () => {
-        const [mainBox, viewerBox, borderRadius] = await Promise.all([
-          main.boundingBox(),
-          viewer.boundingBox(),
-          viewer.evaluate(element => getComputedStyle(element).borderRadius),
-        ]);
-        return {
-          isFloating: Boolean(mainBox && viewerBox && viewerBox.height < mainBox.height * 0.9),
-          borderRadius,
-        };
+        const [mainBox, viewerBox] = await Promise.all([main.boundingBox(), viewer.boundingBox()]);
+        if (!mainBox || !viewerBox) {
+          return false;
+        }
+
+        return (
+          Math.abs(viewerBox.width - mainBox.width / 2) < 2 &&
+          Math.abs(viewerBox.height - mainBox.height) < 2 &&
+          Math.abs(viewerBox.x + viewerBox.width - (mainBox.x + mainBox.width)) < 2
+        );
       })
-      .toEqual({ isFloating: true, borderRadius: '10px' });
+      .toBe(true);
   } finally {
     await kubectl(
       kubeconfig,

--- a/e2e-tests/tests/podsPage.spec.ts
+++ b/e2e-tests/tests/podsPage.spec.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
+import { expect, test } from '@playwright/test';
 import { execFile } from 'node:child_process';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
-import { expect, test } from '@playwright/test';
 import { HeadlampPage } from './headlampPage';
 import { podsPage } from './podsPage';
 
@@ -264,6 +264,88 @@ test('warns and preserves edits when a pod is modified externally', async ({ pag
       '--namespace=default',
       'delete',
       'pod',
+      name,
+      '--ignore-not-found=true'
+    )
+      .catch(() => undefined)
+      .finally(() => rm(tempDirectory, { recursive: true, force: true }));
+  }
+});
+
+test('opens resource YAML in a floating window', async ({ page }) => {
+  test.setTimeout(60000);
+  const name = `headlamp-view-yaml-${Date.now()}`;
+  const tempDirectory = await mkdtemp(join(tmpdir(), 'headlamp-e2e-'));
+  const kubeconfig = join(tempDirectory, 'kubeconfig');
+
+  try {
+    const { stdout } = await execFileAsync('kind', ['get', 'kubeconfig', '--name', 'test']);
+    await writeFile(kubeconfig, stdout);
+    await kubectl(
+      kubeconfig,
+      '--namespace=default',
+      'create',
+      'configmap',
+      name,
+      '--from-literal=example=value'
+    );
+
+    await page.goto('/c/test', { waitUntil: 'domcontentloaded' });
+    const needsAuthentication = await Promise.race([
+      page
+        .getByRole('heading', { level: 1, name: 'Authentication' })
+        .waitFor({ state: 'visible' })
+        .then(() => true),
+      page
+        .getByRole('heading', { name: 'Overview' })
+        .waitFor({ state: 'visible' })
+        .then(() => false),
+    ]);
+    if (needsAuthentication) {
+      const useTokenButton = page.getByRole('button', { name: 'Use A Token' });
+      if (await useTokenButton.isVisible()) {
+        await useTokenButton.click();
+      }
+      const token = process.env.HEADLAMP_TEST_TOKEN;
+      expect(token).toBeTruthy();
+      await page.getByRole('textbox', { name: 'ID token' }).fill(token!);
+      await page.getByRole('button', { name: 'Authenticate' }).click();
+      await expect(page.getByRole('heading', { name: 'Overview' })).toBeVisible();
+    }
+    await page.goto('/c/test/configmaps', { waitUntil: 'domcontentloaded' });
+    await expect(page).toHaveURL(/\/c\/test\/configmaps$/);
+    await expect(page.getByRole('heading', { name: 'Config Maps' })).toBeVisible();
+    const resourceRow = page.getByRole('row').filter({ has: page.getByRole('link', { name }) });
+    await expect(resourceRow).toBeVisible();
+    await page.route(`**/clusters/test/api/v1/namespaces/default/configmaps/${name}`, route =>
+      route.abort('failed')
+    );
+    await resourceRow.getByRole('button', { name: 'Row Actions' }).click();
+    await page.getByRole('menuitem', { name: 'View YAML' }).click();
+
+    const activity = page.locator(`[role="complementary"][aria-label="${name}"]`);
+    const viewer = activity.locator(':scope > div');
+    const main = page.locator('#main');
+    await expect(activity).toBeVisible({ timeout: 15000 });
+    await expect
+      .poll(async () => {
+        const [mainBox, viewerBox, borderRadius] = await Promise.all([
+          main.boundingBox(),
+          viewer.boundingBox(),
+          viewer.evaluate(element => getComputedStyle(element).borderRadius),
+        ]);
+        return {
+          isFloating: Boolean(mainBox && viewerBox && viewerBox.height < mainBox.height * 0.9),
+          borderRadius,
+        };
+      })
+      .toEqual({ isFloating: true, borderRadius: '10px' });
+  } finally {
+    await kubectl(
+      kubeconfig,
+      '--namespace=default',
+      'delete',
+      'configmap',
       name,
       '--ignore-not-found=true'
     )

--- a/e2e-tests/tests/podsPage.spec.ts
+++ b/e2e-tests/tests/podsPage.spec.ts
@@ -272,11 +272,14 @@ test('warns and preserves edits when a pod is modified externally', async ({ pag
   }
 });
 
-test('opens resource YAML beside the current content', async ({ page }) => {
-  test.setTimeout(60000);
+test('positions the resource YAML viewer for each viewport size', async ({ page }) => {
+  test.setTimeout(90000);
   const name = `headlamp-view-yaml-${Date.now()}`;
+  const hundredColumnValue = '1234567890'.repeat(9) + '123456';
   const tempDirectory = await mkdtemp(join(tmpdir(), 'headlamp-e2e-'));
   const kubeconfig = join(tempDirectory, 'kubeconfig');
+
+  expect(`    ${hundredColumnValue}`).toHaveLength(100);
 
   try {
     const { stdout } = await execFileAsync('kind', ['get', 'kubeconfig', '--name', 'test']);
@@ -287,7 +290,8 @@ test('opens resource YAML beside the current content', async ({ page }) => {
       'create',
       'configmap',
       name,
-      '--from-literal=example=value'
+      '--from-literal=example=value',
+      `--from-literal=line100=${hundredColumnValue}`
     );
 
     await page.goto('/c/test', { waitUntil: 'domcontentloaded' });
@@ -312,35 +316,78 @@ test('opens resource YAML beside the current content', async ({ page }) => {
       await page.getByRole('button', { name: 'Authenticate' }).click();
       await expect(page.getByRole('heading', { name: 'Overview' })).toBeVisible();
     }
-    await page.goto('/c/test/configmaps', { waitUntil: 'domcontentloaded' });
-    await expect(page).toHaveURL(/\/c\/test\/configmaps$/);
-    await expect(page.getByRole('heading', { name: 'Config Maps' })).toBeVisible();
-    const resourceRow = page.getByRole('row').filter({ has: page.getByRole('link', { name }) });
-    await expect(resourceRow).toBeVisible();
     await page.route(`**/clusters/test/api/v1/namespaces/default/configmaps/${name}`, route =>
       route.abort('failed')
     );
-    await resourceRow.getByRole('button', { name: 'Row Actions' }).click();
-    await page.getByRole('menuitem', { name: 'View YAML' }).click();
 
-    const activity = page.locator(`[role="complementary"][aria-label="${name}"]`);
-    const viewer = activity.locator(':scope > div');
-    const main = page.locator('#main');
-    await expect(activity).toBeVisible({ timeout: 15000 });
-    await expect
-      .poll(async () => {
-        const [mainBox, viewerBox] = await Promise.all([main.boundingBox(), viewer.boundingBox()]);
-        if (!mainBox || !viewerBox) {
-          return false;
-        }
+    for (const viewport of [
+      { name: 'phone', width: 390, height: 844 },
+      { name: 'medium', width: 1024, height: 900 },
+      { name: 'large', width: 1440, height: 900 },
+      { name: 'extra-large', width: 2560, height: 900 },
+    ]) {
+      await page.setViewportSize(viewport);
+      await page.goto('/c/test/configmaps', { waitUntil: 'domcontentloaded' });
+      await expect(page).toHaveURL(/\/c\/test\/configmaps$/);
+      await expect(page.getByRole('heading', { name: 'Config Maps' })).toBeVisible();
+      const resourceRow = page.getByRole('row').filter({ has: page.getByRole('link', { name }) });
+      await expect(resourceRow).toBeVisible();
+      await resourceRow.locator('td').last().getByRole('button').click();
+      await page.getByRole('menuitem', { name: 'View YAML' }).click();
+      await page.keyboard.press('Escape');
+      await expect(page.getByRole('menu')).toHaveCount(0);
 
-        return (
-          Math.abs(viewerBox.width - mainBox.width / 2) < 2 &&
-          Math.abs(viewerBox.height - mainBox.height) < 2 &&
-          Math.abs(viewerBox.x + viewerBox.width - (mainBox.x + mainBox.width)) < 2
-        );
-      })
-      .toBe(true);
+      const activity = page.locator(`[role="complementary"][aria-label="${name}"]`);
+      const viewer = activity.locator(':scope > div');
+      const main = page.locator('#main');
+      await expect(activity, `${viewport.name} activity`).toBeVisible({ timeout: 15000 });
+      await expect
+        .poll(
+          async () => {
+            const [mainBox, viewerBox] = await Promise.all([
+              main.boundingBox(),
+              viewer.boundingBox(),
+            ]);
+            if (!mainBox || !viewerBox) {
+              return false;
+            }
+
+            if (viewport.name === 'phone') {
+              return (
+                Math.abs(viewerBox.x - mainBox.x) < 2 &&
+                Math.abs(viewerBox.y - mainBox.y) < 2 &&
+                Math.abs(viewerBox.width - mainBox.width) < 2 &&
+                Math.abs(viewerBox.height - mainBox.height) < 2
+              );
+            }
+
+            if (viewport.name === 'medium') {
+              return (
+                Math.abs(viewerBox.x - 8) < 2 &&
+                Math.abs(viewerBox.y - 72) < 2 &&
+                Math.abs(viewerBox.width - (viewport.width - 16)) < 2 &&
+                Math.abs(viewerBox.height - (viewport.height - 80)) < 2
+              );
+            }
+
+            const expectedWidth = Math.min(mainBox.width, Math.max(mainBox.width / 2, 1024));
+            return (
+              Math.abs(viewerBox.width - expectedWidth) < 2 &&
+              Math.abs(viewerBox.height - mainBox.height) < 2 &&
+              Math.abs(viewerBox.x + viewerBox.width - (mainBox.x + mainBox.width)) < 2
+            );
+          },
+          { message: `${viewport.name} viewer placement` }
+        )
+        .toBe(true);
+
+      if (viewport.name === 'large' || viewport.name === 'extra-large') {
+        await expect(activity.locator('.monaco-editor')).toContainText(hundredColumnValue);
+      }
+
+      await activity.locator('button[title="Close"]').evaluate(button => button.click());
+      await expect(activity).toHaveCount(0);
+    }
   } finally {
     await kubectl(
       kubeconfig,

--- a/e2e-tests/tests/podsPage.ts
+++ b/e2e-tests/tests/podsPage.ts
@@ -83,6 +83,9 @@ spec:
     await expect(podLink).toBeVisible();
 
     console.log(`Created pod ${name}`);
+    await expect(page.getByText(`Applied ${name}.`, { exact: true })).toBeHidden({
+      timeout: 10000,
+    });
     await this.a11y();
   }
 

--- a/frontend/src/components/activity/Activity.test.tsx
+++ b/frontend/src/components/activity/Activity.test.tsx
@@ -75,6 +75,24 @@ describe('activitySlice', () => {
       expect(nextState.history).not.toContain('2');
       expect(nextState.activities['1']).toBeDefined();
     });
+
+    it('should preserve a centered window on medium screens', () => {
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: 900 });
+      const mediumActivity = { ...newActivity, location: 'window-medium' as const };
+
+      const nextState = reducer(initialState, launchActivity(mediumActivity));
+
+      expect(nextState.activities['1'].location).toBe('window-medium');
+    });
+
+    it('should make a centered window fullscreen on phones', () => {
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: 390 });
+      const mediumActivity = { ...newActivity, location: 'window-medium' as const };
+
+      const nextState = reducer(initialState, launchActivity(mediumActivity));
+
+      expect(nextState.activities['1'].location).toBe('full');
+    });
   });
 
   describe('close', () => {

--- a/frontend/src/components/activity/Activity.tsx
+++ b/frontend/src/components/activity/Activity.tsx
@@ -59,8 +59,10 @@ type ActivityLocation =
   | 'full'
   | 'split-left'
   | 'split-right'
+  | 'split-right-wide'
   | 'split-top'
   | 'split-bottom'
+  | 'window-medium'
   | 'window';
 
 /** Independent screen or a page rendered on top of the app */
@@ -184,6 +186,14 @@ export function SingleActivityRenderer({
       height: '100%',
       gridColumn: '2 / 4',
     },
+    'split-right-wide': {
+      position: 'absolute',
+      right: 0,
+      width: 'max(50%, 1024px)',
+      maxWidth: '100%',
+      height: '100%',
+      gridColumn: '2 / 4',
+    },
     'split-left': {
       position: 'absolute',
       width: '50%',
@@ -209,6 +219,20 @@ export function SingleActivityRenderer({
       position: 'absolute',
       width: '50%',
       height: '70%',
+      gridColumn: '2 / 4',
+      border: '1px solid',
+      borderTop: '1px solid',
+      borderBottom: '1px solid',
+      borderRadius: '10px',
+    },
+    'window-medium': {
+      position: 'fixed',
+      top: '72px',
+      right: '8px',
+      bottom: '8px',
+      left: '8px',
+      width: 'auto',
+      height: 'auto',
       gridColumn: '2 / 4',
       border: '1px solid',
       borderTop: '1px solid',
@@ -988,8 +1012,7 @@ export const ActivitiesRenderer = React.memo(function ActivitiesRenderer() {
   const locationRef = useRef(location.pathname);
 
   // Minimize activities that block the main content on route change.
-  // Activities in 'split-right' location are kept visible since they
-  // allow the user to see most of the main content.
+  // Right-side activities are kept visible since they leave main content visible.
   useEffect(() => {
     activities.forEach(activity => {
       // If we were triggered just because of the activities changing but the
@@ -998,7 +1021,11 @@ export const ActivitiesRenderer = React.memo(function ActivitiesRenderer() {
         return;
       }
 
-      if (activity.location !== 'split-right' && !activity.minimized) {
+      if (
+        activity.location !== 'split-right' &&
+        activity.location !== 'split-right-wide' &&
+        !activity.minimized
+      ) {
         Activity.update(activity.id, { minimized: true });
       }
     });

--- a/frontend/src/components/activity/activitySlice.tsx
+++ b/frontend/src/components/activity/activitySlice.tsx
@@ -56,8 +56,11 @@ export const activitySlice = createSlice({
         state.activities[action.payload.id].minimized = false;
       }
 
-      // Make it fullscreen on small windows
-      if (window.innerWidth < 1280) {
+      // Keep explicit medium windows floating; all other activities retain the existing behavior.
+      if (
+        window.innerWidth < 600 ||
+        (window.innerWidth < 1280 && action.payload.location !== 'window-medium')
+      ) {
         state.activities[action.payload.id] = {
           ...state.activities[action.payload.id],
           location: 'full',

--- a/frontend/src/components/common/Resource/ViewButton.test.tsx
+++ b/frontend/src/components/common/Resource/ViewButton.test.tsx
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { KubeObject } from '../../../lib/k8s/cluster';
+import ViewButton from './ViewButton';
+
+const { mockActivityClose, mockActivityLaunch, mockFetchLatestKubeObject } = vi.hoisted(() => ({
+  mockActivityClose: vi.fn(),
+  mockActivityLaunch: vi.fn(),
+  mockFetchLatestKubeObject: vi.fn(),
+}));
+
+vi.mock('../../activity/Activity', () => ({
+  Activity: {
+    close: (...args: unknown[]) => mockActivityClose(...args),
+    launch: (...args: unknown[]) => mockActivityLaunch(...args),
+  },
+}));
+
+vi.mock('./fetchLatestKubeObject', () => ({
+  fetchLatestKubeObject: (...args: unknown[]) => mockFetchLatestKubeObject(...args),
+}));
+
+vi.mock('../ActionButton', () => ({
+  default: ({ onClick }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button onClick={onClick}>View</button>
+  ),
+}));
+
+vi.mock('./EditorDialog', () => ({
+  default: () => null,
+}));
+
+vi.mock('@iconify/react', () => ({
+  Icon: () => null,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const item = {
+  cluster: 'test-cluster',
+  jsonData: { metadata: { resourceVersion: '1' } },
+  kind: 'Pod',
+  metadata: {
+    name: 'test-pod',
+    namespace: 'default',
+    uid: 'test-uid',
+  },
+} as KubeObject;
+
+const latestItem = {
+  ...item,
+  jsonData: { metadata: { resourceVersion: '2' } },
+} as KubeObject;
+
+describe('ViewButton', () => {
+  beforeEach(() => {
+    mockActivityClose.mockReset();
+    mockActivityLaunch.mockReset();
+    mockFetchLatestKubeObject.mockReset();
+  });
+
+  it('opens the latest resource in a window when clicked', async () => {
+    mockFetchLatestKubeObject.mockResolvedValue(latestItem);
+
+    render(<ViewButton item={item} />);
+    fireEvent.click(screen.getByRole('button', { name: 'View' }));
+
+    await waitFor(() => {
+      expect(mockActivityClose).toHaveBeenCalledWith('yaml-test-uid');
+      expect(mockActivityLaunch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cluster: 'test-cluster',
+          id: 'yaml-test-uid',
+          location: 'window',
+          title: 'test-pod',
+        })
+      );
+    });
+  });
+
+  it('opens automatically when initially toggled', async () => {
+    mockFetchLatestKubeObject.mockResolvedValue(latestItem);
+
+    render(<ViewButton item={item} initialToggle />);
+
+    await waitFor(() => expect(mockActivityLaunch).toHaveBeenCalledTimes(1));
+  });
+
+  it('falls back to the supplied resource when fetching fails', async () => {
+    const error = new Error('request failed');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockFetchLatestKubeObject.mockRejectedValue(error);
+
+    render(<ViewButton item={item} />);
+    fireEvent.click(screen.getByRole('button', { name: 'View' }));
+
+    await waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        'Error while fetching latest resource for YAML view:',
+        {
+          cluster: 'test-cluster',
+          kind: 'Pod',
+          name: 'test-pod',
+          namespace: 'default',
+        },
+        error
+      );
+      expect(mockActivityLaunch).toHaveBeenCalledTimes(1);
+    });
+    consoleError.mockRestore();
+  });
+
+  it('ignores a stale successful request', async () => {
+    let resolveFirstRequest!: (value: KubeObject) => void;
+    const firstRequest = new Promise<KubeObject>(resolve => {
+      resolveFirstRequest = resolve;
+    });
+    mockFetchLatestKubeObject
+      .mockReturnValueOnce(firstRequest)
+      .mockResolvedValueOnce(latestItem);
+
+    render(<ViewButton item={item} />);
+    const button = screen.getByRole('button', { name: 'View' });
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    await waitFor(() => expect(mockActivityLaunch).toHaveBeenCalledTimes(1));
+    await act(async () => resolveFirstRequest(item));
+    expect(mockActivityLaunch).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores an error from a stale request', async () => {
+    let rejectFirstRequest!: (reason: Error) => void;
+    const firstRequest = new Promise<KubeObject>((_resolve, reject) => {
+      rejectFirstRequest = reject;
+    });
+    mockFetchLatestKubeObject
+      .mockReturnValueOnce(firstRequest)
+      .mockResolvedValueOnce(latestItem);
+
+    render(<ViewButton item={item} />);
+    const button = screen.getByRole('button', { name: 'View' });
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    await waitFor(() => expect(mockActivityLaunch).toHaveBeenCalledTimes(1));
+    await act(async () => rejectFirstRequest(new Error('stale request failed')));
+    expect(mockActivityLaunch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/common/Resource/ViewButton.test.tsx
+++ b/frontend/src/components/common/Resource/ViewButton.test.tsx
@@ -74,6 +74,7 @@ describe('ViewButton', () => {
     mockActivityClose.mockReset();
     mockActivityLaunch.mockReset();
     mockFetchLatestKubeObject.mockReset();
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1440 });
   });
 
   it('opens the latest resource beside the current content when clicked', async () => {
@@ -88,11 +89,37 @@ describe('ViewButton', () => {
         expect.objectContaining({
           cluster: 'test-cluster',
           id: 'yaml-test-uid',
-          location: 'split-right',
+          location: 'split-right-wide',
           title: 'test-pod',
         })
       );
     });
+  });
+
+  it('opens the resource in a centered window on medium screens', async () => {
+    mockFetchLatestKubeObject.mockResolvedValue(latestItem);
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 900 });
+
+    render(<ViewButton item={item} />);
+    fireEvent.click(screen.getByRole('button', { name: 'View' }));
+
+    await waitFor(() =>
+      expect(mockActivityLaunch).toHaveBeenCalledWith(
+        expect.objectContaining({ location: 'window-medium' })
+      )
+    );
+  });
+
+  it('opens the resource fullscreen on phones', async () => {
+    mockFetchLatestKubeObject.mockResolvedValue(latestItem);
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 390 });
+
+    render(<ViewButton item={item} />);
+    fireEvent.click(screen.getByRole('button', { name: 'View' }));
+
+    await waitFor(() =>
+      expect(mockActivityLaunch).toHaveBeenCalledWith(expect.objectContaining({ location: 'full' }))
+    );
   });
 
   it('opens automatically when initially toggled', async () => {

--- a/frontend/src/components/common/Resource/ViewButton.test.tsx
+++ b/frontend/src/components/common/Resource/ViewButton.test.tsx
@@ -76,7 +76,7 @@ describe('ViewButton', () => {
     mockFetchLatestKubeObject.mockReset();
   });
 
-  it('opens the latest resource in a window when clicked', async () => {
+  it('opens the latest resource beside the current content when clicked', async () => {
     mockFetchLatestKubeObject.mockResolvedValue(latestItem);
 
     render(<ViewButton item={item} />);
@@ -88,7 +88,7 @@ describe('ViewButton', () => {
         expect.objectContaining({
           cluster: 'test-cluster',
           id: 'yaml-test-uid',
-          location: 'window',
+          location: 'split-right',
           title: 'test-pod',
         })
       );
@@ -132,9 +132,7 @@ describe('ViewButton', () => {
     const firstRequest = new Promise<KubeObject>(resolve => {
       resolveFirstRequest = resolve;
     });
-    mockFetchLatestKubeObject
-      .mockReturnValueOnce(firstRequest)
-      .mockResolvedValueOnce(latestItem);
+    mockFetchLatestKubeObject.mockReturnValueOnce(firstRequest).mockResolvedValueOnce(latestItem);
 
     render(<ViewButton item={item} />);
     const button = screen.getByRole('button', { name: 'View' });
@@ -151,9 +149,7 @@ describe('ViewButton', () => {
     const firstRequest = new Promise<KubeObject>((_resolve, reject) => {
       rejectFirstRequest = reject;
     });
-    mockFetchLatestKubeObject
-      .mockReturnValueOnce(firstRequest)
-      .mockResolvedValueOnce(latestItem);
+    mockFetchLatestKubeObject.mockReturnValueOnce(firstRequest).mockResolvedValueOnce(latestItem);
 
     render(<ViewButton item={item} />);
     const button = screen.getByRole('button', { name: 'View' });

--- a/frontend/src/components/common/Resource/ViewButton.tsx
+++ b/frontend/src/components/common/Resource/ViewButton.tsx
@@ -31,6 +31,19 @@ export interface ViewButtonProps {
   buttonStyle?: ButtonStyle;
 }
 
+/** Returns a YAML viewer placement suitable for the current viewport width. */
+function getActivityLocation() {
+  if (window.innerWidth >= 1280) {
+    return 'split-right-wide' as const;
+  }
+
+  if (window.innerWidth >= 600) {
+    return 'window-medium' as const;
+  }
+
+  return 'full' as const;
+}
+
 function ViewButton({ item, buttonStyle, initialToggle }: ViewButtonProps) {
   const { t } = useTranslation();
   const activityId = 'yaml-' + item.metadata.uid;
@@ -68,7 +81,7 @@ function ViewButton({ item, buttonStyle, initialToggle }: ViewButtonProps) {
       title: editorItem.metadata.name,
       cluster: editorItem.cluster,
       icon: <Icon icon="mdi:eye" />,
-      location: 'split-right',
+      location: getActivityLocation(),
       content: (
         <EditorDialog
           noDialog

--- a/frontend/src/components/common/Resource/ViewButton.tsx
+++ b/frontend/src/components/common/Resource/ViewButton.tsx
@@ -68,7 +68,7 @@ function ViewButton({ item, buttonStyle, initialToggle }: ViewButtonProps) {
       title: editorItem.metadata.name,
       cluster: editorItem.cluster,
       icon: <Icon icon="mdi:eye" />,
-      location: 'window',
+      location: 'split-right',
       content: (
         <EditorDialog
           noDialog


### PR DESCRIPTION
## Summary

Open the resource table's **View YAML** activity responsively: fullscreen on
phones, in a centered near-full-width window on medium screens, and in a right
pane sized to fit 100 columns or 50% of the content area on large screens. This
keeps manifests readable and editable while preserving as much resource-list
context as the viewport allows.

## Source

- Retained as patch 0060 by Azure/aks-desktop#823:
  https://github.com/Azure/aks-desktop/pull/823
- Originally introduced in Azure/aks-desktop#8:
  https://github.com/Azure/aks-desktop/pull/8
- Original PR commit by Oleksandr Dubenko (`sniok`):
  https://github.com/Azure/aks-desktop/commit/411503745e3febab05abbf084dda9f32e350430d
- Original downstream commit by Oleksandr Dubenko (`sniok`):
  https://github.com/Azure/aks-desktop/commit/c5a969eab0c69f760d638222d24bbdfa1ee38d17
- Original author date: `2025-11-21T11:08:28-05:00`

Azure/aks-desktop#8 bundled this change with namespace-list and query-retry
improvements. The source commit was later rebased in the downstream Headlamp
branch before being retained as patch 0060 by Azure/aks-desktop#823.

## Changes

- Add focused unit coverage before the behavior change.
- Add a Playwright resource-table flow before the behavior change.
- Launch the YAML viewer at `split-right` and update both regression tests in
  the feature commit.
- Adapt the viewer across phone, medium, large, and extra-large viewports, with
  the large editor using a 1024 px minimum and extra-large returning to 50%.

## Screenshots

### Phone (390x844)

![Fullscreen YAML viewer on a phone](https://raw.githubusercontent.com/illume/headlamp/screenshots/pr-screenshots/0060-view-yaml-phone.png)

The phone layout uses the full content area so the editor gets all available
space on a narrow screen.

### Medium (1024x900)

![Centered YAML viewer on a medium viewport](https://raw.githubusercontent.com/illume/headlamp/b6b72bc95aab75ee8050c39425499022c8bd15aa/pr-screenshots/0060-view-yaml-medium.png)

The medium layout keeps an 8 px outer margin and exposes 114 measured Monaco
columns at 1024x900.

### Large (1440x900)

![Split-right YAML viewer on a large viewport](https://raw.githubusercontent.com/illume/headlamp/468bde259ea821ed8c46a69c0aaa0726194fc92b/pr-screenshots/0060-view-yaml-large.png)

The large layout gives this YAML editor at least 1024 px or 50% of the content
width, whichever is larger. At 1440x900 it exposes 115 measured Monaco columns;
on extra-large screens it returns to 50%. The indented `line100` value shown in
the editor is exactly 100 columns wide. Other `split-right` activities remain at
50% width.

### Extra large (2560x900)

![Split-right YAML viewer on an extra-large viewport](https://raw.githubusercontent.com/illume/headlamp/2a424af1b1dd1f1911b32889df66614483fc01f7/pr-screenshots/0060-view-yaml-extra-large.png)

The extra-large layout returns the YAML editor to exactly 50% width and exposes
132 measured Monaco columns. The resource view retains the other half of the
content area.

## Improvements over the existing ones

- Keeps realistic ConfigMap content readable and editable at 100 columns. The
  e2e fixture and large screenshot include an exact 100-column YAML value line.
- Covers refresh success, refresh failure, initial opening, and both stale
  request paths instead of only the initial-toggle happy path.
- Reaches 100% branch coverage for `ViewButton`, above the requested 80%.
- Adds end-to-end assertions for phone, medium, large, and extra-large placement
  using a real ConfigMap row action.
- Centers the editor on medium viewports with only an 8 px outer margin. The
  1024x900 view exposes 114 measured Monaco columns; the previous right split
  made editing 100-column text impractical.
- Gives only the large YAML editor the greater of 1024 px or 50% width. This
  exposes 115 measured Monaco columns at 1440x900, returns to 50% on extra-large
  screens, and leaves generic `split-right` activities unchanged.
- Keeps test additions in preceding atomic commits while retaining placement
  assertions in the original-author feature commit.
- Preserves Oleksandr Dubenko's authorship and original author date, with Rene
  Dudfield recorded as co-author.
- Runs the existing pod accessibility scan after its transient success notice
  closes, so axe measures the steady-state page.

## Testing

- `npx vitest run src/components/common/Resource/ViewButton.test.tsx --coverage --coverage.include=src/components/common/Resource/ViewButton.tsx --coverage.reporter=text --coverage.thresholds.branches=80`
- `npm run tsc`
- `npm run build`
- ESLint and Prettier checks for all changed TypeScript files
- Direct TypeScript check and Playwright execution for the new e2e test

The end-to-end test exercises phone (390x844), medium (1024x900), large
(1440x900), and extra-large (2560x900) viewports. It forces the latest-object
refresh fallback while using the real table action and activity renderer, with
strict fullscreen, centered full-width, minimum-width, and 50% geometry
assertions. Refresh success remains covered by the focused unit tests.

Assisted by copilot.


