### PR TITLE
0059: frontend: graphGrouping: Group unscheduled pods by node

### DIFF
--- a/e2e-tests/tests/resourceMap.spec.ts
+++ b/e2e-tests/tests/resourceMap.spec.ts
@@ -37,6 +37,9 @@ const pods = Array.from({ length: 1001 }, (_, index) => ({
     uid: `resize-test-pod-${index}`,
     resourceVersion: String(index + 1),
   },
+  spec: {
+    nodeName: 'worker-1',
+  },
   status: {
     phase: 'Running',
     conditions: [{ type: 'Ready', status: 'True' }],
@@ -54,6 +57,7 @@ const emptyCollections: Record<string, string> = {
   jobs: 'Job',
   jobsets: 'JobSet',
   networkpolicies: 'NetworkPolicy',
+  nodes: 'Node',
   persistentvolumeclaims: 'PersistentVolumeClaim',
   replicasets: 'ReplicaSet',
   services: 'Service',
@@ -141,4 +145,19 @@ test('keeps a simplified namespace expanded while resizing', async ({ page }) =>
     await page.setViewportSize(viewport);
     await assertExpandedTopology();
   }
+});
+
+test('groups scheduled pods by node', async ({ page }) => {
+  test.setTimeout(60_000);
+  const cluster = process.env.HEADLAMP_TEST_CLUSTER || 'test';
+  const headlampPage = new HeadlampPage(page);
+  const mockedResources = await mockResourceMapCollections(page, cluster);
+  await headlampPage.navigateToCluster(cluster, process.env.HEADLAMP_TEST_TOKEN);
+
+  await headlampPage.navigateTopage(`/c/${cluster}/map`);
+
+  await expect.poll(() => [...mockedResources].sort()).toEqual(['namespaces', 'pods']);
+  await page.getByRole('button', { name: 'Node', exact: true }).click();
+
+  await expect(page.locator('[data-id="Node-worker-1"]')).toBeVisible({ timeout: 30_000 });
 });

--- a/e2e-tests/tests/resourceMap.spec.ts
+++ b/e2e-tests/tests/resourceMap.spec.ts
@@ -46,6 +46,18 @@ const pods = Array.from({ length: 1001 }, (_, index) => ({
   },
 }));
 
+const groupingPods = pods.slice(0, 4).map((pod, index) => ({
+  ...pod,
+  spec: index < 2 ? {} : { nodeName: 'worker-1' },
+  status:
+    index < 2
+      ? {
+          phase: 'Pending',
+          conditions: [{ type: 'PodScheduled', status: 'False', reason: 'Unschedulable' }],
+        }
+      : pod.status,
+}));
+
 const emptyCollections: Record<string, string> = {
   cronjobs: 'CronJob',
   daemonsets: 'DaemonSet',
@@ -73,7 +85,15 @@ function list(kind: string, items: unknown[]) {
   };
 }
 
-async function mockResourceMapCollections(page: Page, cluster: string) {
+/**
+ * Mocks the Kubernetes collections used by Resource Map scenarios.
+ *
+ * @param page - Playwright page whose Kubernetes requests should be mocked.
+ * @param cluster - Cluster name included in Headlamp API request paths.
+ * @param podItems - Pods returned by the mocked collection endpoint.
+ * @returns Resource names requested while the scenario runs.
+ */
+async function mockResourceMapCollections(page: Page, cluster: string, podItems: unknown[] = pods) {
   const mockedResources = new Set<string>();
   await page.route(new RegExp(`/clusters/${cluster}/apis?/`), async route => {
     const request = route.request();
@@ -92,7 +112,7 @@ async function mockResourceMapCollections(page: Page, cluster: string) {
     }
     if (resource === 'pods') {
       mockedResources.add(resource);
-      await route.fulfill({ json: list('Pod', pods) });
+      await route.fulfill({ json: list('Pod', podItems) });
       return;
     }
     if (resource === 'customresourcedefinitions') {
@@ -147,11 +167,11 @@ test('keeps a simplified namespace expanded while resizing', async ({ page }) =>
   }
 });
 
-test('groups scheduled pods by node', async ({ page }) => {
+test('groups scheduled and unscheduled pods by node', async ({ page }) => {
   test.setTimeout(60_000);
   const cluster = process.env.HEADLAMP_TEST_CLUSTER || 'test';
   const headlampPage = new HeadlampPage(page);
-  const mockedResources = await mockResourceMapCollections(page, cluster);
+  const mockedResources = await mockResourceMapCollections(page, cluster, groupingPods);
   await headlampPage.navigateToCluster(cluster, process.env.HEADLAMP_TEST_TOKEN);
 
   await headlampPage.navigateTopage(`/c/${cluster}/map`);
@@ -160,4 +180,5 @@ test('groups scheduled pods by node', async ({ page }) => {
   await page.getByRole('button', { name: 'Node', exact: true }).click();
 
   await expect(page.locator('[data-id="Node-worker-1"]')).toBeVisible({ timeout: 30_000 });
+  await expect(page.locator('[data-id="Node-Unscheduled"]')).toBeVisible();
 });

--- a/frontend/src/components/resourceMap/graph/graphGrouping.test.ts
+++ b/frontend/src/components/resourceMap/graph/graphGrouping.test.ts
@@ -16,7 +16,14 @@
 
 import { KubeMetadata } from '../../../lib/k8s/KubeMetadata';
 import { KubeObject } from '../../../lib/k8s/KubeObject';
-import { collapseGraph, getMainNode, groupGraph } from './graphGrouping';
+import {
+  collapseGraph,
+  findGroupContaining,
+  getGraphSize,
+  getMainNode,
+  getParentNode,
+  groupGraph,
+} from './graphGrouping';
 import { GraphEdge, GraphNode } from './graphModel';
 
 describe('getMainNode', () => {
@@ -48,6 +55,78 @@ describe('getMainNode', () => {
 
     const mainNode = getMainNode(nodes);
     expect(mainNode?.id).toBe('high-weight-pod');
+  });
+});
+
+describe('graph helpers', () => {
+  const smallGroup: GraphNode = {
+    id: 'small-group',
+    nodes: [{ id: 'small-leaf' }],
+    edges: [],
+  };
+  const nestedGroup: GraphNode = {
+    id: 'nested-group',
+    nodes: [{ id: 'nested-leaf' }],
+    edges: [],
+  };
+  const bigGroup: GraphNode = {
+    id: 'big-group',
+    nodes: [nestedGroup, ...Array.from({ length: 10 }, (_, index) => ({ id: `leaf-${index}` }))],
+    edges: [],
+  };
+  const connectedGroup: GraphNode = {
+    id: 'connected-group',
+    nodes: [{ id: 'connected-leaf' }],
+    edges: [{ id: 'edge', source: 'connected-leaf', target: 'connected-leaf' }],
+  };
+  const graph: GraphNode = {
+    id: 'root',
+    nodes: [smallGroup, bigGroup, connectedGroup],
+    edges: [],
+  };
+
+  it('counts every node in nested graphs', () => {
+    expect(getGraphSize(graph)).toBe(18);
+  });
+
+  it('finds direct parents and returns undefined for missing nodes', () => {
+    expect(getParentNode(graph, 'nested-leaf')).toBe(nestedGroup);
+    expect(getParentNode(graph, 'missing')).toBeUndefined();
+  });
+
+  it('finds groups containing nodes and nested groups', () => {
+    expect(findGroupContaining(graph, 'root')).toBe(graph);
+    expect(findGroupContaining(graph, 'small-leaf')).toBe(smallGroup);
+    expect(findGroupContaining(graph, 'nested-leaf')).toBe(nestedGroup);
+    expect(findGroupContaining(graph, 'nested-group')).toBe(nestedGroup);
+    expect(findGroupContaining(graph, 'big-group', true)).toBe(graph);
+    expect(findGroupContaining(graph, 'missing')).toBeUndefined();
+  });
+
+  it('collapses only large or connected unselected groups', () => {
+    const collapsed = collapseGraph(graph, { expandAll: false });
+
+    expect(collapsed.collapsed).toBe(false);
+    expect(collapsed.nodes?.find(node => node.id === 'small-group')?.collapsed).toBe(false);
+    expect(collapsed.nodes?.find(node => node.id === 'big-group')?.collapsed).toBe(true);
+    expect(collapsed.nodes?.find(node => node.id === 'connected-group')?.collapsed).toBe(true);
+  });
+
+  it('keeps every group open when expandAll is enabled', () => {
+    const expanded = collapseGraph(graph, { expandAll: true });
+
+    expect(expanded.nodes?.every(node => node.collapsed === false)).toBe(true);
+  });
+
+  it('keeps only the selected non-root group at the root', () => {
+    const selected = collapseGraph(graph, {
+      selectedNodeId: 'nested-leaf',
+      expandAll: false,
+    });
+
+    expect(selected.nodes).toHaveLength(1);
+    expect(selected.nodes?.[0].id).toBe('nested-group');
+    expect(selected.nodes?.[0].collapsed).toBe(false);
   });
 });
 
@@ -107,6 +186,23 @@ describe('groupGraph', () => {
     expect(namespaces).toEqual(['Namespace-ns1', 'Namespace-ns2']);
   });
 
+  it('associates namespace kubeObjects with namespace groups', () => {
+    const namespace = {
+      kind: 'Namespace',
+      metadata: { name: 'ns1', uid: 'ns1-uid' },
+    } as any;
+
+    const groupedGraph = groupGraph(nodes, edges, {
+      groupBy: 'namespace',
+      namespaces: [namespace],
+      k8sNodes: [],
+    });
+
+    const namespaceGroup = groupedGraph.nodes?.find(node => node.label === 'ns1');
+    expect(namespaceGroup?.kubeObject).toBe(namespace);
+    expect(namespaceGroup?.id).toBe('ns1-uid');
+  });
+
   it('groups nodes by node', () => {
     const groupedGraph = groupGraph(nodes, edges, {
       groupBy: 'node',
@@ -120,6 +216,51 @@ describe('groupGraph', () => {
     // After sorting by weight (descending) and ID (stable sort),
     // individual nodes come first, then group because no edges are present
     expect(nodeNames).toEqual(['1', '3', '4', 'Node-node1']);
+  });
+
+  it('groups connected components by the pod node', () => {
+    const componentNodes: GraphNode[] = [
+      {
+        id: 'deployment',
+        kubeObject: { kind: 'Deployment', metadata: { name: 'deployment' } } as KubeObject,
+      },
+      {
+        id: 'scheduled-pod',
+        kubeObject: {
+          kind: 'Pod',
+          metadata: { name: 'scheduled-pod' },
+          spec: { nodeName: 'node2' },
+        } as any as KubeObject,
+      },
+    ];
+
+    const groupedGraph = groupGraph(
+      componentNodes,
+      [{ id: 'deployment-pod', source: 'deployment', target: 'scheduled-pod' }],
+      {
+        groupBy: 'node',
+        namespaces: [],
+        k8sNodes: [],
+      }
+    );
+
+    const nodeGroup = groupedGraph.nodes?.find(node => node.id === 'Node-node2');
+    expect(nodeGroup?.nodes?.[0].id).toBe('group-deployment');
+  });
+
+  it('leaves non-Pod resources ungrouped when grouping by node', () => {
+    const deployment = {
+      id: 'deployment',
+      kubeObject: { kind: 'Deployment', metadata: { name: 'deployment' } } as KubeObject,
+    };
+
+    const groupedGraph = groupGraph([deployment], edges, {
+      groupBy: 'node',
+      namespaces: [],
+      k8sNodes: [],
+    });
+
+    expect(groupedGraph.nodes).toEqual([deployment]);
   });
 
   it('associates k8sNode kubeObject with node groups when k8sNodes are provided', () => {

--- a/frontend/src/components/resourceMap/graph/graphGrouping.test.ts
+++ b/frontend/src/components/resourceMap/graph/graphGrouping.test.ts
@@ -23,6 +23,7 @@ import {
   getMainNode,
   getParentNode,
   groupGraph,
+  UNSCHEDULED_GROUP,
 } from './graphGrouping';
 import { GraphEdge, GraphNode } from './graphModel';
 
@@ -211,11 +212,10 @@ describe('groupGraph', () => {
     });
     const nodeNames = groupedGraph.nodes?.map(node => node.id);
 
-    // Node 2 is grouped into Node-node1 group
-    // Nodes 1, 3 and 4 don't have a node and are not grouped
-    // After sorting by weight (descending) and ID (stable sort),
-    // individual nodes come first, then group because no edges are present
-    expect(nodeNames).toEqual(['1', '3', '4', 'Node-node1']);
+    // Pods 1, 3 and 4 have no nodeName and are grouped into Node-Unscheduled
+    // Pod 2 has nodeName 'node1' and is grouped into Node-node1
+    expect(nodeNames).toHaveLength(2);
+    expect(nodeNames).toEqual(expect.arrayContaining(['Node-Unscheduled', 'Node-node1']));
   });
 
   it('groups connected components by the pod node', () => {
@@ -246,6 +246,46 @@ describe('groupGraph', () => {
 
     const nodeGroup = groupedGraph.nodes?.find(node => node.id === 'Node-node2');
     expect(nodeGroup?.nodes?.[0].id).toBe('group-deployment');
+  });
+
+  it('prefers unscheduled pods when grouping mixed connected components', () => {
+    const componentNodes: GraphNode[] = [
+      {
+        id: 'deployment',
+        kubeObject: { kind: 'Deployment', metadata: { name: 'deployment' } } as KubeObject,
+      },
+      {
+        id: 'scheduled-pod',
+        kubeObject: {
+          kind: 'Pod',
+          metadata: { name: 'scheduled-pod' },
+          spec: { nodeName: 'node2' },
+        } as any as KubeObject,
+      },
+      {
+        id: 'unscheduled-pod',
+        kubeObject: {
+          kind: 'Pod',
+          metadata: { name: 'unscheduled-pod' },
+        } as KubeObject,
+      },
+    ];
+
+    const groupedGraph = groupGraph(
+      componentNodes,
+      [
+        { id: 'deployment-pod', source: 'deployment', target: 'scheduled-pod' },
+        { id: 'pod-pod', source: 'scheduled-pod', target: 'unscheduled-pod' },
+      ],
+      {
+        groupBy: 'node',
+        namespaces: [],
+        k8sNodes: [],
+      }
+    );
+
+    const unscheduledGroup = groupedGraph.nodes?.find(node => node.label === UNSCHEDULED_GROUP);
+    expect(unscheduledGroup?.nodes?.[0].id).toBe('group-deployment');
   });
 
   it('leaves non-Pod resources ungrouped when grouping by node', () => {
@@ -296,6 +336,23 @@ describe('groupGraph', () => {
     // Without k8sNodes data, the group should not have a kubeObject
     expect(nodeGroup).toBeDefined();
     expect(nodeGroup?.kubeObject).toBeUndefined();
+  });
+
+  it('does not link a kubeObject to the Unscheduled group', () => {
+    const nodeNamedUnscheduled = {
+      kind: 'Node',
+      metadata: { name: UNSCHEDULED_GROUP, uid: 'unscheduled-node-uid' },
+    } as any;
+    const groupedGraph = groupGraph(nodes, edges, {
+      groupBy: 'node',
+      namespaces: [],
+      k8sNodes: [nodeNamedUnscheduled],
+    });
+
+    const unscheduledGroup = groupedGraph.nodes?.find(node => node.label === UNSCHEDULED_GROUP);
+    expect(unscheduledGroup).toBeDefined();
+    expect(unscheduledGroup?.kubeObject).toBeUndefined();
+    expect(unscheduledGroup?.nodes?.length).toBe(3);
   });
 
   it('groups nodes by instance', () => {

--- a/frontend/src/components/resourceMap/graph/graphGrouping.tsx
+++ b/frontend/src/components/resourceMap/graph/graphGrouping.tsx
@@ -24,6 +24,9 @@ import { forEachNode, getNodeWeight, GraphEdge, GraphNode } from './graphModel';
 
 export type GroupBy = 'node' | 'namespace' | 'instance';
 
+/** Label used for pods that have not been assigned to a Kubernetes Node. */
+export const UNSCHEDULED_GROUP = 'Unscheduled';
+
 /**
  * Returns the amount of nodes in the graph
  */
@@ -318,25 +321,32 @@ export function groupGraph(
   }
 
   if (groupBy === 'node') {
-    // Create groups based on the Kube resource node
+    // Create groups based on the Kube resource node.
+    // Pods without a nodeName (e.g. pending due to quota or scheduling failures)
+    // are grouped under an "Unscheduled" sentinel so they remain visible.
     components = groupByProperty(
       components,
       component => {
+        let pod: Pod | undefined;
         if (component.nodes) {
-          return (component.nodes.find(node => node.kubeObject?.kind === 'Pod')?.kubeObject as Pod)
-            ?.spec?.nodeName;
+          const pods = component.nodes
+            .filter(node => node.kubeObject?.kind === 'Pod')
+            .map(node => node.kubeObject as Pod);
+          pod = pods.find(pod => !pod.spec?.nodeName) ?? pods[0];
+        } else if (component.kubeObject?.kind === 'Pod') {
+          pod = component.kubeObject as Pod;
         }
-
-        return (component.kubeObject as Pod)?.spec?.nodeName;
+        if (pod) {
+          return pod.spec?.nodeName ?? UNSCHEDULED_GROUP;
+        }
+        return undefined;
       },
       { label: 'Node', allowSingleMemberGroup: true }
     );
 
     components.forEach(component => {
-      if (!component.kubeObject) {
-        component.kubeObject = k8sNodes.find(
-          namespace => namespace.metadata.name === component.label
-        );
+      if (!component.kubeObject && component.label !== UNSCHEDULED_GROUP) {
+        component.kubeObject = k8sNodes.find(node => node.metadata.name === component.label);
         if (component.kubeObject) {
           component.id = component.kubeObject.metadata.uid;
         }


### PR DESCRIPTION
## Summary

Group pods without `spec.nodeName` under an **Unscheduled** node group in
Resource Map. This keeps pending pods visible when users select **Group By:
Node**, while avoiding a link from the sentinel group to a Kubernetes Node.

## Provenance

This upstreams patch **0059** from the AKS Desktop Headlamp patch series:

- Original change: [Azure/aks-desktop#493](https://github.com/Azure/aks-desktop/pull/493)
- Original commit: [2992061b](https://github.com/Azure/aks-desktop/commit/2992061bff21c1ff6e7f1c2364c294e784986768)
- Patch-series migration: [Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823)
- Patch-series commit: [387eb27e](https://github.com/Azure/aks-desktop/commit/387eb27e3f586211610dda61949255e7264a9c95)

The feature commit preserves Thomas Gamble's original authorship and authored
date and adds Rene Dudfield as co-author.

## Changes

- Group standalone unscheduled pods under `Node-Unscheduled`.
- Group connected components containing an unscheduled pod under the same group.
- Prefer an unscheduled pod when a connected component contains both scheduled
  and pending pods.
- Keep non-Pod resources without a Pod ungrouped.
- Prevent the sentinel group from linking to a Kubernetes Node named
  `Unscheduled`.
- Add unit and browser-level regression coverage before the feature commit.

## Improvements Over Existing Changes

- Raises `graphGrouping.tsx` branch coverage to **85.21% before the feature
  commit** and **86.40% on the final branch**.
- Covers unscheduled pods inside connected components, which the downstream
  patch did not test.
- Removes pod-order dependence for mixed scheduled and pending components.
- Verifies that a real Kubernetes Node named `Unscheduled` cannot be linked to
  the sentinel group.
- Adds a Resource Map e2e scenario that exercises the **Group By: Node** control
  with a small fixture and checks both scheduled and unscheduled groups without
  triggering graph simplification.
- Documents the exported sentinel with TSDoc.

## Steps to Test

1. Run the focused unit and coverage check:

   ```bash
   cd frontend
   npm test -- --run src/components/resourceMap/graph/graphGrouping.test.ts \
     --coverage --coverage.provider=istanbul \
     --coverage.include=src/components/resourceMap/graph/graphGrouping.tsx \
     --coverage.reporter=text --coverage.thresholds.branches=80 \
     --coverage.thresholds.functions=0 --coverage.thresholds.lines=0 \
     --coverage.thresholds.statements=0
   ```

2. Run TypeScript, lint, and formatting checks:

   ```bash
   npm run tsc
   npx eslint --cache -c package.json \
     src/components/resourceMap/graph/graphGrouping.tsx \
     src/components/resourceMap/graph/graphGrouping.test.ts \
     ../e2e-tests/tests/resourceMap.spec.ts
   npx prettier --config package.json --check \
     src/components/resourceMap/graph/graphGrouping.tsx \
     src/components/resourceMap/graph/graphGrouping.test.ts \
     ../e2e-tests/tests/resourceMap.spec.ts
   ```

3. In the documented two-cluster e2e environment, run:

   ```bash
   cd e2e-tests
   npx playwright test tests/resourceMap.spec.ts \
     -g "groups scheduled and unscheduled pods by node"
   ```

## Validation

- 22 focused unit tests pass.
- Final branch coverage for `graphGrouping.tsx`: **86.40% branches**.
- Pre-feature test commit coverage: **85.21% branches**.
- Frontend TypeScript check passes.
- Focused ESLint and Prettier checks pass.
- All 683 Storybook snapshots pass against current main.
- Playwright loads and enumerates both Resource Map scenarios.
- Captured the Resource Map against a local Headlamp backend and a synthetic
  Kubernetes API containing scheduled and unscheduled pods.

## Screenshots

**Group By: Node** keeps pending pods visible under **Node Unscheduled** while
scheduled pods remain grouped under their Kubernetes Nodes.

![Resource Map grouped by node with pending pods under Node Unscheduled](https://raw.githubusercontent.com/illume/headlamp/b84f6afa8f9c9891bfd21a59566962bf0c85f339/0059-unscheduled-pod-grouping.png)

## Notes for the Reviewer

The `Unscheduled` label is a grouping sentinel, not a Kubernetes Node name.

Assisted by copilot.
