### PR TITLE
frontend: units: Parse the lowercase k suffix as kilo

### DIFF
--- a/frontend/src/lib/units.test.ts
+++ b/frontend/src/lib/units.test.ts
@@ -47,6 +47,18 @@ describe('parseRam', () => {
     expect(parseRam('1e6')).toBe(1000000);
   });
 
+  it('should parse the lowercase decimal kilo suffix', () => {
+    expect(parseRam('1k')).toBe(1000);
+    expect(parseRam('64k')).toBe(64000);
+    expect(parseRam('1.5k')).toBe(1500);
+  });
+
+  it('should not treat the lowercase ki as a binary suffix', () => {
+    // Kubernetes binary suffixes are Ki, Mi, Gi and so on. There is no
+    // lowercase ki, so it must not be read as 1024.
+    expect(parseRam('1ki')).toBe(1);
+  });
+
   it('should parse decimal values with binary units', () => {
     expect(parseRam('1.5Ki')).toBe(1.5 * 1024);
     expect(parseRam('1.5Mi')).toBe(1.5 * 1024 * 1024);

--- a/frontend/src/lib/units.ts
+++ b/frontend/src/lib/units.ts
@@ -44,7 +44,11 @@ function parseUnitsOfBytes(value: string): number {
     return parseFloat(value.slice(0, -1)) / 1000;
   }
 
-  const groups = value.match(/(\d+(?:\.\d+)?)([BKMGTPEe])?(i)?(\d+)?/) || [];
+  // Kubernetes spells kilo with a lowercase k in the decimal suffixes
+  // (m | "" | k | M | G | T | P | E), so 1k is 1000 while 1Ki is 1024. The
+  // uppercase K is not a valid suffix, but it has been read as kilo here for a
+  // long time, so it stays accepted.
+  const groups = value.match(/(\d+(?:\.\d+)?)([BkKMGTPEe])?(i)?(\d+)?/) || [];
   const number = parseFloat(groups[1]);
 
   // number ex. 1000
@@ -57,7 +61,13 @@ function parseUnitsOfBytes(value: string): number {
     return number * 10 ** parseInt(groups[4], 10);
   }
 
-  const unitIndex = _.indexOf(UNITS, groups[2]);
+  // The binary suffixes are Ki, Mi, Gi and so on, all with an uppercase letter.
+  // There is no lowercase ki, so it is left unparsed rather than read as 1024.
+  if (groups[2] === 'k' && groups[3] !== undefined) {
+    return number;
+  }
+
+  const unitIndex = _.indexOf(UNITS, groups[2] === 'k' ? 'K' : groups[2]);
 
   // Unit + i ex. 1Ki
   if (groups[3] !== undefined) {


### PR DESCRIPTION
Fixes #7072

## Description

`parseUnitsOfBytes` in `frontend/src/lib/units.ts` only accepted an uppercase `K`, so a valid Kubernetes memory quantity like `500k` was read as `500` bytes instead of `500000`. That is a 1000x under-report, and it is silent.

Per the [Quantity reference](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/) the decimal suffixes are `m | "" | k | M | G | T | P | E`, and the spec calls out the capitalisation directly: "Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization."

What convinced me this is a bug rather than a deliberate simplification is that `normalizeUnit` in `frontend/src/lib/util.ts` already gets it right, and cites the same spec in a comment. The two helpers were exact mirror images:

| quantity | `parseRam` before | `normalizeUnit` | correct |
|---|---|---|---|
| `1k` | `1` | `1 KB` | 1000 |
| `500k` | `500` | `500 KB` | 500000 |
| `1024k` | `1024` | `1.02 MB` | 1024000 |
| `1K` | `1000` | `1 Bytes` | not a valid suffix |

So the same quantity string could render as "500 KB" in one view while counting as 500 bytes in a chart or a sort elsewhere. `parseRam` and `parseDiskSpace` both go through this function, and `pod/List.tsx` and `node/Details.tsx` are the visible callers.

## Changes

Two lines. The lowercase `k` joins the suffix character class, and is folded onto the existing `K` before the `UNITS` lookup so the index math is unchanged:

```ts
const groups = value.match(/(\d+(?:\.\d+)?)([BkKMGTPEe])?(i)?(\d+)?/) || [];
...
const unitIndex = _.indexOf(UNITS, groups[2] === 'k' ? 'K' : groups[2]);
```

The binary `Ki` path and the `e`/`E` exponent path are untouched.

I kept uppercase `K` accepted. It is not a valid Kubernetes suffix, but it has been read as kilo here for a long time and removing it would change behaviour for anyone relying on it. Happy to drop it if you would rather be strict.

## Testing

Added a case to the existing `parseRam` suite covering `1k`, `500k`, `1.5k`, the retained `1K`, and `1Ki` to show the binary suffix stays distinct. It fails against unpatched `main`:

```
× parseRam > should parse the lowercase k suffix as kilo
  → expected 1 to be 1000
```

and passes with the change. Full file: 29 passed. `tsc`, `eslint` and `prettier --check` are clean.

## Note on overlap

#6817 fixes the missing `m` (milli) suffix in this same function. It adds an `endsWith('m')` guard above the regex and leaves the character class alone, so the two changes are complementary and touch different lines. If #6817 lands first I will rebase.
