### PR TITLE
app: Implement graceful shutdown for backend server process

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -801,7 +801,10 @@ async function startServer(flags: string[] = []): Promise<ChildProcessWithoutNul
   const options = {
     detached: true,
     windowsHide: true,
-    env: withBackendMemoryDefaults(extendedEnv),
+    env: {
+      ...withBackendMemoryDefaults(extendedEnv),
+      HEADLAMP_ELECTRON: 'true',
+    },
   };
 
   return spawn(serverFilePath, serverArgs, options);
@@ -830,27 +833,56 @@ async function isWSL(): Promise<boolean> {
 
 let serverProcess: ChildProcessWithoutNullStreams | null;
 let intentionalQuit: boolean;
-let serverProcessQuit: boolean;
+function quitServerProcess(): Promise<void> {
+  return new Promise(resolve => {
+    if (!serverProcess || serverProcess.exitCode !== null || serverProcess.signalCode !== null) {
+      console.error('server process already not running');
+      resolve();
+      return;
+    }
 
-function quitServerProcess() {
-  if ((!serverProcess || serverProcessQuit) && process.platform !== 'win32') {
-    console.error('server process already not running');
-    return;
-  }
+    intentionalQuit = true;
+    console.info('stopping server process...');
 
-  intentionalQuit = true;
-  console.info('stopping server process...');
+    if (!serverProcess) {
+      resolve();
+      return;
+    }
 
-  if (!serverProcess) {
-    return;
-  }
+    serverProcess.stdin.destroy();
 
-  serverProcess.stdin.destroy();
-  // @todo: should we try and end the process a bit more gracefully?
-  //       What happens if the kill signal doesn't kill it?
-  serverProcess.kill();
+    const currentProcess = serverProcess;
+    // On Windows, SIGTERM acts like SIGKILL and terminates abruptly.
+    // Instead, we rely on destroying stdin above to trigger a graceful shutdown.
+    if (process.platform !== 'win32') {
+      currentProcess.kill('SIGTERM');
+    }
 
-  serverProcess = null;
+    let resolved = false;
+    const finish = () => {
+      if (resolved) return;
+      resolved = true;
+      resolve();
+    };
+
+    // Fallback: If the process hasn't exited after 15 seconds, forcefully kill it.
+    const killTimeout = setTimeout(() => {
+      try {
+        currentProcess.kill('SIGKILL');
+        console.info('Server process forcefully stopped.');
+      } catch (e) {
+        // Ignore errors if the process is already gone
+      }
+      finish();
+    }, 15000);
+
+    currentProcess.on('exit', () => {
+      clearTimeout(killTimeout);
+      finish();
+    });
+
+    serverProcess = null;
+  });
 }
 
 function getAcceleratorForPlatform(navigation: 'left' | 'right') {
@@ -1898,7 +1930,21 @@ function startElectron() {
     }
   });
 
-  app.once('before-quit', async () => {
+  let isShutdownComplete = false;
+  let isShutdownInProgress = false;
+
+  app.on('before-quit', async e => {
+    if (isShutdownComplete) {
+      return;
+    }
+
+    e.preventDefault();
+
+    if (isShutdownInProgress) {
+      return;
+    }
+
+    isShutdownInProgress = true;
     isQuitting = true;
     // Persist any zoom change still waiting on the debounced save.
     flushZoomFactorSave();
@@ -1911,17 +1957,30 @@ function startElectron() {
 
     if (mcpClient) {
       try {
-        await mcpClient.cleanup();
+        // Bound the MCP cleanup to 3 seconds to prevent it from hanging the quit process
+        await Promise.race([
+          mcpClient.cleanup(),
+          new Promise((_, reject) =>
+            setTimeout(() => reject(new Error('MCP cleanup timeout')), 3000)
+          ),
+        ]);
         mcpClient = null;
       } catch (err) {
         console.error('Failed to clean up mcpClient:', err);
       }
     }
-  });
-}
 
-if (!isRunningScript) {
-  app.on('quit', quitServerProcess);
+    if (!isRunningScript) {
+      try {
+        await quitServerProcess();
+      } catch (err) {
+        console.error('Failed to quit server process:', err);
+      }
+    }
+
+    isShutdownComplete = true;
+    app.quit();
+  });
 }
 
 /**
@@ -1971,7 +2030,6 @@ function attachServerEventHandlers(serverProcess: ChildProcessWithoutNullStreams
     } else {
       console.info(closeMessage);
     }
-    serverProcessQuit = true;
   });
 }
 

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1568,12 +1568,12 @@ func StartHeadlampServer(config *HeadlampConfig) {
 		return
 	}
 
-	runServer(config, cancel, handler)
+	runServer(config, cancel, handler, nil)
 }
 
 // runServer creates the HTTP server, sets up graceful shutdown, starts
 // listening (TLS or plain), and handles the server completion and errors.
-func runServer(config *HeadlampConfig, cancel context.CancelFunc, handler http.Handler) {
+func runServer(config *HeadlampConfig, cancel context.CancelFunc, handler http.Handler, listener net.Listener) {
 	listenHost := strings.TrimPrefix(strings.TrimSuffix(config.ListenAddr, "]"), "[")
 	addr := net.JoinHostPort(listenHost, fmt.Sprintf("%d", config.Port))
 
@@ -1585,21 +1585,31 @@ func runServer(config *HeadlampConfig, cancel context.CancelFunc, handler http.H
 	}
 
 	serverDone := make(chan struct{})
-	setupGracefulShutdown(server, cancel, serverDone)
+	shutdownComplete := make(chan struct{})
+	setupGracefulShutdown(server, cancel, serverDone, shutdownComplete)
 
 	var err error
 
-	if config.TLSCertPath != "" && config.TLSKeyPath != "" {
+	tlsEnabled := config.TLSCertPath != "" && config.TLSKeyPath != ""
+
+	switch {
+	case listener == nil && tlsEnabled:
 		err = server.ListenAndServeTLS(config.TLSCertPath, config.TLSKeyPath)
-	} else {
+	case listener == nil && !tlsEnabled:
 		err = server.ListenAndServe()
+	case listener != nil && tlsEnabled:
+		err = server.ServeTLS(listener, config.TLSCertPath, config.TLSKeyPath)
+	case listener != nil && !tlsEnabled:
+		err = server.Serve(listener)
 	}
 
 	close(serverDone)
 
-	if err != nil && err != http.ErrServerClosed {
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		logger.Log(logger.LevelError, nil, err, "Failed to start server")
 		HandleServerStartError(&err)
+	} else if errors.Is(err, http.ErrServerClosed) {
+		<-shutdownComplete
 	}
 }
 
@@ -1650,9 +1660,22 @@ func copyStaticFiles(config *HeadlampConfig) error {
 // (SIGINT, SIGTERM) and gracefully shuts down the server. It cancels
 // the context to stop all watcher goroutines. The serverDone channel
 // is used to stop this goroutine if the server exits for a non-signal reason.
-func setupGracefulShutdown(server *http.Server, cancel context.CancelFunc, serverDone <-chan struct{}) {
+func setupGracefulShutdown(
+	server *http.Server,
+	cancel context.CancelFunc,
+	serverDone <-chan struct{},
+	shutdownComplete chan<- struct{},
+) {
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	if os.Getenv("HEADLAMP_ELECTRON") == "true" {
+		go func() {
+			_, _ = io.Copy(io.Discard, os.Stdin)
+
+			sigChan <- syscall.SIGINT
+		}()
+	}
 
 	go func() {
 		defer signal.Stop(sigChan)
@@ -1669,6 +1692,8 @@ func setupGracefulShutdown(server *http.Server, cancel context.CancelFunc, serve
 			if err := server.Shutdown(shutdownCtx); err != nil {
 				logger.Log(logger.LevelError, nil, err, "Failed to gracefully shutdown server")
 			}
+
+			close(shutdownComplete)
 		case <-serverDone:
 			// Server exited on its own, clean up watchers and stop the signal goroutine
 			cancel()

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -4581,3 +4581,152 @@ func TestExternalProxyOversizeResponseGzip(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, int(maxProxyResponseSize), rr.Body.Len())
 }
+
+func setupTestServer(t *testing.T, ctx context.Context) (net.Listener, uint) {
+	t.Helper()
+
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	return listener, uint(port)
+}
+
+func startServerGoroutine(
+	config *HeadlampConfig,
+	cancel context.CancelFunc,
+	handler http.Handler,
+	listener net.Listener,
+) chan struct{} {
+	serverExited := make(chan struct{})
+
+	go func() {
+		runServer(config, cancel, handler, listener)
+		close(serverExited)
+	}()
+
+	return serverExited
+}
+
+func waitForServerUp(t *testing.T, port uint) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		dialer := &net.Dialer{}
+
+		conn, dialErr := dialer.DialContext(context.Background(), "tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		if dialErr == nil {
+			_ = conn.Close()
+
+			return true
+		}
+
+		return false
+	}, 2*time.Second, 100*time.Millisecond)
+}
+
+func startInFlightRequest(serverURL string) chan struct{} {
+	reqDone := make(chan struct{})
+
+	go func() {
+		req, reqErr := http.NewRequestWithContext(context.Background(), http.MethodGet, serverURL, nil)
+		if reqErr == nil {
+			resp, doErr := http.DefaultClient.Do(req)
+			if doErr == nil {
+				_ = resp.Body.Close()
+			}
+		}
+
+		close(reqDone)
+	}()
+
+	return reqDone
+}
+
+func setupGracefulShutdownEnv(t *testing.T) (*os.File, chan struct{}, chan struct{}, http.Handler) {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	oldStdin := os.Stdin
+	os.Stdin = r
+
+	t.Setenv("HEADLAMP_ELECTRON", "true")
+
+	t.Cleanup(func() {
+		os.Stdin = oldStdin
+		_ = r.Close()
+		_ = w.Close()
+	})
+
+	handlerDone := make(chan struct{})
+	inFlightStarted := make(chan struct{})
+
+	handler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		close(inFlightStarted)
+		<-handlerDone
+		rw.WriteHeader(http.StatusOK)
+	})
+
+	return w, handlerDone, inFlightStarted, handler
+}
+
+func TestGracefulShutdownOnEOF(t *testing.T) {
+	w, handlerDone, inFlightStarted, handler := setupGracefulShutdownEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	listener, port := setupTestServer(t, ctx)
+
+	config := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				ListenAddr: "127.0.0.1",
+				Port:       port,
+			},
+		},
+	}
+
+	_, serverCancel := context.WithCancel(context.Background())
+	defer serverCancel()
+
+	serverExited := startServerGoroutine(config, serverCancel, handler, listener)
+	serverURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	waitForServerUp(t, port)
+
+	reqDone := startInFlightRequest(serverURL)
+
+	<-inFlightStarted
+
+	_ = w.Close()
+
+	select {
+	case <-serverExited:
+		t.Fatal("server exited prematurely while a request was in-flight")
+	case <-time.After(500 * time.Millisecond):
+		// Expected
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, serverURL, nil)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err == nil {
+		_ = resp.Body.Close()
+	}
+
+	require.Error(t, err, "new connections should be rejected during graceful shutdown")
+
+	close(handlerDone)
+	<-reqDone
+
+	select {
+	case <-serverExited:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("server failed to exit after in-flight request completed")
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds a graceful shutdown sequence for the backend server process in the Electron application.

## Related Issue
Fixes #7090 

## Changes

- Updated `quitServerProcess()` in `app/electron/main.ts` to implement coordinated shutdown. On Windows, this closes `stdin` so the backend can detect the shutdown event reliably. On non-Windows platforms, it sends a `SIGTERM` signal.
- Added a **15-second timeout fallback** to forcefully kill the process via `SIGKILL` if it hasn't exited gracefully in time. This longer deadline is intentional because backend HTTP shutdown and telemetry flushing can consume up to 10 seconds.
- Bounded MCP client cleanup with a **3-second timeout** to prevent nonresponsive transports from hanging the overall application quit sequence.
- Fixed a TOCTOU (Time-of-Check to Time-of-Use) race condition in the test server setup by injecting the listener directly into the server runner.

## Steps to Test

1. Run the desktop app using `npm run app:start`.
2. Wait for the backend server to spin up and connect successfully.
3. Close the application.
4. Verify that the backend server process shuts down correctly in the terminal logs and leaves no orphaned processes behind.

## Notes for the Reviewer

- Addresses the `@todo: should we try and end the process a bit more gracefully?` comment in `app/electron/main.ts`.
