### PR TITLE
backend: helm: Verify user before upgrade

### DIFF
--- a/backend/pkg/helm/release.go
+++ b/backend/pkg/helm/release.go
@@ -856,6 +856,10 @@ func (h *Handler) upgradeRelease(req UpgradeReleaseRequest, actionConfig *action
 	upgradeClient.Description = req.Description
 	upgradeClient.Version = req.Version
 
+	if !VerifyUser(actionConfig, InstallRequest{CommonInstallUpdateRequest: req.CommonInstallUpdateRequest}) {
+		return
+	}
+
 	chart, err := h.getChart("upgrade", req.Chart, req.Name, upgradeClient.ChartPathOptions, true, h.EnvSettings)
 	if err != nil {
 		logger.Log(logger.LevelError, map[string]string{logFieldChart: req.Chart, logFieldReleaseName: req.Name},

--- a/backend/pkg/helm/release_internal_test.go
+++ b/backend/pkg/helm/release_internal_test.go
@@ -13,7 +13,35 @@ import (
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
+
+// unauthorizedRESTGetter mirrors the staticRESTGetter fake used by TestVerifyUser
+// in release_test.go: its empty host makes the whoami check performed by
+// VerifyUser fail, simulating an unauthorized/anonymous user.
+type unauthorizedRESTGetter struct{}
+
+var _ genericclioptions.RESTClientGetter = (*unauthorizedRESTGetter)(nil)
+
+func (u *unauthorizedRESTGetter) ToRESTConfig() (*rest.Config, error) {
+	return &rest.Config{Host: ""}, nil
+}
+
+func (u *unauthorizedRESTGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	return nil, nil
+}
+
+func (u *unauthorizedRESTGetter) ToRESTMapper() (meta.RESTMapper, error) {
+	return nil, nil
+}
+
+func (u *unauthorizedRESTGetter) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	return nil
+}
 
 func TestGetActionStatus_NilErr(t *testing.T) {
 	h := &Handler{
@@ -73,4 +101,48 @@ func TestGetChart_InvalidType(t *testing.T) {
 	assert.Equal(t, "failed", statusMap.Status)
 	assert.NotNil(t, statusMap.Err)
 	assert.Contains(t, *statusMap.Err, "chart type \"library\" is not installable")
+}
+
+// TestUpgradeRelease_UnauthorizedUser_DoesNotFetchChart verifies that upgradeRelease
+// performs the same VerifyUser authorization check as installRelease, rejecting an
+// unauthorized user before getChart is ever invoked.
+func TestUpgradeRelease_UnauthorizedUser_DoesNotFetchChart(t *testing.T) {
+	h := &Handler{
+		Cache:       cache.New[interface{}](),
+		EnvSettings: cli.New(),
+	}
+
+	// A valid, loadable chart on disk: if getChart were reached, it would
+	// succeed, so any observable failure below can only come from code that
+	// runs after getChart.
+	chartDir := t.TempDir()
+	chartYaml := filepath.Join(chartDir, "Chart.yaml")
+	chartContent := []byte("apiVersion: v2\nname: test-chart\nversion: 1.0.0\ntype: application\n")
+	require.NoError(t, os.WriteFile(chartYaml, chartContent, 0o600))
+
+	// RESTClientGetter with an empty host: the whoami check inside VerifyUser
+	// fails against it, simulating an unauthorized/anonymous user.
+	actionConfig := &action.Configuration{
+		RESTClientGetter: &unauthorizedRESTGetter{},
+	}
+
+	req := UpgradeReleaseRequest{
+		CommonInstallUpdateRequest: CommonInstallUpdateRequest{
+			Name:        "test-upgrade-release",
+			Namespace:   "default",
+			Description: "upgrade",
+			Chart:       chartDir,
+			// Invalid base64: if getChart were called and upgradeRelease
+			// continued past it, decoding this would fail and record a
+			// "failed" status. Its absence proves getChart was never reached.
+			Values:  "not-valid-base64!!!",
+			Version: "1.0.0",
+		},
+	}
+
+	h.upgradeRelease(req, actionConfig)
+
+	_, err := h.Cache.Get(context.Background(), "helm_upgrade_test-upgrade-release")
+	assert.ErrorIs(t, err, cache.ErrNotFound,
+		"no status should be recorded: upgradeRelease must return before getChart or any later step runs")
 }


### PR DESCRIPTION
## Summary

This PR fixes an authorization gap in `upgradeRelease` by adding the same `VerifyUser` check already used by `installRelease`.

Previously, `upgradeRelease` could reach `getChart()` before the requesting user was verified. Unauthorized or anonymous requests could therefore enter the chart-download path before authorization was evaluated.

The new check runs before `getChart()` and preserves the existing authorization semantics without changing `VerifyUser` or `installRelease`.

## Related Issue

Fixes #7096

## Changes

* Added `VerifyUser` validation to `upgradeRelease` before `getChart()` is called.
* Reused the existing `CommonInstallUpdateRequest` data expected by `VerifyUser`.
* Preserved the same authorization behavior and ordering used by `installRelease`.
* Added a regression test verifying that an unauthorized user is rejected before `getChart()` executes.
* Verified that authorized upgrade behavior remains unchanged.

## Steps to Test

1. Run the backend test suite:

   ```bash
   npm run backend:test
   ```
2. Run backend lint:

   ```bash
   npm run backend:lint
   ```
3. Run the Go build:

   ```bash
   go build ./...
   ```
4. Verify the regression test:
   `TestUpgradeRelease_UnauthorizedUser_DoesNotFetchChart`
5. Verify that an unauthorized/anonymous `upgradeRelease` request is rejected before chart fetching occurs.
6. Verify that authorized upgrade requests continue to work normally.

## Screenshots (if applicable)

N/A — backend-only change.

## Notes for the Reviewer

* The implementation intentionally mirrors the existing `installRelease` authorization flow.
* `VerifyUser` is called immediately before `getChart()`.
* The existing `VerifyUser` signature was not changed.
* No downloader or Helm release behavior was modified.
* The regression test uses a loadable chart and deliberately invalid values to ensure that reaching `getChart()` would produce a different failure, allowing the test to verify that authorization returns early.
* Existing integration coverage continues to exercise the authorized upgrade path.
* This is a focused security/authorization fix with no unrelated refactoring.
* `go build ./...` passed.
* `npm run backend:test` passed.
* `npm run backend:lint` passed with 0 issues.
* `gofmt` reported no formatting issues.
* Changes are contained to `backend/pkg/helm/release.go` and `backend/pkg/helm/release_internal_test.go`.
er, so please check language consistency.]
