### PR TITLE
frontend: Update outdated snapshots

### DIFF
--- a/frontend/src/components/storage/__snapshots__/CreatePVCForm.Empty.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/CreatePVCForm.Empty.stories.storyshot
@@ -361,7 +361,7 @@
                         <input
                           checked=""
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3i8:"
+                          name=":r3j2:"
                           type="radio"
                           value="default"
                         />
@@ -409,7 +409,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3i8:"
+                          name=":r3j2:"
                           type="radio"
                           value="none"
                         />
@@ -457,7 +457,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3i8:"
+                          name=":r3j2:"
                           type="radio"
                           value="specify"
                         />

--- a/frontend/src/components/storage/__snapshots__/CreatePVCForm.MinimalValid.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/CreatePVCForm.MinimalValid.stories.storyshot
@@ -369,7 +369,7 @@
                         <input
                           checked=""
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3ii:"
+                          name=":r3jc:"
                           type="radio"
                           value="default"
                         />
@@ -417,7 +417,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3ii:"
+                          name=":r3jc:"
                           type="radio"
                           value="none"
                         />
@@ -465,7 +465,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3ii:"
+                          name=":r3jc:"
                           type="radio"
                           value="specify"
                         />

--- a/frontend/src/components/storage/__snapshots__/CreatePVCForm.MultipleAccessModes.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/CreatePVCForm.MultipleAccessModes.stories.storyshot
@@ -377,7 +377,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3kv:"
+                          name=":r3lp:"
                           type="radio"
                           value="default"
                         />
@@ -425,7 +425,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3kv:"
+                          name=":r3lp:"
                           type="radio"
                           value="none"
                         />
@@ -474,7 +474,7 @@
                         <input
                           checked=""
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3kv:"
+                          name=":r3lp:"
                           type="radio"
                           value="specify"
                         />

--- a/frontend/src/components/storage/__snapshots__/CreatePVCForm.ReadWriteMany.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/CreatePVCForm.ReadWriteMany.stories.storyshot
@@ -368,7 +368,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3kk:"
+                          name=":r3le:"
                           type="radio"
                           value="default"
                         />
@@ -416,7 +416,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3kk:"
+                          name=":r3le:"
                           type="radio"
                           value="none"
                         />
@@ -465,7 +465,7 @@
                         <input
                           checked=""
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3kk:"
+                          name=":r3le:"
                           type="radio"
                           value="specify"
                         />

--- a/frontend/src/components/storage/__snapshots__/CreatePVCForm.StaticProvisioning.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/CreatePVCForm.StaticProvisioning.stories.storyshot
@@ -368,7 +368,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3jv:"
+                          name=":r3kp:"
                           type="radio"
                           value="default"
                         />
@@ -417,7 +417,7 @@
                         <input
                           checked=""
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3jv:"
+                          name=":r3kp:"
                           type="radio"
                           value="none"
                         />
@@ -465,7 +465,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3jv:"
+                          name=":r3kp:"
                           type="radio"
                           value="specify"
                         />

--- a/frontend/src/components/storage/__snapshots__/CreatePVCForm.StorageClassNone.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/CreatePVCForm.StorageClassNone.stories.storyshot
@@ -368,7 +368,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3jb:"
+                          name=":r3k5:"
                           type="radio"
                           value="default"
                         />
@@ -417,7 +417,7 @@
                         <input
                           checked=""
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3jb:"
+                          name=":r3k5:"
                           type="radio"
                           value="none"
                         />
@@ -465,7 +465,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3jb:"
+                          name=":r3k5:"
                           type="radio"
                           value="specify"
                         />

--- a/frontend/src/components/storage/__snapshots__/CreatePVCForm.WithStorageClass.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/CreatePVCForm.WithStorageClass.stories.storyshot
@@ -540,7 +540,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3j0:"
+                          name=":r3jq:"
                           type="radio"
                           value="default"
                         />
@@ -588,7 +588,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3j0:"
+                          name=":r3jq:"
                           type="radio"
                           value="none"
                         />
@@ -637,7 +637,7 @@
                         <input
                           checked=""
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3j0:"
+                          name=":r3jq:"
                           type="radio"
                           value="specify"
                         />

--- a/frontend/src/components/storage/__snapshots__/CreatePVCForm.WithStorageClassAndVolumeName.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/CreatePVCForm.WithStorageClassAndVolumeName.stories.storyshot
@@ -368,7 +368,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3k9:"
+                          name=":r3l3:"
                           type="radio"
                           value="default"
                         />
@@ -416,7 +416,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3k9:"
+                          name=":r3l3:"
                           type="radio"
                           value="none"
                         />
@@ -465,7 +465,7 @@
                         <input
                           checked=""
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3k9:"
+                          name=":r3l3:"
                           type="radio"
                           value="specify"
                         />

--- a/frontend/src/components/storage/__snapshots__/CreatePVCForm.WithVolumeName.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/CreatePVCForm.WithVolumeName.stories.storyshot
@@ -369,7 +369,7 @@
                         <input
                           checked=""
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3jl:"
+                          name=":r3kf:"
                           type="radio"
                           value="default"
                         />
@@ -417,7 +417,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3jl:"
+                          name=":r3kf:"
                           type="radio"
                           value="none"
                         />
@@ -465,7 +465,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3jl:"
+                          name=":r3kf:"
                           type="radio"
                           value="specify"
                         />


### PR DESCRIPTION
These changes updates the snapshots which were missing from https://github.com/kubernetes-sigs/headlamp/pull/5333, causing the `Build frontend / test` check to fail on all PRs.