### PR TITLE
frontend: auth: Clear cached resource data for the logged-out cluster in logout()

### DIFF
--- a/frontend/src/lib/auth.test.ts
+++ b/frontend/src/lib/auth.test.ts
@@ -15,10 +15,11 @@
  */
 
 import { Base64 } from 'js-base64';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import store from '../redux/stores/store';
-import { getUserInfo, setToken } from './auth';
+import { getUserInfo, logout, setToken } from './auth';
 import { backendFetch } from './k8s/api/v2/fetch';
+import { queryClient } from './queryClient';
 
 // Mock the dependencies
 vi.mock('./k8s/api/v2/fetch');
@@ -161,6 +162,56 @@ describe('auth', () => {
       expect(spy).toHaveBeenCalled();
 
       spy.mockRestore();
+    });
+  });
+
+  describe('logout', () => {
+    afterEach(() => {
+      queryClient.clear();
+    });
+
+    it('clears cached resource data for the logged-out cluster but leaves other clusters untouched', async () => {
+      const mockResponse: Partial<Response> = {
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({}),
+      };
+      mockBackendFetch.mockResolvedValue(mockResponse as Response);
+
+      queryClient.setQueryData(['kubeObject', 'list', 'v1', 'pods', 'prod', '', {}], {
+        items: ['prod-list'],
+      });
+      queryClient.setQueryData(['object', 'prod', '/api/v1/pods', 'default', 'nginx', {}], {
+        metadata: { name: 'nginx' },
+      });
+      queryClient.setQueryData(['auth', 'prod'], { allowed: true });
+      queryClient.setQueryData(['clusterMe', 'prod'], { username: 'test-user' });
+      queryClient.setQueryData(['kubeObject', 'list', 'v1', 'pods', 'staging', '', {}], {
+        items: ['staging-list'],
+      });
+      // 'prod' here is the namespace on the 'staging' cluster, not the cluster field.
+      // Must survive logging out of the 'prod' cluster.
+      queryClient.setQueryData(['kubeObject', 'list', 'v1', 'pods', 'staging', 'prod', {}], {
+        items: ['staging-prod-namespace-list'],
+      });
+
+      await logout('prod');
+
+      expect(
+        queryClient.getQueryData(['kubeObject', 'list', 'v1', 'pods', 'prod', '', {}])
+      ).toBeUndefined();
+      expect(
+        queryClient.getQueryData(['object', 'prod', '/api/v1/pods', 'default', 'nginx', {}])
+      ).toBeUndefined();
+      expect(queryClient.getQueryData(['auth', 'prod'])).toBeUndefined();
+      expect(queryClient.getQueryData(['clusterMe', 'prod'])).toBeUndefined();
+
+      expect(
+        queryClient.getQueryData(['kubeObject', 'list', 'v1', 'pods', 'staging', '', {}])
+      ).toEqual({ items: ['staging-list'] });
+      expect(
+        queryClient.getQueryData(['kubeObject', 'list', 'v1', 'pods', 'staging', 'prod', {}])
+      ).toEqual({ items: ['staging-prod-namespace-list'] });
     });
   });
 });

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -141,6 +141,14 @@ export async function logout(cluster: string) {
   return setToken(cluster, null).then(() => {
     queryClient.removeQueries({ queryKey: ['auth'], exact: false });
     queryClient.removeQueries({ queryKey: ['clusterMe', cluster], exact: true });
+    queryClient.removeQueries({
+      predicate: query => {
+        const key = query.queryKey;
+        if (key[0] === 'kubeObject' && key[4] === cluster) return true;
+        if (key[0] === 'object' && key[1] === cluster) return true;
+        return false;
+      },
+    });
   });
 }
 


### PR DESCRIPTION
Fixes #7093

`logout()` removes `['auth']` and `['clusterMe', cluster]` from the React Query cache but
leaves all resource data (`['kubeObject', 'list', ...]`, `['object', ...]`) untouched. If a
user logs back into the same cluster within the 3-minute `staleTime` window, React Query
serves the pre-logout snapshot without refetching.

Added a `removeQueries` call with a cluster-scoped predicate so all cached entries for that
cluster are cleared on logout. Other clusters' caches are not affected.

Note: this covers the resource-cache staleness described in #7093. It does not touch the
separate `AuthRoute` auth-gate bypass for multi-cluster group views mentioned there — that's
a related but distinct gap.

**Testing:** `frontend/src/lib/auth.test.ts` — new `describe('logout', ...)` block seeds
cache entries for two clusters, calls `logout('prod')`, and asserts `prod` entries are gone
while `staging` entries survive untouched.
