### PR TITLE
frontend: CreatePVCForm: Set a stable RadioGroup name

### DIFF
--- a/frontend/src/components/storage/CreatePVCForm.tsx
+++ b/frontend/src/components/storage/CreatePVCForm.tsx
@@ -87,6 +87,7 @@ function StorageClassField({ value, onChange }: StorageClassFieldProps) {
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
       <RadioGroup
         aria-label={t('glossary|Storage Class')}
+        name="storage-class-mode"
         value={mode}
         onChange={e => handleModeChange(e.target.value as StorageClassMode)}
       >

--- a/frontend/src/components/storage/__snapshots__/CreatePVCForm.Empty.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/CreatePVCForm.Empty.stories.storyshot
@@ -361,7 +361,7 @@
                         <input
                           checked=""
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3km:"
+                          name="storage-class-mode"
                           type="radio"
                           value="default"
                         />
@@ -409,7 +409,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3km:"
+                          name="storage-class-mode"
                           type="radio"
                           value="none"
                         />
@@ -457,7 +457,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3km:"
+                          name="storage-class-mode"
                           type="radio"
                           value="specify"
                         />

--- a/frontend/src/components/storage/__snapshots__/CreatePVCForm.MinimalValid.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/CreatePVCForm.MinimalValid.stories.storyshot
@@ -369,7 +369,7 @@
                         <input
                           checked=""
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3l0:"
+                          name="storage-class-mode"
                           type="radio"
                           value="default"
                         />
@@ -417,7 +417,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3l0:"
+                          name="storage-class-mode"
                           type="radio"
                           value="none"
                         />
@@ -465,7 +465,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3l0:"
+                          name="storage-class-mode"
                           type="radio"
                           value="specify"
                         />

--- a/frontend/src/components/storage/__snapshots__/CreatePVCForm.MultipleAccessModes.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/CreatePVCForm.MultipleAccessModes.stories.storyshot
@@ -377,7 +377,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3nd:"
+                          name="storage-class-mode"
                           type="radio"
                           value="default"
                         />
@@ -425,7 +425,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3nd:"
+                          name="storage-class-mode"
                           type="radio"
                           value="none"
                         />
@@ -474,7 +474,7 @@
                         <input
                           checked=""
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3nd:"
+                          name="storage-class-mode"
                           type="radio"
                           value="specify"
                         />

--- a/frontend/src/components/storage/__snapshots__/CreatePVCForm.ReadWriteMany.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/CreatePVCForm.ReadWriteMany.stories.storyshot
@@ -368,7 +368,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3n2:"
+                          name="storage-class-mode"
                           type="radio"
                           value="default"
                         />
@@ -416,7 +416,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3n2:"
+                          name="storage-class-mode"
                           type="radio"
                           value="none"
                         />
@@ -465,7 +465,7 @@
                         <input
                           checked=""
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3n2:"
+                          name="storage-class-mode"
                           type="radio"
                           value="specify"
                         />

--- a/frontend/src/components/storage/__snapshots__/CreatePVCForm.StaticProvisioning.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/CreatePVCForm.StaticProvisioning.stories.storyshot
@@ -368,7 +368,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3md:"
+                          name="storage-class-mode"
                           type="radio"
                           value="default"
                         />
@@ -417,7 +417,7 @@
                         <input
                           checked=""
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3md:"
+                          name="storage-class-mode"
                           type="radio"
                           value="none"
                         />
@@ -465,7 +465,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3md:"
+                          name="storage-class-mode"
                           type="radio"
                           value="specify"
                         />

--- a/frontend/src/components/storage/__snapshots__/CreatePVCForm.StorageClassNone.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/CreatePVCForm.StorageClassNone.stories.storyshot
@@ -368,7 +368,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3lp:"
+                          name="storage-class-mode"
                           type="radio"
                           value="default"
                         />
@@ -417,7 +417,7 @@
                         <input
                           checked=""
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3lp:"
+                          name="storage-class-mode"
                           type="radio"
                           value="none"
                         />
@@ -465,7 +465,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3lp:"
+                          name="storage-class-mode"
                           type="radio"
                           value="specify"
                         />

--- a/frontend/src/components/storage/__snapshots__/CreatePVCForm.WithStorageClass.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/CreatePVCForm.WithStorageClass.stories.storyshot
@@ -540,7 +540,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3le:"
+                          name="storage-class-mode"
                           type="radio"
                           value="default"
                         />
@@ -588,7 +588,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3le:"
+                          name="storage-class-mode"
                           type="radio"
                           value="none"
                         />
@@ -637,7 +637,7 @@
                         <input
                           checked=""
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3le:"
+                          name="storage-class-mode"
                           type="radio"
                           value="specify"
                         />

--- a/frontend/src/components/storage/__snapshots__/CreatePVCForm.WithStorageClassAndVolumeName.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/CreatePVCForm.WithStorageClassAndVolumeName.stories.storyshot
@@ -368,7 +368,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3mn:"
+                          name="storage-class-mode"
                           type="radio"
                           value="default"
                         />
@@ -416,7 +416,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3mn:"
+                          name="storage-class-mode"
                           type="radio"
                           value="none"
                         />
@@ -465,7 +465,7 @@
                         <input
                           checked=""
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3mn:"
+                          name="storage-class-mode"
                           type="radio"
                           value="specify"
                         />

--- a/frontend/src/components/storage/__snapshots__/CreatePVCForm.WithVolumeName.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/CreatePVCForm.WithVolumeName.stories.storyshot
@@ -369,7 +369,7 @@
                         <input
                           checked=""
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3m3:"
+                          name="storage-class-mode"
                           type="radio"
                           value="default"
                         />
@@ -417,7 +417,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3m3:"
+                          name="storage-class-mode"
                           type="radio"
                           value="none"
                         />
@@ -465,7 +465,7 @@
                       >
                         <input
                           class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
-                          name=":r3m3:"
+                          name="storage-class-mode"
                           type="radio"
                           value="specify"
                         />


### PR DESCRIPTION
This change gives the storage-class `RadioGroup` in `CreatePVCForm` an explicit `name`, so MUI stops falling back to React's `useId`.

Without it the radios render `name=":r3l0:"`, and `useId` values shift whenever the number of preceding `useId` calls changes. That made all nine `CreatePVCForm` storyshots churn on unrelated merges — most recently #7082, which re-recorded them. An explicit name makes the attribute deterministic, so the re-record does not have to happen again.

### Changes

- Add `name="storage-class-mode"` to the `RadioGroup`
- Regenerate the nine `CreatePVCForm` storyshots, replacing the generated IDs with the stable name

### Testing

- [x] Storyshots pass and are stable across reruns