### PR TITLE
frontend: CopyableCell: Integrate copy in tables

### DIFF
--- a/frontend/src/components/common/Resource/CopyButton.tsx
+++ b/frontend/src/components/common/Resource/CopyButton.tsx
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { Box } from '@mui/material';
+import { visuallyHidden } from '@mui/utils';
 import type { ComponentProps, MouseEventHandler } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -46,24 +48,31 @@ export default function CopyButton(props: CopyButtonProps) {
   async function onCopy(event: Parameters<MouseEventHandler<HTMLElement>>[0]) {
     onClick?.(event);
 
+    clearTimeout(resetTimeoutRef.current);
+
     try {
       await navigator.clipboard.writeText(copyText);
       setCopied(true);
-      clearTimeout(resetTimeoutRef.current);
       resetTimeoutRef.current = setTimeout(() => setCopied(false), 1500);
     } catch (err) {
+      setCopied(false);
       console.error('Failed to copy to clipboard:', err);
     }
   }
 
   return (
-    <ActionButton
-      description={copied ? t('translation|Copied!') : t('translation|Copy to clipboard')}
-      buttonStyle={buttonStyle}
-      onClick={onCopy}
-      icon={copied ? 'mdi:check' : 'mdi:content-copy'}
-      iconButtonProps={iconButtonProps}
-      width={width}
-    />
+    <>
+      <ActionButton
+        description={copied ? t('translation|Copied!') : t('translation|Copy to clipboard')}
+        buttonStyle={buttonStyle}
+        onClick={onCopy}
+        icon={copied ? 'mdi:check' : 'mdi:content-copy'}
+        iconButtonProps={iconButtonProps}
+        width={width}
+      />
+      <Box role="status" aria-live="polite" aria-atomic="true" sx={visuallyHidden}>
+        {copied ? t('translation|Copied!') : ''}
+      </Box>
+    </>
   );
 }

--- a/frontend/src/components/common/Resource/CopyButton.tsx
+++ b/frontend/src/components/common/Resource/CopyButton.tsx
@@ -14,32 +14,56 @@
  * limitations under the License.
  */
 
+import type { ComponentProps, MouseEventHandler } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ActionButton, { ButtonStyle } from '../ActionButton';
 
 interface CopyButtonProps {
   text?: string;
   buttonStyle?: ButtonStyle;
+  iconButtonProps?: ComponentProps<typeof ActionButton>['iconButtonProps'];
+  width?: ComponentProps<typeof ActionButton>['width'];
+  onClick?: MouseEventHandler<HTMLElement>;
 }
 
 export default function CopyButton(props: CopyButtonProps) {
-  const { text, buttonStyle } = props;
+  const { text, buttonStyle, iconButtonProps, width, onClick } = props;
   const { t } = useTranslation(['translation']);
+  const [copied, setCopied] = useState(false);
+  const resetTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    return () => clearTimeout(resetTimeoutRef.current);
+  }, []);
 
   if (text === undefined || text === null || text === '') {
     return <></>;
   }
 
-  async function onCopy() {
-    await navigator.clipboard.writeText(text!);
+  const copyText = text;
+
+  async function onCopy(event: Parameters<MouseEventHandler<HTMLElement>>[0]) {
+    onClick?.(event);
+
+    try {
+      await navigator.clipboard.writeText(copyText);
+      setCopied(true);
+      clearTimeout(resetTimeoutRef.current);
+      resetTimeoutRef.current = setTimeout(() => setCopied(false), 1500);
+    } catch (err) {
+      console.error('Failed to copy to clipboard:', err);
+    }
   }
 
   return (
     <ActionButton
-      description={t('translation|Copy to clipboard')}
+      description={copied ? t('translation|Copied!') : t('translation|Copy to clipboard')}
       buttonStyle={buttonStyle}
       onClick={onCopy}
-      icon="mdi:content-copy"
+      icon={copied ? 'mdi:check' : 'mdi:content-copy'}
+      iconButtonProps={iconButtonProps}
+      width={width}
     />
   );
 }

--- a/frontend/src/components/common/Resource/CopyableCell.test.tsx
+++ b/frontend/src/components/common/Resource/CopyableCell.test.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../../test';
+import CopyableCell from './CopyableCell';
+
+describe('CopyableCell', () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    writeText.mockClear();
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+  });
+
+  it('copies the value and shows copied feedback', async () => {
+    render(
+      <TestContext>
+        <CopyableCell value="10.0.0.1">10.0.0.1</CopyableCell>
+      </TestContext>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'translation|Copy to clipboard' }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('10.0.0.1'));
+    expect(screen.getByRole('button', { name: 'translation|Copied!' })).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'translation|Copy to clipboard' })
+      ).toBeInTheDocument()
+    );
+  });
+
+  it('renders children without a copy button when the value is empty', () => {
+    render(
+      <TestContext>
+        <CopyableCell value="">empty</CopyableCell>
+      </TestContext>
+    );
+
+    expect(screen.getByText('empty')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'translation|Copy to clipboard' })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/common/Resource/CopyableCell.tsx
+++ b/frontend/src/components/common/Resource/CopyableCell.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Box from '@mui/material/Box';
+import type { ReactNode } from 'react';
+import CopyButton from './CopyButton';
+
+export interface CopyableCellProps {
+  /** The text value to copy to clipboard */
+  value: string;
+  /** The content to display in the cell */
+  children: ReactNode;
+}
+
+/**
+ * A wrapper component that adds a copy-to-clipboard button on hover.
+ * Used for table cells containing values that users commonly need to copy,
+ * such as IP addresses, hostnames, etc.
+ */
+export default function CopyableCell({ value, children }: CopyableCellProps) {
+  if (!value) {
+    return <>{children}</>;
+  }
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.5,
+        '& .copy-button': {
+          opacity: 0,
+          transition: 'opacity 0.2s',
+        },
+        '&:hover .copy-button, &:focus-within .copy-button, & .copy-button:focus-visible': {
+          opacity: 1,
+        },
+      }}
+    >
+      <Box sx={{ flex: 1, minWidth: 0 }}>{children}</Box>
+      <CopyButton
+        text={value}
+        onClick={event => event.stopPropagation()}
+        width="16"
+        iconButtonProps={{
+          className: 'copy-button',
+          size: 'small',
+          sx: { padding: '2px', flexShrink: 0 },
+        }}
+      />
+    </Box>
+  );
+}

--- a/frontend/src/components/common/Resource/MainInfoSection/__snapshots__/MainInfoSection.Normal.stories.storyshot
+++ b/frontend/src/components/common/Resource/MainInfoSection/__snapshots__/MainInfoSection.Normal.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/common/Resource/MainInfoSection/__snapshots__/MainInfoSection.NullBacklink.stories.storyshot
+++ b/frontend/src/components/common/Resource/MainInfoSection/__snapshots__/MainInfoSection.NullBacklink.stories.storyshot
@@ -31,6 +31,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -22,6 +22,7 @@ import MenuItem from '@mui/material/MenuItem';
 import { useTheme } from '@mui/material/styles';
 import { TableCellProps } from '@mui/material/TableCell';
 import {
+  MRT_Cell,
   MRT_FilterFns,
   MRT_Row,
   MRT_SortingFn,
@@ -56,6 +57,7 @@ import { DateLabel } from '../Label';
 import Link from '../Link';
 import Table, { TableColumn } from '../Table';
 import { getA8RMetadata } from './A8RInfo';
+import CopyableCell from './CopyableCell';
 import DeleteButton from './DeleteButton';
 import DownloadButton from './DownloadButton';
 import EditButton from './EditButton';
@@ -102,6 +104,7 @@ export type ResourceTableColumn<RowItem> = {
       datum: keyof RowItem;
       render?: never;
       getValue?: never;
+      copyable?: never;
     }
   | {
       datum?: never;
@@ -109,12 +112,19 @@ export type ResourceTableColumn<RowItem> = {
       render?: (item: RowItem) => ReactNode;
       /** Plain value for filtering and sorting. This is going to be displayed unless render property is defined */
       getValue: (item: RowItem) => string | number | null | undefined;
+      /**
+       * If true, adds a copy-to-clipboard button that appears on hover.
+       * The value from getValue() will be copied when clicked.
+       * @default false
+       */
+      copyable?: boolean;
     }
   | {
       datum?: never;
       render?: never;
       /** @deprecated please use getValue and render (optional, if you need custom renderer) */
       getter: (item: RowItem) => any;
+      copyable?: never;
     }
 );
 
@@ -438,9 +448,33 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
           } else {
             mrtColumn.accessorFn = (item: RowItem) => item[column.datum];
           }
-          if ('render' in column) {
+          if ('render' in column && 'getValue' in column) {
+            const renderFn = column.render;
+            if (column.copyable) {
+              mrtColumn.Cell = ({
+                row,
+                cell,
+              }: {
+                row: MRT_Row<RowItem>;
+                cell: MRT_Cell<RowItem>;
+              }) => {
+                const value = String(cell.getValue<string | number | null | undefined>() ?? '');
+                return (
+                  <CopyableCell value={value}>{renderFn?.(row.original) ?? null}</CopyableCell>
+                );
+              };
+            } else {
+              mrtColumn.Cell = ({ row }: { row: MRT_Row<RowItem> }) =>
+                renderFn?.(row.original) ?? null;
+            }
+          } else if ('render' in column) {
             mrtColumn.Cell = ({ row }: { row: MRT_Row<RowItem> }) =>
               column.render?.(row.original) ?? null;
+          } else if (column.copyable && 'getValue' in column) {
+            mrtColumn.Cell = ({ cell }: { cell: MRT_Cell<RowItem> }) => {
+              const value = String(cell.getValue<string | number | null | undefined>() ?? '');
+              return <CopyableCell value={value}>{value}</CopyableCell>;
+            };
           }
           if (sort && typeof sort === 'function') {
             mrtColumn.sortingFn = sortingFn(sort);

--- a/frontend/src/components/common/Resource/__snapshots__/CopyButton.Default.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/CopyButton.Default.stories.storyshot
@@ -11,5 +11,11 @@
         class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
       />
     </button>
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      class="MuiBox-root css-ty8jgw"
+      role="status"
+    />
   </div>
 </body>

--- a/frontend/src/components/common/Resource/index.test.ts
+++ b/frontend/src/components/common/Resource/index.test.ts
@@ -28,6 +28,7 @@ const avoidCheck = [
   'ErrorBoundary',
   'fetchLatestKubeObject',
   'logSeverityFilter',
+  'CopyableCell',
   // Internal helper exported only so `ResourceTable` and its co-located
   // tests can import it; deliberately kept out of the barrel.
   'getResourceRowId',

--- a/frontend/src/components/configmap/__snapshots__/Details.Empty.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/Details.Empty.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/configmap/__snapshots__/Details.WithBinaryData.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/Details.WithBinaryData.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/configmap/__snapshots__/Details.WithBinaryDataAndData.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/Details.WithBinaryDataAndData.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/configmap/__snapshots__/Details.WithData.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/Details.WithData.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDetails.NoError.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDetails.NoError.stories.storyshot
@@ -58,6 +58,12 @@
                         class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                       />
                     </button>
+                    <div
+                      aria-atomic="true"
+                      aria-live="polite"
+                      class="MuiBox-root css-ty8jgw"
+                      role="status"
+                    />
                   </div>
                 </div>
               </div>

--- a/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryAst.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryAst.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryMinute.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryMinute.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/daemonset/__snapshots__/Details.Default.stories.storyshot
+++ b/frontend/src/components/daemonset/__snapshots__/Details.Default.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/daemonset/__snapshots__/Details.NoTolerations.stories.storyshot
+++ b/frontend/src/components/daemonset/__snapshots__/Details.NoTolerations.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/endpointSlices/List.tsx
+++ b/frontend/src/components/endpointSlices/List.tsx
@@ -39,6 +39,14 @@ function renderEndpoints(endpointSlice: EndpointSlice) {
   });
 }
 
+function getCopyableEndpointAddresses(endpointSlice: EndpointSlice) {
+  return (
+    endpointSlice.spec?.endpoints
+      ?.flatMap((endpoint: { addresses?: string[] }) => endpoint.addresses ?? [])
+      .join('\n') ?? ''
+  );
+}
+
 export default function EndpointSliceList() {
   const { t } = useTranslation(['glossary', 'translation']);
 
@@ -53,8 +61,7 @@ export default function EndpointSliceList() {
         {
           id: 'endpoints',
           label: t('translation|Endpoints'),
-          getValue: endpoint =>
-            endpoint.spec?.endpoints?.map((c: any) => c.addresses?.join(','))?.join(','),
+          getValue: endpoint => getCopyableEndpointAddresses(endpoint),
           render: endpoint => renderEndpoints(endpoint),
           gridTemplate: 'auto',
           cellProps: {
@@ -63,6 +70,7 @@ export default function EndpointSliceList() {
               gap: '4px',
             },
           },
+          copyable: true,
         },
         {
           id: 'ports',

--- a/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceDetails.Default.stories.storyshot
+++ b/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceDetails.Default.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
+++ b/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
@@ -726,13 +726,32 @@
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1g81de4-MuiTableCell-root"
                 >
                   <div
-                    class="MuiBox-root css-1baulvz"
+                    class="MuiBox-root css-18oja2p"
                   >
-                    <span
-                      class="MuiTypography-root MuiTypography-body1 css-1ge3384-MuiTypography-root"
+                    <div
+                      class="MuiBox-root css-1fjtzvx"
                     >
-                      127.0.0.1
-                    </span>
+                      <div
+                        class="MuiBox-root css-1baulvz"
+                      >
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 css-1ge3384-MuiTypography-root"
+                        >
+                          127.0.0.1
+                        </span>
+                      </div>
+                    </div>
+                    <button
+                      aria-label="Copy to clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall copy-button css-d7r42q-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </div>
                 </td>
                 <td

--- a/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
+++ b/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
@@ -752,6 +752,12 @@
                         class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                       />
                     </button>
+                    <div
+                      aria-atomic="true"
+                      aria-live="polite"
+                      class="MuiBox-root css-ty8jgw"
+                      role="status"
+                    />
                   </div>
                 </td>
                 <td

--- a/frontend/src/components/endpoints/List.tsx
+++ b/frontend/src/components/endpoints/List.tsx
@@ -40,9 +40,10 @@ export default function EndpointList() {
         {
           id: 'addresses',
           label: t('translation|Addresses'),
-          getValue: endpoint => endpoint.getAddresses().join(', '),
+          getValue: endpoint => endpoint.getAddresses().join('\n'),
           render: endpoint => <LabelListItem labels={endpoint.getAddresses()} />,
           gridTemplate: 1.5,
+          copyable: true,
         },
         'labels',
         'age',

--- a/frontend/src/components/endpoints/__snapshots__/EndpointDetails.Default.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointDetails.Default.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
@@ -640,6 +640,12 @@
                         class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                       />
                     </button>
+                    <div
+                      aria-atomic="true"
+                      aria-live="polite"
+                      class="MuiBox-root css-ty8jgw"
+                      role="status"
+                    />
                   </div>
                 </td>
                 <td

--- a/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
@@ -615,13 +615,32 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-cxvskc-MuiTableCell-root"
                 >
-                  <span
-                    aria-label="127.0.01:8080"
-                    class=""
-                    data-mui-internal-clone-element="true"
+                  <div
+                    class="MuiBox-root css-18oja2p"
                   >
-                    127.0.01:8080
-                  </span>
+                    <div
+                      class="MuiBox-root css-1fjtzvx"
+                    >
+                      <span
+                        aria-label="127.0.01:8080"
+                        class=""
+                        data-mui-internal-clone-element="true"
+                      >
+                        127.0.01:8080
+                      </span>
+                    </div>
+                    <button
+                      aria-label="Copy to clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall copy-button css-d7r42q-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-14i1ub9-MuiTableCell-root"

--- a/frontend/src/components/gateway/__snapshots__/BackendTLSPolicyDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/BackendTLSPolicyDetails.Basic.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/gateway/__snapshots__/BackendTrafficPolicyDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/BackendTrafficPolicyDetails.Basic.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/gateway/__snapshots__/ClassDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ClassDetails.Basic.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/gateway/__snapshots__/GRPCRouteDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GRPCRouteDetails.Basic.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/gateway/__snapshots__/GatewayDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GatewayDetails.Basic.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/gateway/__snapshots__/HTTPRouteDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/HTTPRouteDetails.Basic.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/gateway/__snapshots__/HTTPRouteDetails.Empty.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/HTTPRouteDetails.Empty.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/gateway/__snapshots__/ReferenceGrantDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ReferenceGrantDetails.Basic.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/gateway/__snapshots__/TCPRouteDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/TCPRouteDetails.Basic.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/gateway/__snapshots__/TCPRouteDetails.Empty.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/TCPRouteDetails.Empty.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/gateway/__snapshots__/UDPRouteDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/UDPRouteDetails.Basic.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/gateway/__snapshots__/UDPRouteDetails.Empty.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/UDPRouteDetails.Empty.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Default.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Default.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/ingress/__snapshots__/ClassDetails.Basic.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/ClassDetails.Basic.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/ingress/__snapshots__/ClassDetails.WithDefault.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/ClassDetails.WithDefault.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/ingress/__snapshots__/Details.WithResource.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.WithResource.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/ingress/__snapshots__/Details.WithTLS.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.WithTLS.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/ingress/__snapshots__/Details.WithWildcardTLS.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.WithWildcardTLS.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/job/__snapshots__/Details.Default.stories.storyshot
+++ b/frontend/src/components/job/__snapshots__/Details.Default.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/job/__snapshots__/Details.Running.stories.storyshot
+++ b/frontend/src/components/job/__snapshots__/Details.Running.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/lease/__snapshots__/Details.LeaseDetail.stories.storyshot
+++ b/frontend/src/components/lease/__snapshots__/Details.LeaseDetail.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/limitRange/__snapshots__/Details.LimitRangeDetail.stories.storyshot
+++ b/frontend/src/components/limitRange/__snapshots__/Details.LimitRangeDetail.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/namespace/__snapshots__/NamespaceDetails.Active.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceDetails.Active.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/networkpolicy/__snapshots__/Details.Default.stories.storyshot
+++ b/frontend/src/components/networkpolicy/__snapshots__/Details.Default.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/node/List.tsx
+++ b/frontend/src/components/node/List.tsx
@@ -135,11 +135,14 @@ export default function NodeList() {
             id: 'internalIP',
             label: t('translation|Internal IP'),
             getValue: node => node.getInternalIP(),
+            copyable: true,
           },
           {
             id: 'externalIP',
             label: t('External IP'),
-            getValue: node => node.getExternalIP() || t('translation|None'),
+            getValue: node => node.getExternalIP() || '',
+            render: node => node.getExternalIP() || t('translation|None'),
+            copyable: true,
           },
           {
             id: 'version',

--- a/frontend/src/components/node/__snapshots__/Details.Default.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/Details.Default.stories.storyshot
@@ -50,6 +50,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/node/__snapshots__/Details.NoMetrics.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/Details.NoMetrics.stories.storyshot
@@ -50,6 +50,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -461,6 +461,7 @@ export function PodListRenderer(props: PodListProps) {
           gridTemplate: 'min-content',
           label: t('glossary|IP'),
           getValue: pod => pod.status?.podIP ?? '',
+          copyable: true,
         },
         {
           id: 'node',

--- a/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
@@ -992,7 +992,26 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-fe8q5p-MuiTableCell-root"
                 >
-                  0.0.0.2
+                  <div
+                    class="MuiBox-root css-18oja2p"
+                  >
+                    <div
+                      class="MuiBox-root css-1fjtzvx"
+                    >
+                      0.0.0.2
+                    </div>
+                    <button
+                      aria-label="Copy to clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall copy-button css-d7r42q-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1eq0ete-MuiTableCell-root"
@@ -1282,7 +1301,26 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-fe8q5p-MuiTableCell-root"
                 >
-                  0.0.0.2
+                  <div
+                    class="MuiBox-root css-18oja2p"
+                  >
+                    <div
+                      class="MuiBox-root css-1fjtzvx"
+                    >
+                      0.0.0.2
+                    </div>
+                    <button
+                      aria-label="Copy to clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall copy-button css-d7r42q-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1eq0ete-MuiTableCell-root"
@@ -1418,7 +1456,26 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-fe8q5p-MuiTableCell-root"
                 >
-                  0.0.0.2
+                  <div
+                    class="MuiBox-root css-18oja2p"
+                  >
+                    <div
+                      class="MuiBox-root css-1fjtzvx"
+                    >
+                      0.0.0.2
+                    </div>
+                    <button
+                      aria-label="Copy to clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall copy-button css-d7r42q-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1eq0ete-MuiTableCell-root"
@@ -1554,7 +1611,26 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-fe8q5p-MuiTableCell-root"
                 >
-                  0.0.0.2
+                  <div
+                    class="MuiBox-root css-18oja2p"
+                  >
+                    <div
+                      class="MuiBox-root css-1fjtzvx"
+                    >
+                      0.0.0.2
+                    </div>
+                    <button
+                      aria-label="Copy to clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall copy-button css-d7r42q-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1eq0ete-MuiTableCell-root"
@@ -1690,7 +1766,26 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-fe8q5p-MuiTableCell-root"
                 >
-                  0.0.0.2
+                  <div
+                    class="MuiBox-root css-18oja2p"
+                  >
+                    <div
+                      class="MuiBox-root css-1fjtzvx"
+                    >
+                      0.0.0.2
+                    </div>
+                    <button
+                      aria-label="Copy to clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall copy-button css-d7r42q-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1eq0ete-MuiTableCell-root"
@@ -1826,7 +1921,26 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-fe8q5p-MuiTableCell-root"
                 >
-                  0.0.0.2
+                  <div
+                    class="MuiBox-root css-18oja2p"
+                  >
+                    <div
+                      class="MuiBox-root css-1fjtzvx"
+                    >
+                      0.0.0.2
+                    </div>
+                    <button
+                      aria-label="Copy to clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall copy-button css-d7r42q-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1eq0ete-MuiTableCell-root"
@@ -1962,7 +2076,26 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-fe8q5p-MuiTableCell-root"
                 >
-                  0.0.0.2
+                  <div
+                    class="MuiBox-root css-18oja2p"
+                  >
+                    <div
+                      class="MuiBox-root css-1fjtzvx"
+                    >
+                      0.0.0.2
+                    </div>
+                    <button
+                      aria-label="Copy to clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall copy-button css-d7r42q-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1eq0ete-MuiTableCell-root"

--- a/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
@@ -1011,6 +1011,12 @@
                         class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                       />
                     </button>
+                    <div
+                      aria-atomic="true"
+                      aria-live="polite"
+                      class="MuiBox-root css-ty8jgw"
+                      role="status"
+                    />
                   </div>
                 </td>
                 <td
@@ -1320,6 +1326,12 @@
                         class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                       />
                     </button>
+                    <div
+                      aria-atomic="true"
+                      aria-live="polite"
+                      class="MuiBox-root css-ty8jgw"
+                      role="status"
+                    />
                   </div>
                 </td>
                 <td
@@ -1475,6 +1487,12 @@
                         class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                       />
                     </button>
+                    <div
+                      aria-atomic="true"
+                      aria-live="polite"
+                      class="MuiBox-root css-ty8jgw"
+                      role="status"
+                    />
                   </div>
                 </td>
                 <td
@@ -1630,6 +1648,12 @@
                         class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                       />
                     </button>
+                    <div
+                      aria-atomic="true"
+                      aria-live="polite"
+                      class="MuiBox-root css-ty8jgw"
+                      role="status"
+                    />
                   </div>
                 </td>
                 <td
@@ -1785,6 +1809,12 @@
                         class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                       />
                     </button>
+                    <div
+                      aria-atomic="true"
+                      aria-live="polite"
+                      class="MuiBox-root css-ty8jgw"
+                      role="status"
+                    />
                   </div>
                 </td>
                 <td
@@ -1940,6 +1970,12 @@
                         class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                       />
                     </button>
+                    <div
+                      aria-atomic="true"
+                      aria-live="polite"
+                      class="MuiBox-root css-ty8jgw"
+                      role="status"
+                    />
                   </div>
                 </td>
                 <td
@@ -2095,6 +2131,12 @@
                         class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                       />
                     </button>
+                    <div
+                      aria-atomic="true"
+                      aria-live="polite"
+                      class="MuiBox-root css-ty8jgw"
+                      role="status"
+                    />
                   </div>
                 </td>
                 <td

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.Default.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.Default.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.Default.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.Default.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.Default.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.Default.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/role/__snapshots__/BindingDetails.ClusterRoleBinding.stories.storyshot
+++ b/frontend/src/components/role/__snapshots__/BindingDetails.ClusterRoleBinding.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/role/__snapshots__/BindingDetails.RoleBinding.stories.storyshot
+++ b/frontend/src/components/role/__snapshots__/BindingDetails.RoleBinding.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/role/__snapshots__/Details.ClusterRole.stories.storyshot
+++ b/frontend/src/components/role/__snapshots__/Details.ClusterRole.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/role/__snapshots__/Details.Role.stories.storyshot
+++ b/frontend/src/components/role/__snapshots__/Details.Role.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/runtimeClass/__snapshots__/Details.Base.stories.storyshot
+++ b/frontend/src/components/runtimeClass/__snapshots__/Details.Base.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/secret/__snapshots__/Details.Empty.stories.storyshot
+++ b/frontend/src/components/secret/__snapshots__/Details.Empty.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/secret/__snapshots__/Details.WithBase.stories.storyshot
+++ b/frontend/src/components/secret/__snapshots__/Details.WithBase.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/service/List.tsx
+++ b/frontend/src/components/service/List.tsx
@@ -43,12 +43,15 @@ export default function ServiceList() {
           label: t('Cluster IP'),
           gridTemplate: 'min-content',
           getValue: service => service.spec.clusterIP,
+          copyable: true,
         },
         {
           id: 'externalIP',
           label: t('External IP'),
           gridTemplate: 'min-content',
-          getValue: service => service.getExternalAddresses() || '-',
+          getValue: service => service.getExternalAddresses() || '',
+          render: service => service.getExternalAddresses() || '-',
+          copyable: true,
         },
         {
           id: 'ports',

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.Default.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.Default.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.ErrorWithEndpoints.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.ErrorWithEndpoints.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.ExternalName.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.ExternalName.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.LoadBalancer.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.LoadBalancer.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.NodePort.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.NodePort.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8RAnnotations.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8RAnnotations.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8ROwnerOnly.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8ROwnerOnly.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/service/__snapshots__/ServiceList.Items.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceList.Items.stories.storyshot
@@ -849,12 +849,50 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-gh78e9-MuiTableCell-root"
                 >
-                  10.96.0.100
+                  <div
+                    class="MuiBox-root css-18oja2p"
+                  >
+                    <div
+                      class="MuiBox-root css-1fjtzvx"
+                    >
+                      10.96.0.100
+                    </div>
+                    <button
+                      aria-label="Copy to clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall copy-button css-d7r42q-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ofzoa7-MuiTableCell-root"
                 >
-                  34.123.45.67
+                  <div
+                    class="MuiBox-root css-18oja2p"
+                  >
+                    <div
+                      class="MuiBox-root css-1fjtzvx"
+                    >
+                      34.123.45.67
+                    </div>
+                    <button
+                      aria-label="Copy to clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall copy-button css-d7r42q-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-ccolv7-MuiTableCell-root"

--- a/frontend/src/components/service/__snapshots__/ServiceList.Items.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceList.Items.stories.storyshot
@@ -868,6 +868,12 @@
                         class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                       />
                     </button>
+                    <div
+                      aria-atomic="true"
+                      aria-live="polite"
+                      class="MuiBox-root css-ty8jgw"
+                      role="status"
+                    />
                   </div>
                 </td>
                 <td
@@ -892,6 +898,12 @@
                         class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                       />
                     </button>
+                    <div
+                      aria-atomic="true"
+                      aria-live="polite"
+                      class="MuiBox-root css-ty8jgw"
+                      role="status"
+                    />
                   </div>
                 </td>
                 <td

--- a/frontend/src/components/service/__snapshots__/ServiceList.WithOwnerAnnotation.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceList.WithOwnerAnnotation.stories.storyshot
@@ -909,7 +909,26 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-gh78e9-MuiTableCell-root"
                 >
-                  10.96.0.101
+                  <div
+                    class="MuiBox-root css-18oja2p"
+                  >
+                    <div
+                      class="MuiBox-root css-1fjtzvx"
+                    >
+                      10.96.0.101
+                    </div>
+                    <button
+                      aria-label="Copy to clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall copy-button css-d7r42q-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ofzoa7-MuiTableCell-root"

--- a/frontend/src/components/service/__snapshots__/ServiceList.WithOwnerAnnotation.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceList.WithOwnerAnnotation.stories.storyshot
@@ -928,6 +928,12 @@
                         class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                       />
                     </button>
+                    <div
+                      aria-atomic="true"
+                      aria-live="polite"
+                      class="MuiBox-root css-ty8jgw"
+                      role="status"
+                    />
                   </div>
                 </td>
                 <td

--- a/frontend/src/components/serviceaccount/__snapshots__/Details.Empty.stories.storyshot
+++ b/frontend/src/components/serviceaccount/__snapshots__/Details.Empty.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/serviceaccount/__snapshots__/Details.ListError.stories.storyshot
+++ b/frontend/src/components/serviceaccount/__snapshots__/Details.ListError.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/serviceaccount/__snapshots__/Details.WithBase.stories.storyshot
+++ b/frontend/src/components/serviceaccount/__snapshots__/Details.WithBase.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/serviceaccount/__snapshots__/Details.WithBindings.stories.storyshot
+++ b/frontend/src/components/serviceaccount/__snapshots__/Details.WithBindings.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/statefulset/__snapshots__/Details.Default.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/Details.Default.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/statefulset/__snapshots__/Details.WithComplexSelector.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/Details.WithComplexSelector.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/statefulset/__snapshots__/Details.WithMultipleContainers.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/Details.WithMultipleContainers.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/statefulset/__snapshots__/Details.WithOnDeleteStrategy.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/Details.WithOnDeleteStrategy.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/storage/__snapshots__/ClaimDetails.Base.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClaimDetails.Base.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/storage/__snapshots__/ClassDetails.Base.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClassDetails.Base.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/storage/__snapshots__/VolumeAttributesClassDetails.Base.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeAttributesClassDetails.Base.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/storage/__snapshots__/VolumeDetails.Base.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeDetails.Base.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Default.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Default.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithService.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithService.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithURL.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithURL.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithService.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithService.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithURL.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithURL.stories.storyshot
@@ -49,6 +49,12 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -320,6 +320,7 @@
   "Read more": "اقرأ المزيد",
   "Disable update notifications": "تعطيل إشعارات التحديث",
   "Install the metrics-server to get usage data.": "قم بتثبيت metrics-server للحصول على بيانات الاستخدام.",
+  "Copied!": "",
   "Copy to clipboard": "نسخ إلى الحافظة",
   "Resource Type": "نوع المورد",
   "Create / Apply": "إنشاء / تطبيق",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -312,6 +312,7 @@
   "Read more": "আরও পড়ুন",
   "Disable update notifications": "আপডেট বিজ্ঞপ্তি নিষ্ক্রিয় করুন",
   "Install the metrics-server to get usage data.": "ব্যবহারের Data পেতে Metrics্স-সার্ভার ইনস্টল করুন।",
+  "Copied!": "",
   "Copy to clipboard": "ক্লিপবোর্ডে কপি করুন",
   "Resource Type": "Resource ধরন",
   "Create / Apply": "Create / Apply করুন",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -312,6 +312,7 @@
   "Read more": "",
   "Disable update notifications": "",
   "Install the metrics-server to get usage data.": "",
+  "Copied!": "",
   "Copy to clipboard": "",
   "Resource Type": "",
   "Create / Apply": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -312,6 +312,7 @@
   "Read more": "Read more",
   "Disable update notifications": "Disable update notifications",
   "Install the metrics-server to get usage data.": "Install the metrics-server to get usage data.",
+  "Copied!": "Copied!",
   "Copy to clipboard": "Copy to clipboard",
   "Resource Type": "Resource Type",
   "Create / Apply": "Create / Apply",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -314,6 +314,7 @@
   "Read more": "",
   "Disable update notifications": "",
   "Install the metrics-server to get usage data.": "",
+  "Copied!": "",
   "Copy to clipboard": "",
   "Resource Type": "",
   "Create / Apply": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -314,6 +314,7 @@
   "Read more": "",
   "Disable update notifications": "",
   "Install the metrics-server to get usage data.": "",
+  "Copied!": "",
   "Copy to clipboard": "",
   "Resource Type": "",
   "Create / Apply": "",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -314,6 +314,7 @@
   "Read more": "Read more",
   "Disable update notifications": "Disable update notifications",
   "Install the metrics-server to get usage data.": "Install the metrics-server to get usage data.",
+  "Copied!": "",
   "Copy to clipboard": "Copy to clipboard",
   "Resource Type": "Resource Type",
   "Create / Apply": "Create / Apply",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -312,6 +312,7 @@
   "Read more": "",
   "Disable update notifications": "",
   "Install the metrics-server to get usage data.": "",
+  "Copied!": "",
   "Copy to clipboard": "",
   "Resource Type": "",
   "Create / Apply": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -314,6 +314,7 @@
   "Read more": "",
   "Disable update notifications": "",
   "Install the metrics-server to get usage data.": "",
+  "Copied!": "",
   "Copy to clipboard": "",
   "Resource Type": "",
   "Create / Apply": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -310,6 +310,7 @@
   "Read more": "",
   "Disable update notifications": "",
   "Install the metrics-server to get usage data.": "",
+  "Copied!": "",
   "Copy to clipboard": "",
   "Resource Type": "",
   "Create / Apply": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -310,6 +310,7 @@
   "Read more": "",
   "Disable update notifications": "",
   "Install the metrics-server to get usage data.": "",
+  "Copied!": "",
   "Copy to clipboard": "",
   "Resource Type": "",
   "Create / Apply": "",

--- a/frontend/src/i18n/locales/pt-br/translation.json
+++ b/frontend/src/i18n/locales/pt-br/translation.json
@@ -314,6 +314,7 @@
   "Read more": "",
   "Disable update notifications": "",
   "Install the metrics-server to get usage data.": "",
+  "Copied!": "",
   "Copy to clipboard": "",
   "Resource Type": "",
   "Create / Apply": "",

--- a/frontend/src/i18n/locales/pt-pt/translation.json
+++ b/frontend/src/i18n/locales/pt-pt/translation.json
@@ -314,6 +314,7 @@
   "Read more": "",
   "Disable update notifications": "",
   "Install the metrics-server to get usage data.": "",
+  "Copied!": "",
   "Copy to clipboard": "",
   "Resource Type": "",
   "Create / Apply": "",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -316,6 +316,7 @@
   "Read more": "Читать далее",
   "Disable update notifications": "Отключить уведомления об обновлениях",
   "Install the metrics-server to get usage data.": "Установите сервер метрик, чтобы получать данные об использовании.",
+  "Copied!": "",
   "Copy to clipboard": "Скопировать в буфер обмена",
   "Resource Type": "Тип ресурса",
   "Create / Apply": "Создать/применить",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -312,6 +312,7 @@
   "Read more": "",
   "Disable update notifications": "",
   "Install the metrics-server to get usage data.": "",
+  "Copied!": "",
   "Copy to clipboard": "",
   "Resource Type": "",
   "Create / Apply": "",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -312,6 +312,7 @@
   "Read more": "مزید پڑھیں",
   "Disable update notifications": "اپ ڈیٹ اطلاعات بند کریں",
   "Install the metrics-server to get usage data.": "استعمال کا ڈیٹا حاصل کرنے کے لیے metrics-server انسٹال کریں",
+  "Copied!": "",
   "Copy to clipboard": "کلپ بورڈ میں کاپی کریں",
   "Resource Type": "وسیلے کی قسم",
   "Create / Apply": "بنائیں / لاگو کریں",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -310,6 +310,7 @@
   "Read more": "",
   "Disable update notifications": "",
   "Install the metrics-server to get usage data.": "",
+  "Copied!": "",
   "Copy to clipboard": "",
   "Resource Type": "",
   "Create / Apply": "",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -310,6 +310,7 @@
   "Read more": "",
   "Disable update notifications": "",
   "Install the metrics-server to get usage data.": "",
+  "Copied!": "",
   "Copy to clipboard": "",
   "Resource Type": "",
   "Create / Apply": "",

--- a/frontend/src/storybook.test.tsx
+++ b/frontend/src/storybook.test.tsx
@@ -105,6 +105,7 @@ function replaceUseId(node: any) {
   const attributesToReplace = [
     'id',
     'for',
+    'name',
     'aria-describedby',
     'aria-labelledby',
     'aria-controls',


### PR DESCRIPTION
### Summary
This is an extension of the stale PR #4459. It adds a hover copy button on table cells (IP, address columns) so users can grab values like Pod IP, Cluster IP, External IP, Internal IP, and Endpoint/EndpointSlice Addresses without selecting text manually.

It also carries the fixes requested in review on #4459: reuses ActionButton instead of a bespoke button, avoids recomputing getValue twice per cell, cleans up the copy reset timer on unmount, makes the button usable from the keyboard, and tightens the copyable column type. Rebased onto latest main to resolve the branch's merge conflict, and fixed a flaky storyshot test plus a couple of translation file issues (duplicate/missing keys) uncovered along the way.

### Related Issue
Fixes #3983

### Steps to Test

- Open the Nodes, Pods, Services, Endpoints, or EndpointSlices list.
- Hover over an IP/address column (or tab to it) and click the copy icon that appears.
- Paste to confirm the correct value was copied.
- Check a row with no IP (e.g. a node with no external IP) to confirm the fallback text still shows and nothing gets copied incorrectly.

Screen recording of the copy interaction (Cluster IP and External IP columns):

https://github.com/user-attachments/assets/b83002fc-229e-4f63-be6c-3c2f80073424

Adds a hover copy button to IP and address columns in the resource tables so values can be copied without selecting text.