### PR TITLE
frontend: useSidebarItems: Fix react-hooks/exhaustive-deps

### DIFF
--- a/frontend/src/components/Sidebar/useSidebarItems.test.tsx
+++ b/frontend/src/components/Sidebar/useSidebarItems.test.tsx
@@ -14,16 +14,39 @@
  * limitations under the License.
  */
 
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { configureStore } from '@reduxjs/toolkit';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
+import { vi } from 'vitest';
 import App from '../../App';
 import reducers from '../../redux/reducers/reducers';
 import { TestContext } from '../../test';
 import { DefaultSidebars, SidebarEntry } from './sidebarSlice';
 import { useSidebarItems } from './useSidebarItems';
+
+// Force a deterministic appearance so the accent-color fallback to
+// theme.palette.getContrastText(...) is always exercised, regardless of
+// any stored per-cluster appearance overrides.
+vi.mock('../../helpers/clusterAppearance', () => ({
+  getClusterAppearanceFromMeta: () => ({ accentColor: undefined, icon: undefined }),
+}));
+
+// Guarantee at least one selected cluster so the cluster badge subtitle
+// (and therefore the theme-dependent accent color) is actually rendered.
+const { MOCK_SELECTED_CLUSTERS } = vi.hoisted(() => ({
+  MOCK_SELECTED_CLUSTERS: ['test-cluster'],
+}));
+
+vi.mock('../../lib/k8s', async () => {
+  const actual = await vi.importActual('../../lib/k8s');
+  return {
+    ...actual,
+    useSelectedClusters: () => MOCK_SELECTED_CLUSTERS,
+  };
+});
 
 // Fix for a circular dependency issue
 // App import will load the whole app dependency tree
@@ -251,5 +274,59 @@ describe('useSidebarItems', () => {
 
     // Check that home is still present
     expect(result.current.find(it => it.name === 'home')).toBeDefined();
+  });
+
+  it('should recompute cluster badge accent color when the theme changes', () => {
+    // Regression test for a missing `theme` dependency on the `sidebars`
+    // useMemo: theme.palette.getContrastText(...) is used to color cluster
+    // badges, but the memo previously didn't list `theme` as a dependency,
+    // so badges kept a stale accent color after a light/dark theme switch.
+    let setTheme: (theme: ReturnType<typeof createTheme>) => void = () => {};
+
+    const lightTheme = createTheme({ palette: { mode: 'light' } });
+    const darkTheme = createTheme({ palette: { mode: 'dark' } });
+
+    const ThemeSwitcher = ({ children }: { children: React.ReactNode }) => {
+      const [theme, setThemeState] = React.useState(lightTheme);
+      React.useEffect(() => {
+        setTheme = setThemeState;
+      }, []);
+      return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+    };
+
+    const store = mockStore({}, []);
+
+    const themeWrapper = ({ children }: any) => (
+      <TestContext>
+        <Provider store={store}>
+          <QueryClientProvider client={queryClient}>
+            <ThemeSwitcher>{children}</ThemeSwitcher>
+          </QueryClientProvider>
+        </Provider>
+      </TestContext>
+    );
+
+    const { result, rerender } = renderHook(() => useSidebarItems(), {
+      wrapper: themeWrapper,
+    });
+
+    const getAccentColor = () => {
+      const clusterItem = result.current.find(it => it.name === 'cluster');
+      const badge = (clusterItem?.subtitle as any)?.props?.children?.[0];
+      return badge?.props?.accentColor;
+    };
+
+    const lightAccent = getAccentColor();
+    expect(lightAccent).toBeDefined();
+
+    act(() => {
+      setTheme(darkTheme);
+    });
+    rerender();
+
+    const darkAccent = getAccentColor();
+
+    expect(darkAccent).toBeDefined();
+    expect(darkAccent).not.toEqual(lightAccent);
   });
 });

--- a/frontend/src/components/Sidebar/useSidebarItems.tsx
+++ b/frontend/src/components/Sidebar/useSidebarItems.tsx
@@ -20,7 +20,7 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getClusterAppearanceFromMeta } from '../../helpers/clusterAppearance';
 import { isElectron } from '../../helpers/isElectron';
-import { useClustersConf, useSelectedClusters } from '../../lib/k8s';
+import { useSelectedClusters } from '../../lib/k8s';
 import CRD from '../../lib/k8s/crd';
 import { createRouteURL } from '../../lib/router/createRouteURL';
 import { useTypedSelector } from '../../redux/hooks';
@@ -36,6 +36,12 @@ const forEachEntry = (items: SidebarItemProps[], cb: (item: SidebarItemProps) =>
     }
   });
 };
+
+// Stable reference so the `?? EMPTY_CLUSTERS` fallback below doesn't create
+// a new object identity on every render when there's no cluster config yet
+// — an unstable fallback here would defeat the `sidebars` memo's dependency
+// on `clusters`.
+const EMPTY_CLUSTERS: Record<string, unknown> = {};
 
 const sortSidebarItems = (items: SidebarItemProps[]): SidebarItemProps[] => {
   const homeItems = items.filter(({ name }) => name === 'home');
@@ -53,14 +59,13 @@ const sortSidebarItems = (items: SidebarItemProps[]): SidebarItemProps[] => {
 };
 
 export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER) => {
-  const clusters = useTypedSelector(state => state.config.clusters) ?? {};
+  const clusters = useTypedSelector(state => state.config.clusters) ?? EMPTY_CLUSTERS;
   const settings = useTypedSelector(state => state.config.settings);
   const customSidebarEntries = useTypedSelector(state => state.sidebar.entries);
   const customSidebarFilters = useTypedSelector(state => state.sidebar.filters);
   const customHomeSidebarFilters = useTypedSelector(state => state.sidebar.homeFilters);
   const shouldShowHomeItem = isElectron() || Object.keys(clusters).length !== 1;
   const selectedClusters = useSelectedClusters();
-  const allClustersConf = useClustersConf();
   const { t } = useTranslation();
   const theme = useTheme();
 
@@ -543,30 +548,25 @@ export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER
     }
 
     return sidebars;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     customSidebarEntries,
     shouldShowHomeItem,
     customSidebarFilters,
     customHomeSidebarFilters,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    Object.keys(clusters).join(','),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    selectedClusters.join(','),
-    allClustersConf,
+    clusters,
+    selectedClusters,
     crdsSidebarEntries,
     t,
+    theme,
   ]);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const unsortedItems =
-    sidebars[sidebarName === '' ? DefaultSidebars.IN_CLUSTER : sidebarName] ?? [];
-
   const sortedItems = useMemo(() => {
+    const unsortedItems =
+      sidebars[sidebarName === '' ? DefaultSidebars.IN_CLUSTER : sidebarName] ?? [];
     // Make a copy so that we always start from the original (unsorted) order.
     const itemsCopy = [...unsortedItems];
     return settings?.sidebarSortAlphabetically ? sortSidebarItems(itemsCopy) : itemsCopy;
-  }, [unsortedItems, settings.sidebarSortAlphabetically]);
+  }, [sidebars, sidebarName, settings.sidebarSortAlphabetically]);
 
   return sortedItems;
 };


### PR DESCRIPTION
## Summary

This PR fixes suppressed react-hooks/exhaustive-deps lint violations in useSidebarItems.tsx by adding the missing theme dependency and cleaning up unnecessary/incorrect suppressions, so the sidebar's cluster badge accent color correctly updates when the theme changes.

## Related Issue

Part of #5183

## Changes

- Added the missing theme dependency to the sidebars useMemo — theme.palette.getContrastText(...) is used to compute cluster badge accent colors, but theme wasn't listed, so badges kept a stale color after switching light/dark theme.
- The memo now depends directly on clusters and selectedClusters instead of derived expressions like Object.keys(clusters).join(',') and selectedClusters.join(','), which eslint couldn't statically verify as safe dependencies. Depending on the real values removes the need for those inline suppressions.
- Added a stable EMPTY_CLUSTERS constant so the clusters ?? {} fallback doesn't create a new object identity on every render — an unstable fallback there would have defeated the memo's new dependency on clusters.
- Folded the unsortedItems lookup directly into the sortedItems memo. The previous standalone sidebars[...] ?? [] created a fresh array reference on every render even when nothing changed, which meant sortedItems's own memoization was silently broken; it also carried a stray, no-op suppression, since unsortedItems was a plain const, not a hook call.
- Removed the top-level // eslint-disable-next-line react-hooks/exhaustive-deps above the sidebars memo — no longer needed once the dependency array is complete and correct.
- Removed the now-unused useClustersConf import and allClustersConf variable, since nothing in the memo reads it once the suppression was removed.
- Added a regression test (should recompute cluster badge accent color when the theme changes) that fails without the theme fix and passes with it.

## Steps to Test

1) Run npm test -- useSidebarItems --run in frontend/ — all 8 tests should pass, including the new theme-recompute test.
2) Run npx eslint src/components/Sidebar/useSidebarItems.tsx — no react-hooks/exhaustive-deps warnings should remain.
3) Optionally, run the app, select a cluster with no custom appearance override, and toggle light/dark theme — the cluster badge's accent color should update immediately rather than requiring an unrelated re-render.

## Screenshots (if applicable)
NA

## Notes for the Reviewer

- No functional behavior changes for the common case (first render always computed correctly regardless of the deps array); this specifically fixes a stale-memo bug that only appears when the theme changes on an already-mounted sidebar.
- This is one of the 73 open react-hooks/exhaustive-deps items tracked in #5183 — scoped to this single file only, per the maintainer's guidance in that issue not to bundle multiple unrelated fixes together.
