### PR TITLE
0062: Allow custom cluster empty states

### DIFF
--- a/docs/development/api/modules/plugin_registry.md
+++ b/docs/development/api/modules/plugin_registry.md
@@ -322,6 +322,44 @@ registerClusterChooser(({ clickHandler, cluster }: ClusterChooserProps) => {
 
 ___
 
+### registerClusterEmptyState
+
+▸ **registerClusterEmptyState**(`component`): `void`
+
+Replace the empty state shown on the Home page when no clusters are configured.
+
+The component receives Headlamp's default content so a product can wrap it.
+Registering another component replaces the previous registration.
+
+**`example`**
+
+```tsx
+import { registerClusterEmptyState } from '@kinvolk/headlamp-plugin/lib';
+
+registerClusterEmptyState(({ defaultContent }) => (
+  <section>
+    <p>Choose how to connect your first cluster.</p>
+    {defaultContent}
+  </section>
+));
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `component` | `ClusterEmptyStateComponent` | Product-owned empty state component. |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[plugin/registry.tsx:972](https://github.com/kubernetes-sigs/headlamp/blob/558672b5a/frontend/src/plugin/registry.tsx#L972)
+
+___
+
 ### registerDetailsViewHeaderAction
 
 ▸ **registerDetailsViewHeaderAction**(`headerAction`): `void`

--- a/docs/development/plugins/functionality/index.md
+++ b/docs/development/plugins/functionality/index.md
@@ -93,6 +93,17 @@ Change the Cluster Chooser button in the top right of the app bar with
 - Example plugin: [How To Register Cluster Chooser button](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/cluster-chooser)
 - API reference: [registerClusterChooser](../../api/plugin/registry/functions/registerclusterchooser)
 
+### Cluster Empty State
+
+Customize the Home page shown when no clusters are configured with
+[registerClusterEmptyState](../../api/plugin/registry/functions/registerclusteremptystate).
+The registered component receives Headlamp's standard empty state as
+`defaultContent`. Render it to extend the default onboarding, or omit it to
+replace the empty state completely.
+
+- Example plugin: [How To Customize The Cluster Empty State](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/cluster-chooser)
+- API reference: [registerClusterEmptyState](../../api/plugin/registry/functions/registerclusteremptystate)
+
 ### Details View Header Action
 
 Show a component in the top right of a detail view with

--- a/e2e-tests/tests/clusterEmptyState.spec.ts
+++ b/e2e-tests/tests/clusterEmptyState.spec.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import { HeadlampPage } from './headlampPage';
+
+test('cluster chooser plugin extends the empty cluster state', async ({ page }) => {
+  await page.route('**/config', async route => {
+    const response = await route.fetch();
+    const config = await response.json();
+
+    await route.fulfill({
+      response,
+      json: {
+        ...config,
+        clusters: [],
+      },
+    });
+  });
+
+  const headlampPage = new HeadlampPage(page);
+  await headlampPage.navigateTopage('/', /Choose a cluster/);
+
+  await expect(page.getByText('Choose a cluster provider')).toBeVisible();
+  await expect(page.getByText('No clusters found')).toBeVisible();
+  await headlampPage.a11y();
+});

--- a/frontend/src/components/App/Home/ClusterTable.test.tsx
+++ b/frontend/src/components/App/Home/ClusterTable.test.tsx
@@ -17,7 +17,7 @@
 import { ThemeProvider } from '@mui/material/styles';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
-import { ReactNode } from 'react';
+import { ComponentType, ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Cluster } from '../../../lib/k8s/cluster';
@@ -26,6 +26,7 @@ import ClusterContextMenu from './ClusterContextMenu';
 import ClusterTable from './ClusterTable';
 
 const theme = createMuiTheme({ name: 'light', base: 'light' });
+let ClusterEmptyState: ComponentType<{ defaultContent: ReactNode }> | null = null;
 
 function renderWithTheme(ui: ReactNode) {
   return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
@@ -58,6 +59,7 @@ vi.mock('../../../redux/hooks', () => ({
         clusterStatuses: [],
         dialogs: [],
         menuItems: [],
+        clusterEmptyState: ClusterEmptyState,
       },
       config: {
         allowKubeconfigChanges: true,
@@ -96,6 +98,66 @@ vi.mock('../../common/Table', () => ({
 describe('ClusterTable', () => {
   afterEach(() => {
     vi.clearAllMocks();
+    ClusterEmptyState = null;
+  });
+
+  it('renders the standard empty state when no custom state is registered', () => {
+    renderWithTheme(
+      <MemoryRouter>
+        <ClusterTable
+          customNameClusters={[]}
+          clusters={{}}
+          versions={{}}
+          errors={{}}
+          warningLabels={{}}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('No clusters found')).toBeInTheDocument();
+  });
+
+  it('renders a registered cluster empty state instead of the default', () => {
+    ClusterEmptyState = () => <div>Choose a cluster provider</div>;
+
+    renderWithTheme(
+      <MemoryRouter>
+        <ClusterTable
+          customNameClusters={[]}
+          clusters={{}}
+          versions={{}}
+          errors={{}}
+          warningLabels={{}}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Choose a cluster provider')).toBeInTheDocument();
+    expect(screen.queryByText('No clusters found')).not.toBeInTheDocument();
+  });
+
+  it('passes the standard empty state to a registered wrapper', () => {
+    ClusterEmptyState = ({ defaultContent }) => (
+      <section>
+        <div>Before</div>
+        {defaultContent}
+      </section>
+    );
+
+    renderWithTheme(
+      <MemoryRouter>
+        <ClusterTable
+          customNameClusters={[]}
+          clusters={{}}
+          versions={{}}
+          errors={{}}
+          warningLabels={{}}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Before')).toBeInTheDocument();
+    expect(screen.getByText('No clusters found')).toBeInTheDocument();
   });
 
   it('renders Cluster Inventory source labels', () => {

--- a/frontend/src/components/App/Home/ClusterTable.tsx
+++ b/frontend/src/components/App/Home/ClusterTable.tsx
@@ -56,6 +56,7 @@ import {
 import { canSelectCluster } from './clusterStatus';
 import { CONNECT_ON_CLUSTER_LINK, MULTI_HOME_ENABLED } from './config';
 import { getCustomClusterNames } from './customClusterNames';
+import RegisteredClusterEmptyState from './RegisteredClusterEmptyState';
 
 /**
  * ClusterStatus component displays the status of a cluster.
@@ -272,7 +273,7 @@ export default function ClusterTable({
 
   const clustersList = Object.values(customNameClusters);
   if (clustersList.length === 0) {
-    return (
+    const defaultContent = (
       <Box
         display="flex"
         flexDirection="column"
@@ -304,6 +305,7 @@ export default function ClusterTable({
         )}
       </Box>
     );
+    return <RegisteredClusterEmptyState defaultContent={defaultContent} />;
   }
 
   return (

--- a/frontend/src/components/App/Home/RegisteredClusterEmptyState.tsx
+++ b/frontend/src/components/App/Home/RegisteredClusterEmptyState.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createElement, ReactNode } from 'react';
+import { useTypedSelector } from '../../../redux/hooks';
+
+/** Properties for the registered cluster empty-state renderer. */
+interface RegisteredClusterEmptyStateProps {
+  /** Headlamp's standard no-cluster content. */
+  defaultContent: ReactNode;
+}
+
+/** Render a plugin-provided cluster empty state or Headlamp's standard content. */
+export default function RegisteredClusterEmptyState({
+  defaultContent,
+}: RegisteredClusterEmptyStateProps): ReactNode {
+  const ClusterEmptyState = useTypedSelector(state => state.clusterProvider.clusterEmptyState);
+
+  return ClusterEmptyState ? createElement(ClusterEmptyState, { defaultContent }) : defaultContent;
+}

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -707,6 +707,7 @@
   "registerAppLogo": [Function],
   "registerAppTheme": [Function],
   "registerClusterChooser": [Function],
+  "registerClusterEmptyState": [Function],
   "registerClusterProviderDialog": [Function],
   "registerClusterProviderMenuItem": [Function],
   "registerClusterStatus": [Function],

--- a/frontend/src/plugin/registry.test.ts
+++ b/frontend/src/plugin/registry.test.ts
@@ -34,7 +34,7 @@ vi.mock('../components/resourceMap/sources/definitions/relationIds', () => ({
   BUILT_IN_RELATION_IDS: ['owner', 'owner-reversed', 'pod-configmap'],
 }));
 
-import { registerResourceRelationProvider } from './registry';
+import { registerClusterEmptyState, registerResourceRelationProvider } from './registry';
 
 describe('registerResourceRelationProvider', () => {
   let warnSpy: any;
@@ -210,5 +210,13 @@ describe('registerResourceRelationProvider', () => {
     // Try to register the same relation again (duplicate check)
     registerResourceRelationProvider(validRelation);
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('already exists. Skipping'));
+  });
+
+  it('registers a custom cluster empty state', () => {
+    const emptyState = vi.fn(() => null);
+
+    registerClusterEmptyState(emptyState);
+
+    expect(activeStore.getState().clusterProvider.clusterEmptyState).toBe(emptyState);
   });
 });

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -71,10 +71,12 @@ import {
   addClusterStatus,
   addDialog,
   addMenuItem,
+  ClusterEmptyStateComponent,
   ClusterProviderInfo,
   ClusterStatusComponent,
   DialogComponent,
   MenuItemComponent,
+  setClusterEmptyState,
 } from '../redux/clusterProviderSlice';
 import {
   addEventCallback,
@@ -943,6 +945,32 @@ export function registerClusterProviderMenuItem(item: MenuItemComponent) {
  */
 export function registerClusterStatus(item: ClusterStatusComponent) {
   store.dispatch(addClusterStatus(item));
+}
+
+/**
+ * Replace the empty state shown on the Home page when no clusters are configured.
+ *
+ * The component receives Headlamp's default content so a product can wrap it.
+ * Registering another component replaces the previous registration.
+ *
+ * @param component - Product-owned empty state component.
+ * @returns Nothing.
+ *
+ * @example
+ *
+ * ```tsx
+ * import { registerClusterEmptyState } from '@kinvolk/headlamp-plugin/lib';
+ *
+ * registerClusterEmptyState(({ defaultContent }) => (
+ *   <section>
+ *     <p>Choose how to connect your first cluster.</p>
+ *     {defaultContent}
+ *   </section>
+ * ));
+ * ```
+ */
+export function registerClusterEmptyState(component: ClusterEmptyStateComponent): void {
+  store.dispatch(setClusterEmptyState(component));
 }
 
 /**

--- a/frontend/src/redux/clusterProviderSlice.test.ts
+++ b/frontend/src/redux/clusterProviderSlice.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import clusterProviderReducer, {
+  ClusterEmptyStateComponent,
+  initialState,
+  setClusterEmptyState,
+} from './clusterProviderSlice';
+
+describe('clusterProviderSlice', () => {
+  it('starts without a custom cluster empty state', () => {
+    expect(clusterProviderReducer(undefined, { type: '' })).toEqual(initialState);
+    expect(initialState.clusterEmptyState).toBeNull();
+  });
+
+  it('keeps the latest registered cluster empty state', () => {
+    const firstEmptyState: ClusterEmptyStateComponent = () => null;
+    const secondEmptyState: ClusterEmptyStateComponent = () => null;
+
+    const stateWithFirstRegistration = clusterProviderReducer(
+      initialState,
+      setClusterEmptyState(firstEmptyState)
+    );
+    const stateWithSecondRegistration = clusterProviderReducer(
+      stateWithFirstRegistration,
+      setClusterEmptyState(secondEmptyState)
+    );
+
+    expect(stateWithFirstRegistration.clusterEmptyState).toBe(firstEmptyState);
+    expect(stateWithSecondRegistration.clusterEmptyState).toBe(secondEmptyState);
+  });
+});

--- a/frontend/src/redux/clusterProviderSlice.ts
+++ b/frontend/src/redux/clusterProviderSlice.ts
@@ -15,6 +15,7 @@
  */
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { ReactNode } from 'react';
 import type { ApiError } from '../lib/k8s/api/v2/ApiError';
 
 export interface DialogProps {
@@ -34,9 +35,19 @@ export interface ClusterStatusProps {
   error: ApiError | null | undefined;
 }
 
+/** Props passed to a custom Home page cluster empty-state component. */
+export interface ClusterEmptyStateProps {
+  /** Headlamp's standard empty state, for products that want to wrap rather than replace it. */
+  defaultContent: ReactNode;
+}
+
 export type DialogComponent = (props: DialogProps) => React.ReactElement | null;
 export type MenuItemComponent = (props: MenuItemProps) => React.ReactElement | null;
 export type ClusterStatusComponent = (props: ClusterStatusProps) => React.ReactElement | null;
+/** A component that replaces or wraps the Home page cluster empty state. */
+export type ClusterEmptyStateComponent = (
+  props: ClusterEmptyStateProps
+) => React.ReactElement | null;
 
 /**
  * Information about a cluster provider, that is shown on the add cluster page.
@@ -61,6 +72,8 @@ export interface ClusterProviderSliceState {
   clusterProviders: ClusterProviderInfo[];
   /** Cluster statuses for the Home page. */
   clusterStatuses: ClusterStatusComponent[];
+  /** Optional product-owned replacement for the Home page's empty cluster state. */
+  clusterEmptyState: ClusterEmptyStateComponent | null;
 }
 
 export const initialState: ClusterProviderSliceState = {
@@ -68,6 +81,7 @@ export const initialState: ClusterProviderSliceState = {
   dialogs: [],
   clusterProviders: [],
   clusterStatuses: [],
+  clusterEmptyState: null,
 };
 
 const clusterProviderSlice = createSlice({
@@ -86,10 +100,18 @@ const clusterProviderSlice = createSlice({
     addClusterStatus(state, action: PayloadAction<ClusterStatusComponent>) {
       state.clusterStatuses.push(action.payload);
     },
+    setClusterEmptyState(state, action: PayloadAction<ClusterEmptyStateComponent>) {
+      state.clusterEmptyState = action.payload;
+    },
   },
 });
 
-export const { addDialog, addMenuItem, addAddClusterProvider, addClusterStatus } =
-  clusterProviderSlice.actions;
+export const {
+  addDialog,
+  addMenuItem,
+  addAddClusterProvider,
+  addClusterStatus,
+  setClusterEmptyState,
+} = clusterProviderSlice.actions;
 
 export default clusterProviderSlice.reducer;

--- a/plugins/examples/cluster-chooser/src/index.tsx
+++ b/plugins/examples/cluster-chooser/src/index.tsx
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { ClusterChooserProps, K8s, registerClusterChooser } from '@kinvolk/headlamp-plugin/lib';
+import {
+  ClusterChooserProps,
+  ClusterEmptyStateProps,
+  K8s,
+  registerClusterChooser,
+  registerClusterEmptyState,
+} from '@kinvolk/headlamp-plugin/lib';
 import { Button } from '@mui/material';
 
 /** Props for the ClusterChooserButton component. */
@@ -37,8 +43,20 @@ export function ClusterChooserButton({ clickHandler, cluster }: ClusterChooserBu
   );
 }
 
+/** Demonstrates how a product can extend Headlamp's no-cluster experience. */
+export function CustomClusterEmptyState({ defaultContent }: ClusterEmptyStateProps) {
+  return (
+    <section>
+      <p>Choose a cluster provider</p>
+      {defaultContent}
+    </section>
+  );
+}
+
 // Replaces the default cluster chooser in the top bar with a button that shows
 // the current cluster name and total number of configured clusters (e.g. "Cluster: minikube (3 clusters)").
 registerClusterChooser(({ clickHandler, cluster }: ClusterChooserProps) => (
   <ClusterChooserButton clickHandler={clickHandler} cluster={cluster} />
 ));
+
+registerClusterEmptyState(CustomClusterEmptyState);

--- a/plugins/headlamp-plugin/src/index.ts
+++ b/plugins/headlamp-plugin/src/index.ts
@@ -50,6 +50,7 @@ import Registry, {
   registerAppLogo,
   registerAppTheme,
   registerClusterChooser,
+  registerClusterEmptyState,
   registerClusterProviderDialog,
   registerClusterProviderMenuItem,
   registerClusterStatus,
@@ -80,6 +81,7 @@ import Registry, {
   registerUIPanel,
   runCommand,
 } from './plugin/registry';
+import type { ClusterEmptyStateProps } from './redux/clusterProviderSlice';
 export type { ApiResource } from './plugin/registry';
 
 // We export k8s (lowercase) since someone may use it as we do in the Headlamp source code.
@@ -102,6 +104,7 @@ export {
   registerAppLogo,
   registerAppBarAction,
   registerClusterChooser,
+  registerClusterEmptyState,
   registerDetailsViewHeaderAction,
   registerDetailsViewSection,
   registerDetailsViewSectionsProcessor,
@@ -148,6 +151,7 @@ export type {
   PluginSettingsDetailsProps,
   CallbackActionOptions,
   ClusterChooserProps,
+  ClusterEmptyStateProps,
   DetailsViewSectionProps,
   DefaultSidebars,
   HeadlampEvent,


### PR DESCRIPTION
## Summary

- Add `registerClusterEmptyState` so plugins can replace or wrap the Home page
  shown when no clusters are configured.
- Pass Headlamp's standard empty content to registered components so products can
  preserve the default onboarding actions.
- Add focused unit, public package, and Playwright coverage for the new contract.

## Improvements over the existing change

- Exports both `registerClusterEmptyState` and `ClusterEmptyStateProps` from the
  published `@kinvolk/headlamp-plugin/lib` entry point.
- Uses explicit dynamic component rendering that passes Headlamp's React lint
  rules.
- Covers default, replacement, wrapping, reducer replacement, and public registry
  behavior; the isolated empty-state renderer reaches 100% branch coverage.
- Adds browser coverage through the shipped cluster-chooser example and keeps the
  default empty state visible for accessible fallback onboarding.
- Updates the plugin compatibility snapshot so the public API addition is
  intentional and reviewable.
- Documents the API in the plugin functionality guide and tracked TypeDoc output.

## Provenance

The standalone retained patch
`0062-headlamp-upstream-cluster-empty-state.patch` records original downstream
Headlamp commit `aa2a01c13411102ade6068d20c68cb14a1e6c525` by Oleksandr
Dubenko, authored on 2026-08-01. The implementation commit preserves that author
and date and adds René Dudfield as co-author.

Patch 0062 was retained in Azure/aks-desktop commit
[`387eb27e3f586211610dda61949255e7264a9c95`](https://github.com/Azure/aks-desktop/commit/387eb27e3f586211610dda61949255e7264a9c95)
as part of [Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823).
No separate Azure/aks-desktop PR was found for the original downstream commit.

## Testing

- Focused Vitest suites: 22 tests passed.
- `RegisteredClusterEmptyState.tsx`: 100% branch coverage with an enforced 80%
  threshold.
- Frontend TypeScript and ownership-scoped CI ESLint checks.
- Frontend production build: 4,876 modules transformed; postbuild completed.
- Local `@kinvolk/headlamp-plugin` SDK build and generated export verification.
- Cluster-chooser consumer typecheck, lint, and production build.
- Playwright discovery: one Chromium test in `clusterEmptyState.spec.ts`.
- TypeDoc generation completed and includes `registerClusterEmptyState`.

## Screenshots

![Custom cluster empty state](https://raw.githubusercontent.com/illume/headlamp/pr-7075-assets/pr-assets/7075/cluster-empty-state.png)

The cluster-chooser example adds a provider prompt while preserving Headlamp's
default no-cluster guidance.

Assisted by copilot.
