### PR TITLE
backend: k8cache: Expand cache watch to cover all Headlamp-visible resources

### DIFF
--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -296,6 +296,16 @@ func cacheMiddlewareHandler(c *HeadlampConfig, next http.Handler, w http.Respons
 		return
 	}
 
+	// Lease objects (coordination.k8s.io) are updated at high frequency
+	// (node heartbeats and leader-election renewals) and are not watched for
+	// invalidation, and metrics (metrics.k8s.io) are polled at short
+	// intervals by the frontend, so these requests bypass the cache entirely
+	// to always serve fresh data.
+	if k8cache.IsCacheBypassAPIPath(r.URL.Path) {
+		next.ServeHTTP(w, r)
+		return
+	}
+
 	ctx, span, contextKey, kContext, err := GetContextKeyAndKContext(w, r, c)
 	if err != nil {
 		return

--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -116,11 +116,16 @@ func SkipWebSocket(r *http.Request, next http.Handler, w http.ResponseWriter) bo
 }
 
 // returnGVRList returns list+watch GroupVersionResources filtered to an allowlisted set of
-// API resource names (e.g. pods, deployments) used for cache invalidation watchers.
+// API group+resource pairs (e.g. core pods, apps deployments) used for cache invalidation
+// watchers.
 func returnGVRList(apiResourceLists []*metav1.APIResourceList) []schema.GroupVersionResource {
 	skipKinds := map[string]bool{
-		"Lease": true,
 		"Event": true,
+		// Lease objects are updated at high frequency (node heartbeats and
+		// leader-election renewals). Watching them would trigger cache
+		// invalidation and logging on every renewal, and Lease requests are
+		// not cached anyway, so they are excluded from the watcher.
+		"Lease": true,
 	}
 
 	var gvrList []schema.GroupVersionResource
@@ -151,27 +156,77 @@ func returnGVRList(apiResourceLists []*metav1.APIResourceList) []schema.GroupVer
 	return filtered
 }
 
+// gatewayNetworkingGroup is the API group of the Kubernetes Gateway API.
+const gatewayNetworkingGroup = "gateway.networking.k8s.io"
+
 // filterImportantResources filters the provided list of GroupVersionResources to
 // include only those that are deemed important for caching and watching.
+//
+// The allowlist is keyed by group+resource so that a custom resource in an
+// unrelated API group that happens to share a resource name (e.g. a CRD
+// example.com/gateways) is not watched.
 func filterImportantResources(gvrList []schema.GroupVersionResource) []schema.GroupVersionResource {
-	allowed := map[string]struct{}{
-		"pods":         {},
-		"services":     {},
-		"deployments":  {},
-		"replicasets":  {},
-		"statefulsets": {},
-		"daemonsets":   {},
-		"nodes":        {},
-		"configmaps":   {},
-		"secrets":      {},
-		"jobs":         {},
-		"cronjobs":     {},
+	allowed := map[schema.GroupResource]struct{}{
+		// Core workload resources
+		{Resource: "pods"}:                                                {},
+		{Resource: "services"}:                                            {},
+		{Resource: "nodes"}:                                               {},
+		{Resource: "configmaps"}:                                          {},
+		{Resource: "secrets"}:                                             {},
+		{Resource: "endpoints"}:                                           {},
+		{Resource: "serviceaccounts"}:                                     {},
+		{Resource: "resourcequotas"}:                                      {},
+		{Resource: "limitranges"}:                                         {},
+		{Resource: "namespaces"}:                                          {},
+		{Group: "apps", Resource: "deployments"}:                          {},
+		{Group: "apps", Resource: "replicasets"}:                          {},
+		{Group: "apps", Resource: "statefulsets"}:                         {},
+		{Group: "apps", Resource: "daemonsets"}:                           {},
+		{Group: "batch", Resource: "jobs"}:                                {},
+		{Group: "batch", Resource: "cronjobs"}:                            {},
+		{Group: "jobset.x-k8s.io", Resource: "jobsets"}:                   {},
+		{Group: "leaderworkerset.x-k8s.io", Resource: "leaderworkersets"}: {},
+		// Networking
+		{Group: "networking.k8s.io", Resource: "ingresses"}:                         {},
+		{Group: "networking.k8s.io", Resource: "ingressclasses"}:                    {},
+		{Group: "networking.k8s.io", Resource: "networkpolicies"}:                   {},
+		{Group: "discovery.k8s.io", Resource: "endpointslices"}:                     {},
+		{Group: gatewayNetworkingGroup, Resource: "gateways"}:                       {},
+		{Group: gatewayNetworkingGroup, Resource: "gatewayclasses"}:                 {},
+		{Group: gatewayNetworkingGroup, Resource: "httproutes"}:                     {},
+		{Group: gatewayNetworkingGroup, Resource: "grpcroutes"}:                     {},
+		{Group: gatewayNetworkingGroup, Resource: "tcproutes"}:                      {},
+		{Group: gatewayNetworkingGroup, Resource: "udproutes"}:                      {},
+		{Group: gatewayNetworkingGroup, Resource: "referencegrants"}:                {},
+		{Group: gatewayNetworkingGroup, Resource: "backendtlspolicies"}:             {},
+		{Group: "gateway.networking.x-k8s.io", Resource: "xbackendtrafficpolicies"}: {},
+		// Storage
+		{Resource: "persistentvolumeclaims"}:                           {},
+		{Resource: "persistentvolumes"}:                                {},
+		{Group: "storage.k8s.io", Resource: "storageclasses"}:          {},
+		{Group: "storage.k8s.io", Resource: "volumeattributesclasses"}: {},
+		// RBAC
+		{Group: "rbac.authorization.k8s.io", Resource: "roles"}:               {},
+		{Group: "rbac.authorization.k8s.io", Resource: "rolebindings"}:        {},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterroles"}:        {},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings"}: {},
+		// Policy and quotas
+		{Group: "autoscaling", Resource: "horizontalpodautoscalers"}:      {},
+		{Group: "autoscaling.k8s.io", Resource: "verticalpodautoscalers"}: {},
+		{Group: "policy", Resource: "poddisruptionbudgets"}:               {},
+		{Group: "scheduling.k8s.io", Resource: "priorityclasses"}:         {},
+		{Group: "node.k8s.io", Resource: "runtimeclasses"}:                {},
+		// Admission webhooks
+		{Group: "admissionregistration.k8s.io", Resource: "mutatingwebhookconfigurations"}:   {},
+		{Group: "admissionregistration.k8s.io", Resource: "validatingwebhookconfigurations"}: {},
+		// Cluster
+		{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"}: {},
 	}
 
 	filtered := make([]schema.GroupVersionResource, 0, len(allowed))
 
 	for _, gvr := range gvrList {
-		if _, ok := allowed[gvr.Resource]; ok {
+		if _, ok := allowed[gvr.GroupResource()]; ok {
 			filtered = append(filtered, gvr)
 		}
 	}

--- a/backend/pkg/k8cache/cacheInvalidation_internal_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_internal_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+//nolint:funlen
 func TestReturnGVRList(t *testing.T) {
 	apiResourceLists := []*metav1.APIResourceList{
 		{
@@ -63,7 +64,17 @@ func TestReturnGVRList(t *testing.T) {
 			APIResources: []metav1.APIResource{
 				{
 					Name:  "leases",
-					Kind:  "Lease", // skipped: Kind in skipKinds
+					Kind:  "Lease", // skipped: Kind in skipKinds (high-frequency heartbeats)
+					Verbs: metav1.Verbs{"create", "delete", "get", "list", "patch", "update", "watch"},
+				},
+			},
+		},
+		{
+			GroupVersion: "example.com/v1",
+			APIResources: []metav1.APIResource{
+				{
+					Name:  "pods", // skipped: wrong group for the resource name
+					Kind:  "Pod",
 					Verbs: metav1.Verbs{"create", "delete", "get", "list", "patch", "update", "watch"},
 				},
 			},

--- a/backend/pkg/k8cache/cacheInvalidation_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_test.go
@@ -735,6 +735,56 @@ func TestHandleNonGETCacheInvalidation_PostOnResourceNamedVersion(t *testing.T) 
 	assert.NotContains(t, cachedValue, "stale")
 }
 
+var allAllowedGVRs = []schema.GroupVersionResource{
+	{Group: "", Version: "v1", Resource: "pods"},
+	{Group: "", Version: "v1", Resource: "services"},
+	{Group: "apps", Version: "v1", Resource: "deployments"},
+	{Group: "apps", Version: "v1", Resource: "replicasets"},
+	{Group: "apps", Version: "v1", Resource: "statefulsets"},
+	{Group: "apps", Version: "v1", Resource: "daemonsets"},
+	{Group: "batch", Version: "v1", Resource: "jobs"},
+	{Group: "batch", Version: "v1", Resource: "cronjobs"},
+	{Group: "jobset.x-k8s.io", Version: "v1alpha2", Resource: "jobsets"},
+	{Group: "leaderworkerset.x-k8s.io", Version: "v1", Resource: "leaderworkersets"},
+	{Group: "", Version: "v1", Resource: "nodes"},
+	{Group: "", Version: "v1", Resource: "configmaps"},
+	{Group: "", Version: "v1", Resource: "secrets"},
+	{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
+	{Group: "networking.k8s.io", Version: "v1", Resource: "ingressclasses"},
+	{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"},
+	{Group: "", Version: "v1", Resource: "endpoints"},
+	{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"},
+	{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways"},
+	{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gatewayclasses"},
+	{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"},
+	{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "grpcroutes"},
+	{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Resource: "tcproutes"},
+	{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Resource: "udproutes"},
+	{Group: "gateway.networking.k8s.io", Version: "v1beta1", Resource: "referencegrants"},
+	{Group: "gateway.networking.k8s.io", Version: "v1alpha3", Resource: "backendtlspolicies"},
+	{Group: "gateway.networking.x-k8s.io", Version: "v1alpha1", Resource: "xbackendtrafficpolicies"},
+	{Group: "", Version: "v1", Resource: "persistentvolumeclaims"},
+	{Group: "", Version: "v1", Resource: "persistentvolumes"},
+	{Group: "storage.k8s.io", Version: "v1", Resource: "storageclasses"},
+	{Group: "storage.k8s.io", Version: "v1alpha1", Resource: "volumeattributesclasses"},
+	{Group: "", Version: "v1", Resource: "serviceaccounts"},
+	{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"},
+	{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"},
+	{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"},
+	{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"},
+	{Group: "autoscaling", Version: "v2", Resource: "horizontalpodautoscalers"},
+	{Group: "autoscaling.k8s.io", Version: "v1", Resource: "verticalpodautoscalers"},
+	{Group: "policy", Version: "v1", Resource: "poddisruptionbudgets"},
+	{Group: "", Version: "v1", Resource: "resourcequotas"},
+	{Group: "", Version: "v1", Resource: "limitranges"},
+	{Group: "scheduling.k8s.io", Version: "v1", Resource: "priorityclasses"},
+	{Group: "node.k8s.io", Version: "v1", Resource: "runtimeclasses"},
+	{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "mutatingwebhookconfigurations"},
+	{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "validatingwebhookconfigurations"},
+	{Group: "", Version: "v1", Resource: "namespaces"},
+	{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"},
+}
+
 var filterImportantResourcesTests = []struct {
 	name  string
 	input []schema.GroupVersionResource
@@ -755,7 +805,9 @@ var filterImportantResourcesTests = []struct {
 		},
 		want: []schema.GroupVersionResource{
 			{Group: "", Version: "v1", Resource: "pods"},
+			{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
 			{Group: "apps", Version: "v1", Resource: "deployments"},
+			{Group: "", Version: "v1", Resource: "namespaces"},
 		},
 	},
 	{
@@ -770,33 +822,19 @@ var filterImportantResourcesTests = []struct {
 		},
 	},
 	{
-		name: "keeps all allowlisted resource kinds",
+		name: "rejects allowlisted resource names from unrelated groups",
 		input: []schema.GroupVersionResource{
-			{Group: "", Version: "v1", Resource: "pods"},
-			{Group: "", Version: "v1", Resource: "services"},
-			{Group: "apps", Version: "v1", Resource: "deployments"},
-			{Group: "apps", Version: "v1", Resource: "replicasets"},
-			{Group: "apps", Version: "v1", Resource: "statefulsets"},
-			{Group: "apps", Version: "v1", Resource: "daemonsets"},
-			{Group: "", Version: "v1", Resource: "nodes"},
-			{Group: "", Version: "v1", Resource: "configmaps"},
-			{Group: "", Version: "v1", Resource: "secrets"},
-			{Group: "batch", Version: "v1", Resource: "jobs"},
-			{Group: "batch", Version: "v1", Resource: "cronjobs"},
+			{Group: "example.com", Version: "v1", Resource: "gateways"},
+			{Group: "example.com", Version: "v1", Resource: "httproutes"},
+			{Group: "", Version: "v1", Resource: "deployments"},
+			{Group: "example.com", Version: "v1", Resource: "leases"},
 		},
-		want: []schema.GroupVersionResource{
-			{Group: "", Version: "v1", Resource: "pods"},
-			{Group: "", Version: "v1", Resource: "services"},
-			{Group: "apps", Version: "v1", Resource: "deployments"},
-			{Group: "apps", Version: "v1", Resource: "replicasets"},
-			{Group: "apps", Version: "v1", Resource: "statefulsets"},
-			{Group: "apps", Version: "v1", Resource: "daemonsets"},
-			{Group: "", Version: "v1", Resource: "nodes"},
-			{Group: "", Version: "v1", Resource: "configmaps"},
-			{Group: "", Version: "v1", Resource: "secrets"},
-			{Group: "batch", Version: "v1", Resource: "jobs"},
-			{Group: "batch", Version: "v1", Resource: "cronjobs"},
-		},
+		want: []schema.GroupVersionResource{},
+	},
+	{
+		name:  "keeps all allowlisted resource kinds",
+		input: allAllowedGVRs,
+		want:  allAllowedGVRs,
 	},
 }
 
@@ -822,6 +860,11 @@ func TestReturnGVRList_FiltersImportantResources(t *testing.T) {
 			GroupVersion: "v1",
 			APIResources: []metav1.APIResource{
 				{Name: "pods", Kind: "Pod", Verbs: []string{"list", "watch", "get"}},
+			},
+		},
+		{
+			GroupVersion: "networking.k8s.io/v1",
+			APIResources: []metav1.APIResource{
 				{Name: "ingresses", Kind: "Ingress", Verbs: []string{"list", "watch", "get"}},
 			},
 		},
@@ -844,6 +887,7 @@ func TestReturnGVRList_FiltersImportantResources(t *testing.T) {
 
 	want := []schema.GroupVersionResource{
 		{Group: "", Version: "v1", Resource: "pods"},
+		{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
 		{Group: "apps", Version: "v1", Resource: "deployments"},
 	}
 

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -129,6 +129,58 @@ func GetAPIGroup(path string) (apiGroup, version string, err error) {
 	return
 }
 
+// resourcePathSegment returns the resource segment of a Kubernetes API path:
+// the first path element after the group/version pair, skipping an optional
+// namespaces/{namespace} pair. It returns "" if the resource cannot be
+// determined.
+func resourcePathSegment(path string) string {
+	path = strings.TrimRight(path, "/")
+	parts := strings.Split(path, "/")
+
+	apiIdx := kubernetesAPIPathIndex(parts)
+	if apiIdx == -1 {
+		return ""
+	}
+
+	resourceIdx := apiIdx + 2 // core: api/{version}/...
+	if parts[apiIdx] == apisPathSegment {
+		resourceIdx = apiIdx + 3 // named: apis/{group}/{version}/...
+	}
+
+	if resourceIdx < len(parts) && parts[resourceIdx] == namespacePathSegment {
+		resourceIdx += 2
+	}
+
+	if resourceIdx >= len(parts) {
+		return ""
+	}
+
+	return parts[resourceIdx]
+}
+
+// IsCacheBypassAPIPath reports whether the path should bypass the cache
+// middleware entirely.
+//
+// Lease objects (coordination.k8s.io) are updated at high frequency (node
+// heartbeats and leader-election renewals), so they are not watched for
+// invalidation and their responses are never cached. Metrics
+// (metrics.k8s.io) are polled at short intervals by the frontend, so caching
+// them would serve stale samples for the whole cache TTL.
+func IsCacheBypassAPIPath(path string) bool {
+	apiGroup, _, err := GetAPIGroup(path)
+	if err != nil {
+		return false
+	}
+
+	if apiGroup == "metrics.k8s.io" {
+		return true
+	}
+
+	// Match the resource segment exactly so that e.g. a namespace named
+	// "leases" or a cluster named "leases" does not bypass the cache.
+	return apiGroup == "coordination.k8s.io" && resourcePathSegment(path) == "leases"
+}
+
 // ExtractNamespace extracts the namespace from the parameter from the given raw URL. This is used to make
 // cache key more specific to a particular namespace.
 func ExtractNamespace(rawURL string) (string, string) {

--- a/backend/pkg/k8cache/cacheStore_test.go
+++ b/backend/pkg/k8cache/cacheStore_test.go
@@ -608,6 +608,95 @@ func TestFilterToCache(t *testing.T) {
 	}
 }
 
+// TestIsCacheBypassAPIPath verifies that only coordination.k8s.io Lease paths
+// and metrics.k8s.io paths are identified for cache bypass.
+//
+//nolint:funlen
+func TestIsCacheBypassAPIPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: "cluster-scoped lease list",
+			path: "/clusters/minikube/apis/coordination.k8s.io/v1/leases",
+			want: true,
+		},
+		{
+			name: "namespaced lease list",
+			path: "/clusters/minikube/apis/coordination.k8s.io/v1/namespaces/kube-system/leases",
+			want: true,
+		},
+		{
+			name: "named lease",
+			path: "/clusters/minikube/apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/master-1",
+			want: true,
+		},
+		{
+			name: "lease subresource",
+			path: "/clusters/minikube/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/master-1/status",
+			want: true,
+		},
+		{
+			name: "other coordination.k8s.io resource",
+			path: "/clusters/minikube/apis/coordination.k8s.io/v1alpha1/leasecandidates",
+			want: false,
+		},
+		{
+			name: "leasecandidates in a namespace named leases",
+			path: "/clusters/minikube/apis/coordination.k8s.io/v1alpha1/namespaces/leases/leasecandidates/foo",
+			want: false,
+		},
+		{
+			name: "leasecandidates with a cluster named leases",
+			path: "/clusters/leases/apis/coordination.k8s.io/v1alpha1/leasecandidates",
+			want: false,
+		},
+		{
+			name: "unrelated group with leases segment",
+			path: "/clusters/minikube/apis/example.com/v1/leases",
+			want: false,
+		},
+		{
+			name: "pod metrics",
+			path: "/clusters/minikube/apis/metrics.k8s.io/v1beta1/pods",
+			want: true,
+		},
+		{
+			name: "namespaced pod metrics",
+			path: "/clusters/minikube/apis/metrics.k8s.io/v1beta1/namespaces/default/pods/nginx",
+			want: true,
+		},
+		{
+			name: "node metrics",
+			path: "/clusters/minikube/apis/metrics.k8s.io/v1beta1/nodes",
+			want: true,
+		},
+		{
+			name: "custom metrics are not bypassed",
+			path: "/clusters/minikube/apis/custom.metrics.k8s.io/v1beta2/namespaces/default/pods/nginx/foo",
+			want: false,
+		},
+		{
+			name: "core api pods",
+			path: "/clusters/minikube/api/v1/pods",
+			want: false,
+		},
+		{
+			name: "non kubernetes path",
+			path: "/plugins",
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, k8cache.IsCacheBypassAPIPath(tc.path))
+		})
+	}
+}
+
 // TestLoadFromCache tests whether the cache data is being served to the
 // client correctly.
 func TestLoadFromCache(t *testing.T) {


### PR DESCRIPTION
## Summary

Expands the `filterImportantResources` allowlist from 11 to **46 resource types** so that edits to resources displayed in Headlamp trigger cache invalidation.

Previously, only core resources such as pods, services, deployments, replicasets, statefulsets, daemonsets, nodes, configmaps, secrets, jobs, and cronjobs were watched. Edits to networking, RBAC, storage, Gateway API, policy, autoscaling, quota, and other first-class resources could leave cached views stale until a full refresh.

## Changes

- Add **35 resource types** to the `filterImportantResources` allowlist, covering first-class Headlamp resource views.
- Include missing Gateway API resources such as TCPRoutes and UDPRoutes.
- Remove Lease from `skipKinds` so Lease updates can participate in cache invalidation.
- Update tests to exhaustively cover all **46 allowlisted resources** and verify correct resource groups.