### PR TITLE
app: Kill the headlamp-server process tree on Windows quit

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -917,10 +917,27 @@ function quitServerProcess() {
     return;
   }
 
+  const pid = serverProcess.pid;
+
   serverProcess.stdin.destroy();
-  // @todo: should we try and end the process a bit more gracefully?
-  //       What happens if the kill signal doesn't kill it?
-  serverProcess.kill();
+
+  if (process.platform === 'win32') {
+    // On Windows, SIGTERM can leave the backend (and its children) running,
+    // so force-kill the whole process tree with taskkill instead.
+    if (pid !== undefined) {
+      try {
+        killProcess(pid);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`Failed to kill server process with PID ${pid}: ${message}`);
+        serverProcess.kill();
+      }
+    } else {
+      serverProcess.kill();
+    }
+  } else {
+    serverProcess.kill();
+  }
 
   serverProcess = null;
 }


### PR DESCRIPTION
## Summary

This PR fixes the Windows desktop app leaving a zombie `headlamp-server` process running after the app is closed. `quitServerProcess()` used `serverProcess.kill()` (SIGTERM), which is unreliable on Windows and can leave the backend (and any children) running, so a later relaunch connects to a stale process and clusters show as inactive with 502 errors. On Windows the existing `killProcess()` helper is now used instead, which force-kills the whole process tree with `taskkill /pid <pid> /T /F`.

## Related Issue

Fixes #6156

## Changes

- Updated `quitServerProcess()` in `app/electron/main.ts` to force-kill the backend process tree on Windows using the existing `killProcess()` helper
- Kept the original `serverProcess.kill()` behavior on all other platforms
- Falls back to `serverProcess.kill()` when no PID is available or `taskkill` fails

## Steps to Test

1. On Windows, build and run the desktop app (`npm run app:start`).
2. Connect to a cluster.
3. Quit the app.
4. Open Task Manager and confirm `headlamp-server.exe` is no longer running.
5. Relaunch the app and confirm the cluster reconnects instead of showing 502 Bad Gateway.

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- The `killProcess()` helper already existed and is used by the port-conflict recovery paths; this PR reuses it for the normal quit path.
- I verified locally that `taskkill /pid <pid> /T /F` terminates a spawned process and its children on Windows.
- Local validation on Windows: `npm run app:tsc` passes, eslint passes, and `npm run app:test:unit` passes (144 tests). Prettier's format-check only flags the 14 pre-existing CRLF files tracked in #7038; the changed file is clean.
- Related: #6367 (for issue #6366) also touches `quitServerProcess()` with a graceful-shutdown approach. This PR is the direct fix for #6156 and focuses on the Windows process-tree kill.
