### PR TITLE
frontend: Don't leak Secret values through the Details page cache-seed

### DIFF
--- a/frontend/src/components/common/Link.test.tsx
+++ b/frontend/src/components/common/Link.test.tsx
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { kubeObjectQueryKey } from '../../lib/k8s/api/v2/hooks';
+import Pod from '../../lib/k8s/pod';
+import Secret from '../../lib/k8s/secret';
+import Link from './Link';
+
+// drawerMode disabled: keeps KubeObjectLink's onClick as plain navigation
+// (no Activity-panel launch) so we can assert on it directly.
+vi.mock('../../redux/hooks', () => ({ useTypedSelector: vi.fn(() => undefined) }));
+// These pull in the full resource-class barrel (lib/k8s/index), which isn't
+// needed for this test and errors when imported outside the app's normal
+// module load order.
+vi.mock('../resourceMap/details/KubeNodeDetails', () => ({
+  canRenderDetails: () => false,
+  KubeObjectDetails: () => null,
+}));
+vi.mock('../resourceMap/kubeIcon/KubeIcon', () => ({ KubeIcon: () => null }));
+vi.mock('../activity/Activity', () => ({ Activity: { launch: vi.fn() } }));
+// The real route registry pulls in every resource class (including ones with
+// circular-import issues when loaded outside the app's normal entry point).
+vi.mock('../../lib/router/createRouteURL', () => ({
+  createRouteURL: (routeName: string, params?: Record<string, string>) =>
+    `/${routeName}/${params?.namespace ?? ''}/${params?.name ?? ''}`,
+}));
+
+function renderLink(kubeObject: Secret | Pod, queryClient: QueryClient) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <Link kubeObject={kubeObject} />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('KubeObjectLink', () => {
+  it('does not seed the query cache with list-derived data for Secrets', async () => {
+    const secret = new Secret(
+      {
+        kind: 'Secret',
+        apiVersion: 'v1',
+        metadata: { name: 'demo-secret', namespace: 'headlamp', uid: '1' },
+        data: { password: 'UzNjcjN0UEBzc3cwcmQh' },
+        type: 'Opaque',
+      } as any,
+      'test-cluster'
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    renderLink(secret, queryClient);
+
+    await userEvent.click(screen.getByText('demo-secret'));
+
+    const key = kubeObjectQueryKey({
+      cluster: 'test-cluster',
+      endpoint: (Secret.apiEndpoint as any).apiInfo[0],
+      namespace: 'headlamp',
+      name: 'demo-secret',
+    });
+
+    expect(queryClient.getQueryData(key)).toBeUndefined();
+  });
+
+  it('clears a pre-existing cache entry for a Secret before navigation', async () => {
+    const secret = new Secret(
+      {
+        kind: 'Secret',
+        apiVersion: 'v1',
+        metadata: { name: 'demo-secret', namespace: 'headlamp', uid: '1' },
+        data: { password: 'UzNjcjN0UEBzc3cwcmQh' },
+        type: 'Opaque',
+      } as any,
+      'test-cluster'
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const key = kubeObjectQueryKey({
+      cluster: 'test-cluster',
+      endpoint: (Secret.apiEndpoint as any).apiInfo[0],
+      namespace: 'headlamp',
+      name: 'demo-secret',
+    });
+
+    // Simulate a value cached from an earlier authorized view.
+    queryClient.setQueryData(key, secret);
+
+    renderLink(secret, queryClient);
+
+    await userEvent.click(screen.getByText('demo-secret'));
+
+    expect(queryClient.getQueryData(key)).toBeUndefined();
+  });
+
+  it('still seeds the query cache with list-derived data for other resource kinds', async () => {
+    const pod = new Pod(
+      {
+        kind: 'Pod',
+        apiVersion: 'v1',
+        metadata: { name: 'demo-pod', namespace: 'headlamp', uid: '2' },
+        spec: { containers: [] },
+        status: {},
+      } as any,
+      'test-cluster'
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    renderLink(pod, queryClient);
+
+    await userEvent.click(screen.getByText('demo-pod'));
+
+    const key = kubeObjectQueryKey({
+      cluster: 'test-cluster',
+      endpoint: (Pod.apiEndpoint as any).apiInfo[0],
+      namespace: 'headlamp',
+      name: 'demo-pod',
+    });
+
+    expect(queryClient.getQueryData(key)).toBe(pod);
+  });
+});

--- a/frontend/src/components/common/Link.tsx
+++ b/frontend/src/components/common/Link.tsx
@@ -75,8 +75,22 @@ function KubeObjectLink(props: {
           namespace,
           name,
         });
-        // prepopulate the query cache with existing object
-        client.setQueryData(key, kubeObject);
+
+        // Don't prepopulate the cache from a list-derived object for Secrets. The
+        // RBAC verbs for "list"/"watch" and "get" are independent: a LIST response
+        // already contains full (decodable) secret data for a user who only has
+        // list/watch access, even when a "get" on that specific Secret is denied.
+        // Seeding the details-page cache with that data would flash the real
+        // values before the authoritative "get" request confirms access.
+        if (kubeObject.kind !== 'Secret') {
+          // prepopulate the query cache with existing object
+          client.setQueryData(key, kubeObject);
+        } else {
+          // Also drop any value already cached under this key (e.g. from an
+          // earlier authorized view), so a stale Secret can't be served from
+          // cache while the authoritative "get" request is pending.
+          client.removeQueries({ queryKey: key });
+        }
         // and invalidate it (mark as stale)
         // so that the latest version will be downloaded in the background
         client.invalidateQueries({ queryKey: key });


### PR DESCRIPTION
## Summary

Fixes #4857.

Clicking a Secret in a list would prepopulate the Details page's query cache with the object from the clicked list row (`KubeObjectLink`'s `client.setQueryData`) before navigating, then refetch the authoritative copy in the background.

That's fine for most resources, but Kubernetes RBAC treats `list`/`watch` and `get` as independent verbs — a `list secrets` response already contains the full, decodable `data` field for every secret it returns, even for a user who can't `get` an individual secret by name. So a user with only list/watch access on Secrets would see the real values on the Details page (and could reveal them via "Show values") immediately after clicking, while the actual `get` request ran in the background and eventually came back `403 Forbidden` — by which point the value had already been visible.

## Root cause

`frontend/src/components/common/Link.tsx`'s `KubeObjectLink`:

```tsx
client.setQueryData(key, kubeObject); // seeded from the LIST row's object
client.invalidateQueries({ queryKey: key }); // refetch in the background
```

## Fix

Skip the cache-seeding step specifically for Secrets, so the Details view (and the Activity side-panel, which shares the same query cache) always waits for an authorized `get` before rendering anything. Other resource kinds keep the existing fast-navigation/cache-seed behavior, since it's not a confidentiality concern for them.

## Testing

- Reproduced locally end-to-end: a standalone `etcd` + `kube-apiserver`, a Role granting only `list`/`watch` on Secrets, and the real Headlamp frontend + backend pointed at it. Confirmed the exposure before the fix and confirmed it's gone after (Details view now shows a loading state and then the correct Forbidden error, with no data ever rendered).
- Added `frontend/src/components/common/Link.test.tsx`: asserts the cache is not seeded for Secrets, and is still seeded for other resource kinds (e.g. Pods).
- `npx vitest run` on the touched test file and the existing `TopBar`/`Layout`/`HeadlampButton`/`Secret` storyshots — all pass.
- `npm run tsc` — clean.
- `eslint` on changed files — clean.

## Steps to test manually

1. Create a Role/RoleBinding granting a user `list`+`watch` (but not `get`) on `secrets` in some namespace.
2. As that user, open Headlamp and go to that namespace's Secrets list — it loads fine.
3. Click a Secret. Before this fix: the Details page immediately shows the real (decodable) values, then a Forbidden error a moment later. After this fix: it shows a loading state and then only the Forbidden error — the values are never rendered.