### PR TITLE
frontend: Map: Make Back return to the map overview

### DIFF
--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -37,10 +37,12 @@ import {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router';
 import Namespace from '../../lib/k8s/namespace';
 import K8sNode from '../../lib/k8s/node';
 import { setNamespaceFilter } from '../../redux/filterSlice';
 import { useTypedSelector } from '../../redux/hooks';
+import { Activity } from '../activity/Activity';
 import { NamespacesAutocomplete } from '../common/NamespacesAutocomplete';
 import { filterGraph, filterGraphIncremental, GraphFilter } from './graph/graphFiltering';
 import { getGraphForNamespaceSelection } from './graph/graphForNamespaceSelection';
@@ -179,14 +181,42 @@ function GraphViewContent({
   );
   const setSelectedNodeId = useCallback(
     (id: string | undefined) => {
-      if (id === 'root') {
-        _setSelectedNodeId(undefined);
-        return;
-      }
-      _setSelectedNodeId(id);
+      _setSelectedNodeId(id === 'root' ? undefined : id);
     },
     [_setSelectedNodeId]
   );
+
+  // The details panel and the ?node= history entry are two views of the same selection,
+  // so keep them in sync: closing the panel pops the entry that opened it, and popping it
+  // (Back) closes the panel. Without this, Back only cleared the highlight of an
+  // already-closed panel and looked like a no-op.
+  const history = useHistory();
+  const isPanelOpen = useTypedSelector(
+    state => !!selectedNodeId && !!state.activity.activities[selectedNodeId]
+  );
+  const panelNodeId = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    if (isPanelOpen) {
+      panelNodeId.current = selectedNodeId;
+      return;
+    }
+    const closedId = panelNodeId.current;
+    panelNodeId.current = undefined;
+    // Panel closed while its node is still selected: undo the entry the click pushed.
+    // A different selection means history already moved, so leave it alone.
+    if (closedId && closedId === selectedNodeId) {
+      history.goBack();
+    }
+  }, [isPanelOpen, selectedNodeId, history]);
+
+  const prevSelectedNodeId = useRef(selectedNodeId);
+  useEffect(() => {
+    const prevId = prevSelectedNodeId.current;
+    prevSelectedNodeId.current = selectedNodeId;
+    if (prevId && prevId !== selectedNodeId) {
+      Activity.close(prevId);
+    }
+  }, [selectedNodeId]);
 
   // Expand all groups state
   const [expandAll, setExpandAll] = useState(false);

--- a/frontend/src/components/resourceMap/useQueryParamsState.test.tsx
+++ b/frontend/src/components/resourceMap/useQueryParamsState.test.tsx
@@ -65,6 +65,27 @@ describe('useQueryParamsState', () => {
     expect(history.length).toBe(2);
   });
 
+  it('should not push a history entry when setting the same value again', () => {
+    const history = createMemoryHistory();
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <Router history={history}>{children}</Router>
+    );
+
+    const { result } = renderHook(() => useQueryParamsState<string>('test', 'initial'), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current[1]('same');
+    });
+    act(() => {
+      result.current[1]('same');
+    });
+
+    expect(history.location.search).toBe('?test=same');
+    expect(history.length).toBe(2);
+  });
+
   it('should remove the query param if the new value is undefined', () => {
     const history = createMemoryHistory();
     history.replace('?test=value');

--- a/frontend/src/components/resourceMap/useQueryParamsState.tsx
+++ b/frontend/src/components/resourceMap/useQueryParamsState.tsx
@@ -61,7 +61,8 @@ export function useQueryParamsState<T extends string | undefined>(
 
       // Apply new search params
       const newSearch = '?' + newParams;
-      if (params.replace) {
+      // Re-setting the same value must not stack up identical history entries
+      if (params.replace || newSearch === history.location.search) {
         history.replace(newSearch);
       } else {
         history.push(newSearch);


### PR DESCRIPTION
Clicking a Map node pushes a `?node=<id>` history entry and opens the details activity panel, but the panel and that entry were never kept in sync: closing the panel left the entry and the node highlight behind, so the first Back press only cleared the highlight and stayed on the page. Pressing Back with the panel open had the mirror problem — highlight gone, panel still open.

Fixes: https://github.com/kubernetes-sigs/headlamp/issues/7110

- `GraphView.tsx`: when the panel closes while its node is still selected, pop the entry the click pushed; when the selection changes (e.g. Back), close the panel of the previous selection.
- `useQueryParamsState.tsx`: setting a param to the value it already has no longer stacks an identical history entry (clicking the same node twice).
- `useQueryParamsState.test.tsx`: test for that guard.

How to test: open the Map, click a node, close the panel with the X or its taskbar tab, press Back — you should leave the Map instead of only losing the highlight. Then click a node again and press Back with the panel open: panel closes and the highlight clears in one press.
