### PR TITLE
frontend: Fix details panel header overlapping content

### DIFF
--- a/frontend/src/components/DetailsViewSection/detailsViewSectionSlice.ts
+++ b/frontend/src/components/DetailsViewSection/detailsViewSectionSlice.ts
@@ -16,7 +16,7 @@
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { get, set } from 'lodash';
-import { ReactNode } from 'react';
+import { createContext, ReactNode } from 'react';
 import { KubeObject } from '../../lib/k8s/KubeObject';
 import { DetailsViewSectionType } from './DetailsViewSection';
 
@@ -34,6 +34,9 @@ export enum DefaultDetailsViewSection {
   LOADING = 'LOADING',
   CHILDREN = 'CHILDREN',
 }
+
+/** Set to true when resource details render in a side panel rather than a full page, to omit the back link. */
+export const DetailsGridContext = createContext<{ isInPanel?: boolean }>({});
 
 type HeaderActionFuncType = (
   resource: KubeObject | null,

--- a/frontend/src/components/common/Resource/MainInfoSection/MainInfoSection.tsx
+++ b/frontend/src/components/common/Resource/MainInfoSection/MainInfoSection.tsx
@@ -24,6 +24,7 @@ import { HeaderAction } from '../../../../redux/actionButtonsSlice';
 import Loader from '../../../common/Loader';
 import { HeaderStyle } from '../../../common/SectionHeader';
 import { NameValueTableRow } from '../../../common/SimpleTable';
+import { DetailsGridContext } from '../../../DetailsViewSection/detailsViewSectionSlice';
 import Empty from '../../EmptyContent';
 import SectionBox from '../../SectionBox';
 import A8RInfo from '../A8RInfo';
@@ -60,9 +61,14 @@ export function MainInfoSection<T extends KubeObject>(props: MainInfoSectionProp
     error = null,
   } = props;
   const { t } = useTranslation();
+  const { isInPanel } = React.useContext(DetailsGridContext);
   const header = typeof headerSection === 'function' ? headerSection(resource) : headerSection;
 
   function getBackLink() {
+    if (isInPanel) {
+      return false;
+    }
+
     if (backLink === null) {
       return false;
     }

--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -61,6 +61,7 @@ import { SectionBox } from '../../common/SectionBox';
 import SimpleTable, { NameValueTable } from '../../common/SimpleTable';
 import {
   DefaultDetailsViewSection,
+  DetailsGridContext,
   DetailsViewSection,
 } from '../../DetailsViewSection/detailsViewSectionSlice';
 import { JobsListRenderer } from '../../job/List';
@@ -157,6 +158,7 @@ export function DetailsGrid<T extends KubeObjectClass>(props: DetailsGridProps<T
   const { t } = useTranslation();
   const location = useLocation<{ backLink: NavLinkProps['location'] }>();
   const hasPreviousRoute = useHasPreviousRoute();
+  const { isInPanel } = React.useContext(DetailsGridContext);
   const detailViews = useTypedSelector(state => state.detailsViewSection.detailsViewSections);
   const detailViewsProcessors = useTypedSelector(
     state => state.detailsViewSection.detailsViewSectionsProcessors
@@ -210,6 +212,11 @@ export function DetailsGrid<T extends KubeObjectClass>(props: DetailsGridProps<T
   }, [item, error]);
 
   const actualBackLink: string | Location | undefined = React.useMemo(() => {
+    // No back link in side panels
+    if (isInPanel) {
+      return undefined;
+    }
+
     if (!!backLink || backLink === '') {
       return backLink;
     }
@@ -243,7 +250,7 @@ export function DetailsGrid<T extends KubeObjectClass>(props: DetailsGridProps<T
 
     return createRouteURL(route);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [item]);
+  }, [item, isInPanel]);
 
   const sections: (DetailsViewSection | ReactNode)[] = [];
 

--- a/frontend/src/components/resourceMap/details/KubeNodeDetails.tsx
+++ b/frontend/src/components/resourceMap/details/KubeNodeDetails.tsx
@@ -25,6 +25,7 @@ import { CustomResourceDetails } from '../../crd/CustomResourceDetails';
 import CustomResourceDefinitionDetails from '../../crd/Details';
 import CronJobDetails from '../../cronjob/Details';
 import DaemonSetDetails from '../../daemonset/Details';
+import { DetailsGridContext } from '../../DetailsViewSection/detailsViewSectionSlice';
 import EndpointDetails from '../../endpoints/Details';
 import EndpointSliceDetails from '../../endpointSlices/Details';
 import BackendTLSPolicyDetails from '../../gateway/BackendTLSPolicyDetails';
@@ -168,9 +169,9 @@ export const KubeObjectDetails = memo(
     }, [kind, kindComponentMap]);
 
     return (
-      <Box>
-        <Box sx={{ marginTop: '-70px' }}>{content}</Box>
-      </Box>
+      <DetailsGridContext.Provider value={{ isInPanel: true }}>
+        <Box>{content}</Box>
+      </DetailsGridContext.Provider>
     );
   }
 );

--- a/frontend/src/components/resourceMap/details/PanelBackLink.test.tsx
+++ b/frontend/src/components/resourceMap/details/PanelBackLink.test.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { TestContext } from '../../../test';
+import { MainInfoSection } from '../../common/Resource/MainInfoSection/MainInfoSection';
+import { DetailsGrid } from '../../common/Resource/Resource';
+import { DetailsGridContext } from '../../DetailsViewSection/detailsViewSectionSlice';
+
+class TestResource {
+  static apiName = 'test-resources';
+  static useGet = () => [null, null];
+
+  get listRoute() {
+    return TestResource.apiName;
+  }
+}
+
+function DetailsPanel() {
+  return (
+    <>
+      <DetailsGrid resourceType={TestResource as any} name="test-resource" backLink="" />
+      <MainInfoSection resource={null} backLink="" />
+    </>
+  );
+}
+
+describe('details panel back links', () => {
+  it('hides back links on details and custom resource panels', () => {
+    render(
+      <TestContext>
+        <DetailsGridContext.Provider value={{ isInPanel: true }}>
+          <DetailsPanel />
+        </DetailsGridContext.Provider>
+      </TestContext>
+    );
+
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

When viewing resource details in a side panel (ex. nodes, namespaces, deployments, etc.), the sticky header overlapped the top of the content, and also the backlink in the panel is now visible when it was previously hidden. Looks like recent changes to make the header sticky conflicted with old style changes.

## Cause/Context

The details panel used a `-70px` top margin to hide the back link. The recently added sticky header stays pinned while that margin pulls the body up, so the header sits over the content. Alongside this, the recent sticky changes make this no longer do it's original goal : hiding the backlink at the top of the panel.

**Broken behavior: (Top of content is hidden in all panels) (Backlink is also visible)**
<img width="70%" height="auto" alt="image" src="https://github.com/user-attachments/assets/ae82ebad-6f50-4d38-9c05-351b6654c7b3" />

**Fixed: (Top of content is viewable and backlink is hidden)**
<img width="70%" height="auto" alt="image" src="https://github.com/user-attachments/assets/e793e7f7-f69f-4e4d-9387-bcedeb15ac56" />


## Changes

- Added `DetailsGridContext`: a small context that tells `DetailsGrid` when it is rendering inside a panel, so it skips the back link.
- Removed the `-70px` margin. Offset is no longer needed and overlap is gone.

Note: The full-page detail views render `DetailsGrid` directly, not via the panel wrapper, so they're unaffected and reatin their back link.

## Steps to Test

1. Open a resource's details in the panel (ex. a node or namespace).
2. Observe the header at top to confirm there is no overlap or back link.