### PR TITLE
frontend: useKubeObjectList: Guard empty-string namespace watch predicate

### DIFF
--- a/frontend/src/lib/k8s/KubeObject.ts
+++ b/frontend/src/lib/k8s/KubeObject.ts
@@ -433,6 +433,11 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
     opts?: {
       queryParams?: QueryParameters;
       cluster?: string;
+      /**
+       * Seed data to use before the query resolves. Must be reference-stable across
+       * renders (memoize it or capture it once) — an object rebuilt on every render
+       * will cause repeated re-renders.
+       */
       initialData?: K;
     }
   ) {

--- a/frontend/src/lib/k8s/api/v2/hooks.ts
+++ b/frontend/src/lib/k8s/api/v2/hooks.ts
@@ -122,6 +122,11 @@ export function useKubeObject<K extends KubeObject>({
   /** Cluster name */
   cluster?: string;
   queryParams?: QueryParameters;
+  /**
+   * Seed data to use before the query resolves. Must be reference-stable across
+   * renders (memoize it or capture it once) — an object rebuilt on every render
+   * will cause repeated re-renders.
+   */
   initialData?: K;
 }): [K | null, ApiError | null] & QueryResponse<K, ApiError> {
   type Instance = K;

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
@@ -247,6 +247,17 @@ describe('isWatchedListStillRequested', () => {
 
     expect(isWatchedListStillRequested(watching, requests)).toBe(false);
   });
+
+  // The mirror image of the 9542b5cb5 regression: '' must not be read as "matches
+  // anything" either. Without this case, '' is never checked against a non-empty
+  // namespace list anywhere in the suite, so an implementation short-circuiting ''
+  // to a match would pass every other test here.
+  it('should drop a watch entry with an empty-string namespace when a specific namespace is requested', () => {
+    const watching = { cluster: 'default', namespace: '' };
+    const requests = [{ cluster: 'default', namespaces: ['default'] }];
+
+    expect(isWatchedListStillRequested(watching, requests)).toBe(false);
+  });
 });
 
 describe('useWatchKubeObjectLists', () => {

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
@@ -22,6 +22,7 @@ import { ApiError } from './ApiError';
 import { clusterFetch } from './fetch';
 import {
   DEFAULT_LIST_LIMIT,
+  isWatchedListStillRequested,
   kubeObjectListQuery,
   ListResponse,
   makeListRequests,
@@ -202,6 +203,51 @@ function deferred<T>() {
   });
   return { promise, resolve };
 }
+
+describe('isWatchedListStillRequested', () => {
+  // Regression test for 9542b5cb5: an empty-string namespace means "all namespaces"
+  // for a namespaced resource and is a valid, meaningful value — but it is falsy, so
+  // a naive truthiness check (`!watching.namespace`) treats it the same as "no
+  // namespace at all" and incorrectly drops the watch entry. It must never get
+  // "cleaned up" just because it's an empty string.
+  it('should keep a watch entry with an empty-string namespace when still requested', () => {
+    const watching = { cluster: 'default', namespace: '' };
+    const requests = [{ cluster: 'default', namespaces: [''] }];
+
+    expect(isWatchedListStillRequested(watching, requests)).toBe(true);
+  });
+
+  it('should drop a watch entry whose cluster is no longer requested', () => {
+    const watching = { cluster: 'default', namespace: '' };
+    const requests = [{ cluster: 'other-cluster', namespaces: [''] }];
+
+    expect(isWatchedListStillRequested(watching, requests)).toBe(false);
+  });
+
+  it('should keep a watch entry with no namespace for a non-namespaced resource', () => {
+    const watching = { cluster: 'default', namespace: undefined };
+    const requests = [{ cluster: 'default', namespaces: undefined }];
+
+    expect(isWatchedListStillRequested(watching, requests)).toBe(true);
+  });
+
+  // A request with no namespace filter is served by kubeObjectListQuery with its
+  // default namespace of '', so the resulting watch entry carries '' rather than
+  // undefined. It still matches that request.
+  it('should keep a watch entry with an empty-string namespace when the request has no namespaces', () => {
+    const watching = { cluster: 'default', namespace: '' };
+    const requests = [{ cluster: 'default', namespaces: undefined }];
+
+    expect(isWatchedListStillRequested(watching, requests)).toBe(true);
+  });
+
+  it('should drop a watch entry whose namespace is no longer requested', () => {
+    const watching = { cluster: 'default', namespace: 'gone' };
+    const requests = [{ cluster: 'default', namespaces: ['kept'] }];
+
+    expect(isWatchedListStillRequested(watching, requests)).toBe(false);
+  });
+});
 
 describe('useWatchKubeObjectLists', () => {
   beforeEach(() => {

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -488,6 +488,29 @@ function flattenListRequests(
   );
 }
 
+/**
+ * Whether a currently-watched list is still covered by one of the given requests.
+ *
+ * An empty-string namespace is a real, valid value: it means "all namespaces" for a
+ * namespaced resource, and it is what a request with no namespace filter produces.
+ * Because it is falsy, matching it against a request's namespace list needs an
+ * explicit undefined check rather than a truthiness check, or the watch entry is
+ * dropped every render and immediately re-added, looping setState (see 9542b5cb5).
+ * The unfiltered branch keeps the falsy check on purpose, so a watch on '' still
+ * matches a request that asks for no particular namespace.
+ */
+export function isWatchedListStillRequested(
+  watching: { cluster: string; namespace?: string },
+  requests: Array<{ cluster: string; namespaces?: string[] }>
+): boolean {
+  return requests.some(request => {
+    if (watching.cluster !== request?.cluster) return false;
+    return !request.namespaces?.length
+      ? !watching.namespace
+      : watching.namespace !== undefined && request.namespaces.includes(watching.namespace);
+  });
+}
+
 function getPositiveLimit(queryParams: QueryParameters): number | undefined {
   const limit = Number(queryParams.limit);
 
@@ -647,14 +670,8 @@ export function useKubeObjectList<K extends KubeObject>({
 
   useEffect(() => {
     setListsToWatch(currentListsToWatch => {
-      const keptListsToWatch = currentListsToWatch.filter(
-        watching =>
-          requests.find(request => {
-            if (watching.cluster !== request?.cluster) return false;
-            return !request.namespaces?.length
-              ? !watching.namespace
-              : !!watching.namespace && request.namespaces.includes(watching.namespace);
-          }) !== undefined
+      const keptListsToWatch = currentListsToWatch.filter(watching =>
+        isWatchedListStillRequested(watching, requests)
       );
 
       if (!shouldWatch) {


### PR DESCRIPTION
## Summary

This PR fixes a latent regression in `useKubeObjectList`, where a watch entry with an
empty-string namespace can be dropped by a truthiness check that was reintroduced by a
long-lived branch after it had already been fixed.

`9542b5cb5` ("frontend: useKubeObjectList: Fix infinite re-render when namespace is empty
string") matched watch entries against requested namespaces with an explicit
`!== undefined` check instead of truthiness. An empty-string namespace is a real value —
it means "all namespaces" for a namespaced resource — but it is falsy, so the truthiness
check dropped the entry on every render while query data immediately re-added it, looping
`setState`.

`1f35a61bc` ("frontend: pod list: Add pagination") was authored 2026-05-15, before that
fix, and merged 2026-07-27, after it. The merge reinstated the old truthiness form.

**This is latent, not live.** On the watching path `keptListsToWatch` is discarded: the
`shouldWatch` branch recomputes `nextListsToWatch` from `query.data` and never derives
from it, so the stale predicate is only consumed when `shouldWatch` is false, where it
converges. I could not produce a user-visible failure on current `main` and do not believe
one exists today. The reason it stays inert is incidental, though — a future refactor that
feeds `keptListsToWatch` back into the watch path would reanimate the original infinite
re-render, with no test standing in the way.

## Related Issue

None — found while testing a third-party plugin that passes `namespace: ''` to `useList`,
a common `useState('')` pattern.

## Changes

- Restored the explicit `!== undefined` check in the namespace-matching branch of the
  watch-reconciliation predicate, exactly as `9542b5cb5` had it.
- Extracted that predicate into an exported `isWatchedListStillRequested` helper so it is
  directly testable, leaving the `useEffect` call site to a single filter.
- Added unit tests covering both branches of the helper, citing `9542b5cb5` in a comment.
  Following review, added a sixth case pinning an empty-string namespace against a
  *specific* requested namespace. Without it, `''` was never checked against a non-empty
  namespace list anywhere in the suite, so an implementation treating `''` as
  always-matching would have passed every other test.
- Documented that `initialData` on `useKubeObject` and `KubeObject.useGet` must be
  reference-stable. It is seeded through a layout effect, so a value rebuilt on every
  render re-seeds on every render. The one in-tree caller (`EditButton.tsx`) passes a
  stable prop; this is a comment-only change aimed at plugin authors and future callers.
  It rides along deliberately: it is a second, unrelated re-render hazard in the same
  hook family, found during the same investigation of a plugin passing `namespace: ''`.
  It has no behavioral effect — happy to split it into a follow-up PR if preferred.

## Steps to Test

1. `cd frontend && npx vitest run src/lib/k8s/api/v2/useKubeObjectList.test.tsx`
2. Observe 37 tests passing.
3. To confirm the new tests discriminate, mutate `isWatchedListStillRequested`:
   - Flip either branch back to its truthiness form (`watching.namespace === undefined` /
     `!!watching.namespace`). Each mutation fails exactly one of the two
     empty-string-namespace tests.
   - Or short-circuit the else branch with `watching.namespace === '' ||`, treating `''`
     as universal. That fails only the sixth test, and no other.

## Screenshots (if applicable)

N/A — no user-visible change.

## Notes for the Reviewer

- The unfiltered branch deliberately keeps `!watching.namespace` rather than
  `=== undefined`, matching `9542b5cb5`, which changed only the else branch.
  `kubeObjectListQuery` defaults `namespace` to `''`, so a request carrying no namespace
  filter produces a watch entry whose namespace is `''`, not `undefined`; tightening that
  branch would drop it. The second test pins this case.
- The behavior change is confined to the predicate; extracting the helper is otherwise a
  pure move. `keptListsToWatch` is only consumed on the `!shouldWatch` path, which is why
  this is a defensive fix rather than a live one.
- Verified locally: `vitest` 37/37 on the touched file, `tsc --noEmit` clean, `eslint`
  clean, `prettier --check` clean.

