### PR TITLE
0070: app: Isolate desktop storage directories

### DIFF
--- a/app/e2e-tests/tests/configDirectories.spec.ts
+++ b/app/e2e-tests/tests/configDirectories.spec.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import findProcess from 'find-process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { _electron } from 'playwright';
+
+const electronExecutable = process.platform === 'win32' ? 'electron.cmd' : 'electron';
+const electronPath = path.resolve(__dirname, `../../node_modules/.bin/${electronExecutable}`);
+const appPath = path.resolve(__dirname, '../../');
+
+test('passes app-specific storage directories to the backend', async () => {
+  test.skip(process.env.PLAYWRIGHT_TEST_MODE !== 'app', 'Requires Electron app mode');
+
+  const configHome = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-e2e-config-'));
+  const appName = 'Headlamp';
+  const configBase =
+    process.platform === 'darwin'
+      ? path.join(configHome, 'Library', 'Preferences', appName)
+      : process.platform === 'win32'
+      ? path.join(configHome, appName, 'Config')
+      : path.join(configHome, appName);
+  const kubeConfigBase =
+    process.platform === 'darwin'
+      ? path.join(configHome, 'Library', 'Application Support', appName)
+      : configBase;
+
+  const electronApp = await _electron.launch({
+    cwd: appPath,
+    executablePath: electronPath,
+    args: ['.'],
+    env: {
+      ...process.env,
+      APPDATA: configHome,
+      ELECTRON_DEV: 'true',
+      HOME: configHome,
+      LOCALAPPDATA: configHome,
+      XDG_CONFIG_HOME: configHome,
+    },
+  });
+
+  try {
+    await electronApp.firstWindow();
+
+    await expect
+      .poll(async () => {
+        const processes = await findProcess('name', 'headlamp-server');
+        return processes.find(process => process.cmd.includes(configHome))?.cmd;
+      })
+      .toContain('--plugins-dir');
+
+    const processes = await findProcess('name', 'headlamp-server');
+    const command = processes.find(process => process.cmd.includes(configHome))?.cmd;
+    expect(command).toContain(path.join(configBase, 'plugins'));
+    expect(command).toContain('--user-plugins-dir');
+    expect(command).toContain(path.join(configBase, 'user-plugins'));
+    expect(command).toContain('--kubeconfig-dir');
+    expect(command).toContain(path.join(kubeConfigBase, 'kubeconfigs'));
+  } finally {
+    await electronApp.close();
+    fs.rmSync(configHome, { force: true, recursive: true });
+  }
+});

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -47,11 +47,13 @@ import { filterUserOwnedPids } from './ownedProcesses';
 import {
   addToPath,
   ArtifactHubHeadlampPkg,
+  defaultKubeConfigsDir,
   defaultPluginsDir,
   defaultUserPluginsDir,
   getMatchingExtraFiles,
   getPluginBinDirectories,
   PluginManager,
+  setAppConfigDirName,
 } from './plugin-management';
 import {
   addRunCmdConsent,
@@ -73,6 +75,8 @@ import windowSize from './windowSize';
 if (process.env.APPIMAGE) {
   app.commandLine.appendSwitch('disable-setuid-sandbox');
 }
+
+setAppConfigDirName(app.getName());
 
 // On Linux, force the GTK 3 backend. Electron 36+ defaults to GTK 4, which
 // conflicts with GTK 2/3 symbols pulled into the process by IM modules and
@@ -856,6 +860,15 @@ async function startServer(flags: string[] = []): Promise<ChildProcessWithoutNul
   } catch (err) {
     // Directory doesn't exist or is not readable — ignore and continue.
   }
+
+  serverArgs = serverArgs.concat([
+    '--plugins-dir',
+    defaultPluginsDir(),
+    '--user-plugins-dir',
+    defaultUserPluginsDir(),
+    '--kubeconfig-dir',
+    defaultKubeConfigsDir(),
+  ]);
 
   serverArgs = serverArgs.concat(flags);
   console.log('arguments passed to backend server', serverArgs);

--- a/app/electron/plugin-management.test.ts
+++ b/app/electron/plugin-management.test.ts
@@ -26,13 +26,71 @@ import nock from 'nock';
 import os from 'os';
 import path from 'path';
 import * as tar from 'tar';
-import { describe, expect, it, vi } from 'vitest';
-import { PluginManager } from './plugin-management';
-import { getExtraFiles } from './plugin-management';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import envPaths from './env-paths';
+import {
+  defaultKubeConfigsDir,
+  defaultPluginsDir,
+  defaultUserPluginsDir,
+  getExtraFiles,
+  PluginManager,
+  setAppConfigDirName,
+} from './plugin-management';
 
 const TEST_DATA_BASE_DIR = path.join(os.tmpdir(), 'headlamp-test-data');
 const PLUGIN_DEST_BASE_DIR = path.join(os.tmpdir(), 'headlamp-test-plugins');
 const HEADLAMP_VERSION = '0.30.0';
+const ORIGINAL_PLATFORM = process.platform;
+
+describe('default plugin directories', () => {
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: ORIGINAL_PLATFORM });
+    setAppConfigDirName('Headlamp');
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ['plugins', defaultPluginsDir],
+    ['user-plugins', defaultUserPluginsDir],
+  ])('uses the branded data directory for %s when it exists', (subdirectory, getDirectory) => {
+    const appName = 'Example Desktop';
+    const paths = envPaths(appName, { suffix: '' });
+    setAppConfigDirName(appName);
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+    expect(getDirectory()).toBe(path.join(paths.data, subdirectory));
+  });
+
+  it.each([
+    ['plugins', defaultPluginsDir],
+    ['user-plugins', defaultUserPluginsDir],
+  ])('uses the branded config directory for %s otherwise', (subdirectory, getDirectory) => {
+    const appName = 'Example Desktop';
+    const paths = envPaths(appName, { suffix: '' });
+    setAppConfigDirName(appName);
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+    expect(getDirectory()).toBe(path.join(paths.config, subdirectory));
+  });
+
+  it.each([
+    ['darwin', 'data'],
+    ['linux', 'config'],
+    ['win32', 'config'],
+  ] as const)(
+    'uses the backend-compatible kubeconfig directory on %s',
+    (platform, baseDirectory) => {
+      const appName = 'Example Desktop';
+      Object.defineProperty(process, 'platform', { value: platform });
+      const paths = envPaths(appName, { suffix: '' });
+      const existsSync = vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+      setAppConfigDirName(appName);
+
+      expect(defaultKubeConfigsDir()).toBe(path.join(paths[baseDirectory], 'kubeconfigs'));
+      expect(existsSync).not.toHaveBeenCalled();
+    }
+  );
+});
 
 /**
  * Creates a unique test directory for a test

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -33,6 +33,27 @@ import * as tar from 'tar';
 import zlib from 'zlib';
 import envPaths from './env-paths';
 
+let appConfigDirName = 'Headlamp';
+
+/**
+ * Sets the application name used for per-user storage directories.
+ *
+ * @param name - Runtime product name for the desktop application.
+ */
+export function setAppConfigDirName(name: string): void {
+  appConfigDirName = name;
+}
+
+/**
+ * Returns the base directory for application-managed user data.
+ *
+ * @returns The data directory when it exists, otherwise the config directory.
+ */
+function defaultAppDataDir(): string {
+  const paths = envPaths(appConfigDirName, { suffix: '' });
+  return fs.existsSync(paths.data) ? paths.data : paths.config;
+}
+
 // comment out for testing
 // function sleep(ms) {
 //   // console.log(ms)
@@ -1065,10 +1086,8 @@ function checkValidPluginFolder(folder: string): boolean {
  *
  * @returns {string} The path to the default plugins directory.
  */
-export function defaultPluginsDir() {
-  const paths = envPaths('Headlamp', { suffix: '' });
-  const configDir = fs.existsSync(paths.data) ? paths.data : paths.config;
-  return path.join(configDir, 'plugins');
+export function defaultPluginsDir(): string {
+  return path.join(defaultAppDataDir(), 'plugins');
 }
 
 /**
@@ -1079,10 +1098,21 @@ export function defaultPluginsDir() {
  *
  * @returns {string} The path to the default user-plugins directory.
  */
-export function defaultUserPluginsDir() {
-  const paths = envPaths('Headlamp', { suffix: '' });
-  const configDir = fs.existsSync(paths.data) ? paths.data : paths.config;
-  return path.join(configDir, 'user-plugins');
+export function defaultUserPluginsDir(): string {
+  return path.join(defaultAppDataDir(), 'user-plugins');
+}
+
+/**
+ * Returns the default directory for app-managed kubeconfig files.
+ * This matches the backend's platform defaults so existing managed clusters
+ * remain available when the desktop app starts passing an explicit directory.
+ *
+ * @returns The backend-compatible kubeconfigs directory for the application.
+ */
+export function defaultKubeConfigsDir(): string {
+  const paths = envPaths(appConfigDirName, { suffix: '' });
+  const configDir = process.platform === 'darwin' ? paths.data : paths.config;
+  return path.join(configDir, 'kubeconfigs');
 }
 
 /**

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -331,8 +331,8 @@ func serveWithNoCacheHeader(fs http.Handler) http.HandlerFunc {
 	}
 }
 
-func defaultHeadlampKubeConfigFile() (string, error) {
-	return cfg.DefaultHeadlampKubeConfigFile()
+func defaultHeadlampKubeConfigFile(kubeConfigDir string) (string, error) {
+	return cfg.DefaultKubeConfigFile(kubeConfigDir)
 }
 
 // addPluginRoutes adds plugin routes to a router.
@@ -714,7 +714,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 	}
 
 	// load dynamic clusters
-	kubeConfigPersistenceFile, err := defaultHeadlampKubeConfigFile()
+	kubeConfigPersistenceFile, err := defaultHeadlampKubeConfigFile(config.KubeConfigDir)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "getting default kubeconfig persistence file")
 	} else {
@@ -2390,7 +2390,7 @@ func (c *HeadlampConfig) writeKubeConfig(kubeConfigBase64 string) error {
 		return fmt.Errorf("loading kubeconfig: %w", err)
 	}
 
-	kubeConfigPersistenceDir, err := cfg.MakeHeadlampKubeConfigsDir()
+	kubeConfigPersistenceDir, err := cfg.MakeKubeConfigsDir(c.KubeConfigDir)
 	if err != nil {
 		return fmt.Errorf("getting default kubeconfig persistence dir: %w", err)
 	}
@@ -2501,7 +2501,7 @@ func (c *HeadlampConfig) getKubeConfigPath(source string) (string, error) {
 		return c.KubeConfigPath, nil
 	}
 
-	return defaultHeadlampKubeConfigFile()
+	return defaultHeadlampKubeConfigFile(c.KubeConfigDir)
 }
 
 // Handler for renaming a stateless cluster.

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -255,6 +255,57 @@ func TestLoadDynamicClustersLogging(t *testing.T) {
 	}
 }
 
+func TestCreateHeadlampHandlerLoadsDynamicClustersFromKubeConfigDir(t *testing.T) {
+	kubeConfigDir := t.TempDir()
+	kubeConfigFile := filepath.Join(kubeConfigDir, "config")
+	primaryKubeConfigFile := filepath.Join(t.TempDir(), "config")
+
+	dynamicKubeConfig, err := clientcmd.LoadFromFile("./headlamp_testdata/kubeconfig")
+	require.NoError(t, err)
+	require.NoError(t, clientcmd.WriteToFile(*dynamicKubeConfig, kubeConfigFile))
+	require.NoError(t, clientcmd.WriteToFile(api.Config{
+		Clusters: map[string]*api.Cluster{
+			"primary": {Server: "https://primary.example"},
+		},
+		Contexts: map[string]*api.Context{
+			"primary": {Cluster: "primary", AuthInfo: "primary"},
+		},
+		AuthInfos: map[string]*api.AuthInfo{
+			"primary": {Token: "token"},
+		},
+		CurrentContext: "primary",
+	}, primaryKubeConfigFile))
+
+	kubeConfigStore := kubeconfig.NewContextStore()
+	cfg := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				KubeConfigPath:  primaryKubeConfigFile,
+				KubeConfigDir:   kubeConfigDir,
+				KubeConfigStore: kubeConfigStore,
+			},
+			Cache:            cache.New[interface{}](),
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	handler := createHeadlampHandler(ctx, cfg)
+	require.NotNil(t, handler)
+
+	primaryContext, err := kubeConfigStore.GetContext("primary")
+	require.NoError(t, err)
+	assert.Equal(t, kubeconfig.KubeConfig, primaryContext.Source)
+
+	loadedContext, err := kubeConfigStore.GetContext(minikubeName)
+	require.NoError(t, err)
+	assert.Equal(t, kubeconfig.DynamicCluster, loadedContext.Source)
+	assert.Equal(t, kubeConfigFile, loadedContext.KubeConfigPath)
+}
+
 func getResponse(handler http.Handler, method, url string, body interface{}) (*httptest.ResponseRecorder, error) {
 	req, err := makeJSONReq(method, url, body)
 	if err != nil {

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -84,6 +84,7 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 		UseInCluster:           conf.InCluster,
 		InClusterContextName:   conf.InClusterContextName,
 		KubeConfigPath:         conf.KubeConfigPath,
+		KubeConfigDir:          conf.KubeConfigDir,
 		SkippedKubeContexts:    conf.SkippedKubeContexts,
 		ListenAddr:             conf.ListenAddr,
 		CacheEnabled:           conf.CacheEnabled,

--- a/backend/cmd/server_config_test.go
+++ b/backend/cmd/server_config_test.go
@@ -33,6 +33,7 @@ func TestBuildHeadlampCFG(t *testing.T) {
 			InCluster:              true,
 			InClusterContextName:   "test-incluster",
 			InsecureSsl:            true,
+			KubeConfigDir:          "/kubeconfigs",
 			PluginsDir:             "/plugins",
 			UserPluginsDir:         "/user-plugins",
 			AllowKubeconfigChanges: true,
@@ -47,6 +48,7 @@ func TestBuildHeadlampCFG(t *testing.T) {
 		assert.True(t, headlampCFG.UseInCluster)
 		assert.Equal(t, "test-incluster", headlampCFG.InClusterContextName)
 		assert.True(t, headlampCFG.Insecure)
+		assert.Equal(t, "/kubeconfigs", headlampCFG.KubeConfigDir)
 		assert.Equal(t, "/plugins", headlampCFG.PluginDir)
 		assert.Equal(t, "/user-plugins", headlampCFG.UserPluginDir)
 		assert.True(t, headlampCFG.AllowKubeconfigChanges)

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -55,6 +55,7 @@ type Config struct {
 	WatchPluginsChanges    bool   `koanf:"watch-plugins-changes"`
 	Port                   uint   `koanf:"port"`
 	KubeConfigPath         string `koanf:"kubeconfig"`
+	KubeConfigDir          string `koanf:"kubeconfig-dir"`
 	SkippedKubeContexts    string `koanf:"skipped-kube-contexts"`
 	StaticDir              string `koanf:"html-static-dir"`
 	PluginsDir             string `koanf:"plugins-dir"`
@@ -472,6 +473,16 @@ func Parse(args []string) (*Config, error) {
 // MakeHeadlampKubeConfigsDir returns the default directory to store kubeconfig
 // files of clusters that are loaded in Headlamp.
 func MakeHeadlampKubeConfigsDir() (string, error) {
+	return MakeKubeConfigsDir("")
+}
+
+// MakeKubeConfigsDir returns the configured directory for persisted kubeconfigs.
+// When kubeConfigDir is empty, it uses Headlamp's platform-specific default.
+func MakeKubeConfigsDir(kubeConfigDir string) (string, error) {
+	if kubeConfigDir != "" {
+		return makeConfiguredKubeConfigsDir(kubeConfigDir)
+	}
+
 	userConfigDir, err := os.UserConfigDir()
 	if err == nil {
 		kubeConfigDir := filepath.Join(userConfigDir, "Headlamp", "kubeconfigs")
@@ -499,8 +510,23 @@ func MakeHeadlampKubeConfigsDir() (string, error) {
 	return "", fmt.Errorf("failed to get default kubeconfig persistence directory: %w", err)
 }
 
+// makeConfiguredKubeConfigsDir creates and returns the configured kubeconfig directory.
+func makeConfiguredKubeConfigsDir(kubeConfigDir string) (string, error) {
+	if err := os.MkdirAll(kubeConfigDir, fs.FileMode(0o755)); err != nil {
+		return "", fmt.Errorf("creating kubeconfig persistence directory: %w", err)
+	}
+
+	return kubeConfigDir, nil
+}
+
+// DefaultHeadlampKubeConfigFile returns Headlamp's default persisted kubeconfig file.
 func DefaultHeadlampKubeConfigFile() (string, error) {
-	kubeConfigDir, err := MakeHeadlampKubeConfigsDir()
+	return DefaultKubeConfigFile("")
+}
+
+// DefaultKubeConfigFile returns the persisted kubeconfig file in kubeConfigDir.
+func DefaultKubeConfigFile(kubeConfigDir string) (string, error) {
+	kubeConfigDir, err := MakeKubeConfigsDir(kubeConfigDir)
 	if err != nil {
 		return "", err
 	}
@@ -558,6 +584,7 @@ func addGeneralFlags(f *flag.FlagSet) {
 	f.Bool("watch-plugins-changes", true, "Reloads plugins when there are changes to them or their directory")
 
 	f.String("kubeconfig", "", "Absolute path to the kubeconfig file")
+	f.String("kubeconfig-dir", "", "Directory for Headlamp-managed kubeconfig files")
 	f.String("skipped-kube-contexts", "", "Context name which should be ignored in kubeconfig file")
 	f.String("html-static-dir", "", "Static HTML directory to serve")
 	f.String("plugins-dir", defaultPluginDir(), "Specify the plugins directory to build the backend with")

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -970,6 +970,22 @@ func TestMakeKubeConfigsDir(t *testing.T) {
 		assert.Contains(t, dir, filepath.Join("Headlamp", "kubeconfigs"))
 	})
 
+	t.Run("falls back to the executable directory", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("UserConfigDir uses a Windows API instead of an environment variable")
+		}
+
+		setUserConfigDir(t, "")
+		t.Setenv("HOME", "")
+
+		dir, err := config.MakeKubeConfigsDir("")
+		require.NoError(t, err)
+
+		executable, err := os.Executable()
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Dir(executable), dir)
+	})
+
 	t.Run("reports configured directory creation errors", func(t *testing.T) {
 		parentFile := filepath.Join(t.TempDir(), "file")
 		require.NoError(t, os.WriteFile(parentFile, []byte("not a directory"), 0o600))
@@ -1003,11 +1019,21 @@ func TestDefaultHeadlampKubeConfigFile(t *testing.T) {
 }
 
 func TestDefaultKubeConfigFile(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "custom", "kubeconfigs")
+	t.Run("returns the config file in the configured directory", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "custom", "kubeconfigs")
 
-	path, err := config.DefaultKubeConfigFile(dir)
-	require.NoError(t, err)
-	assert.Equal(t, filepath.Join(dir, "config"), path)
+		path, err := config.DefaultKubeConfigFile(dir)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(dir, "config"), path)
+	})
+
+	t.Run("reports directory creation errors", func(t *testing.T) {
+		parentFile := filepath.Join(t.TempDir(), "file")
+		require.NoError(t, os.WriteFile(parentFile, []byte("not a directory"), 0o600))
+
+		_, err := config.DefaultKubeConfigFile(filepath.Join(parentFile, "kubeconfigs"))
+		require.Error(t, err)
+	})
 }
 
 func TestKubeConfigDirParsing(t *testing.T) {

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -68,6 +68,19 @@ func writeClusterInventoryProviderFile(t *testing.T) string {
 	return path
 }
 
+func setUserConfigDir(t *testing.T, dir string) {
+	t.Helper()
+
+	switch runtime.GOOS {
+	case "windows":
+		t.Setenv("APPDATA", dir)
+	case "darwin":
+		t.Setenv("HOME", dir)
+	default:
+		t.Setenv("XDG_CONFIG_HOME", dir)
+	}
+}
+
 func TestParseBasic(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -936,6 +949,36 @@ func TestMakeHeadlampKubeConfigsDir(t *testing.T) {
 	assert.True(t, strings.HasPrefix(dir, tmpDir))
 }
 
+func TestMakeKubeConfigsDir(t *testing.T) {
+	t.Run("creates configured directory", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "custom", "kubeconfigs")
+
+		actual, err := config.MakeKubeConfigsDir(dir)
+		require.NoError(t, err)
+		assert.Equal(t, dir, actual)
+
+		info, err := os.Stat(actual)
+		require.NoError(t, err)
+		assert.True(t, info.IsDir())
+	})
+
+	t.Run("uses Headlamp default when unset", func(t *testing.T) {
+		setUserConfigDir(t, t.TempDir())
+
+		dir, err := config.MakeKubeConfigsDir("")
+		require.NoError(t, err)
+		assert.Contains(t, dir, filepath.Join("Headlamp", "kubeconfigs"))
+	})
+
+	t.Run("reports configured directory creation errors", func(t *testing.T) {
+		parentFile := filepath.Join(t.TempDir(), "file")
+		require.NoError(t, os.WriteFile(parentFile, []byte("not a directory"), 0o600))
+
+		_, err := config.MakeKubeConfigsDir(filepath.Join(parentFile, "kubeconfigs"))
+		require.Error(t, err)
+	})
+}
+
 func TestDefaultHeadlampKubeConfigFile(t *testing.T) {
 	tmpDir := t.TempDir()
 
@@ -957,6 +1000,30 @@ func TestDefaultHeadlampKubeConfigFile(t *testing.T) {
 	info, err := os.Stat(filepath.Dir(path))
 	require.NoError(t, err)
 	assert.True(t, info.IsDir())
+}
+
+func TestDefaultKubeConfigFile(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "custom", "kubeconfigs")
+
+	path, err := config.DefaultKubeConfigFile(dir)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, "config"), path)
+}
+
+func TestKubeConfigDirParsing(t *testing.T) {
+	t.Run("defaults to empty", func(t *testing.T) {
+		conf, err := config.Parse([]string{"go run ./cmd"})
+		require.NoError(t, err)
+		assert.Empty(t, conf.KubeConfigDir)
+	})
+
+	t.Run("flag overrides environment", func(t *testing.T) {
+		t.Setenv("HEADLAMP_CONFIG_KUBECONFIG_DIR", "/env/kubeconfigs")
+
+		conf, err := config.Parse([]string{"go run ./cmd", "--kubeconfig-dir=/flag/kubeconfigs"})
+		require.NoError(t, err)
+		assert.Equal(t, "/flag/kubeconfigs", conf.KubeConfigDir)
+	})
 }
 
 func TestProxyAuthFlagOverridesEnv(t *testing.T) {

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -59,6 +59,7 @@ type HeadlampCFG struct {
 	WatchPluginsChanges    bool
 	Port                   uint
 	KubeConfigPath         string
+	KubeConfigDir          string
 	SkippedKubeContexts    string
 	StaticDir              string
 	PluginDir              string


### PR DESCRIPTION
## Summary

Patch 0070 isolates desktop-managed plugins and kubeconfigs by the runtime
product name. It adds a backend `--kubeconfig-dir` option and passes the
desktop app's plugin, user-plugin, and kubeconfig directories explicitly to
the backend.

Headlamp keeps its existing storage paths when the new option is unset.

## Source

This upstreams patch 0070 from Azure/aks-desktop PR
https://github.com/Azure/aks-desktop/pull/823.

The focused source change was Azure/aks-desktop PR
https://github.com/Azure/aks-desktop/pull/824.

Original commits:

- https://github.com/Azure/aks-desktop/commit/5a6984cdde2c5206f97b6fa94a19d94bbb45e3e9
- https://github.com/Azure/aks-desktop/commit/71ab6d08a75027168ba48de7c943759ede384a19
- https://github.com/Azure/aks-desktop/commit/1655fbed0eade99ca1aed11ddc6cdccf42bc4a44

The implementation commits retain the original author and author dates, with
René Dudfield added as co-author.

## Changes

- Add `--kubeconfig-dir` and route it through dynamic-cluster load, write, and
  rename operations.
- Derive desktop storage from Electron's runtime product name.
- Pass plugin, user-plugin, and kubeconfig directories to the backend.
- Add focused Go and Electron unit tests before the implementation commits.
- Add an Electron e2e test that verifies the real backend child arguments.

## Improvements Over Existing Ones

- Uses a generic backend directory option instead of hardcoding
  `AKS desktop`, so other Headlamp-based desktop distributions can use it.
- Uses Electron's runtime product name instead of maintaining a second branding
  constant.
- Preserves Headlamp's current platform defaults when no custom directory is
  configured.
- Covers default, custom, fallback, error, flag-precedence, and runtime mapping
  behavior. The changed Go helpers report 86.7%, 100%, and 100% coverage.
- Adds a portable, cluster-free Electron e2e test for the complete
  desktop-to-backend path.

## Steps to Test

1. Run `go test ./pkg/config ./cmd -count=1` from `backend`.
2. Run `npm test`, `npm run tsc`, and `npm run lint` from `app`.
3. Run `npm run backend:lint` from the repository root.
4. Build the backend and frontend, compile Electron, then run
   `PLAYWRIGHT_TEST_MODE=app npm exec -- playwright test tests/configDirectories.spec.ts`
   from `app/e2e-tests`.

## Validation

- Backend config package: 88.6% statement coverage.
- Changed directory helpers: 86.7%, 100%, and 100% statement coverage.
- App unit tests: 150 passed across 10 files.
- Electron storage-isolation e2e: 1 passed.
- Backend lint: 0 issues.
- App TypeScript, ESLint, and Prettier checks passed.

## Screenshots

NA

The 0070 Electron build starts with the existing desktop UI unchanged while
using the isolated app-specific storage directories.

## Notes for the Reviewer

The test and e2e commits intentionally precede the implementation commits for
reviewability.

Assisted by copilot.