### PR TITLE
backend: Support JWT client assertion for OIDC provider

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -191,7 +191,10 @@ type OauthConfig struct {
 	Ctx          context.Context
 	CodeVerifier string // PKCE code verifier
 	Cluster      string // cluster context name this is associated with
-	createdAt    time.Time
+	// ClientAssertionFile is the path to the JWT client assertion (RFC 7523)
+	// used to authenticate at the token endpoint.
+	ClientAssertionFile string
+	createdAt           time.Time
 }
 
 // evictExpiredOidcStates removes entries from m whose createdAt timestamp is
@@ -550,6 +553,7 @@ func setupInClusterContext(config *HeadlampConfig) {
 		config.InClusterContextName,
 		config.OidcIdpIssuerURL,
 		config.OidcClientID, config.OidcClientSecret,
+		config.OidcClientAssertionFile,
 		strings.Join(config.OidcScopes, ","),
 		config.OidcSkipTLSVerify,
 		config.OidcCACert,
@@ -996,6 +1000,18 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			return
 		}
 
+		clientAssertionFile := oidcAuthConfig.ClientAssertionFile
+
+		clientSecret := oidcAuthConfig.ClientSecret
+		if clientAssertionFile != "" {
+			// Config validation rejects setting both values through flags/env, but
+			// kubeconfig auth-provider entries bypass that validation. Prefer the
+			// assertion so client_secret is never sent with client_assertion.
+			clientSecret = ""
+		}
+
+		endpoint := auth.SetClientAssertionAuthStyle(provider.Endpoint(), clientAssertionFile)
+
 		validatorClientID := oidcAuthConfig.ClientID
 		if config.OidcValidatorClientID != "" {
 			validatorClientID = config.OidcValidatorClientID
@@ -1008,8 +1024,8 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		verifier := provider.Verifier(oidcConfig)
 		oauthConfig := &oauth2.Config{
 			ClientID:     oidcAuthConfig.ClientID,
-			ClientSecret: oidcAuthConfig.ClientSecret,
-			Endpoint:     provider.Endpoint(),
+			ClientSecret: clientSecret,
+			Endpoint:     endpoint,
 			RedirectURL:  getOidcCallbackURL(r, config),
 			Scopes:       append([]string{oidc.ScopeOpenID}, oidcAuthConfig.Scopes...),
 		}
@@ -1029,11 +1045,12 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		}
 
 		entry := &OauthConfig{
-			Config:    oauthConfig,
-			Verifier:  verifier,
-			Ctx:       ctx,
-			Cluster:   cluster,
-			createdAt: time.Now(),
+			Config:              oauthConfig,
+			Verifier:            verifier,
+			Ctx:                 ctx,
+			Cluster:             cluster,
+			ClientAssertionFile: clientAssertionFile,
+			createdAt:           time.Now(),
 		}
 
 		var authURL string
@@ -1087,24 +1104,29 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			return
 		}
 
-		var oauth2Token *oauth2.Token
-
-		// Exchange authorization code for token, with or without PKCE
+		var exchangeOpts []oauth2.AuthCodeOption
+		// Use PKCE code verifier for token exchange
 		if config.OidcUsePKCE && oauthConfig.CodeVerifier != "" {
-			// Use PKCE code verifier for token exchange
-			oauth2Token, err = oauthConfig.Config.Exchange(
-				oauthConfig.Ctx,
-				r.URL.Query().Get("code"),
-				oauth2.SetAuthURLParam("code_verifier", oauthConfig.CodeVerifier),
-			)
-		} else {
-			// Standard token exchange without PKCE
-			oauth2Token, err = oauthConfig.Config.Exchange(
-				oauthConfig.Ctx,
-				r.URL.Query().Get("code"),
-			)
+			exchangeOpts = append(exchangeOpts, oauth2.SetAuthURLParam("code_verifier", oauthConfig.CodeVerifier))
 		}
 
+		// Authenticate the client with a JWT assertion instead of a secret,
+		// when one is configured
+		assertionOpts, err := auth.ClientAssertionAuthCodeOptions(oauthConfig.ClientAssertionFile)
+		if err != nil {
+			logger.Log(logger.LevelError, nil, err, "failed to read client assertion")
+			http.Error(w, "Failed to read client assertion: "+err.Error(), http.StatusInternalServerError)
+
+			return
+		}
+
+		exchangeOpts = append(exchangeOpts, assertionOpts...)
+
+		oauth2Token, err := oauthConfig.Config.Exchange(
+			oauthConfig.Ctx,
+			r.URL.Query().Get("code"),
+			exchangeOpts...,
+		)
 		if err != nil {
 			logger.Log(logger.LevelError, nil, err, "failed to exchange token")
 			http.Error(w, "Failed to exchange token: "+err.Error(), http.StatusInternalServerError)
@@ -2388,7 +2410,7 @@ func (c *HeadlampConfig) processManualConfig(clusterReq ClusterReq) ([]kubeconfi
 		},
 	}
 
-	return kubeconfig.LoadContextsFromAPIConfig(conf, false)
+	return kubeconfig.LoadContextsFromAPIConfig(conf, kubeconfig.DynamicCluster, false)
 }
 
 // handleLoadErrors handles the load errors.
@@ -2604,9 +2626,21 @@ func customNameToExtensions(config *api.Config, contextName, newClusterName, pat
 	return nil
 }
 
+// contextSourceFor maps a request's source string to its context source constant.
+// It mirrors getKubeConfigPath, which picks the file from the same string.
+func contextSourceFor(source string) int {
+	if source == kubeConfigSource {
+		return kubeconfig.KubeConfig
+	}
+
+	return kubeconfig.DynamicCluster
+}
+
 // updateCustomContextToCache updates the custom context to the cache.
-func (c *HeadlampConfig) updateCustomContextToCache(config *api.Config, clusterName string) []error {
-	contexts, errs := kubeconfig.LoadContextsFromAPIConfig(config, false)
+// source is where config was loaded from; dropping it on reload would clear the
+// DynamicCluster mark on a renamed cluster.
+func (c *HeadlampConfig) updateCustomContextToCache(config *api.Config, clusterName string, source int) []error {
+	contexts, errs := kubeconfig.LoadContextsFromAPIConfig(config, source, false)
 	if len(contexts) == 0 {
 		logger.Log(logger.LevelError, nil, errs, "no contexts found in kubeconfig")
 		errs = append(errs, errors.New("no contexts found in kubeconfig"))
@@ -2728,7 +2762,7 @@ func (c *HeadlampConfig) handleClusterRename(w http.ResponseWriter, r *http.Requ
 		return err
 	}
 
-	if errs := c.updateCustomContextToCache(config, clusterName); len(errs) > 0 {
+	if errs := c.updateCustomContextToCache(config, clusterName, contextSourceFor(reqBody.Source)); len(errs) > 0 {
 		cacheErr := errors.Join(errs...)
 		c.handleError(w, ctx, span, cacheErr, "failed to update context to cache", http.StatusInternalServerError)
 

--- a/backend/cmd/oidc_handlers_test.go
+++ b/backend/cmd/oidc_handlers_test.go
@@ -68,9 +68,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/gorilla/mux"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/auth"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
@@ -146,18 +150,47 @@ func failingTokenHandler() http.HandlerFunc {
 	}
 }
 
-// oidcTestOption customizes the HeadlampConfig built by newOIDCTestHandler.
-type oidcTestOption func(*HeadlampConfig)
+// oidcTestSetup holds what newOIDCTestHandler builds and its options may
+// customize.
+type oidcTestSetup struct {
+	config   *HeadlampConfig
+	oidcConf *kubeconfig.OidcConfig
+	// authProviderConfig, when set, stores the OIDC settings as a kubeconfig
+	// oidc auth-provider stanza of source instead of a prebuilt OidcConf.
+	authProviderConfig map[string]string
+	source             int
+}
+
+// oidcTestOption customizes what newOIDCTestHandler builds.
+type oidcTestOption func(*oidcTestSetup)
 
 // withPKCE enables the OidcUsePKCE code path on the handler under test.
 func withPKCE() oidcTestOption {
-	return func(c *HeadlampConfig) { c.OidcUsePKCE = true }
+	return func(s *oidcTestSetup) { s.config.OidcUsePKCE = true }
 }
 
 // withStateReader replaces the reader backing OIDC state generation, so a
 // test can force the state-generation failure path.
 func withStateReader(r io.Reader) oidcTestOption {
-	return func(c *HeadlampConfig) { c.oidcStateReader = r }
+	return func(s *oidcTestSetup) { s.config.oidcStateReader = r }
+}
+
+// withClientAssertionFile makes the cluster context authenticate to the token
+// endpoint with a JWT client assertion instead of a client secret.
+func withClientAssertionFile(path string) oidcTestOption {
+	return func(s *oidcTestSetup) {
+		s.oidcConf.ClientAssertionFile = path
+	}
+}
+
+// withKubeconfigAuthProvider stores the OIDC settings the way a kubeconfig
+// carries them, so the handler resolves them and the checks on caller-supplied
+// values are part of the path under test.
+func withKubeconfigAuthProvider(source int, config map[string]string) oidcTestOption {
+	return func(s *oidcTestSetup) {
+		s.source = source
+		s.authProviderConfig = config
+	}
 }
 
 // newOIDCTestHandler builds a Headlamp handler with one OIDC-configured
@@ -170,21 +203,12 @@ func newOIDCTestHandler(t *testing.T, oidcSrv *oidcTestServer, opts ...oidcTestO
 
 	kubeConfigStore := kubeconfig.NewContextStore()
 
-	err := kubeConfigStore.AddContext(&kubeconfig.Context{
-		Name: clusterName,
-		Cluster: &api.Cluster{
-			Server: "https://test-cluster.example.com",
-		},
-		AuthInfo: &api.AuthInfo{},
-		OidcConf: &kubeconfig.OidcConfig{
-			ClientID:     "test-client-id",
-			ClientSecret: "test-client-secret",
-			IdpIssuerURL: oidcSrv.URL(),
-			Scopes:       []string{"profile", "email"},
-		},
-		Source: kubeconfig.KubeConfig,
-	})
-	require.NoError(t, err)
+	oidcConf := &kubeconfig.OidcConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		IdpIssuerURL: oidcSrv.URL(),
+		Scopes:       []string{"profile", "email"},
+	}
 
 	c := &HeadlampConfig{
 		HeadlampConfig: &headlampconfig.HeadlampConfig{
@@ -198,11 +222,59 @@ func newOIDCTestHandler(t *testing.T, oidcSrv *oidcTestServer, opts ...oidcTestO
 		},
 	}
 
+	setup := &oidcTestSetup{config: c, oidcConf: oidcConf, source: kubeconfig.KubeConfig}
 	for _, opt := range opts {
-		opt(c)
+		opt(setup)
 	}
 
+	storedContext := &kubeconfig.Context{
+		Name: clusterName,
+		Cluster: &api.Cluster{
+			Server: "https://test-cluster.example.com",
+		},
+		AuthInfo: &api.AuthInfo{},
+		OidcConf: oidcConf,
+		Source:   setup.source,
+	}
+
+	if setup.authProviderConfig != nil {
+		storedContext.OidcConf = nil
+		storedContext.AuthInfo.AuthProvider = &api.AuthProviderConfig{
+			Name:   "oidc",
+			Config: setup.authProviderConfig,
+		}
+	}
+
+	err := kubeConfigStore.AddContext(storedContext)
+	require.NoError(t, err)
+
 	return createHeadlampHandler(context.Background(), c), clusterName
+}
+
+// statelessOIDCKubeconfig returns the kubeconfig a caller would hand over in the
+// KUBECONFIG header to have Headlamp read assertionFile and send it to issuerURL.
+func statelessOIDCKubeconfig(issuerURL, assertionFile string) string {
+	return fmt.Sprintf(`apiVersion: v1
+clusters:
+- cluster:
+    server: https://test-cluster.example.com
+  name: stateless-oidc
+contexts:
+- context:
+    cluster: stateless-oidc
+    user: stateless-user
+  name: stateless-oidc
+current-context: stateless-oidc
+kind: Config
+users:
+- name: stateless-user
+  user:
+    auth-provider:
+      config:
+        client-id: "test-client-id"
+        client-assertion-file: %q
+        idp-issuer-url: %q
+      name: oidc`, assertionFile, issuerURL)
 }
 
 // driveOIDCStart calls /oidc?cluster=<cluster> against the supplied handler
@@ -527,4 +599,295 @@ func TestOIDCCallback_PKCEVerifierSentOnExchange(t *testing.T) {
 		assert.Empty(t, form.Get("code_verifier"),
 			"no code_verifier should be sent when PKCE is off")
 	})
+}
+
+// TestOIDCCallback_ClientAssertionSentOnExchange covers JWT bearer client
+// authentication (RFC 7523). With an assertion file configured, /oidc-callback
+// authenticates the code exchange with client_assertion instead of a client
+// secret, and the assertion is read from disk at exchange time.
+func TestOIDCCallback_ClientAssertionSentOnExchange(t *testing.T) {
+	const assertion = "header.payload.signature"
+
+	assertionFile := filepath.Join(t.TempDir(), "assertion.jwt")
+	require.NoError(t, os.WriteFile(assertionFile, []byte(assertion+"\n"), 0o600))
+
+	// The exchange form is recorded and then rejected, so the test observes the
+	// request without needing to mint a signed ID token.
+	var forms []url.Values
+
+	oidcSrv := newOIDCTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err == nil {
+			forms = append(forms, r.PostForm)
+		}
+
+		failingTokenHandler()(w, r)
+	})
+
+	handler, cluster := newOIDCTestHandler(t, oidcSrv, withClientAssertionFile(assertionFile))
+
+	state := extractState(t, driveOIDCStart(t, handler, cluster))
+
+	rr := callOIDCCallback(t, handler, fmt.Sprintf("state=%s&code=fake", state))
+	require.Equal(t, http.StatusInternalServerError, rr.Code,
+		"sanity: the exchange ran and failed at the mock /token")
+
+	// The pinned AuthStyleInParams puts the credentials in the body right away,
+	// so the endpoint is called once.
+	require.Len(t, forms, 1)
+
+	form := forms[0]
+	assert.Equal(t, "test-client-id", form.Get("client_id"))
+	assert.Equal(t, auth.ClientAssertionTypeJWTBearer, form.Get("client_assertion_type"))
+	assert.Equal(t, assertion, form.Get("client_assertion"))
+	assert.Empty(t, form.Get("client_secret"))
+}
+
+// TestOIDCCallback_UnreadableClientAssertionFails checks the callback reports a
+// failure instead of falling back to an unauthenticated exchange when the
+// configured assertion cannot be read.
+func TestOIDCCallback_UnreadableClientAssertionFails(t *testing.T) {
+	exchanges := 0
+
+	oidcSrv := newOIDCTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		exchanges++
+
+		failingTokenHandler()(w, r)
+	})
+
+	handler, cluster := newOIDCTestHandler(t, oidcSrv,
+		withClientAssertionFile(filepath.Join(t.TempDir(), "absent.jwt")))
+
+	state := extractState(t, driveOIDCStart(t, handler, cluster))
+
+	rr := callOIDCCallback(t, handler, fmt.Sprintf("state=%s&code=fake", state))
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Failed to read client assertion")
+	assert.Zero(t, exchanges, "no code should be exchanged without the client assertion")
+}
+
+// TestOIDCCallback_ClientSecretUnaffected checks the default client secret path
+// keeps sending client_secret and no assertion parameters.
+func TestOIDCCallback_ClientSecretUnaffected(t *testing.T) {
+	var forms []url.Values
+
+	oidcSrv := newOIDCTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err == nil {
+			forms = append(forms, r.PostForm)
+		}
+
+		failingTokenHandler()(w, r)
+	})
+
+	handler, cluster := newOIDCTestHandler(t, oidcSrv)
+
+	state := extractState(t, driveOIDCStart(t, handler, cluster))
+
+	rr := callOIDCCallback(t, handler, fmt.Sprintf("state=%s&code=fake", state))
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+
+	require.NotEmpty(t, forms)
+
+	for _, form := range forms {
+		assert.Empty(t, form.Get("client_assertion"))
+		assert.Empty(t, form.Get("client_assertion_type"))
+	}
+}
+
+// TestOIDCStart_DynamicClusterClientAssertionRejected checks a kubeconfig
+// supplied by the caller cannot make the server read a local file and post it
+// to an identity provider of the caller's choosing.
+func TestOIDCStart_DynamicClusterClientAssertionRejected(t *testing.T) {
+	assertionFile := filepath.Join(t.TempDir(), "stolen.jwt")
+	require.NoError(t, os.WriteFile(assertionFile, []byte("secret.token.value"), 0o600))
+
+	idpRequests := 0
+
+	idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		idpRequests++
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(idp.Close)
+
+	handler, cluster := newOIDCTestHandler(t, &oidcTestServer{server: idp},
+		withKubeconfigAuthProvider(kubeconfig.DynamicCluster, map[string]string{
+			"client-id":             "test-client-id",
+			"client-assertion-file": assertionFile,
+			"idp-issuer-url":        idp.URL,
+		}))
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/oidc?cluster="+cluster, nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "client-assertion-file is not allowed in a dynamic cluster kubeconfig")
+	assert.Empty(t, rr.Header().Get("Location"), "no login should start for a rejected context")
+	assert.Zero(t, idpRequests, "the caller-supplied issuer should never be contacted")
+}
+
+// TestOIDCStart_StatelessDynamicClusterClientAssertionRejected walks the whole
+// path a caller would take: a kubeconfig carrying the assertion file is handed
+// over in the KUBECONFIG header of a cluster request, which caches it as a
+// dynamic cluster context, and /oidc is then called for that context.
+func TestOIDCStart_StatelessDynamicClusterClientAssertionRejected(t *testing.T) {
+	const clusterName = "stateless-oidc"
+
+	assertionFile := filepath.Join(t.TempDir(), "stolen.jwt")
+	require.NoError(t, os.WriteFile(assertionFile, []byte("secret.token.value"), 0o600))
+
+	idpRequests := 0
+	idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		idpRequests++
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(idp.Close)
+
+	kubeConfigStore := kubeconfig.NewContextStore()
+	config := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				// The deployment mode this is reachable in. The flag itself gates
+				// getContextKeyForRequest, which the test skips by calling
+				// handleStatelessReq directly.
+				EnableDynamicClusters: true,
+				KubeConfigStore:       kubeConfigStore,
+			},
+			Cache:            cache.New[interface{}](),
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	}
+
+	encodedKubeconfig := base64.StdEncoding.EncodeToString([]byte(statelessOIDCKubeconfig(idp.URL, assertionFile)))
+
+	statelessReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/clusters/"+clusterName+"/api", nil)
+	statelessReq = mux.SetURLVars(statelessReq, map[string]string{"clusterName": clusterName})
+
+	// No X-HEADLAMP-USER-ID, so the cached context is keyed by cluster name alone
+	// and /oidc?cluster=<name> reaches it.
+	contextKey, err := config.handleStatelessReq(statelessReq, encodedKubeconfig)
+	require.NoError(t, err)
+	require.Equal(t, clusterName, contextKey)
+
+	storedContext, err := kubeConfigStore.GetContext(contextKey)
+	require.NoError(t, err)
+	assert.Equal(t, kubeconfig.DynamicCluster, storedContext.Source)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/oidc?cluster="+contextKey, nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	createHeadlampHandler(context.Background(), config).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "client-assertion-file is not allowed in a dynamic cluster kubeconfig")
+	assert.Empty(t, rr.Header().Get("Location"), "no login should start for a rejected context")
+	assert.Zero(t, idpRequests, "the caller-supplied issuer should never be contacted")
+}
+
+// TestOIDCStart_KubeconfigClientAssertionAccepted checks the same auth-provider
+// key still works for a kubeconfig the server operator supplies.
+func TestOIDCStart_KubeconfigClientAssertionAccepted(t *testing.T) {
+	assertionFile := filepath.Join(t.TempDir(), "assertion.jwt")
+	require.NoError(t, os.WriteFile(assertionFile, []byte("header.payload.signature"), 0o600))
+
+	oidcSrv := newOIDCTestServer(t, nil)
+
+	handler, cluster := newOIDCTestHandler(t, oidcSrv,
+		withKubeconfigAuthProvider(kubeconfig.KubeConfig, map[string]string{
+			"client-id":             "test-client-id",
+			"client-assertion-file": assertionFile,
+			"idp-issuer-url":        oidcSrv.URL(),
+		}))
+
+	state := extractState(t, driveOIDCStart(t, handler, cluster))
+	assert.NotEmpty(t, state)
+}
+
+// newDynamicClusterHandler builds a handler that takes dynamic clusters and
+// persists them under the test's own config dirs.
+func newDynamicClusterHandler(t *testing.T, kubeConfigStore kubeconfig.ContextStore) http.Handler {
+	t.Helper()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("APPDATA", t.TempDir())
+
+	config := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				EnableDynamicClusters: true,
+				KubeConfigPath:        filepath.Join(t.TempDir(), "missing-kubeconfig"),
+				KubeConfigStore:       kubeConfigStore,
+			},
+			Cache:            cache.New[interface{}](),
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	}
+
+	return createHeadlampHandler(context.Background(), config)
+}
+
+// TestOIDCStart_RenamedDynamicClusterClientAssertionRejected covers the path a caller would
+// take to launder a dynamic cluster into a trusted one. The caller first
+// issues POST /cluster, then PUT /cluster/{name}, and finally hits /oidc
+// under the new name. Renaming reloads the persisted kubeconfig, and any
+// context that came back with the zero source would slip past the check
+// in OidcConfig.
+func TestOIDCStart_RenamedDynamicClusterClientAssertionRejected(t *testing.T) {
+	const (
+		clusterName = "stateless-oidc"
+		renamedName = "renamed-oidc"
+	)
+
+	assertionFile := filepath.Join(t.TempDir(), "stolen.jwt")
+	require.NoError(t, os.WriteFile(assertionFile, []byte("secret.token.value"), 0o600))
+
+	idpRequests := 0
+	idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		idpRequests++
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(idp.Close)
+
+	kubeConfigStore := kubeconfig.NewContextStore()
+	handler := newDynamicClusterHandler(t, kubeConfigStore)
+
+	encodedKubeconfig := base64.StdEncoding.EncodeToString([]byte(statelessOIDCKubeconfig(idp.URL, assertionFile)))
+
+	rr, err := getResponseFromRestrictedEndpoint(handler, http.MethodPost, "/cluster",
+		ClusterReq{KubeConfig: &encodedKubeconfig})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, rr.Code, "adding the dynamic cluster failed: %s", rr.Body.String())
+
+	rr, err = getResponseFromRestrictedEndpoint(handler, http.MethodPut, "/cluster/"+clusterName,
+		RenameClusterRequest{NewClusterName: renamedName, Source: "dynamic_cluster"})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, rr.Code, "renaming the dynamic cluster failed: %s", rr.Body.String())
+
+	storedContext, err := kubeConfigStore.GetContext(renamedName)
+	require.NoError(t, err)
+	assert.Equal(t, kubeconfig.DynamicCluster, storedContext.Source,
+		"the rename must not clear the DynamicCluster mark")
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/oidc?cluster="+renamedName, nil)
+	require.NoError(t, err)
+
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "client-assertion-file is not allowed in a dynamic cluster kubeconfig")
+	assert.Empty(t, rr.Header().Get("Location"), "no login should start for a rejected context")
+	assert.Zero(t, idpRequests, "the caller-supplied issuer should never be contacted")
 }

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -209,6 +209,7 @@ func createHeadlampConfig(conf *config.Config) *HeadlampConfig {
 		OidcClientID:              conf.OidcClientID,
 		OidcValidatorClientID:     conf.OidcValidatorClientID,
 		OidcClientSecret:          conf.OidcClientSecret,
+		OidcClientAssertionFile:   conf.OidcClientAssertionFile,
 		OidcIdpIssuerURL:          conf.OidcIdpIssuerURL,
 		OidcCallbackURL:           conf.OidcCallbackURL,
 		OidcValidatorIdpIssuerURL: conf.OidcValidatorIdpIssuerURL,

--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -183,14 +183,35 @@ func CacheRefreshedToken(token *oauth2.Token, tokenType string, oldToken string,
 	return nil
 }
 
+// GetNewTokenParams groups the inputs needed to exchange a cached refresh
+// token for a new OAuth2 token.
+type GetNewTokenParams struct {
+	// ClientID is the OIDC client ID.
+	ClientID string
+	// ClientSecret is the OIDC client secret. It is unused when
+	// ClientAssertionFile is set.
+	ClientSecret string
+	// ClientAssertionFile is the path to a file holding a JWT sent as
+	// client_assertion (RFC 7523) to authenticate at the token endpoint
+	// instead of a client secret.
+	ClientAssertionFile string
+	// Cache holds the refresh token keyed by the current token.
+	Cache cache.Cache[interface{}]
+	// TokenType is the token field passed on to the client, either
+	// "id_token" or "access_token".
+	TokenType string
+	// Token is the current token, used as the cache key of the refresh token.
+	Token string
+	// TokenURL is the token endpoint of the identity provider.
+	TokenURL string
+}
+
 // GetNewToken uses the provided credentials and fetches the old refresh
 // token from the cache to obtain a new OAuth2 token
 // from the specified token URL endpoint.
-func GetNewToken(clientID, clientSecret string, cache cache.Cache[interface{}],
-	tokenType string, token string, tokenURL string, ctx context.Context,
-) (*oauth2.Token, error) {
+func GetNewToken(ctx context.Context, params GetNewTokenParams) (*oauth2.Token, error) {
 	// get refresh token
-	refreshToken, err := cache.Get(ctx, oidcKeyPrefix+token)
+	refreshToken, err := params.Cache.Get(ctx, oidcKeyPrefix+params.Token)
 	if err != nil {
 		return nil, fmt.Errorf("getting refresh token: %w", err)
 	}
@@ -200,27 +221,38 @@ func GetNewToken(clientID, clientSecret string, cache cache.Cache[interface{}],
 		return nil, fmt.Errorf("failed to get refresh token")
 	}
 
-	// Create OAuth2 config with client credentials and token endpoint
-	conf := &oauth2.Config{
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-		Endpoint: oauth2.Endpoint{
-			TokenURL: tokenURL,
-		},
-	}
-
-	// Request new token using the refresh token
-	newToken, err := conf.TokenSource(ctx, &oauth2.Token{RefreshToken: rToken}).Token()
+	newToken, err := redeemRefreshToken(ctx, params, rToken)
 	if err != nil {
 		return nil, err
 	}
 
 	// update the refresh token in the cache
-	if err := CacheRefreshedToken(newToken, tokenType, token, rToken, cache); err != nil {
+	if err := CacheRefreshedToken(newToken, params.TokenType, params.Token, rToken, params.Cache); err != nil {
 		return nil, fmt.Errorf("caching refreshed token: %w", err)
 	}
 
 	return newToken, nil
+}
+
+// redeemRefreshToken requests a new token from the token endpoint, using
+// whichever client authentication method is configured.
+func redeemRefreshToken(ctx context.Context, params GetNewTokenParams, refreshToken string) (*oauth2.Token, error) {
+	if params.ClientAssertionFile != "" {
+		return RefreshTokenWithClientAssertion(ctx,
+			params.TokenURL, params.ClientID, params.ClientAssertionFile, refreshToken)
+	}
+
+	// Create OAuth2 config with client credentials and token endpoint
+	conf := &oauth2.Config{
+		ClientID:     params.ClientID,
+		ClientSecret: params.ClientSecret,
+		Endpoint: oauth2.Endpoint{
+			TokenURL: params.TokenURL,
+		},
+	}
+
+	// Request new token using the refresh token
+	return conf.TokenSource(ctx, &oauth2.Token{RefreshToken: refreshToken}).Token()
 }
 
 // ConfigureTLSContext configures TLS settings for the HTTP client in the context.
@@ -306,15 +338,15 @@ func RefreshAndCacheNewToken(ctx context.Context, oidcAuthConfig *kubeconfig.Oid
 		return nil, fmt.Errorf("getting provider: %w", err)
 	}
 	// get refresh token
-	newToken, err := GetNewToken(
-		oidcAuthConfig.ClientID,
-		oidcAuthConfig.ClientSecret,
-		cache,
-		tokenType,
-		token,
-		provider.Endpoint().TokenURL,
-		ctx,
-	)
+	newToken, err := GetNewToken(ctx, GetNewTokenParams{
+		ClientID:            oidcAuthConfig.ClientID,
+		ClientSecret:        oidcAuthConfig.ClientSecret,
+		ClientAssertionFile: oidcAuthConfig.ClientAssertionFile,
+		Cache:               cache,
+		TokenType:           tokenType,
+		Token:               token,
+		TokenURL:            provider.Endpoint().TokenURL,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("refreshing token: %w", err)
 	}

--- a/backend/pkg/auth/auth_test.go
+++ b/backend/pkg/auth/auth_test.go
@@ -698,13 +698,26 @@ var oauthSuccessBody = map[string]any{
 	"id_token":      "NEW",
 }
 
+// newTokenParams builds the params for a client secret authenticated refresh of
+// the token cached under "oidc-token-OLD".
+func newTokenParams(c cache.Cache[interface{}], tokenURL string) auth.GetNewTokenParams {
+	return auth.GetNewTokenParams{
+		ClientID:     "cid",
+		ClientSecret: "secret",
+		Cache:        c,
+		TokenType:    "id_token",
+		Token:        "OLD",
+		TokenURL:     tokenURL,
+	}
+}
+
 func TestGetNewToken_Success(t *testing.T) {
 	srv := newTokenServerJSON(t, http.StatusOK, oauthSuccessBody)
 
 	// Seed cache with old token -> old refresh mapping
 	fc := &fakeCache{store: map[string]interface{}{"oidc-token-OLD": "REFRESH_OLD"}}
 
-	newTok, err := auth.GetNewToken("cid", "secret", fc, "id_token", "OLD", srv.URL, context.Background())
+	newTok, err := auth.GetNewToken(context.Background(), newTokenParams(fc, srv.URL))
 	if err != nil {
 		t.Fatalf("GetNewToken unexpected error: %v", err)
 	}
@@ -763,7 +776,7 @@ func TestGetNewToken_PreHTTPFailures(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// Fails before HTTP; no server needed.
-			_, err := auth.GetNewToken("cid", "secret", tc.cache, "id_token", "OLD", "http://127.0.0.1", context.Background())
+			_, err := auth.GetNewToken(context.Background(), newTokenParams(tc.cache, "http://127.0.0.1"))
 			if err == nil || !strings.Contains(err.Error(), tc.expect) {
 				t.Fatalf("want error containing %q, got %v", tc.expect, err)
 			}
@@ -786,7 +799,7 @@ func TestGetNewToken_EndpointFailures(t *testing.T) {
 			srv := newTokenServerJSON(t, tc.status, tc.body)
 			fc := &fakeCache{store: map[string]interface{}{"oidc-token-OLD": "REFRESH_OLD"}}
 
-			if _, err := auth.GetNewToken("cid", "secret", fc, "id_token", "OLD", srv.URL, context.Background()); err == nil {
+			if _, err := auth.GetNewToken(context.Background(), newTokenParams(fc, srv.URL)); err == nil {
 				t.Fatal("expected error, got nil")
 			}
 		})
@@ -810,7 +823,7 @@ func TestGetNewToken_CacheUpdateErrors(t *testing.T) {
 				errOnSetWithTTL: tc.setTTLErr,
 			}
 
-			if _, err := auth.GetNewToken("cid", "secret", fc, "id_token", "OLD", srv.URL, context.Background()); err == nil {
+			if _, err := auth.GetNewToken(context.Background(), newTokenParams(fc, srv.URL)); err == nil {
 				t.Fatal("expected error containing 'caching refreshed token', got nil")
 			}
 		})

--- a/backend/pkg/auth/client_assertion.go
+++ b/backend/pkg/auth/client_assertion.go
@@ -1,0 +1,265 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// ClientAssertionTypeJWTBearer is the client assertion type registered by
+// RFC 7523 for JWT bearer client authentication.
+// See https://datatracker.ietf.org/doc/html/rfc7523#section-2.2
+//
+//nolint:gosec // G101: a URN naming the assertion type, not a credential
+const ClientAssertionTypeJWTBearer = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+
+// maxTokenResponseBytes caps how much of a token endpoint response is read, so
+// a misbehaving or hostile endpoint cannot exhaust memory.
+const maxTokenResponseBytes = 1 << 20 // 1 MiB
+
+// ReadClientAssertion returns the JWT to send as the token request
+// client_assertion.
+//
+// The file is read on every call so a credential rotated in place, such as a
+// Kubernetes projected service account token, is picked up before the identity
+// provider rejects an expired assertion.
+func ReadClientAssertion(assertionFile string) (string, error) {
+	contents, err := os.ReadFile(assertionFile) //nolint:gosec
+	if err != nil {
+		return "", fmt.Errorf("reading client assertion file: %w", err)
+	}
+
+	assertion := strings.TrimSpace(string(contents))
+	if assertion == "" {
+		return "", fmt.Errorf("client assertion file %q is empty", assertionFile)
+	}
+
+	return assertion, nil
+}
+
+// ClientAssertionAuthCodeOptions returns the extra token request parameters
+// that authenticate the client with a JWT assertion when redeeming an
+// authorization code with oauth2.Config.Exchange.
+//
+// It returns no options when no assertion file is configured.
+//
+// TODO: This is a temporary workaround for the lack of client assertion
+// support in golang.org/x/oauth2. Once the upstream feature lands, drop this
+// in favour of oauth2.Config.Exchange authenticating the client itself.
+// See https://github.com/golang/oauth2/issues/744
+func ClientAssertionAuthCodeOptions(assertionFile string) ([]oauth2.AuthCodeOption, error) {
+	if assertionFile == "" {
+		return nil, nil
+	}
+
+	assertion, err := ReadClientAssertion(assertionFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return []oauth2.AuthCodeOption{
+		oauth2.SetAuthURLParam("client_assertion_type", ClientAssertionTypeJWTBearer),
+		oauth2.SetAuthURLParam("client_assertion", assertion),
+	}, nil
+}
+
+// SetClientAssertionAuthStyle pins the token endpoint auth style to
+// AuthStyleInParams when a client assertion is used, so the oauth2 package does
+// not first probe the endpoint with HTTP Basic auth and an empty client secret.
+func SetClientAssertionAuthStyle(endpoint oauth2.Endpoint, assertionFile string) oauth2.Endpoint {
+	if assertionFile != "" {
+		endpoint.AuthStyle = oauth2.AuthStyleInParams
+	}
+
+	return endpoint
+}
+
+// RefreshTokenWithClientAssertion exchanges a refresh token for a new token,
+// authenticating the client with a JWT assertion (RFC 7523) instead of a
+// client secret.
+//
+// TODO: This is a temporary workaround for the lack of client assertion
+// support in golang.org/x/oauth2, where oauth2.Config.TokenSource also offers
+// no way to add parameters to the refresh request. Once the upstream feature
+// lands, drop this in favour of oauth2.Config.TokenSource.
+// See https://github.com/golang/oauth2/issues/744
+func RefreshTokenWithClientAssertion(ctx context.Context,
+	tokenURL, clientID, assertionFile, refreshToken string,
+) (*oauth2.Token, error) {
+	assertion, err := ReadClientAssertion(assertionFile)
+	if err != nil {
+		return nil, err
+	}
+
+	params := url.Values{}
+	params.Set("grant_type", "refresh_token")
+	params.Set("refresh_token", refreshToken)
+	params.Set("client_id", clientID)
+	params.Set("client_assertion_type", ClientAssertionTypeJWTBearer)
+	params.Set("client_assertion", assertion)
+
+	token, err := requestToken(ctx, tokenURL, params)
+	if err != nil {
+		return nil, err
+	}
+
+	// Providers may answer a refresh without issuing a new refresh token. Keep
+	// the current one then, as oauth2.Config.TokenSource does, so it stays
+	// available for the next refresh.
+	if token.RefreshToken == "" {
+		token.RefreshToken = refreshToken
+	}
+
+	return token, nil
+}
+
+// requestToken posts params to the token endpoint and builds an oauth2.Token
+// from the response. It uses the HTTP client carried by ctx, if any, so custom
+// CA bundles and TLS settings configured for OIDC still apply.
+//
+// TODO: This is a temporary workaround for the lack of client assertion
+// support in golang.org/x/oauth2. Only the refresh request needs it, so once
+// the upstream feature lands, drop this and the response parsing helpers below
+// in favour of oauth2.Config.TokenSource.
+// See https://github.com/golang/oauth2/issues/744
+func requestToken(ctx context.Context, tokenURL string, params url.Values) (*oauth2.Token, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(params.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("creating token request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	// A nil token source makes NewClient return the HTTP client carried by ctx.
+	resp, err := oauth2.NewClient(ctx, nil).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("requesting token: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxTokenResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("reading token response: %w", err)
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("token endpoint returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+
+	return tokenFromResponse(body, resp.Header.Get("Content-Type"))
+}
+
+// tokenFromResponse builds an oauth2.Token from a token endpoint response
+// body, parsing it as JSON or as form-encoded per Content-Type, matching
+// oauth2.Config.TokenSource.
+// The whole response is attached as the token's extra data, so provider
+// specific fields such as id_token stay reachable through Token.Extra.
+func tokenFromResponse(body []byte, contentType string) (*oauth2.Token, error) {
+	mediaType, _, _ := mime.ParseMediaType(contentType)
+
+	var raw map[string]interface{}
+
+	switch mediaType {
+	case "application/x-www-form-urlencoded", "text/plain":
+		vals, err := url.ParseQuery(string(body))
+		if err != nil {
+			return nil, fmt.Errorf("parsing token response: %w", err)
+		}
+
+		raw = make(map[string]interface{}, len(vals))
+		for key, values := range vals {
+			if len(values) > 0 {
+				raw[key] = values[0]
+			}
+		}
+	default:
+		if err := json.Unmarshal(body, &raw); err != nil {
+			return nil, fmt.Errorf("unmarshalling token response: %w", err)
+		}
+	}
+
+	// RFC 6749 says errors use 400, but some providers don't comply and use
+	// 2xx instead; check error/error_description first for compatibility.
+	// https://cs.opensource.google/go/x/oauth2/+/refs/tags/v0.36.0:internal/token.go;l=323-328
+	if errCode := stringFromTokenResponse(raw, "error"); errCode != "" {
+		if desc := stringFromTokenResponse(raw, "error_description"); desc != "" {
+			return nil, fmt.Errorf("token endpoint returned error %q: %s", errCode, desc)
+		}
+
+		return nil, fmt.Errorf("token endpoint returned error %q", errCode)
+	}
+
+	token := &oauth2.Token{
+		AccessToken:  stringFromTokenResponse(raw, "access_token"),
+		TokenType:    stringFromTokenResponse(raw, "token_type"),
+		RefreshToken: stringFromTokenResponse(raw, "refresh_token"),
+	}
+
+	if token.AccessToken == "" {
+		return nil, errors.New("token endpoint response has no access_token")
+	}
+
+	// oauth2.Token keeps the wire value separate from the computed expiry.
+	if expiresIn, ok := expiresInFromTokenResponse(raw); ok {
+		token.ExpiresIn = expiresIn
+		token.Expiry = time.Now().Add(time.Duration(expiresIn) * time.Second)
+	}
+
+	return token.WithExtra(raw), nil
+}
+
+// stringFromTokenResponse returns the named string field of a token response,
+// or the empty string when it is absent or not a string.
+func stringFromTokenResponse(raw map[string]interface{}, field string) string {
+	value, _ := raw[field].(string)
+
+	return value
+}
+
+// expiresInFromTokenResponse returns the expires_in value of a token response
+// in seconds. Providers are known to send it either as a JSON number or as a
+// string, so both are accepted.
+func expiresInFromTokenResponse(raw map[string]interface{}) (int64, bool) {
+	switch value := raw["expires_in"].(type) {
+	case float64:
+		return int64(value), value != 0
+	case string:
+		seconds, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return 0, false
+		}
+
+		return seconds, seconds != 0
+	default:
+		return 0, false
+	}
+}

--- a/backend/pkg/auth/client_assertion_test.go
+++ b/backend/pkg/auth/client_assertion_test.go
@@ -1,0 +1,529 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/auth"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+const testAssertion = "header.payload.signature"
+
+func writeAssertionFile(t *testing.T, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "assertion.jwt")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+
+	return path
+}
+
+// tokenRequests records the form of every request a test token endpoint
+// receives. The mutex guards the slice because handlers run on their own
+// goroutine while the test goroutine reads it.
+type tokenRequests struct {
+	mu    sync.Mutex
+	forms []url.Values
+}
+
+func (r *tokenRequests) add(form url.Values) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.forms = append(r.forms, form)
+}
+
+func (r *tokenRequests) all() []url.Values {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return append([]url.Values(nil), r.forms...)
+}
+
+// tokenEndpoint serves body as the token response and records the requests.
+func tokenEndpoint(t *testing.T, body map[string]any) (string, *tokenRequests) {
+	t.Helper()
+
+	requests := &tokenRequests{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Handlers run off the test goroutine, so they report with assert
+		// rather than require, whose FailNow is only valid on it.
+		if !assert.NoError(t, r.ParseForm()) {
+			return
+		}
+
+		requests.add(r.PostForm)
+
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv.URL, requests
+}
+
+// rawTokenEndpoint serves body verbatim, for responses an encoder would reject.
+func rawTokenEndpoint(t *testing.T, status int, body string) string {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv.URL
+}
+
+func TestReadClientAssertion(t *testing.T) {
+	t.Run("trims surrounding whitespace", func(t *testing.T) {
+		// Projected token files and kubectl create token both end in a newline.
+		assertion, err := auth.ReadClientAssertion(writeAssertionFile(t, "\n"+testAssertion+"\n"))
+		require.NoError(t, err)
+		assert.Equal(t, testAssertion, assertion)
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		_, err := auth.ReadClientAssertion(filepath.Join(t.TempDir(), "absent.jwt"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reading client assertion file")
+	})
+
+	t.Run("empty file", func(t *testing.T) {
+		_, err := auth.ReadClientAssertion(writeAssertionFile(t, " \n"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "is empty")
+	})
+}
+
+func TestClientAssertionAuthCodeOptions(t *testing.T) {
+	t.Run("no assertion file", func(t *testing.T) {
+		opts, err := auth.ClientAssertionAuthCodeOptions("")
+		require.NoError(t, err)
+		assert.Empty(t, opts)
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		_, err := auth.ClientAssertionAuthCodeOptions(filepath.Join(t.TempDir(), "absent.jwt"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reading client assertion file")
+	})
+
+	t.Run("empty file", func(t *testing.T) {
+		_, err := auth.ClientAssertionAuthCodeOptions(writeAssertionFile(t, "\n"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "is empty")
+	})
+}
+
+func TestSetClientAssertionAuthStyle(t *testing.T) {
+	const idp = "https://idp.example"
+
+	endpoint := oauth2.Endpoint{AuthURL: idp + "/auth", TokenURL: idp + "/token"}
+
+	t.Run("assertion pins the auth style", func(t *testing.T) {
+		got := auth.SetClientAssertionAuthStyle(endpoint, "/var/run/assertion.jwt")
+		assert.Equal(t, oauth2.AuthStyleInParams, got.AuthStyle)
+		assert.Equal(t, endpoint.TokenURL, got.TokenURL)
+	})
+
+	t.Run("no assertion leaves the endpoint untouched", func(t *testing.T) {
+		// A client secret deployment must keep oauth2 probing Basic auth first.
+		assert.Equal(t, endpoint, auth.SetClientAssertionAuthStyle(endpoint, ""))
+	})
+}
+
+func TestClientAssertionAuthCodeOptions_SentOnExchange(t *testing.T) {
+	authorizationCode := "test-authorization-code"
+
+	tokenURL, requests := tokenEndpoint(t, oauthSuccessBody)
+	clientAssertionFile := writeAssertionFile(t, testAssertion)
+
+	opts, err := auth.ClientAssertionAuthCodeOptions(clientAssertionFile)
+	require.NoError(t, err)
+
+	endpoint := auth.SetClientAssertionAuthStyle(
+		oauth2.Endpoint{TokenURL: tokenURL}, clientAssertionFile)
+	conf := &oauth2.Config{ClientID: "cid", Endpoint: endpoint}
+
+	_, err = conf.Exchange(context.Background(), authorizationCode, opts...)
+	require.NoError(t, err)
+
+	forms := requests.all()
+	require.Len(t, forms, 1)
+
+	assert.Equal(t, authorizationCode, forms[0].Get("code"))
+	// client_id in the body is what the pinned AuthStyleInParams buys: with the
+	// oauth2 default it would be probed in an Authorization: Basic header first.
+	assert.Equal(t, "cid", forms[0].Get("client_id"))
+	assert.Equal(t, auth.ClientAssertionTypeJWTBearer, forms[0].Get("client_assertion_type"))
+	assert.Equal(t, testAssertion, forms[0].Get("client_assertion"))
+	assert.Empty(t, forms[0].Get("client_secret"))
+}
+
+func TestRefreshTokenWithClientAssertion_Success(t *testing.T) {
+	tokenURL, requests := tokenEndpoint(t, oauthSuccessBody)
+	clientAssertionFile := writeAssertionFile(t, testAssertion)
+
+	token, err := auth.RefreshTokenWithClientAssertion(context.Background(),
+		tokenURL, "cid", clientAssertionFile, "REFRESH_OLD")
+	require.NoError(t, err)
+
+	assert.Equal(t, "AT", token.AccessToken)
+	assert.Equal(t, "Bearer", token.TokenType)
+	assert.Equal(t, refreshNew, token.RefreshToken)
+	assert.Equal(t, "NEW", token.Extra("id_token"))
+	assert.WithinDuration(t, time.Now().Add(time.Hour), token.Expiry, time.Minute)
+
+	forms := requests.all()
+	require.Len(t, forms, 1)
+
+	assert.Equal(t, "refresh_token", forms[0].Get("grant_type"))
+	assert.Equal(t, "REFRESH_OLD", forms[0].Get("refresh_token"))
+	assert.Equal(t, "cid", forms[0].Get("client_id"))
+	assert.Equal(t, auth.ClientAssertionTypeJWTBearer, forms[0].Get("client_assertion_type"))
+	assert.Equal(t, testAssertion, forms[0].Get("client_assertion"))
+	assert.Empty(t, forms[0].Get("client_secret"))
+}
+
+// formEncodedTokenEndpoint serves body as a query string with the given
+// Content-Type, mimicking IdPs that answer with form-encoded token responses
+// instead of JSON.
+func formEncodedTokenEndpoint(t *testing.T, contentType string, body url.Values) string {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", contentType)
+		_, _ = w.Write([]byte(body.Encode()))
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv.URL
+}
+
+func TestRefreshTokenWithClientAssertion_FormEncodedResponse(t *testing.T) {
+	for _, contentType := range []string{"application/x-www-form-urlencoded", "text/plain"} {
+		t.Run(contentType, func(t *testing.T) {
+			body := url.Values{
+				"access_token":  {"AT"},
+				"token_type":    {"Bearer"},
+				"refresh_token": {refreshNew},
+				"expires_in":    {"3600"},
+				"id_token":      {"NEW"},
+			}
+
+			tokenURL := formEncodedTokenEndpoint(t, contentType, body)
+
+			token, err := auth.RefreshTokenWithClientAssertion(context.Background(),
+				tokenURL, "cid", writeAssertionFile(t, testAssertion), "REFRESH_OLD")
+			require.NoError(t, err)
+
+			assert.Equal(t, "AT", token.AccessToken)
+			assert.Equal(t, "Bearer", token.TokenType)
+			assert.Equal(t, refreshNew, token.RefreshToken)
+			assert.Equal(t, "NEW", token.Extra("id_token"))
+			assert.WithinDuration(t, time.Now().Add(time.Hour), token.Expiry, time.Minute)
+		})
+	}
+}
+
+func TestRefreshTokenWithClientAssertion_RereadsAssertionFile(t *testing.T) {
+	tokenURL, requests := tokenEndpoint(t, oauthSuccessBody)
+	clientAssertionFile := writeAssertionFile(t, testAssertion)
+
+	_, err := auth.RefreshTokenWithClientAssertion(context.Background(),
+		tokenURL, "cid", clientAssertionFile, "REFRESH_OLD")
+	require.NoError(t, err)
+
+	const rotatedAssertion = "rotated.payload.signature"
+
+	require.NoError(t, os.WriteFile(clientAssertionFile, []byte(rotatedAssertion), 0o600))
+
+	_, err = auth.RefreshTokenWithClientAssertion(context.Background(),
+		tokenURL, "cid", clientAssertionFile, "REFRESH_OLD")
+	require.NoError(t, err)
+
+	forms := requests.all()
+	require.Len(t, forms, 2)
+	assert.Equal(t, testAssertion, forms[0].Get("client_assertion"))
+	assert.Equal(t, rotatedAssertion, forms[1].Get("client_assertion"))
+}
+
+func TestRefreshTokenWithClientAssertion_Expiry(t *testing.T) {
+	tests := []struct {
+		name string
+		// expiresIn is the expires_in value of the response, omitted when nil.
+		expiresIn any
+		// wantExpiresIn is 0 for the responses that yield no expiry at all.
+		wantExpiresIn int64
+	}{
+		{name: "json number", expiresIn: 3600, wantExpiresIn: 3600},
+		// Some providers send expires_in as a JSON string.
+		{name: "json string", expiresIn: "300", wantExpiresIn: 300},
+		{name: "absent", expiresIn: nil},
+		{name: "zero", expiresIn: 0},
+		{name: "zero as string", expiresIn: "0"},
+		{name: "unparsable string", expiresIn: "soon"},
+		{name: "unexpected type", expiresIn: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := map[string]any{"access_token": "AT", "token_type": "Bearer"}
+			if tt.expiresIn != nil {
+				body["expires_in"] = tt.expiresIn
+			}
+
+			tokenURL, _ := tokenEndpoint(t, body)
+
+			token, err := auth.RefreshTokenWithClientAssertion(context.Background(),
+				tokenURL, "cid", writeAssertionFile(t, testAssertion), "REFRESH_OLD")
+			require.NoError(t, err, "an unusable expires_in must not fail the refresh")
+			assert.Equal(t, tt.wantExpiresIn, token.ExpiresIn)
+
+			if tt.wantExpiresIn == 0 {
+				assert.True(t, token.Expiry.IsZero())
+
+				return
+			}
+
+			assert.WithinDuration(t, time.Now().Add(time.Duration(tt.wantExpiresIn)*time.Second),
+				token.Expiry, time.Minute)
+		})
+	}
+}
+
+func TestRefreshTokenWithClientAssertion_KeepsRefreshToken(t *testing.T) {
+	tokenURL, _ := tokenEndpoint(t, map[string]any{
+		"access_token": "AT",
+		"token_type":   "Bearer",
+		"expires_in":   3600,
+		"id_token":     "NEW",
+	})
+
+	token, err := auth.RefreshTokenWithClientAssertion(context.Background(),
+		tokenURL, "cid", writeAssertionFile(t, testAssertion), "REFRESH_OLD")
+	require.NoError(t, err)
+	assert.Equal(t, "REFRESH_OLD", token.RefreshToken)
+}
+
+func TestRefreshTokenWithClientAssertion_Errors(t *testing.T) {
+	assertionFile := writeAssertionFile(t, testAssertion)
+
+	tests := []struct {
+		name          string
+		status        int
+		body          string
+		errorContains string
+	}{
+		{
+			name:          "token endpoint rejects the assertion",
+			status:        http.StatusUnauthorized,
+			body:          `{"error":"invalid_client"}`,
+			errorContains: "invalid_client",
+		},
+		{
+			name:          "token endpoint fails without a body",
+			status:        http.StatusInternalServerError,
+			errorContains: "token endpoint returned 500 Internal Server Error",
+		},
+		{
+			name:          "token endpoint returns an error with a 2xx status",
+			status:        http.StatusOK,
+			body:          `{"error":"invalid_client","error_description":"client assertion expired"}`,
+			errorContains: "invalid_client",
+		},
+		{
+			name:          "response is not JSON",
+			status:        http.StatusOK,
+			body:          "not json",
+			errorContains: "unmarshalling token response",
+		},
+		{
+			name:          "response has no access token",
+			status:        http.StatusOK,
+			body:          `{"token_type":"Bearer"}`,
+			errorContains: "no access_token",
+		},
+		{
+			// Fields are read leniently, so a non-string access_token reads as
+			// absent rather than as a type error.
+			name:          "access token is not a string",
+			status:        http.StatusOK,
+			body:          `{"access_token":123,"token_type":"Bearer"}`,
+			errorContains: "no access_token",
+		},
+		{
+			// Truncating at maxTokenResponseBytes leaves the JSON unparsable.
+			name:          "response exceeds the read cap",
+			status:        http.StatusOK,
+			body:          `{"padding":"` + strings.Repeat("x", 1<<20) + `","access_token":"AT"}`,
+			errorContains: "unmarshalling token response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := auth.RefreshTokenWithClientAssertion(context.Background(),
+				rawTokenEndpoint(t, tt.status, tt.body), "cid", assertionFile, "REFRESH_OLD")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errorContains)
+		})
+	}
+}
+
+func TestRefreshTokenWithClientAssertion_UnparsableTokenURL(t *testing.T) {
+	_, err := auth.RefreshTokenWithClientAssertion(context.Background(),
+		"http://idp.example/\x7f", "cid", writeAssertionFile(t, testAssertion), "REFRESH_OLD")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "creating token request")
+}
+
+func TestRefreshTokenWithClientAssertion_TruncatedResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Promising more than is written makes net/http close the connection,
+		// so the client fails while reading the body rather than the headers.
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", "2048")
+
+		_, _ = w.Write([]byte(`{"access_token":`))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := auth.RefreshTokenWithClientAssertion(context.Background(),
+		srv.URL, "cid", writeAssertionFile(t, testAssertion), "REFRESH_OLD")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading token response")
+}
+
+func TestRefreshTokenWithClientAssertion_CanceledContext(t *testing.T) {
+	tokenURL, requests := tokenEndpoint(t, oauthSuccessBody)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := auth.RefreshTokenWithClientAssertion(ctx,
+		tokenURL, "cid", writeAssertionFile(t, testAssertion), "REFRESH_OLD")
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Empty(t, requests.all(), "a canceled context should not reach the token endpoint")
+}
+
+func TestRefreshTokenWithClientAssertion_MissingAssertionFile(t *testing.T) {
+	tokenURL, requests := tokenEndpoint(t, oauthSuccessBody)
+
+	_, err := auth.RefreshTokenWithClientAssertion(context.Background(),
+		tokenURL, "cid", filepath.Join(t.TempDir(), "absent.jwt"), "REFRESH_OLD")
+	require.Error(t, err)
+	assert.Empty(t, requests.all(), "no token request should be made without an assertion")
+}
+
+func TestRefreshTokenWithClientAssertion_UsesContextHTTPClient(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(oauthSuccessBody))
+	}))
+	t.Cleanup(srv.Close)
+
+	assertionFile := writeAssertionFile(t, testAssertion)
+
+	_, err := auth.RefreshTokenWithClientAssertion(context.Background(),
+		srv.URL, "cid", assertionFile, "REFRESH_OLD")
+	require.Error(t, err, "the default client does not trust the test server certificate")
+
+	// oidc.ClientContext and oauth2 both store the client under this key.
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, srv.Client())
+
+	token, err := auth.RefreshTokenWithClientAssertion(ctx, srv.URL, "cid", assertionFile, "REFRESH_OLD")
+	require.NoError(t, err)
+	assert.Equal(t, "AT", token.AccessToken)
+}
+
+func TestRefreshAndCacheNewToken_ClientAssertion(t *testing.T) {
+	const oldToken = "OLD"
+
+	fc := &fakeCache{store: map[string]interface{}{"oidc-token-" + oldToken: "REFRESH_OLD"}}
+	srv := newOIDCProviderServer(t, "", func(w http.ResponseWriter, r *http.Request) {
+		if !assert.NoError(t, r.ParseForm()) {
+			return
+		}
+
+		assert.Equal(t, "refresh_token", r.PostForm.Get("grant_type"))
+		assert.Equal(t, "REFRESH_OLD", r.PostForm.Get("refresh_token"))
+		assert.Equal(t, auth.ClientAssertionTypeJWTBearer, r.PostForm.Get("client_assertion_type"))
+		assert.Equal(t, testAssertion, r.PostForm.Get("client_assertion"))
+		// The client is authenticated by the assertion, never by a secret.
+		assert.Empty(t, r.Header.Get("Authorization"))
+		assert.Empty(t, r.PostForm.Get("client_secret"))
+
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(oauthSuccessBody))
+	})
+
+	oidcConfig := &kubeconfig.OidcConfig{
+		ClientID:            "cid",
+		ClientAssertionFile: writeAssertionFile(t, testAssertion),
+	}
+
+	tok, err := auth.RefreshAndCacheNewToken(context.Background(), oidcConfig, fc,
+		"id_token", oldToken, srv.URL, "")
+	require.NoError(t, err)
+	assert.Equal(t, refreshNew, tok.RefreshToken)
+	assert.Equal(t, "NEW", tok.Extra("id_token"))
+}
+
+func TestGetNewToken_ClientAssertion(t *testing.T) {
+	tokenURL, requests := tokenEndpoint(t, oauthSuccessBody)
+	fc := &fakeCache{store: map[string]interface{}{"oidc-token-OLD": "REFRESH_OLD"}}
+
+	params := newTokenParams(fc, tokenURL)
+	params.ClientSecret = ""
+	params.ClientAssertionFile = writeAssertionFile(t, testAssertion)
+
+	newTok, err := auth.GetNewToken(context.Background(), params)
+	require.NoError(t, err)
+	assert.Equal(t, "AT", newTok.AccessToken)
+
+	forms := requests.all()
+	require.Len(t, forms, 1)
+	assert.Equal(t, auth.ClientAssertionTypeJWTBearer, forms[0].Get("client_assertion_type"))
+	assert.Equal(t, testAssertion, forms[0].Get("client_assertion"))
+
+	// The refreshed token replaces the cached one, keyed by the new id_token.
+	require.Len(t, fc.setCalls, 1)
+	assert.Equal(t, "oidc-token-NEW", fc.setCalls[0].key)
+	assert.Equal(t, refreshNew, fc.setCalls[0].val)
+	require.Len(t, fc.setWithTTLCalls, 1)
+	assert.Equal(t, "oidc-token-OLD", fc.setWithTTLCalls[0].key)
+}

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -76,6 +76,7 @@ type Config struct {
 	OidcClientID                 string `koanf:"oidc-client-id"`
 	OidcValidatorClientID        string `koanf:"oidc-validator-client-id"`
 	OidcClientSecret             string `koanf:"oidc-client-secret"`
+	OidcClientAssertionFile      string `koanf:"oidc-client-assertion-file"`
 	OidcIdpIssuerURL             string `koanf:"oidc-idp-issuer-url"`
 	OidcCallbackURL              string `koanf:"oidc-callback-url"`
 	OidcValidatorIdpIssuerURL    string `koanf:"oidc-validator-idp-issuer-url"`
@@ -128,10 +129,11 @@ func (c *Config) Validate() error {
 		return err
 	}
 
-	if !c.InCluster && !c.OidcUseCookie && (c.OidcClientID != "" || c.OidcClientSecret != "" || c.OidcIdpIssuerURL != "" ||
+	if !c.InCluster && !c.OidcUseCookie && (c.OidcClientID != "" || c.OidcClientSecret != "" ||
+		c.OidcClientAssertionFile != "" || c.OidcIdpIssuerURL != "" ||
 		c.OidcValidatorClientID != "" || c.OidcValidatorIdpIssuerURL != "") {
-		return errors.New("oidc-client-id, oidc-client-secret, oidc-idp-issuer-url, " +
-			"oidc-validator-client-id, oidc-validator-idp-issuer-url, flags are only " +
+		return errors.New("oidc-client-id, oidc-client-secret, oidc-client-assertion-file, " +
+			"oidc-idp-issuer-url, oidc-validator-client-id, oidc-validator-idp-issuer-url, flags are only " +
 			"meant to be used in inCluster mode or with --oidc-use-cookie")
 	}
 
@@ -151,6 +153,10 @@ func (c *Config) Validate() error {
 		return err
 	}
 
+	if err := c.validateOIDCClientAssertionFile(); err != nil {
+		return err
+	}
+
 	if c.BaseURL != "" && !strings.HasPrefix(c.BaseURL, "/") {
 		return errors.New("base-url needs to start with a '/' or be empty")
 	}
@@ -164,21 +170,8 @@ func (c *Config) Validate() error {
 		return errors.New("session-ttl cannot be greater than 1 year")
 	}
 
-	if c.TracingEnabled != nil && *c.TracingEnabled {
-		if c.ServiceName == "" {
-			return errors.New("service-name is required when tracing is enabled")
-		}
-
-		if (c.JaegerEndpoint != nil && *c.JaegerEndpoint == "") &&
-			(c.OTLPEndpoint != nil && *c.OTLPEndpoint == "") &&
-			(c.StdoutTraceEnabled != nil && *c.StdoutTraceEnabled) {
-			return errors.New("at least one tracing exporter (jaeger, otlp, or stdout) must be configured")
-		}
-
-		if (c.UseOTLPHTTP != nil && *c.UseOTLPHTTP) &&
-			(c.OTLPEndpoint == nil || *c.OTLPEndpoint == "") {
-			return errors.New("otlp-endpoint must be configured when use-otlp-http is enabled")
-		}
+	if err := c.validateTracing(); err != nil {
+		return err
 	}
 
 	if err := c.validateClusterInventory(); err != nil {
@@ -200,6 +193,32 @@ func (c *Config) validateAppName() error {
 	return nil
 }
 
+// validateTracing checks the telemetry flags that only apply when tracing is
+// enabled. Extracted to keep Validate's cyclomatic complexity within the
+// linter limit.
+func (c *Config) validateTracing() error {
+	if c.TracingEnabled == nil || !*c.TracingEnabled {
+		return nil
+	}
+
+	if c.ServiceName == "" {
+		return errors.New("service-name is required when tracing is enabled")
+	}
+
+	if (c.JaegerEndpoint != nil && *c.JaegerEndpoint == "") &&
+		(c.OTLPEndpoint != nil && *c.OTLPEndpoint == "") &&
+		(c.StdoutTraceEnabled != nil && *c.StdoutTraceEnabled) {
+		return errors.New("at least one tracing exporter (jaeger, otlp, or stdout) must be configured")
+	}
+
+	if (c.UseOTLPHTTP != nil && *c.UseOTLPHTTP) &&
+		(c.OTLPEndpoint == nil || *c.OTLPEndpoint == "") {
+		return errors.New("otlp-endpoint must be configured when use-otlp-http is enabled")
+	}
+
+	return nil
+}
+
 func (c *Config) validateOIDCCAFile() error {
 	if c.OidcCAFile == "" {
 		return nil
@@ -213,6 +232,18 @@ func (c *Config) validateOIDCCAFile() error {
 	caCertPool := x509.NewCertPool()
 	if !caCertPool.AppendCertsFromPEM(caFileContents) {
 		return errors.New("invalid oidc-ca-file")
+	}
+
+	return nil
+}
+
+func (c *Config) validateOIDCClientAssertionFile() error {
+	if c.OidcClientAssertionFile == "" {
+		return nil
+	}
+
+	if c.OidcClientSecret != "" {
+		return errors.New("oidc-client-assertion-file is mutually exclusive with oidc-client-secret")
 	}
 
 	return nil
@@ -645,6 +676,10 @@ func addGeneralFlags(f *flag.FlagSet, appName string) {
 func addOIDCFlags(f *flag.FlagSet) {
 	f.String("oidc-client-id", "", "ClientID for OIDC")
 	f.String("oidc-client-secret", "", "ClientSecret for OIDC")
+	f.String("oidc-client-assertion-file", "", "Path to a file holding a JWT sent as client_assertion to "+
+		"authenticate at the OIDC token endpoint (RFC 7523) instead of a client secret. The file is read on "+
+		"every token request, so it can hold a credential rotated in place, such as a Kubernetes projected "+
+		"service account token. Mutually exclusive with oidc-client-secret")
 	f.String("oidc-validator-client-id", "", "Override ClientID for OIDC during validation")
 	f.String("oidc-idp-issuer-url", "", "Identity provider issuer URL for OIDC")
 	f.String("oidc-callback-url", "", "Callback URL for OIDC")

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -748,6 +748,105 @@ func TestOIDCTLSValidation(t *testing.T) {
 	}
 }
 
+// writeTestAssertionFile writes a client assertion file with the given contents
+// and returns its path.
+func writeTestAssertionFile(t *testing.T, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "assertion.jwt")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+
+	return path
+}
+
+type oidcClientAssertionFileTest struct {
+	name          string
+	args          []string
+	expectedPath  string
+	expectError   bool
+	errorContains string
+}
+
+// oidcClientAssertionFileTests builds the parse cases, given a readable
+// assertion file and a path that does not exist.
+func oidcClientAssertionFileTests(assertionFile, absentAssertionFile string) []oidcClientAssertionFileTest {
+	return []oidcClientAssertionFileTest{
+		{
+			name: "valid_assertion_file",
+			args: []string{
+				"go run ./cmd",
+				"--in-cluster",
+				"--oidc-client-assertion-file=" + assertionFile,
+			},
+			expectedPath: assertionFile,
+			expectError:  false,
+		},
+		{
+			name: "assertion_file_with_client_secret",
+			args: []string{
+				"go run ./cmd",
+				"--in-cluster",
+				"--oidc-client-assertion-file=" + assertionFile,
+				"--oidc-client-secret=aSecret",
+			},
+			expectError:   true,
+			errorContains: "mutually exclusive with oidc-client-secret",
+		},
+		{
+			name: "unreadable_file_is_accepted_at_config_parse_time",
+			args: []string{
+				"go run ./cmd",
+				"--in-cluster",
+				"--oidc-client-assertion-file=" + absentAssertionFile,
+			},
+			expectedPath: absentAssertionFile,
+			expectError:  false,
+		},
+		{
+			name: "assertion_file_without_incluster",
+			args: []string{
+				"go run ./cmd",
+				"--oidc-client-assertion-file=" + assertionFile,
+			},
+			expectError:   true,
+			errorContains: "flags are only meant to be used in inCluster mode or with --oidc-use-cookie",
+		},
+	}
+}
+
+func TestOIDCClientAssertionFile(t *testing.T) {
+	assertionFile := writeTestAssertionFile(t, "header.payload.signature\n")
+	absentAssertionFile := filepath.Join(t.TempDir(), "absent.jwt")
+
+	for _, tt := range oidcClientAssertionFileTests(assertionFile, absentAssertionFile) {
+		t.Run(tt.name, func(t *testing.T) {
+			conf, err := config.Parse(tt.args)
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Nil(t, conf)
+				assert.Contains(t, err.Error(), tt.errorContains)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, conf)
+				assert.Equal(t, tt.expectedPath, conf.OidcClientAssertionFile)
+			}
+		})
+	}
+}
+
+func TestOIDCClientAssertionFileEnvironmentVariables(t *testing.T) {
+	assertionFile := writeTestAssertionFile(t, "header.payload.signature\n")
+
+	t.Setenv("HEADLAMP_CONFIG_IN_CLUSTER", "true")
+	t.Setenv("HEADLAMP_CONFIG_OIDC_CLIENT_ASSERTION_FILE", assertionFile)
+
+	conf, err := config.Parse([]string{"go run ./cmd"})
+	require.NoError(t, err)
+	require.NotNil(t, conf)
+	assert.Equal(t, assertionFile, conf.OidcClientAssertionFile)
+}
+
 func TestOIDCTLSEnvironmentVariables(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -22,6 +22,7 @@ type HeadlampConfig struct {
 	OidcClientID              string
 	OidcValidatorClientID     string
 	OidcClientSecret          string
+	OidcClientAssertionFile   string
 	OidcIdpIssuerURL          string
 	OidcCallbackURL           string
 	OidcValidatorIdpIssuerURL string

--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -87,10 +87,11 @@ func (c *Context) Copy() *Context {
 	var oidcConf *OidcConfig
 	if c.OidcConf != nil {
 		oidcConf = &OidcConfig{
-			ClientID:     c.OidcConf.ClientID,
-			ClientSecret: c.OidcConf.ClientSecret,
-			IdpIssuerURL: c.OidcConf.IdpIssuerURL,
-			Scopes:       make([]string, len(c.OidcConf.Scopes)),
+			ClientID:            c.OidcConf.ClientID,
+			ClientSecret:        c.OidcConf.ClientSecret,
+			ClientAssertionFile: c.OidcConf.ClientAssertionFile,
+			IdpIssuerURL:        c.OidcConf.IdpIssuerURL,
+			Scopes:              make([]string, len(c.OidcConf.Scopes)),
 		}
 		copy(oidcConf.Scopes, c.OidcConf.Scopes)
 
@@ -150,6 +151,9 @@ type OidcConfig struct {
 	ClientID string
 	// OIDC client secret.
 	ClientSecret string
+	// ClientAssertionFile is the path to a file holding a JWT that is sent as
+	// client_assertion to authenticate at the token endpoint (RFC 7523).
+	ClientAssertionFile string
 	// OIDC issuer URL.
 	IdpIssuerURL string
 	// OIDC scopes.
@@ -349,6 +353,18 @@ func (c *Context) OidcConfig() (*OidcConfig, error) {
 		return nil, errors.New("authProvider is nil")
 	}
 
+	clientAssertionFile := c.AuthInfo.AuthProvider.Config["client-assertion-file"]
+
+	// client-assertion-file names a path on the Headlamp server's filesystem, and its
+	// contents are sent to the token endpoint discovered from the same kubeconfig.
+	// Dynamic cluster kubeconfigs are supplied by callers through request headers, so
+	// honouring the key for them would let a caller have the server read any file it can
+	// read and post it to an identity provider the caller controls. Only kubeconfigs the
+	// server operator provides are trusted with it.
+	if clientAssertionFile != "" && c.Source == DynamicCluster {
+		return nil, errors.New("client-assertion-file is not allowed in a dynamic cluster kubeconfig")
+	}
+
 	var caCert *string
 
 	// if custom CA is configured in the kubeconfig auth provider use it.
@@ -378,11 +394,12 @@ func (c *Context) OidcConfig() (*OidcConfig, error) {
 	}
 
 	return &OidcConfig{
-		ClientID:     c.AuthInfo.AuthProvider.Config["client-id"],
-		ClientSecret: c.AuthInfo.AuthProvider.Config["client-secret"],
-		Scopes:       strings.Split(c.AuthInfo.AuthProvider.Config["scope"], ","),
-		IdpIssuerURL: c.AuthInfo.AuthProvider.Config["idp-issuer-url"],
-		CACert:       caCert,
+		ClientID:            c.AuthInfo.AuthProvider.Config["client-id"],
+		ClientSecret:        c.AuthInfo.AuthProvider.Config["client-secret"],
+		ClientAssertionFile: clientAssertionFile,
+		Scopes:              strings.Split(c.AuthInfo.AuthProvider.Config["scope"], ","),
+		IdpIssuerURL:        c.AuthInfo.AuthProvider.Config["idp-issuer-url"],
+		CACert:              caCert,
 	}, nil
 }
 
@@ -1073,7 +1090,10 @@ func convertToContext(contextName string, clientConfig *api.Config, source int, 
 }
 
 // LoadContextsFromAPIConfig loads contexts from the given api.Config.
-func LoadContextsFromAPIConfig(config *api.Config, skipProxySetup bool) ([]Context, []error) {
+// source must be the one config was originally loaded with: OidcConfig refuses
+// client-assertion-file, which it reads off the Headlamp server, for
+// DynamicCluster contexts.
+func LoadContextsFromAPIConfig(config *api.Config, source int, skipProxySetup bool) ([]Context, []error) {
 	contexts := []Context{}
 	errors := []error{}
 
@@ -1095,6 +1115,7 @@ func LoadContextsFromAPIConfig(config *api.Config, skipProxySetup bool) ([]Conte
 			KubeContext: context,
 			Cluster:     cluster,
 			AuthInfo:    authInfo,
+			Source:      source,
 		}
 
 		if !skipProxySetup {
@@ -1193,6 +1214,7 @@ func GetInClusterContext(
 	contextName string,
 	oidcIssuerURL string,
 	oidcClientID string, oidcClientSecret string,
+	oidcClientAssertionFile string,
 	oidcScopes string,
 	oidcSkipTLSVerify bool,
 	oidcCACert string,
@@ -1214,6 +1236,7 @@ func GetInClusterContext(
 		oidcIssuerURL,
 		oidcClientID,
 		oidcClientSecret,
+		oidcClientAssertionFile,
 		oidcScopes,
 		oidcSkipTLSVerify,
 		oidcCACert,
@@ -1228,6 +1251,7 @@ func newInClusterContextFromConfig(
 	oidcIssuerURL string,
 	oidcClientID string,
 	oidcClientSecret string,
+	oidcClientAssertionFile string,
 	oidcScopes string,
 	oidcSkipTLSVerify bool,
 	oidcCACert string,
@@ -1256,32 +1280,53 @@ func newInClusterContextFromConfig(
 		inClusterAuthInfo.TokenFile = resolveServiceAccountTokenPath(clusterConfig, serviceAccountTokenPath)
 	}
 
-	var oidcConf *OidcConfig
-
-	if oidcClientID != "" && oidcIssuerURL != "" && oidcScopes != "" {
-		var caCert *string
-		if oidcCACert != "" {
-			caCert = &oidcCACert
-		}
-
-		// client secret is optional for in-cluster OIDC configuration
-		oidcConf = &OidcConfig{
-			ClientID:      oidcClientID,
-			ClientSecret:  oidcClientSecret,
-			IdpIssuerURL:  oidcIssuerURL,
-			Scopes:        strings.Split(oidcScopes, ","),
-			SkipTLSVerify: &oidcSkipTLSVerify,
-			CACert:        caCert,
-		}
-	}
-
 	return &Context{
 		Name:        contextName,
 		KubeContext: inClusterContext,
 		Cluster:     cluster,
 		AuthInfo:    inClusterAuthInfo,
 		Source:      InCluster,
-		OidcConf:    oidcConf,
+		OidcConf: newInClusterOidcConfig(
+			oidcIssuerURL,
+			oidcClientID,
+			oidcClientSecret,
+			oidcClientAssertionFile,
+			oidcScopes,
+			oidcSkipTLSVerify,
+			oidcCACert,
+		),
+	}
+}
+
+// newInClusterOidcConfig builds the OIDC config of the in-cluster context, or
+// returns nil when OIDC is not configured.
+func newInClusterOidcConfig(
+	oidcIssuerURL string,
+	oidcClientID string,
+	oidcClientSecret string,
+	oidcClientAssertionFile string,
+	oidcScopes string,
+	oidcSkipTLSVerify bool,
+	oidcCACert string,
+) *OidcConfig {
+	if oidcClientID == "" || oidcIssuerURL == "" || oidcScopes == "" {
+		return nil
+	}
+
+	var caCert *string
+	if oidcCACert != "" {
+		caCert = &oidcCACert
+	}
+
+	// client secret is optional for in-cluster OIDC configuration
+	return &OidcConfig{
+		ClientID:            oidcClientID,
+		ClientSecret:        oidcClientSecret,
+		ClientAssertionFile: oidcClientAssertionFile,
+		IdpIssuerURL:        oidcIssuerURL,
+		Scopes:              strings.Split(oidcScopes, ","),
+		SkipTLSVerify:       &oidcSkipTLSVerify,
+		CACert:              caCert,
 	}
 }
 

--- a/backend/pkg/kubeconfig/kubeconfig_test.go
+++ b/backend/pkg/kubeconfig/kubeconfig_test.go
@@ -328,6 +328,94 @@ users:
 	})
 }
 
+// oidcKubeconfig returns a kubeconfig whose oidc auth provider carries the given
+// extra config keys next to the client id and issuer URL.
+func oidcKubeconfig(t *testing.T, extraConfig map[string]string) string {
+	t.Helper()
+
+	var extra string
+	for key, value := range extraConfig {
+		extra += fmt.Sprintf("\n        %s: %q", key, value)
+	}
+
+	return fmt.Sprintf(`apiVersion: v1
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+kind: Config
+users:
+- name: test-user
+  user:
+    auth-provider:
+      config:
+        client-id: "test-client-id"
+        idp-issuer-url: "https://oidc.example.com"%s
+      name: oidc`, extra)
+}
+
+// serviceAccountTokenPath is the file a caller would target to have Headlamp
+// leak its own credential.
+const serviceAccountTokenPath = "/var/run/secrets/headlamp/oidc-client-assertion/token" //nolint:gosec
+
+// loadOneDynamicContext loads the single context of a kubeconfig the way a
+// dynamic cluster request does, from a base64 payload supplied by the caller.
+func loadOneDynamicContext(t *testing.T, kubeConfig string) kubeconfig.Context {
+	t.Helper()
+
+	encoded := base64.StdEncoding.EncodeToString([]byte(kubeConfig))
+
+	contexts, contextErrors, err := kubeconfig.LoadContextsFromBase64String(encoded, kubeconfig.DynamicCluster)
+	require.NoError(t, err)
+	require.Empty(t, contextErrors)
+	require.Len(t, contexts, 1)
+
+	return contexts[0]
+}
+
+func TestOidcConfigClientAssertionFile(t *testing.T) {
+	t.Run("honoured for a kubeconfig the server loads itself", func(t *testing.T) {
+		tempFile := createTempKubeconfig(t, oidcKubeconfig(t,
+			map[string]string{"client-assertion-file": serviceAccountTokenPath}))
+		defer func() { _ = os.Remove(tempFile) }()
+
+		contexts, contextErrors, err := kubeconfig.LoadContextsFromFile(tempFile, kubeconfig.KubeConfig)
+		require.NoError(t, err)
+		require.Empty(t, contextErrors)
+		require.Len(t, contexts, 1)
+
+		oidcConfig, err := contexts[0].OidcConfig()
+		require.NoError(t, err)
+		assert.Equal(t, serviceAccountTokenPath, oidcConfig.ClientAssertionFile)
+	})
+
+	t.Run("rejected for a dynamic cluster kubeconfig", func(t *testing.T) {
+		context := loadOneDynamicContext(t, oidcKubeconfig(t,
+			map[string]string{"client-assertion-file": serviceAccountTokenPath}))
+
+		oidcConfig, err := context.OidcConfig()
+		require.Error(t, err)
+		assert.Nil(t, oidcConfig)
+		assert.EqualError(t, err, "client-assertion-file is not allowed in a dynamic cluster kubeconfig")
+	})
+
+	t.Run("dynamic cluster kubeconfig without an assertion file still works", func(t *testing.T) {
+		context := loadOneDynamicContext(t, oidcKubeconfig(t,
+			map[string]string{"client-secret": "test-client-secret"}))
+
+		oidcConfig, err := context.OidcConfig()
+		require.NoError(t, err)
+		assert.Empty(t, oidcConfig.ClientAssertionFile)
+		assert.Equal(t, "test-client-secret", oidcConfig.ClientSecret)
+	})
+}
+
 func TestOidcConfigWithNilAuthInfo(t *testing.T) {
 	context := &kubeconfig.Context{AuthInfo: nil}
 

--- a/backend/pkg/kubeconfig/service_account_token_test.go
+++ b/backend/pkg/kubeconfig/service_account_token_test.go
@@ -87,7 +87,7 @@ func TestGetInClusterContextServiceAccountTokenFile(t *testing.T) {
 					BearerTokenFile: tt.clusterBearerTokenFile,
 				},
 				DefaultInClusterContextName,
-				"", "", "", "",
+				"", "", "", "", "",
 				false,
 				"",
 				tt.unsafeUseServiceAccountToken,

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -159,6 +159,7 @@ volume or volume mount.
 |-----|------|---------|-------------|
 | config.oidc.clientID | string | `""` | OIDC client ID |
 | config.oidc.clientSecret | string | `""` | OIDC client secret |
+| config.oidc.clientAssertionFile | string | `""` | Path to a JWT sent as `client_assertion` to authenticate at the OIDC token endpoint ([RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523)), instead of a client secret. Cannot be combined with `config.oidc.clientSecret`. Mount the JWT at this path through `.volumeMounts` and `.volumes`. |
 | config.oidc.issuerURL | string | `""` | OIDC issuer URL |
 | config.oidc.scopes | string | `""` | OIDC scopes to be used |
 | config.oidc.usePKCE | bool | `false` | Use PKCE (Proof Key for Code Exchange) for enhanced security in OIDC flow |

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -310,6 +310,9 @@ spec:
             - "-cluster-inventory-no-crd-cache-ttl={{ . }}"
             {{- end }}
             {{- end }}
+            {{- with $oidc.clientAssertionFile }}
+            - "-oidc-client-assertion-file={{ . }}"
+            {{- end }}
             {{- if not $oidc.externalSecret.enabled}}
             # Check if externalSecret is disabled
             {{- if or (ne $oidc.clientID "") (ne $clientID "") }}
@@ -352,7 +355,9 @@ spec:
             {{- end }}
             {{- else }}
             - "-oidc-client-id=$(OIDC_CLIENT_ID)"
+            {{- if not $oidc.clientAssertionFile }}
             - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
+            {{- end }}
             - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
             {{- if $oidc.externalSecret.hasScopes }}
             - "-oidc-scopes=$(OIDC_SCOPES)"

--- a/charts/headlamp/tests/expected_templates/oidc-client-assertion-external-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-client-assertion-external-secret.yaml
@@ -1,0 +1,150 @@
+---
+# Source: headlamp/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.44.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.44.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: headlamp/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+  labels:
+    helm.sh/chart: headlamp-0.44.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.44.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: headlamp
+  namespace: default
+---
+# Source: headlamp/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.44.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.44.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+---
+# Source: headlamp/templates/deployment.yaml
+# This block of code is used to extract the values from the env.
+# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.44.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.44.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+      app.kubernetes.io/instance: headlamp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: headlamp
+        app.kubernetes.io/instance: headlamp
+    spec:
+      serviceAccountName: headlamp
+      automountServiceAccountToken: true
+      hostUsers: true
+      securityContext:
+        {}
+      containers:
+        - name: headlamp
+          securityContext:
+            privileged: false
+            runAsGroup: 101
+            runAsNonRoot: true
+            runAsUser: 100
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.44.0"
+          imagePullPolicy: IfNotPresent
+          
+          # Check if externalSecret is enabled
+          envFrom:
+          - secretRef:
+              name: oidc
+          args:
+            - "-in-cluster"
+            - "-in-cluster-context-name=main"
+            - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
+            - "-oidc-client-assertion-file=/var/run/secrets/headlamp/oidc-client-assertion/token"
+            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
+            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
+          ports:
+            - name: http
+              containerPort: 4466
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: "/"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            {}
+          volumeMounts:
+            - mountPath: /var/run/secrets/headlamp/oidc-client-assertion
+              name: oidc-client-assertion
+              readOnly: true
+      volumes:
+        - name: oidc-client-assertion
+          projected:
+            sources:
+            - serviceAccountToken:
+                audience: testIssuerURL
+                expirationSeconds: 3600
+                path: token

--- a/charts/headlamp/tests/expected_templates/oidc-client-assertion.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-client-assertion.yaml
@@ -1,0 +1,158 @@
+---
+# Source: headlamp/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.44.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.44.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: headlamp/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+  labels:
+    helm.sh/chart: headlamp-0.44.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.44.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: headlamp
+  namespace: default
+---
+# Source: headlamp/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.44.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.44.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+---
+# Source: headlamp/templates/deployment.yaml
+# This block of code is used to extract the values from the env.
+# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.44.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.44.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+      app.kubernetes.io/instance: headlamp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: headlamp
+        app.kubernetes.io/instance: headlamp
+    spec:
+      serviceAccountName: headlamp
+      automountServiceAccountToken: true
+      hostUsers: true
+      securityContext:
+        {}
+      containers:
+        - name: headlamp
+          securityContext:
+            privileged: false
+            runAsGroup: 101
+            runAsNonRoot: true
+            runAsUser: 100
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.44.0"
+          imagePullPolicy: IfNotPresent
+          
+          env:
+            - name: OIDC_CLIENT_ID
+              value: testClientId
+            - name: OIDC_ISSUER_URL
+              value: testIssuerURL
+            - name: OIDC_SCOPES
+              value: testScope
+          args:
+            - "-in-cluster"
+            - "-in-cluster-context-name=main"
+            - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
+            - "-oidc-client-assertion-file=/var/run/secrets/headlamp/oidc-client-assertion/token"
+            # Check if externalSecret is disabled
+            # Check if clientID is non empty either from env or oidc.config
+            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
+            # Check if issuerURL is non empty either from env or oidc.config
+            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
+            # Check if scopes are non empty either from env or oidc.config
+            - "-oidc-scopes=$(OIDC_SCOPES)"
+          ports:
+            - name: http
+              containerPort: 4466
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: "/"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            {}
+          volumeMounts:
+            - mountPath: /var/run/secrets/headlamp/oidc-client-assertion
+              name: oidc-client-assertion
+              readOnly: true
+      volumes:
+        - name: oidc-client-assertion
+          projected:
+            sources:
+            - serviceAccountToken:
+                audience: testIssuerURL
+                expirationSeconds: 3600
+                path: token

--- a/charts/headlamp/tests/test_cases/oidc-client-assertion-external-secret.yaml
+++ b/charts/headlamp/tests/test_cases/oidc-client-assertion-external-secret.yaml
@@ -1,0 +1,28 @@
+# This is a test case for JWT bearer client authentication (RFC 7523) combined
+# with an external OIDC secret.
+# The external secret holds the client id and issuer URL but no client secret,
+# because Headlamp authenticates at the token endpoint with the assertion read
+# from oidc.clientAssertionFile. The rendered args must therefore leave out
+# -oidc-client-secret.
+config:
+  oidc:
+    secret:
+      create: false
+    externalSecret:
+      enabled: true
+      name: oidc
+    clientAssertionFile: "/var/run/secrets/headlamp/oidc-client-assertion/token"
+
+volumeMounts:
+  - name: oidc-client-assertion
+    mountPath: /var/run/secrets/headlamp/oidc-client-assertion
+    readOnly: true
+
+volumes:
+  - name: oidc-client-assertion
+    projected:
+      sources:
+        - serviceAccountToken:
+            path: token
+            audience: testIssuerURL
+            expirationSeconds: 3600

--- a/charts/headlamp/tests/test_cases/oidc-client-assertion.yaml
+++ b/charts/headlamp/tests/test_cases/oidc-client-assertion.yaml
@@ -1,0 +1,28 @@
+# This is a test case for JWT bearer client authentication (RFC 7523), where
+# Headlamp authenticates at the OIDC token endpoint with a client assertion
+# instead of a client secret.
+# The oidc.clientAssertionFile field is the path Headlamp reads the assertion
+# from on every token request, here a projected service account token mounted
+# through .volumes and .volumeMounts.
+config:
+  oidc:
+    secret:
+      create: false
+    clientID: "testClientId"
+    issuerURL: "testIssuerURL"
+    scopes: "testScope"
+    clientAssertionFile: "/var/run/secrets/headlamp/oidc-client-assertion/token"
+
+volumeMounts:
+  - name: oidc-client-assertion
+    mountPath: /var/run/secrets/headlamp/oidc-client-assertion
+    readOnly: true
+
+volumes:
+  - name: oidc-client-assertion
+    projected:
+      sources:
+        - serviceAccountToken:
+            path: token
+            audience: testIssuerURL
+            expirationSeconds: 3600

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -79,6 +79,11 @@ config:
     clientID: ""
     # -- OIDC client secret
     clientSecret: ""
+    # -- Path to a JWT sent as client_assertion to authenticate at the OIDC
+    # token endpoint (RFC 7523), instead of a client secret. Cannot be combined
+    # with clientSecret. Mount the JWT at this path through .volumeMounts and
+    # .volumes.
+    clientAssertionFile: ""
     # -- OIDC issuer URL
     issuerURL: ""
     # -- OIDC scopes to be used

--- a/docs/installation/in-cluster/oidc.md
+++ b/docs/installation/in-cluster/oidc.md
@@ -11,6 +11,7 @@ To use OIDC, Headlamp needs to know how to configure it, so you have to provide 
 
 - the client ID: `-oidc-client-id` or env var `HEADLAMP_CONFIG_OIDC_CLIENT_ID`
 - the client secret: `-oidc-client-secret` or env var `HEADLAMP_CONFIG_OIDC_CLIENT_SECRET`
+  (or, instead of a secret, a [JWT client assertion](#jwt-bearer-client-authentication))
 - the issuer URL: `-oidc-idp-issuer-url` or env var `HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL`
 - (optionally) the OpenId scopes: `-oidc-scopes` or env var `HEADLAMP_CONFIG_OIDC_SCOPES`
 
@@ -64,6 +65,88 @@ then add them all to the option:
 **Note:** Before Headlamp 0.3.0, a scope _groups_ was also included, as it's
 used by Dex and other services, but since it's not part of the default spec,
 it was removed in the mentioned version.
+
+### JWT bearer client authentication
+
+Instead of a client secret, Headlamp can authenticate at the token endpoint with
+a JWT client assertion, as specified by
+[RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523). This removes the need
+to manage a static credential, which is useful in Kubernetes where a projected
+service account token can be used as the assertion.
+
+- `-oidc-client-assertion-file=<path to the JWT>` or env var `HEADLAMP_CONFIG_OIDC_CLIENT_ASSERTION_FILE`
+
+The file must contain the JWT only. It is read on every token request, both when
+redeeming the authorization code and when refreshing a token, so a credential
+rotated in place is picked up without restarting Headlamp.
+
+The flag is mutually exclusive with `-oidc-client-secret`, and it requires an
+identity provider that accepts assertions issued by a third party, such as
+Keycloak 26.4 or later, whose realm trusts the cluster's service account issuer
+through [federated client authentication](https://www.keycloak.org/2026/01/federated-client-authentication)
+(generally available since 26.6).
+
+Example (Kubernetes manifest snippet):
+
+```yaml
+containers:
+  - name: headlamp
+    image: ...
+    args:
+      ...
+      - "-oidc-client-id=your-client-id"
+      - "-oidc-client-assertion-file=/var/run/secrets/headlamp/oidc-client-assertion/token"
+    volumeMounts:
+      - name: oidc-client-assertion
+        mountPath: /var/run/secrets/headlamp/oidc-client-assertion
+        readOnly: true
+serviceAccountName: headlamp
+volumes:
+  - name: oidc-client-assertion
+    projected:
+      sources:
+        - serviceAccountToken:
+            path: token
+            audience: https://your-issuer.example.com
+            expirationSeconds: 3600
+```
+
+Example (Helm chart):
+
+```yaml
+config:
+  oidc:
+    secret:
+      create: false
+    clientID: "your-client-id"
+    issuerURL: https://your-issuer.example.com
+    scopes: "openid profile email"
+    clientAssertionFile: /var/run/secrets/headlamp/oidc-client-assertion/token
+
+volumeMounts:
+  - name: oidc-client-assertion
+    mountPath: /var/run/secrets/headlamp/oidc-client-assertion
+    readOnly: true
+
+volumes:
+  - name: oidc-client-assertion
+    projected:
+      sources:
+        - serviceAccountToken:
+            path: token
+            audience: https://your-issuer.example.com
+            expirationSeconds: 3600
+```
+
+For clusters configured from a kubeconfig instead of in-cluster flags, the same
+credential can be set per context with the `client-assertion-file` key of the
+`oidc` auth provider config, alongside `client-id` and `idp-issuer-url`.
+
+The key names a path on the machine running Headlamp, so it is only honored for
+kubeconfigs Headlamp loads itself, such as those passed with `-kubeconfig`. It is
+rejected in kubeconfigs supplied by clients at request time, which is how dynamic
+clusters (`-enable-dynamic-clusters`) are configured; a context using it there
+fails to log in instead of having the server read the file.
 
 ### Token Validation Overrides
 


### PR DESCRIPTION
## Summary

This PR adds JWT bearer client authentication ([RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523)) for OIDC by letting Headlamp authenticate at the token endpoint with a `client_assertion` read from a file, instead of a static client secret.

## Related Issue

Fixes #7131 

## Changes

- A new option `-oidc-client-assertion-file` (env var `HEADLAMP_CONFIG_OIDC_CLIENT_ASSERTION_FILE`) points at a file that holds the JWT. It replaces the client secret, so the two cannot be combined, and like the other OIDC flags it is only accepted with `--in-cluster` or `--oidc-use-cookie`.
- The assertion is used both when logging in and when Headlamp refreshes an expiring token, and it works alongside PKCE. It is re-read from disk on every token request, so rotating the credential needs no restart.
- Clusters configured from a kubeconfig can set the same credential per context, with a `client-assertion-file` key in the `oidc` auth provider config.
- The Helm chart passes the option through a new `config.oidc.clientAssertionFile` value, and the JWT is mounted with the existing `volumes` / `volumeMounts` values.
- The OIDC docs page gains a section covering the option, what the identity provider has to support, and manifest and Helm examples.

## Steps to Test

Manually, against a real identity provider (verified on EKS with Keycloak):

1. In Keycloak, register the cluster's OIDC issuer as a Kubernetes identity provider in the realm, and set the client's authenticator to `Signed JWT - Federated`. Keycloak resolves the client from the `sub` claim of the assertion, so the client must be identified by the service account subject, e.g. `system:serviceaccount:kube-system:headlamp`.
2. Deploy Headlamp with a projected service account token requested with the Keycloak realm URL as its audience, and set `config.oidc.clientAssertionFile` to the mount path, `config.oidc.clientID` to the same subject, and no client secret.
3. Click "Sign in" and log in. The code exchange succeeds without a client secret, and the pod log shows no `failed to exchange token`.

## Screenshots (if applicable)

N/A (no UI changes)

## Notes for the Reviewer

- The refresh request is built by hand. `oauth2.Config.TokenSource` offers no way to add parameters to it, so there is no way to attach the assertion through the library. This is marked with a `TODO` referencing [golang/oauth2#744](https://github.com/golang/oauth2/issues/744), the upstream request for client assertion support, so it can be dropped once that lands.
- That hand-built request keeps the current refresh token when the response does not carry a new one, matching what `oauth2.Config.TokenSource` does. Headlamp caches refresh tokens keyed by the issued token, so writing an empty value would break every subsequent refresh.
- When an assertion is configured, the token endpoint auth style is pinned to `AuthStyleInParams`. There is no client secret in that case, and the oauth2 default is to auto-detect the style by first trying HTTP Basic, which here means a header carrying the client id and an empty secret. Providers reject that, and oauth2 then retries with form params reusing the same single-use authorization code, so the login depends on a retry and the identity provider records a failed client authentication on every attempt. Pinning the style puts the client id and the assertion in the body from the first request.
  - That pin overlaps with #7095, which makes the auth style configurable through `-oidc-auth-style` and touches the same two `oauth2.Config` sites. If it is merged first, I will rebase and fold this pin into that option, so that an assertion implies `params` unless a style is set explicitly.
- `Validate` in `backend/pkg/config/config.go` was at the cyclomatic complexity limit, so the tracing checks moved into a `validateTracing` method, following the existing `validateClusterInventory` pattern. No behaviour change.