### PR TITLE
frontend: Fix default custom theme radius

### DIFF
--- a/frontend/src/lib/themes.test.ts
+++ b/frontend/src/lib/themes.test.ts
@@ -103,6 +103,27 @@ describe('themes.ts', () => {
 
       expect(theme.palette.secondary.contrastText).toBe('#000');
     });
+
+    it.each(['light', 'dark'] as const)(
+      'should use the default radius when a %s theme omits radius',
+      base => {
+        const theme = createMuiTheme({ base, name: `${base} theme` });
+
+        expect(theme.shape.borderRadius).toBe(4);
+      }
+    );
+
+    it('should preserve a zero radius', () => {
+      const theme = createMuiTheme({ base: 'light', name: 'Square', radius: 0 });
+
+      expect(theme.shape.borderRadius).toBe(0);
+    });
+
+    it('should preserve a custom radius', () => {
+      const theme = createMuiTheme({ base: 'light', name: 'Rounded', radius: 8 });
+
+      expect(theme.shape.borderRadius).toBe(8);
+    });
   });
 
   describe('getThemeName', () => {

--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -344,7 +344,7 @@ export function createMuiTheme(currentTheme: AppTheme) {
       },
     },
     shape: {
-      borderRadius: Number(currentTheme.radius) ?? 4,
+      borderRadius: Number(currentTheme.radius ?? 4),
     },
     components: {
       MuiPaper: {


### PR DESCRIPTION
## Summary

Fix custom themes that omit `radius` so MUI uses the default value of `4`
instead of `NaN`. Explicit zero and custom radii stay unchanged.

## Related Issue

Fixes #7025

## Changes

- Apply the radius fallback before numeric conversion.
- Add regression tests for omitted, zero, and custom radius values.

## Steps to Test

1. `cd frontend && npm test -- --run src/lib/themes.test.ts` — 25 tests passed.
2. `npm run frontend:tsc` — passed.
3. `cd frontend && npm run ci-lint` — passed.
4. `CI=true npm test` — passed.
5. `npm run lint` — passed.
6. `npm run build` — passed.

## Screenshots

### Before

The custom theme omits `radius`; the selected card renders with square corners
(`0px`).

![Before: custom theme without radius renders square corners](https://raw.githubusercontent.com/areycruzer/headlamp/5dcf86f6b786fc2a4eed01d28328719258e9a816/pr-7074/theme-radius-before.jpg)

### After

The same theme uses the default shape radius; the selected card is `8px` and
the Window preview is `4px`.

![After: custom theme without radius uses default rounded corners](https://raw.githubusercontent.com/areycruzer/headlamp/5dcf86f6b786fc2a4eed01d28328719258e9a816/pr-7074/theme-radius-after.jpg)

## Notes for the Reviewer

No public API or dependency changes.
