### PR TITLE
fix: resolve AuthVisible hook dependencies

### DIFF
--- a/frontend/src/components/common/Resource/AuthVisible.test.tsx
+++ b/frontend/src/components/common/Resource/AuthVisible.test.tsx
@@ -220,4 +220,72 @@ describe('AuthVisible', () => {
 
     expect(screen.queryByText('Authorized Content')).toBeNull();
   });
+
+  it('does not invoke onAuthResult again when only the callback identity changes, and uses the latest callback on subsequent updates', async () => {
+    let authAllowed = true;
+    const mockItem = {
+      _class: () => ({
+        apiName: 'pods',
+        apiVersion: 'v1',
+      }),
+      getName: () => 'test-pod',
+      getAuthorization: vi.fn().mockImplementation(() =>
+        Promise.resolve({
+          status: {
+            allowed: authAllowed,
+            reason: authAllowed ? 'Allowed' : 'Forbidden',
+          },
+        })
+      ),
+    };
+
+    const initialCallback = vi.fn();
+    const updatedCallback = vi.fn();
+
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <AuthVisible item={mockItem as any} authVerb="get" onAuthResult={initialCallback}>
+          <div>Authorized Content</div>
+        </AuthVisible>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(initialCallback).toHaveBeenCalledWith({
+        allowed: true,
+        reason: 'Allowed',
+      });
+    });
+
+    initialCallback.mockClear();
+
+    // Rerender with a new callback identity
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <AuthVisible item={mockItem as any} authVerb="get" onAuthResult={updatedCallback}>
+          <div>Authorized Content</div>
+        </AuthVisible>
+      </QueryClientProvider>
+    );
+
+    // Wait a tick to ensure no unexpected calls
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(updatedCallback).not.toHaveBeenCalled();
+    expect(initialCallback).not.toHaveBeenCalled();
+
+    // Trigger a new authorization result
+    authAllowed = false;
+    queryClient.invalidateQueries();
+
+    await waitFor(() => {
+      expect(updatedCallback).toHaveBeenCalledWith({
+        allowed: false,
+        reason: 'Forbidden',
+      });
+    });
+
+    // The initial callback should still not have been called again
+    expect(initialCallback).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/components/common/Resource/AuthVisible.tsx
+++ b/frontend/src/components/common/Resource/AuthVisible.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { getCluster } from '../../../lib/cluster';
 import { KubeObject } from '../../../lib/k8s/KubeObject';
 import { KubeObjectClass } from '../../../lib/k8s/KubeObject';
@@ -97,15 +97,20 @@ export default function AuthVisible(props: AuthVisibleProps) {
 
   const visible = data?.status?.allowed ?? false;
 
+  const onAuthResultRef = useRef(onAuthResult);
+
+  useEffect(() => {
+    onAuthResultRef.current = onAuthResult;
+  }, [onAuthResult]);
+
   useEffect(() => {
     if (data) {
-      onAuthResult?.({
+      onAuthResultRef.current?.({
         allowed: visible,
         reason: data.status?.reason ?? '',
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data]);
+  }, [data, visible]);
 
   if (!isAuthVerbValid) {
     return null;


### PR DESCRIPTION
## What this PR does

Fixes the React Hooks dependency warning in `AuthVisible`.

- Removes the `react-hooks/exhaustive-deps` suppression.
- Keeps the latest `onAuthResult` callback in a ref to avoid unnecessary effect reruns.
- Ensures the effect uses the latest callback safely.

## Why

The existing effect suppressed the `react-hooks/exhaustive-deps` warning. Adding the callback directly to the dependency array could cause unnecessary reruns because callers may provide an inline callback.

This change keeps the callback up to date without making the effect rerun when the callback reference changes.

## Steps to test

1. Run the frontend tests.
2. Verify that the `AuthVisible` tests pass.
3. Verify that the frontend lint check passes.

Related to #5183