### PR TITLE
backend: k8cache: Fix potential DoS from gzip bombs

### DIFF
--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -83,10 +83,18 @@ func GetResponseBody(bodyBytes []byte, encoding string) (string, error) {
 
 		defer func() { _ = reader.Close() }()
 
-		decompressedBody, err := io.ReadAll(reader)
+		// Use LimitReader to prevent gzip bomb DoS (max 50MB)
+		decompressedBody, err := io.ReadAll(io.LimitReader(reader, 50*1024*1024+1))
 		if err != nil {
 			logger.Log(logger.LevelError, nil, err, "failed to decompress body")
 			return "", fmt.Errorf("failed to decompress body: %w", err)
+		}
+
+		if len(decompressedBody) > 50*1024*1024 {
+			err = fmt.Errorf("response body exceeds maximum allowed size (50MB)")
+			logger.Log(logger.LevelError, nil, err, "failed to decompress body")
+
+			return "", err
 		}
 
 		dcmpBody = decompressedBody


### PR DESCRIPTION
## Summary

This PR fixes a Denial of Service (DoS) vulnerability in the Kubernetes API caching layer by enforcing a maximum size limit when decompressing gzip payloads. 

## Related Issue

Fixes #7119

## Changes

- Updated `GetResponseBody()` in `backend/pkg/k8cache/cacheStore.go` to wrap the gzip reader with `io.LimitReader`.
- Enforced a hard limit of 50MB for decompressed payloads to prevent malicious or misconfigured Kubernetes APIs from sending "gzip bombs" that cause Out-Of-Memory (OOM) crashes in the Headlamp backend.

## Steps to Test

1. Ensure you have a standard Headlamp backend running (`npm run backend:start`).
2. Verify that general cluster navigation and caching of large resources (like viewing a large number of Pods or large ConfigMaps) still functions normally without hitting the 50MB limit.
3. Review the code changes in `cacheStore.go` to confirm the `io.LimitReader` is appropriately placed before `io.ReadAll`.

## Screenshots (if applicable)

N/A (Backend-only security fix)

## Notes for the Reviewer

- I chose 50MB (`50 * 1024 * 1024 + 1`) as a generous upper bound for a single decompressed Kubernetes API response to ensure legitimate large clusters don't experience truncation, while still preventing catastrophic OOM crashes.

