### PR TITLE
backend: k8cache: Strip request-body headers from GET refetch request

### DIFF
--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -86,6 +86,10 @@ func HandleNonGETCacheInvalidation(k8scache cache.Cache[string], w http.Response
 	}
 
 	freshReq.Header = r.Header.Clone()
+	freshReq.Header.Del("Content-Length")
+	freshReq.Header.Del("Content-Type")
+	freshReq.Header.Del("Transfer-Encoding")
+	freshReq.Header.Del("Content-Encoding")
 	next.ServeHTTP(w, r)
 
 	rr := httptest.NewRecorder()

--- a/backend/pkg/k8cache/cacheInvalidation_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_test.go
@@ -882,3 +882,48 @@ func TestSyncWatchers(t *testing.T) {
 	assert.True(t, canceled["ctx2"], "ctx2 should be canceled")
 	assert.False(t, canceled["ctx3"], "ctx3 should not be canceled")
 }
+
+func TestHandleNonGETCacheInvalidation_StripsBodyHeaders(t *testing.T) {
+	mockCache := NewMockCache()
+
+	req := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		"/api/v1/namespaces/default/pods",
+		nil,
+	)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Length", "1024")
+	req.Header.Set("Transfer-Encoding", "chunked")
+	req.Header.Set("Content-Encoding", "gzip")
+	req.Header.Set("Authorization", "Bearer test-token")
+
+	var refetchHeaders http.Header
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			refetchHeaders = r.Header.Clone()
+
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"kind":"PodList"}`))
+		} else {
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"kind":"Pod"}`))
+		}
+	})
+
+	rec := httptest.NewRecorder()
+	err := k8cache.HandleNonGETCacheInvalidation(mockCache, rec, req, next, "test-context")
+	assert.ErrorIs(t, err, k8cache.ErrHandled)
+
+	assert.Empty(t, refetchHeaders.Get("Content-Length"),
+		"Content-Length should be stripped from GET refetch request")
+	assert.Empty(t, refetchHeaders.Get("Content-Type"),
+		"Content-Type should be stripped from GET refetch request")
+	assert.Empty(t, refetchHeaders.Get("Transfer-Encoding"),
+		"Transfer-Encoding should be stripped from GET refetch request")
+	assert.Empty(t, refetchHeaders.Get("Content-Encoding"),
+		"Content-Encoding should be stripped from GET refetch request")
+	assert.Equal(t, "Bearer test-token", refetchHeaders.Get("Authorization"),
+		"Authorization header should be preserved")
+}


### PR DESCRIPTION
## Summary

When backend caching is enabled (`--cache-enabled=true`), non-GET mutating requests (`POST`, `PUT`, `PATCH`, `DELETE`) are handled by `HandleNonGETCacheInvalidation`. To keep the cache consistent, the backend clones the original request's headers and makes a background `GET` request (`freshReq`) to refetch the updated resource state.

However, `freshReq.Header = r.Header.Clone()` copies **all** headers from the original request — including body-specific headers such as `Content-Length`, `Content-Type`, and `Transfer-Encoding`. Because `freshReq` is a `GET` request created with a `nil` (0-byte) body, sending a `GET` request with a non-zero `Content-Length` header causes upstream proxies or the Kubernetes API server to reject the request with `400 Bad Request` or throw stream errors in Go's HTTP transport.

## Related Issue

Fixes #7085

## Changes

- Stripped `Content-Length`, `Content-Type`, and `Transfer-Encoding` from `freshReq.Header` in `HandleNonGETCacheInvalidation`.
- Added unit test `TestHandleNonGETCacheInvalidation_StripsBodyHeaders` in `backend/pkg/k8cache/cacheInvalidation_test.go` to verify that body headers are stripped while authentication/other headers are preserved.

## Steps to Test

1. Run the `k8cache` package unit tests:
   ```bash
   cd backend && go test ./pkg/k8cache/... -v
   ```
2. Verify all tests pass including the new `TestHandleNonGETCacheInvalidation_StripsBodyHeaders` test.
