### PR TITLE
Frontend : Add right click menu in terminal

### DIFF
--- a/frontend/src/components/App/icons.ts
+++ b/frontend/src/components/App/icons.ts
@@ -441,6 +441,9 @@ const mdiIcons = {
     'content-copy': {
       body: '\u003Cpath fill="currentColor" d="M19 21H8V7h11m0-2H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2m-3-4H4a2 2 0 0 0-2 2v14h2V3h12z"/\u003E',
     },
+    'content-paste': {
+      body: '\u003Cpath fill="currentColor" d="M19 20H5V4h2v3h10V4h2m-7-2a1 1 0 0 1 1 1a1 1 0 0 1-1 1a1 1 0 0 1-1-1a1 1 0 0 1 1-1m7 0h-4.18C14.4.84 13.3 0 12 0S9.6.84 9.18 2H5a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2"/\u003E',
+    },
     'arrow-left': {
       body: '\u003Cpath fill="currentColor" d="M20 11v2H8l5.5 5.5l-1.42 1.42L4.16 12l7.92-7.92L13.5 5.5L8 11z"/\u003E',
     },

--- a/frontend/src/components/common/Terminal.test.tsx
+++ b/frontend/src/components/common/Terminal.test.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { act, render } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { Terminal as XTerminal } from '@xterm/xterm';
 import React from 'react';
 import { TestContext } from '../../test';
 import Terminal from './Terminal';
@@ -156,6 +157,114 @@ describe('Terminal', () => {
       await act(() => new Promise(res => process.nextTick(res)));
 
       expect(capturedContainer).toBe('main');
+    });
+  });
+
+  describe('context menu (Electron)', () => {
+    async function renderTerminal(socket: { readyState: number; send: (d: any) => void } | null) {
+      const streamReturn = {
+        cancel: () => {},
+        getSocket: () => socket,
+      };
+      const pod = createMockPod(async () => streamReturn);
+
+      render(
+        <TestContext>
+          <Terminal item={pod as any} open onClose={() => {}} />
+        </TestContext>
+      );
+
+      await act(async () => {
+        vi.advanceTimersByTime(100);
+      });
+      await act(() => new Promise(res => process.nextTick(res)));
+    }
+
+    let getSelectionSpy: ReturnType<typeof vi.spyOn> | null = null;
+    const originalUserAgent = window.navigator.userAgent;
+
+    beforeEach(() => {
+      Object.defineProperty(window.navigator, 'userAgent', {
+        value: 'Electron',
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window.navigator, 'userAgent', {
+        value: originalUserAgent,
+        configurable: true,
+      });
+      getSelectionSpy?.mockRestore();
+      getSelectionSpy = null;
+      delete (navigator as any).clipboard;
+    });
+
+    it('shows the context menu with Copy and Paste on right click', async () => {
+      await renderTerminal({ readyState: 1, send: () => {} });
+
+      fireEvent.contextMenu(document.getElementById('xterm-container')!);
+
+      expect(screen.getByRole('menuitem', { name: 'translation|Copy' })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'translation|Paste' })).toBeInTheDocument();
+    });
+
+    it('disables Paste when the socket is not ready', async () => {
+      await renderTerminal({ readyState: 0, send: () => {} });
+
+      fireEvent.contextMenu(document.getElementById('xterm-container')!);
+
+      expect(screen.getByRole('menuitem', { name: 'translation|Paste' })).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
+    });
+
+    it('disables Copy when there is no selection', async () => {
+      getSelectionSpy = vi.spyOn(XTerminal.prototype, 'getSelection').mockReturnValue('');
+      await renderTerminal({ readyState: 1, send: () => {} });
+
+      fireEvent.contextMenu(document.getElementById('xterm-container')!);
+
+      expect(screen.getByRole('menuitem', { name: 'translation|Copy' })).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
+    });
+
+    it('copies the current selection to the clipboard', async () => {
+      getSelectionSpy = vi
+        .spyOn(XTerminal.prototype, 'getSelection')
+        .mockReturnValue('selected text');
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.assign(navigator, { clipboard: { writeText } });
+
+      await renderTerminal({ readyState: 1, send: () => {} });
+
+      fireEvent.contextMenu(document.getElementById('xterm-container')!);
+      fireEvent.click(screen.getByRole('menuitem', { name: 'translation|Copy' }));
+      await act(() => new Promise(res => process.nextTick(res)));
+
+      expect(writeText).toHaveBeenCalledWith('selected text');
+    });
+
+    it('sends pasted clipboard text over the socket on stdin channel 0', async () => {
+      const send = vi.fn();
+      const readText = vi.fn().mockResolvedValue('pasted text');
+      Object.assign(navigator, { clipboard: { readText } });
+
+      await renderTerminal({ readyState: 1, send });
+
+      fireEvent.contextMenu(document.getElementById('xterm-container')!);
+      fireEvent.click(screen.getByRole('menuitem', { name: 'translation|Paste' }));
+      await act(() => new Promise(res => process.nextTick(res)));
+
+      expect(readText).toHaveBeenCalled();
+      expect(send).toHaveBeenCalled();
+      const sentBuffer = send.mock.calls[0][0] as ArrayBuffer;
+      const sentBytes = new Uint8Array(sentBuffer);
+      expect(sentBytes[0]).toBe(0);
+      expect(new TextDecoder().decode(sentBytes.slice(1))).toBe('pasted text');
     });
   });
 });

--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -15,11 +15,15 @@
  */
 
 import '@xterm/xterm/css/xterm.css';
+import { Icon } from '@iconify/react';
 import Box from '@mui/material/Box';
 import { DialogProps } from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import { useTheme } from '@mui/material/styles';
@@ -29,6 +33,7 @@ import { Terminal as XTerminal } from '@xterm/xterm';
 import _ from 'lodash';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { isElectron } from '../../helpers/isElectron';
 import { getDefaultContainer, resolveContainerName } from '../../helpers/podContainer';
 import Pod from '../../lib/k8s/pod';
 import { Dialog } from './Dialog';
@@ -75,10 +80,17 @@ export default function Terminal(props: TerminalProps) {
     available: getAvailableShells(),
     currentIdx: 0,
   });
+  const [contextMenu, setContextMenu] = React.useState<{
+    mouseX: number;
+    mouseY: number;
+    hasSelection: boolean;
+    canPaste: boolean;
+  } | null>(null);
   const { t } = useTranslation(['translation', 'glossary']);
   const muiTheme = useTheme();
   const xtermTheme = React.useMemo(() => getXtermTheme(muiTheme), [muiTheme]);
   const isMobile = useMediaQuery(muiTheme.breakpoints.down('sm'));
+  const isDesktopApp = isElectron();
 
   // @todo: Give the real exec type when we have it.
   function setupTerminal(containerRef: HTMLElement, xterm: XTerminal, fitAddon: FitAddon) {
@@ -389,6 +401,53 @@ export default function Terminal(props: TerminalProps) {
     setContainer(event.target.value);
   }
 
+  function canPasteIntoTerminal() {
+    const socket = execOrAttachRef.current?.getSocket();
+
+    return !!socket && socket.readyState === 1;
+  }
+
+  const handleContextMenu = (event: React.MouseEvent) => {
+    event.preventDefault();
+    const hasSelection = !!xtermRef.current?.xterm.getSelection();
+    setContextMenu({
+      mouseX: event.clientX + 2,
+      mouseY: event.clientY - 6,
+      hasSelection,
+      canPaste: canPasteIntoTerminal(),
+    });
+  };
+
+  const handleContextMenuClose = () => {
+    setContextMenu(null);
+  };
+
+  const handleCopy = async () => {
+    if (xtermRef.current) {
+      const selection = xtermRef.current.xterm.getSelection();
+      if (selection) {
+        try {
+          await navigator.clipboard.writeText(selection);
+        } catch (err) {
+          console.error('Failed to copy text: ', err);
+        }
+      }
+    }
+    handleContextMenuClose();
+  };
+
+  const handlePaste = async () => {
+    if (xtermRef.current && canPasteIntoTerminal()) {
+      try {
+        const text = await navigator.clipboard.readText();
+        xtermRef.current.xterm.paste(text);
+      } catch (err) {
+        console.error('Failed to paste text: ', err);
+      }
+    }
+    handleContextMenuClose();
+  };
+
   function isSuccessfulExitError(channel: number, text: string): boolean {
     // Linux container Error
     if (channel === 3) {
@@ -514,8 +573,38 @@ export default function Terminal(props: TerminalProps) {
         <div
           id="xterm-container"
           ref={x => setTerminalContainerRef(x)}
-          style={{ flex: 1, display: 'flex', flexDirection: 'column-reverse' }}
+          onContextMenu={isDesktopApp ? handleContextMenu : undefined}
+          style={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column-reverse',
+          }}
         />
+        {isDesktopApp && (
+          <Menu
+            open={contextMenu !== null}
+            onClose={handleContextMenuClose}
+            anchorReference="anchorPosition"
+            anchorPosition={
+              contextMenu !== null
+                ? { top: contextMenu.mouseY, left: contextMenu.mouseX }
+                : undefined
+            }
+          >
+            <MenuItem onClick={handleCopy} disabled={!contextMenu?.hasSelection}>
+              <ListItemIcon>
+                <Icon icon="mdi:content-copy" />
+              </ListItemIcon>
+              <ListItemText>{t('translation|Copy')}</ListItemText>
+            </MenuItem>
+            <MenuItem onClick={handlePaste} disabled={!contextMenu?.canPaste}>
+              <ListItemIcon>
+                <Icon icon="mdi:content-paste" />
+              </ListItemIcon>
+              <ListItemText>{t('translation|Paste')}</ListItemText>
+            </MenuItem>
+          </Menu>
+        )}
       </Box>
     </DialogContent>
   );

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -581,6 +581,7 @@
   "Failed to run \"{{ command }}\"": "فشل تشغيل \"{{ command }}\"",
   "Trying to attach to the container {{ container }}…": "جارٍ محاولة الاتصال بالحاوية {{ container }}…",
   "Trying to run \"{{command}}\"…": "جارٍ محاولة تشغيل \"{{command}}\"…",
+  "Paste": "",
   "Attach: {{ itemName }}": "اتصال: {{ itemName }}",
   "Terminal: {{ itemName }}": "الطرفية: {{ itemName }}",
   "Timezone": "المنطقة الزمنية",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -561,6 +561,7 @@
   "Failed to run \"{{ command }}\"": "Run করতে Failed \"{{ command }}\"",
   "Trying to attach to the container {{ container }}…": "Container এ সংযুক্ত করার চেষ্টা করছি {{ container }}…",
   "Trying to run \"{{command}}\"…": "চালানোর চেষ্টা করছি \"{{command}}\"…",
+  "Paste": "",
   "Attach: {{ itemName }}": "সংযুক্ত: {{ itemName }}",
   "Terminal: {{ itemName }}": "Terminal: {{ itemName }}",
   "Timezone": "Timezone",

--- a/frontend/src/i18n/locales/cs/translation.json
+++ b/frontend/src/i18n/locales/cs/translation.json
@@ -571,6 +571,7 @@
   "Failed to run \"{{ command }}\"": "Nepodařilo se spustit {{ command }}.",
   "Trying to attach to the container {{ container }}…": "Probíhá pokus o připojení ke kontejneru {{ container }}...",
   "Trying to run \"{{command}}\"…": "Probíhá pokus o spuštění {{command}}...",
+  "Paste": "",
   "Attach: {{ itemName }}": "Připojit: {{ itemName }}",
   "Terminal: {{ itemName }}": "Terminál: {{ itemName }}",
   "Timezone": "Časové pásmo",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -561,6 +561,7 @@
   "Failed to run \"{{ command }}\"": "Ausführung von \"{{ command }}\" fehlgeschlagen",
   "Trying to attach to the container {{ container }}…": "Versuche, an den Container {{ container }} anzuhängen…",
   "Trying to run \"{{command}}\"…": "Versuche, \"{{command}}\" auszuführen…",
+  "Paste": "Einfügen",
   "Attach: {{ itemName }}": "",
   "Terminal: {{ itemName }}": "",
   "Timezone": "Zeitzone",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -561,6 +561,7 @@
   "Failed to run \"{{ command }}\"": "Failed to run \"{{ command }}\"",
   "Trying to attach to the container {{ container }}…": "Trying to attach to the container {{ container }}…",
   "Trying to run \"{{command}}\"…": "Trying to run \"{{command}}\"…",
+  "Paste": "Paste",
   "Attach: {{ itemName }}": "Attach: {{ itemName }}",
   "Terminal: {{ itemName }}": "Terminal: {{ itemName }}",
   "Timezone": "Timezone",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -566,6 +566,7 @@
   "Failed to run \"{{ command }}\"": "Fallo al ejecutar \"{{ command }}\"",
   "Trying to attach to the container {{ container }}…": "Intentando adjuntarse al contenedor {{ container }}…",
   "Trying to run \"{{command}}\"…": "Intentando ejecutar \"{{command}}\"…",
+  "Paste": "Pegar",
   "Attach: {{ itemName }}": "",
   "Terminal: {{ itemName }}": "",
   "Timezone": "Huso horario",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -566,6 +566,7 @@
   "Failed to run \"{{ command }}\"": "Échec de l'exécution de \"{commande }}\"",
   "Trying to attach to the container {{ container }}…": "Tentative de connexion au conteneur {{ container }}…",
   "Trying to run \"{{command}}\"…": "Essayer d'exécuter \"{{command}}\"…",
+  "Paste": "Coller",
   "Attach: {{ itemName }}": "Attacher : {{ itemName }}",
   "Terminal: {{ itemName }}": "Terminal : {{ itemName }}",
   "Timezone": "Fuseau horaire",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -566,6 +566,7 @@
   "Failed to run \"{{ command }}\"": "Failed to run \"{{ command }}\"",
   "Trying to attach to the container {{ container }}…": "Trying to attach to the container {{ container }}…",
   "Trying to run \"{{command}}\"…": "Trying to run \"{{command}}\"…",
+  "Paste": "",
   "Attach: {{ itemName }}": "Attach: {{ itemName }}",
   "Terminal: {{ itemName }}": "Terminal: {{ itemName }}",
   "Timezone": "Timezone",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -561,6 +561,7 @@
   "Failed to run \"{{ command }}\"": "",
   "Trying to attach to the container {{ container }}…": "",
   "Trying to run \"{{command}}\"…": "",
+  "Paste": "पेस्ट करें",
   "Attach: {{ itemName }}": "",
   "Terminal: {{ itemName }}": "",
   "Timezone": "",

--- a/frontend/src/i18n/locales/hu/translation.json
+++ b/frontend/src/i18n/locales/hu/translation.json
@@ -561,6 +561,7 @@
   "Failed to run \"{{ command }}\"": "A(z) {{ command }} futtatása nem sikerült",
   "Trying to attach to the container {{ container }}…": "Kísérlet a(z) {{ container }} tárolóhoz való csatolásra…",
   "Trying to run \"{{command}}\"…": "Próbálkozás a(z) {{command}} futtatásával…",
+  "Paste": "",
   "Attach: {{ itemName }}": "Csatolás: {{ itemName }}",
   "Terminal: {{ itemName }}": "Terminál: {{ itemName }}",
   "Timezone": "Időzóna",

--- a/frontend/src/i18n/locales/id/translation.json
+++ b/frontend/src/i18n/locales/id/translation.json
@@ -556,6 +556,7 @@
   "Failed to run \"{{ command }}\"": "Gagal menjalankan \"{{ command }}\"",
   "Trying to attach to the container {{ container }}…": "Mencoba memasangkan ke kontainer {{ container }}…",
   "Trying to run \"{{command}}\"…": "Mencoba menjalankan \"{{command}}\"…",
+  "Paste": "",
   "Attach: {{ itemName }}": "Pasang: {{ itemName }}",
   "Terminal: {{ itemName }}": "Terminal: {{ itemName }}",
   "Timezone": "Zona waktu",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -566,6 +566,7 @@
   "Failed to run \"{{ command }}\"": "Impossibile eseguire \"{{ command }}\"",
   "Trying to attach to the container {{ container }}…": "Tentativo di collegamento al container {{ container }}…",
   "Trying to run \"{{command}}\"…": "Sto tentando di eseguire \"{{command}}\"…",
+  "Paste": "Incolla",
   "Attach: {{ itemName }}": "Collega: {{ itemName }}",
   "Terminal: {{ itemName }}": "Terminale: {{ itemName }}",
   "Timezone": "Fuso orario",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -556,6 +556,7 @@
   "Failed to run \"{{ command }}\"": "\"{{ command }}\" の実行に失敗しました",
   "Trying to attach to the container {{ container }}…": "コンテナー {{ container }} にアタッチしようとしています…",
   "Trying to run \"{{command}}\"…": "\"{{command}}\" を実行しようとしています…",
+  "Paste": "貼り付け",
   "Attach: {{ itemName }}": "アタッチ: {{ itemName }}",
   "Terminal: {{ itemName }}": "ターミナル: {{ itemName }}",
   "Timezone": "タイムゾーン",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -556,6 +556,7 @@
   "Failed to run \"{{ command }}\"": "\"{{ command }}\" 실행에 실패했습니다.",
   "Trying to attach to the container {{ container }}…": "컨테이너 {{ container }}에 연결을 시도 중…",
   "Trying to run \"{{command}}\"…": "\"{{command}}\" 실행 중…",
+  "Paste": "붙여넣기",
   "Attach: {{ itemName }}": "연결: {{ itemName }}",
   "Terminal: {{ itemName }}": "터미널: {{ itemName }}",
   "Timezone": "시간대",

--- a/frontend/src/i18n/locales/nl/translation.json
+++ b/frontend/src/i18n/locales/nl/translation.json
@@ -561,6 +561,7 @@
   "Failed to run \"{{ command }}\"": "Kan \"{{ command }}\" niet uitvoeren",
   "Trying to attach to the container {{ container }}…": "Bezig met koppelen aan container {{ container }}...",
   "Trying to run \"{{command}}\"…": "Bezig met uitvoeren van {{command}}...",
+  "Paste": "",
   "Attach: {{ itemName }}": "Koppel: {{ itemName }}",
   "Terminal: {{ itemName }}": "Terminal: {{ itemName }}",
   "Timezone": "Tijdzone",

--- a/frontend/src/i18n/locales/pl/translation.json
+++ b/frontend/src/i18n/locales/pl/translation.json
@@ -571,6 +571,7 @@
   "Failed to run \"{{ command }}\"": "Nie można uruchomić „{{ command }}”",
   "Trying to attach to the container {{ container }}…": "Trwa próba dołączenia do kontenera {{ container }}...",
   "Trying to run \"{{command}}\"…": "Trwa próba uruchomienia „{{command}}”...",
+  "Paste": "",
   "Attach: {{ itemName }}": "Dołącz: {{ itemName }}",
   "Terminal: {{ itemName }}": "Terminal: {{ itemName }}",
   "Timezone": "Strefa czasowa",

--- a/frontend/src/i18n/locales/pt-br/translation.json
+++ b/frontend/src/i18n/locales/pt-br/translation.json
@@ -566,6 +566,7 @@
   "Failed to run \"{{ command }}\"": "Falha ao executar \"{{ command }}\"",
   "Trying to attach to the container {{ container }}…": "A tentar anexar ao container {{ container }}…",
   "Trying to run \"{{command}}\"…": "A tentar executar \"{{command}}\"…",
+  "Paste": "Colar",
   "Attach: {{ itemName }}": "Anexar: {{ itemName }}",
   "Terminal: {{ itemName }}": "Terminal: {{ itemName }}",
   "Timezone": "Fuso horário",

--- a/frontend/src/i18n/locales/pt-pt/translation.json
+++ b/frontend/src/i18n/locales/pt-pt/translation.json
@@ -566,6 +566,7 @@
   "Failed to run \"{{ command }}\"": "",
   "Trying to attach to the container {{ container }}…": "",
   "Trying to run \"{{command}}\"…": "",
+  "Paste": "",
   "Attach: {{ itemName }}": "",
   "Terminal: {{ itemName }}": "",
   "Timezone": "",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -571,6 +571,7 @@
   "Failed to run \"{{ command }}\"": "Не удалось запустить \"{{ command }}\"",
   "Trying to attach to the container {{ container }}…": "Пытаюсь присоединиться к контейнеру {{ container }}…",
   "Trying to run \"{{command}}\"…": "Пытаюсь запустить \"{{command}}\"…",
+  "Paste": "",
   "Attach: {{ itemName }}": "Прикрепить: {{ itemName }}",
   "Terminal: {{ itemName }}": "Терминал: {{ itemName }}",
   "Timezone": "Часовой пояс",

--- a/frontend/src/i18n/locales/sv/translation.json
+++ b/frontend/src/i18n/locales/sv/translation.json
@@ -561,6 +561,7 @@
   "Failed to run \"{{ command }}\"": "Det gick inte att köra {{ command }}",
   "Trying to attach to the container {{ container }}…": "Försöker ansluta till containern {{ container }}…",
   "Trying to run \"{{command}}\"…": "Försöker köra {{command}}…",
+  "Paste": "",
   "Attach: {{ itemName }}": "Anslut: {{ itemName }}",
   "Terminal: {{ itemName }}": "Terminal: {{ itemName }}",
   "Timezone": "Tidszon",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -561,6 +561,7 @@
   "Failed to run \"{{ command }}\"": "\"{{ command }}\"-ஐ இயக்குவதில் தோல்வி",
   "Trying to attach to the container {{ container }}…": "{{ container }} கண்டெய்னருடன் இணைக்க முயற்சிக்கிறது...",
   "Trying to run \"{{command}}\"…": "\"{{command}}\"-ஐ இயக்க முயற்சிக்கிறது...",
+  "Paste": "ஒட்டு",
   "Attach: {{ itemName }}": "அட்டாச்: {{ itemName }}",
   "Terminal: {{ itemName }}": "டெர்மினல்: {{ itemName }}",
   "Timezone": "டைம்ஸோன்",

--- a/frontend/src/i18n/locales/tr/translation.json
+++ b/frontend/src/i18n/locales/tr/translation.json
@@ -561,6 +561,7 @@
   "Failed to run \"{{ command }}\"": "\"{{ command }}\" çalıştırılamadı",
   "Trying to attach to the container {{ container }}…": "{{ container }} kapsayıcısına bağlanmaya çalışılıyor…",
   "Trying to run \"{{command}}\"…": "\"{{command}}\" komutunu çalıştırma deneniyor…",
+  "Paste": "",
   "Attach: {{ itemName }}": "Ekle: {{ itemName }}",
   "Terminal: {{ itemName }}": "Terminal: {{ itemName }}",
   "Timezone": "Saat dilimi",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -561,6 +561,7 @@
   "Failed to run \"{{ command }}\"": "\"{{ command }}\" چلانے میں ناکامی",
   "Trying to attach to the container {{ container }}…": "کنٹینر {{ container }} سے منسلک ہونے کی کوشش کی جا رہی ہے…",
   "Trying to run \"{{command}}\"…": "\"{{command}}\" چلانے کی کوشش کی جا رہی ہے…",
+  "Paste": "",
   "Attach: {{ itemName }}": "منسلک کریں: {{ itemName }}",
   "Terminal: {{ itemName }}": "ٹرمنل: {{ itemName }}",
   "Timezone": "ٹائم زون",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -556,6 +556,7 @@
   "Failed to run \"{{ command }}\"": "執行 \"{{ command }}\" 失敗",
   "Trying to attach to the container {{ container }}…": "嘗試附加到容器 {{ container }}…",
   "Trying to run \"{{command}}\"…": "嘗試執行 \"{{command}}\"…",
+  "Paste": "貼上",
   "Attach: {{ itemName }}": "附加：{{ itemName }}",
   "Terminal: {{ itemName }}": "終端：{{ itemName }}",
   "Timezone": "時區",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -556,6 +556,7 @@
   "Failed to run \"{{ command }}\"": "执行 \"{{ command }}\" 失败",
   "Trying to attach to the container {{ container }}…": "尝试附加到容器 {{ container }}…",
   "Trying to run \"{{command}}\"…": "尝试执行 \"{{command}}\"…",
+  "Paste": "粘贴",
   "Attach: {{ itemName }}": "附加：{{ itemName }}",
   "Terminal: {{ itemName }}": "终端：{{ itemName }}",
   "Timezone": "时区",


### PR DESCRIPTION
## Summary

- This PR adds  right click menu in terminal (e.g. copy/paste)

## Related Issue

- Fixes #3797 

## Preview 


https://github.com/user-attachments/assets/ec38a7b8-fa92-4135-82b3-a0c7026a17ad

## Screenshots (if applicable)

Both taken from the real app, right-clicking inside a pod's terminal.

Before : right-clicking the terminal does nothing, there's no way to copy or paste.
<img width="1900" height="950" alt="Before: right-clicking inside the terminal produces no menu" src="https://raw.githubusercontent.com/rootp1/headlamp/rootp1/pr-7146-screenshots/pr-7121-before.png" />

After : right-clicking opens a Copy/Paste context menu.
<img width="1900" height="950" alt="After: right-clicking inside the terminal opens a Copy/Paste context menu" src="https://raw.githubusercontent.com/rootp1/headlamp/rootp1/pr-7146-screenshots/pr-7121-after.png" />

## Notes for the Reviewer

- [e.g., This touches the i18n layer, so please check language consistency.]
