### PR TITLE
frontend: plugins: Prefer @headlamp-k8s scoped names for renamed plugins 

### DIFF
--- a/frontend/src/components/App/PluginSettings/PluginSettings.test.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettings.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import { ThemeProvider } from '@mui/material/styles';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createMuiTheme } from '../../../lib/themes';
 import { PluginInfo, setPluginSettings } from '../../../plugin/pluginsSlice';
@@ -200,6 +200,57 @@ describe('PluginSettingsPure', () => {
     await waitFor(() => {
       expect(screen.getAllByLabelText('Delete Plugin')).toHaveLength(2);
     });
+  });
+});
+
+describe('PluginSettingsPure with an overridden plugin', () => {
+  /** A plugin renamed into the official scope, next to the old unscoped copy it overrides. */
+  function createRenamedPlugins(): PluginInfo[] {
+    return [
+      {
+        name: '@headlamp-k8s/app-catalog',
+        description: 'The renamed plugin',
+        isEnabled: true,
+        isCompatible: true,
+        isLoaded: true,
+        type: 'shipped' as const,
+        homepage: '',
+      },
+      {
+        name: 'app-catalog',
+        description: 'The old unscoped copy',
+        isEnabled: true,
+        isCompatible: true,
+        isLoaded: false,
+        overriddenBy: 'shipped' as const,
+        type: 'user' as const,
+        homepage: '',
+      },
+    ];
+  }
+
+  it('does not offer to save when nothing has been changed', () => {
+    renderPluginSettings({ plugins: createRenamedPlugins() });
+
+    expect(screen.getByText('Not Loaded')).toBeInTheDocument();
+    expect(screen.queryByText('Save & Apply')).not.toBeInTheDocument();
+  });
+
+  it('keeps the overridden plugin enabled when the settings are saved', () => {
+    const onSave = vi.fn();
+
+    renderPluginSettings({ plugins: createRenamedPlugins(), onSave });
+
+    // Turn the loaded plugin off, so there is something to save.
+    const toggle = screen.getByLabelText('Toggle @headlamp-k8s/app-catalog');
+    fireEvent.click(within(toggle).getByRole('checkbox'));
+    fireEvent.click(screen.getByText('Save & Apply'));
+
+    const saved = onSave.mock.calls[0][0] as PluginInfo[];
+    expect(saved.find(plugin => plugin.name === '@headlamp-k8s/app-catalog')?.isEnabled).toBe(
+      false
+    );
+    expect(saved.find(plugin => plugin.name === 'app-catalog')?.isEnabled).toBe(true);
   });
 });
 

--- a/frontend/src/components/App/PluginSettings/PluginSettings.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettings.tsx
@@ -130,7 +130,7 @@ export function PluginSettingsPure(props: PluginSettingsPureProps) {
   /**
    * pluginChanges state is the array of plugin data and any current changes made by the user to a plugin's "Enable" field via toggler.
    * The name and origin fields are split for consistency.
-   * Plugins that are not loaded (isLoaded === false) are initialized with isEnabled = false.
+   * isEnabled is the stored user preference, kept independent of the runtime isLoaded state.
    */
   const [pluginChanges, setPluginChanges] = useState(() =>
     pluginArr.map((plugin: PluginInfo) => {
@@ -142,8 +142,7 @@ export function PluginSettingsPure(props: PluginSettingsPureProps) {
         ...plugin,
         displayName: name ?? plugin.name,
         origin: plugin.origin ?? author?.substring(1) ?? t('translation|Unknown'),
-        // If the plugin is not loaded, ensure it's disabled
-        isEnabled: plugin.isLoaded === false ? false : plugin.isEnabled,
+        isEnabled: plugin.isEnabled,
       };
     })
   );

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -201,26 +201,53 @@ export function filterSources(
   };
 }
 
+/** The npm scope Headlamp controls, see https://github.com/kubernetes-sigs/headlamp/issues/2597 */
+const OFFICIAL_PLUGIN_SCOPE = '@headlamp-k8s';
+
+/**
+ * Strips the official scope, so that a renamed plugin and its old unscoped name, like
+ * "@headlamp-k8s/app-catalog" and "app-catalog", are treated as one plugin. Other scopes
+ * are returned unchanged.
+ *
+ * @param name the plugin name, as found in its package.json.
+ * @returns the name without the official scope prefix.
+ */
+function getPluginBaseName(name: string): string {
+  const scopePrefix = `${OFFICIAL_PLUGIN_SCOPE}/`;
+  return name.startsWith(scopePrefix) ? name.slice(scopePrefix.length) : name;
+}
+
+/**
+ * @param plugin the plugin to check.
+ * @returns true if the plugin is published under the scope Headlamp controls.
+ */
+function isOfficiallyScoped(plugin: PluginInfo): boolean {
+  return plugin.name.startsWith(`${OFFICIAL_PLUGIN_SCOPE}/`);
+}
+
 /**
  * Apply priority-based plugin loading logic.
  *
  * When multiple versions of the same plugin exist across different locations:
+ * - Plugins renamed into the official scope take priority over their old unscoped name
  * - Priority order: development > user > shipped
  * - Only the highest priority ENABLED version is loaded
- * - If a higher priority version is disabled, the next enabled version is loaded
+ * - If a higher priority version is disabled, the next enabled version is loaded, without
+ *   falling back to a name outside the official scope
  * - Lower priority versions are marked with isLoaded=false and overriddenBy info
  *
  * @param plugins List of all plugins from all locations
  * @returns Plugins with isLoaded and overriddenBy fields set appropriately
  */
 export function applyPluginPriority(plugins: PluginInfo[]): PluginInfo[] {
-  // Group plugins by name
+  // Group plugins by name, ignoring the official scope
   const pluginsByName = new Map<string, PluginInfo[]>();
 
   plugins.forEach(plugin => {
-    const existing = pluginsByName.get(plugin.name) || [];
+    const name = getPluginBaseName(plugin.name);
+    const existing = pluginsByName.get(name) || [];
     existing.push(plugin);
-    pluginsByName.set(plugin.name, existing);
+    pluginsByName.set(name, existing);
   });
 
   const result: PluginInfo[] = [];
@@ -250,10 +277,15 @@ export function applyPluginPriority(plugins: PluginInfo[]): PluginInfo[] {
       return aPriority - bPriority;
     });
 
+    // A name we do not control must not run while the scoped package is installed, even if that
+    // package is disabled
+    const officialVersions = sortedVersions.filter(isOfficiallyScoped);
+    const candidates = officialVersions.length > 0 ? officialVersions : sortedVersions;
+
     // Find the highest priority enabled version
     let loadedVersion: PluginInfo | null = null;
 
-    for (const version of sortedVersions) {
+    for (const version of candidates) {
       if (version.isEnabled !== false) {
         loadedVersion = version;
         break;
@@ -269,11 +301,13 @@ export function applyPluginPriority(plugins: PluginInfo[]): PluginInfo[] {
           isLoaded: true,
         });
       } else {
-        // This version is overridden by a higher priority version
+        // This version is overridden by a higher priority version, or by a disabled scoped one
         result.push({
           ...version,
           isLoaded: false,
-          overriddenBy: loadedVersion?.type,
+          overriddenBy:
+            loadedVersion?.type ??
+            (isOfficiallyScoped(version) ? undefined : officialVersions[0]?.type),
         });
       }
     });

--- a/frontend/src/plugin/updateSettingsPackages.test.ts
+++ b/frontend/src/plugin/updateSettingsPackages.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { updateSettingsPackages } from './index';
+import { applyPluginPriority, updateSettingsPackages } from './index';
 import { PluginInfo } from './pluginsSlice';
 
 describe('updateSettingsPackages tests', () => {
@@ -181,5 +181,134 @@ describe('updateSettingsPackages tests', () => {
     const updatedSettingsPlugins = updateSettingsPackages(backendPlugins, settingsPlugins);
 
     expect(updatedSettingsPlugins[0].isEnabled).toBe(false);
+  });
+});
+
+function makePlugin(name: string, type: PluginInfo['type'], isEnabled = true): PluginInfo {
+  return {
+    name,
+    description: `description for ${name}`,
+    homepage: `https://example.com/${name}`,
+    version: '1.0.0',
+    type,
+    isEnabled,
+  };
+}
+
+function findPlugin(plugins: PluginInfo[], name: string, type: PluginInfo['type']) {
+  return plugins.find(plugin => plugin.name === name && plugin.type === type);
+}
+
+describe('applyPluginPriority tests', () => {
+  test('a single plugin is loaded when enabled', () => {
+    const result = applyPluginPriority([makePlugin('app-catalog', 'user')]);
+    expect(result[0].isLoaded).toBe(true);
+  });
+
+  test('a single plugin is not loaded when disabled', () => {
+    const result = applyPluginPriority([makePlugin('app-catalog', 'user', false)]);
+    expect(result[0].isLoaded).toBe(false);
+  });
+
+  test('development takes priority over user and shipped', () => {
+    const result = applyPluginPriority([
+      makePlugin('@headlamp-k8s/app-catalog', 'shipped'),
+      makePlugin('@headlamp-k8s/app-catalog', 'development'),
+      makePlugin('@headlamp-k8s/app-catalog', 'user'),
+    ]);
+
+    expect(findPlugin(result, '@headlamp-k8s/app-catalog', 'development')?.isLoaded).toBe(true);
+    expect(findPlugin(result, '@headlamp-k8s/app-catalog', 'user')?.isLoaded).toBe(false);
+    expect(findPlugin(result, '@headlamp-k8s/app-catalog', 'shipped')?.isLoaded).toBe(false);
+  });
+
+  test('the next enabled version is loaded when the highest priority one is disabled', () => {
+    const result = applyPluginPriority([
+      makePlugin('@headlamp-k8s/app-catalog', 'development', false),
+      makePlugin('@headlamp-k8s/app-catalog', 'user'),
+    ]);
+
+    expect(findPlugin(result, '@headlamp-k8s/app-catalog', 'user')?.isLoaded).toBe(true);
+    expect(findPlugin(result, '@headlamp-k8s/app-catalog', 'development')?.isLoaded).toBe(false);
+  });
+
+  test('the scoped plugin is loaded instead of the old unscoped one', () => {
+    const result = applyPluginPriority([
+      makePlugin('app-catalog', 'user'),
+      makePlugin('@headlamp-k8s/app-catalog', 'shipped'),
+    ]);
+
+    expect(findPlugin(result, '@headlamp-k8s/app-catalog', 'shipped')?.isLoaded).toBe(true);
+
+    const unscoped = findPlugin(result, 'app-catalog', 'user');
+    expect(unscoped?.isLoaded).toBe(false);
+    expect(unscoped?.overriddenBy).toBe('shipped');
+  });
+
+  test('the scoped plugin is loaded when both are in the same location', () => {
+    const result = applyPluginPriority([
+      makePlugin('app-catalog', 'user'),
+      makePlugin('@headlamp-k8s/app-catalog', 'user'),
+    ]);
+
+    expect(findPlugin(result, '@headlamp-k8s/app-catalog', 'user')?.isLoaded).toBe(true);
+    expect(findPlugin(result, 'app-catalog', 'user')?.isLoaded).toBe(false);
+  });
+
+  test('the old unscoped plugin is not loaded when the scoped one is disabled', () => {
+    const result = applyPluginPriority([
+      makePlugin('app-catalog', 'user'),
+      makePlugin('@headlamp-k8s/app-catalog', 'shipped', false),
+    ]);
+
+    expect(findPlugin(result, '@headlamp-k8s/app-catalog', 'shipped')?.isLoaded).toBe(false);
+
+    const unscoped = findPlugin(result, 'app-catalog', 'user');
+    expect(unscoped?.isLoaded).toBe(false);
+    expect(unscoped?.overriddenBy).toBe('shipped');
+  });
+
+  test('a disabled scoped plugin falls back to another scoped one, not to the old name', () => {
+    const result = applyPluginPriority([
+      makePlugin('app-catalog', 'user'),
+      makePlugin('@headlamp-k8s/app-catalog', 'development', false),
+      makePlugin('@headlamp-k8s/app-catalog', 'shipped'),
+    ]);
+
+    expect(findPlugin(result, '@headlamp-k8s/app-catalog', 'shipped')?.isLoaded).toBe(true);
+    expect(findPlugin(result, '@headlamp-k8s/app-catalog', 'development')?.isLoaded).toBe(false);
+    expect(findPlugin(result, 'app-catalog', 'user')?.isLoaded).toBe(false);
+  });
+
+  test('an unscoped plugin is still loaded when there is no scoped one', () => {
+    const result = applyPluginPriority([makePlugin('app-catalog', 'user')]);
+
+    expect(result[0].isLoaded).toBe(true);
+    expect(result[0].overriddenBy).toBeUndefined();
+  });
+
+  test('the old plugin loads again once the scoped one is removed', () => {
+    // What the settings page persists while both are installed: both stay enabled, only the
+    // scoped one is loaded.
+    const saved = applyPluginPriority([
+      makePlugin('app-catalog', 'user'),
+      makePlugin('@headlamp-k8s/app-catalog', 'shipped'),
+    ]);
+
+    // The scoped plugin is then removed from disk, so the backend only reports the old one.
+    const updated = updateSettingsPackages([makePlugin('app-catalog', 'user')], saved);
+
+    expect(updated[0].isEnabled).toBe(true);
+    expect(applyPluginPriority(updated)[0].isLoaded).toBe(true);
+  });
+
+  test('plugins in other scopes are not treated as the same plugin', () => {
+    const result = applyPluginPriority([
+      makePlugin('app-catalog', 'user'),
+      makePlugin('@someone-else/app-catalog', 'user'),
+    ]);
+
+    expect(result.length).toBe(2);
+    expect(result.every(plugin => plugin.isLoaded)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
Plugins `prometheus`, `kmesh`, and `app-catalog` are renamed with the `@headlamp-k8s` scope added
see: https://github.com/headlamp-k8s/plugins/pull/1003

So now `applyPluginPriority` treats for example `app-catalog` and `@headlamp-k8s/app-catalog` as different, and ends up showing 2 entries of the same app-catalog plugin.

## Related Issue
Fixes #2597  

## Changes
- `applyPluginPriority`: group plugins by name with the `@headlamp-k8s` scope stripped, so both copies land in the same group
- While a scoped copy is installed, only scoped copies can load, the old unscoped name is never a candidate
- Other scopes are left alone `@someone-else/app-catalog` stays a separate plugin
- Added tests for `applyPluginPriority` in `updateSettingsPackages.test.ts` the function had no coverage

## Steps to Test
1. Put the renamed `@headlamp-k8s/app-catalog` and a pre-rename `app-catalog` in the plugin dirs
2. Settings → Plugins → only one entry of new plugins with changed origin from `unknown` to `@headlamp-k8s`
3. Settings → Plugins → the old row is chipped "Not Loaded"
4. Remove the scoped one → the old one loads normally

## Screenshots
<img width="1920" height="1073" alt="image" src="https://github.com/user-attachments/assets/195400c9-c58f-435b-a19c-c027603283ed" />

## Notes for the Reviewer
- Eligibility is separate from priority: the existing `development > user > shipped` order is unchanged, it just applies among the scoped copies. A disabled scoped development build still falls back to the scoped shipped one
- **Disabling the scoped plugin does not hand over to the old name.** An unscoped name isn't one we control, so switching off the trusted package must not be what activates the look-alike. The old name loads again only once the scoped package is removed (per the Copilot review). Desktop only in practice, browser mode ignores `isEnabled`
- Side effect: a pre-rename local **development** build no longer overrides the shipped plugin. Rebuilding from the renamed source restores it. **Happy to flip this if you'd prefer development always wins**
- **Not handled here:** a plugin disabled under its old name comes back enabled after this update. Settings are keyed by `name + type`, so the renamed plugin misses its old entry and defaults to enabled as a new plugin. We can't just rewrite the stored key to the new name an unscoped `app-catalog` isn't necessarily ours
