### PR TITLE
frontend: Move window.plugins to window.Headlamp.plugins

### DIFF
--- a/frontend/src/plugin/index.test.ts
+++ b/frontend/src/plugin/index.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { initializePlugins } from './index';
+import { Headlamp } from './lib';
+import Registry from './registry';
+
+describe('Plugin Registry and Initialization', () => {
+  beforeEach(() => {
+    // Reset the window objects for test isolation
+    window.Headlamp = window.Headlamp || {};
+    window.Headlamp.plugins = {};
+    (window as any).plugins = {}; // Mock old plugins path
+  });
+
+  it('should register a plugin to window.Headlamp.plugins and initialize it', async () => {
+    const mockInitialize = vi.fn();
+    const pluginObj = {
+      initialize: mockInitialize,
+    };
+
+    const pluginId = 'test-plugin';
+    Headlamp.registerPlugin(pluginId, pluginObj as any);
+
+    // Assert it appears under window.Headlamp.plugins and not window.plugins
+    expect(window.Headlamp.plugins[pluginId]).toBe(pluginObj);
+    expect((window as any).plugins[pluginId]).toBeUndefined();
+
+    // Verify initializePlugins() invokes it
+    await initializePlugins();
+
+    expect(mockInitialize).toHaveBeenCalledTimes(1);
+    expect(mockInitialize).toHaveBeenCalledWith(expect.any(Registry));
+  });
+});

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -111,9 +111,9 @@ window.pluginLib = {
 // backwards compat.
 window.pluginLib.MuiCore = window.pluginLib.MuiMaterial;
 
-// @todo: should window.plugins be private?
-// @todo: Should all the plugin objects be in a single window.Headlamp object?
-window.plugins = {};
+// @todo: should window.Headlamp.plugins be private?
+window.Headlamp = window.Headlamp || {};
+window.Headlamp.plugins = {};
 
 /**
  * Load external, then local plugins. Then initialize() them in order with a Registry.
@@ -121,8 +121,8 @@ window.plugins = {};
 export async function initializePlugins() {
   // Initialize every plugin in the order they were loaded.
   return new Promise(resolve => {
-    for (const pluginName of Object.keys(window.plugins)) {
-      const plugin = window.plugins[pluginName];
+    for (const pluginName of Object.keys(window.Headlamp.plugins)) {
+      const plugin = window.Headlamp.plugins[pluginName];
       try {
         // @todo: what should happen if this fails?
         plugin.initialize(new Registry());

--- a/frontend/src/plugin/lib.ts
+++ b/frontend/src/plugin/lib.ts
@@ -72,8 +72,10 @@ declare global {
     pluginLib: {
       [libName: string]: any;
     };
-    plugins: {
-      [pluginId: string]: Plugin;
+    Headlamp: {
+      plugins: {
+        [pluginId: string]: Plugin;
+      };
     };
     registerPlugin: (pluginId: string, pluginObj: Plugin) => void;
     desktopApi: any;
@@ -124,7 +126,7 @@ export abstract class Headlamp {
   static registerPlugin(pluginId: string, pluginObj: Plugin) {
     // @todo: what happens if this plugin exists? (and is already initialized?)
     //        Should it raise an error? Silently keep going? Do we need quit() methods on plugins?
-    window.plugins[pluginId] = pluginObj;
+    window.Headlamp.plugins[pluginId] = pluginObj;
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR moves the global plugin registry from `window.plugins` to `window.Headlamp.plugins` to prevent polluting the global window scope.

## Related Issue

Fixes #7105 

## Changes

- Updated `interface Window` in `frontend/src/plugin/lib.ts` to include a structured `Headlamp` object.
- Replaced global `window.plugins` assignments and references with `window.Headlamp.plugins` in `frontend/src/plugin/index.ts` and `frontend/src/plugin/lib.ts`.

## Steps to Test

1. Build and run the frontend (`npm run frontend:start`).
2. Load Headlamp in the browser and verify plugins load successfully without errors in the developer console.
3. In the browser developer console, verify `window.Headlamp.plugins` is populated and `window.plugins` is no longer used by Headlamp.


## Notes for the Reviewer

- Addressed the `@todo: Should all the plugin objects be in a single window.Headlamp object?` comment to improve API hygiene and prevent potential global collisions with other scripts.
