### PR TITLE
frontend: TooltipLight: Fix dropped styles via slotProps

### DIFF
--- a/frontend/src/components/common/Tooltip/TooltipLight.test.tsx
+++ b/frontend/src/components/common/Tooltip/TooltipLight.test.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @vitest-environment jsdom
+
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { createMuiTheme } from '../../../lib/themes';
+import TooltipLight from './TooltipLight';
+
+const lightTheme = createMuiTheme({ name: 'light', base: 'light' });
+const darkTheme = createMuiTheme({ name: 'dark', base: 'dark' });
+
+describe('TooltipLight', () => {
+  it('does not forward sx to the anchor element', () => {
+    render(
+      <ThemeProvider theme={lightTheme}>
+        <TooltipLight title="tip">
+          <button data-testid="trigger">hover</button>
+        </TooltipLight>
+      </ThemeProvider>
+    );
+
+    // The bug: sx was passed directly to <Tooltip>, which spread it onto the
+    // child <button> as a DOM attribute. React dropped it, so the tooltip
+    // surface styles were never applied.
+    expect(screen.getByTestId('trigger')).not.toHaveAttribute('sx');
+  });
+
+  it('renders newline-separated text preserving each line', async () => {
+    const user = userEvent.setup();
+    const multiLine = 'nginx\ncoredns\nistio-proxy';
+
+    render(
+      <ThemeProvider theme={lightTheme}>
+        <TooltipLight title={multiLine}>
+          <button data-testid="trigger">containers</button>
+        </TooltipLight>
+      </ThemeProvider>
+    );
+
+    await user.hover(screen.getByTestId('trigger'));
+
+    const tooltip = await screen.findByRole('tooltip');
+
+    // The tooltip text must preserve the newlines that the deployment
+    // container list builds with containers.join('\n').
+    expect(tooltip.textContent).toBe(multiLine);
+
+    // The tooltip surface itself is the element with the .MuiTooltip-tooltip class.
+    // That is where our slotProps.tooltip.sx styles should be applied.
+    const tooltipSurface = tooltip.className.includes('MuiTooltip-tooltip')
+      ? tooltip
+      : tooltip.querySelector('.MuiTooltip-tooltip');
+
+    // Verify that the required styling actually reached the tooltip surface
+    expect(tooltipSurface).toHaveStyle({ whiteSpace: 'pre-line' });
+  });
+
+  it('renders the tooltip under the dark theme without leaking sx', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ThemeProvider theme={darkTheme}>
+        <TooltipLight title="dark tip">
+          <button data-testid="trigger">hover</button>
+        </TooltipLight>
+      </ThemeProvider>
+    );
+
+    expect(screen.getByTestId('trigger')).not.toHaveAttribute('sx');
+
+    await user.hover(screen.getByTestId('trigger'));
+
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent('dark tip');
+  });
+});

--- a/frontend/src/components/common/Tooltip/TooltipLight.tsx
+++ b/frontend/src/components/common/Tooltip/TooltipLight.tsx
@@ -15,6 +15,7 @@
  */
 
 import Fade from '@mui/material/Fade';
+import { SxProps, Theme } from '@mui/material/styles';
 import Tooltip, { TooltipProps } from '@mui/material/Tooltip';
 import { ReactElement, ReactNode } from 'react';
 
@@ -28,39 +29,49 @@ export interface TooltipLightProps extends Omit<TooltipProps, 'children'> {
   children: ReactNode;
 }
 
+// TooltipLight is a custom wrapper around MUI's Tooltip component.
+// It gives tooltips a light background, custom font size, and allows multi-line text using \n.
 export default function TooltipLight(props: TooltipLightProps) {
-  const { children, interactive = true, ...rest } = props;
+  const { children, interactive = true, slotProps, componentsProps, ...rest } = props;
   const disableInteractive = !interactive;
 
-  if (typeof children === 'string') {
-    return (
-      <Tooltip
-        disableInteractive={disableInteractive}
-        TransitionComponent={Fade}
-        TransitionProps={{ timeout: 0 }}
-        sx={theme => ({
-          backgroundColor: theme.palette.background.default,
-          color: theme.palette.resourceToolTip.color,
-          boxShadow: theme.shadows[1],
-          fontSize: '1rem',
-          whiteSpace: 'pre-line',
-        })}
-        {...rest}
-      >
-        <span>{children}</span>
-      </Tooltip>
-    );
-  }
+  // Define our default light styling for the tooltip popover box.
+  // Note: whiteSpace: 'pre-line' makes sure \n inside text creates new lines!
+  const defaultSx = (theme: Theme) => ({
+    backgroundColor: theme.palette.background.default,
+    color: theme.palette.resourceToolTip.color,
+    boxShadow: theme.shadows[1],
+    fontSize: '1rem',
+    whiteSpace: 'pre-line',
+  });
+
+  // Check if whoever called <TooltipLight /> passed their own slotProps.tooltip.sx styles.
+  const callerTooltipProps = slotProps?.tooltip ?? componentsProps?.tooltip ?? {};
+  const callerSx = callerTooltipProps.sx;
+
+  // We use slotProps.tooltip.sx to apply styles directly to the tooltip box in MUI v5.
+  // We merge our default light styles with any extra styles passed in by the caller.
+  const mergedSlotProps: TooltipProps['slotProps'] = {
+    ...slotProps,
+    tooltip: {
+      ...callerTooltipProps,
+      sx: [defaultSx, ...(Array.isArray(callerSx) ? callerSx : [callerSx])] as SxProps<Theme>,
+    } as any,
+  };
+
+  // If children is a plain string text, wrap it inside a <span> tag.
+  // Otherwise, use the ReactElement child directly.
+  const childrenNode =
+    typeof children === 'string' ? <span>{children}</span> : (children as ReactElement);
 
   return (
     <Tooltip
-      {...rest}
+      disableInteractive={disableInteractive}
       TransitionComponent={Fade}
       TransitionProps={{ timeout: 0 }}
-      // children prop in the mui Tooltip is defined as ReactElement which is not totally correct
-      // string should be a valid child and is used a lot in this project
-      // but it's not included in the ReactElement type
-      children={props.children as unknown as ReactElement}
+      slotProps={mergedSlotProps}
+      {...rest}
+      children={childrenNode}
     />
   );
 }


### PR DESCRIPTION
## Summary

This PR fixes `TooltipLight` silently dropping all its custom styling (light background, text color, font size, and `white-space: pre-line`) because `sx` was passed directly to MUI's `<Tooltip>`, which has no root DOM element and forwards unrecognised props onto the anchor child. The styles are moved to `slotProps.tooltip.sx` so MUI applies them to the actual tooltip popover surface. Both render branches (string and ReactElement children) are consolidated into one, and caller-provided `slotProps` are safely merged instead of overwritten.

## Related Issue

Fixes #7080

## Changes

- **Updated `TooltipLight.tsx`**:
  - Moved styling to `slotProps.tooltip.sx` so MUI applies custom styles (background, font size, multi-line support) directly to the tooltip popover box.
  - Safely merged any custom `slotProps` passed by parent components.
  - Simplified and combined duplicate rendering logic for text and element children into a single clean path.
- **Added `TooltipLight.test.tsx`**:
  - Added unit tests to verify style application, multi-line text rendering (`\n`), and theme compatibility.

## Steps to Test

1. Run the frontend dev server: `npm start` in `frontend/`.
2. Navigate to **Workloads → Deployments** and select a deployment with multiple containers.
3. Hover the **Containers** cell.
4. Verify the tooltip now renders with:
   - A **light/themed background** (not the default dark MUI tooltip).
   - Each container name on a **separate line** (`white-space: pre-line` working).
   - Correct **font size** (`1rem`, not the default `0.875rem`).
5. Run the unit tests to confirm all pass:
   ```bash
   cd frontend && npx vitest run src/components/common/Tooltip/TooltipLight.test.tsx
   ```

## Screenshots

### Before:
<img width="1166" height="143" alt="Before - Dark Tooltip with collapsed lines" src="https://github.com/user-attachments/assets/46453f16-b11d-43ca-8145-c8e87df049a0" />

### After:
<img width="1172" height="137" alt="After - Styled Light Tooltip with multi-line container list" src="https://github.com/user-attachments/assets/79d59e4f-1b40-4986-b18f-fbd4a26e82eb" />

The fix restores styles that were silently dropped; the tooltip surface changes from the default dark appearance to the intended light-themed appearance.

## Notes for the Reviewer

- This is my second PR to the organization! (beacuse the bot rejected the first one 🥲)I would be delighted if you could suggest any improvements or feedback.
