### PR TITLE
frontend: api/v2: Guard WebSocket message JSON parsing against malformed frames

### DIFF
--- a/frontend/src/lib/k8s/api/v2/webSocket.test.ts
+++ b/frontend/src/lib/k8s/api/v2/webSocket.test.ts
@@ -170,6 +170,36 @@ describe('useWebSockets', () => {
     });
   });
 
+  it('drops a malformed frame instead of throwing, and keeps delivering later messages', async () => {
+    const url = 'api/v1/pods?watch=1&resourceVersion=2.5';
+    const server = new WS(`${BASE_WS_URL}${url}`);
+    const onMessageA = vi.fn();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    renderHook(() =>
+      useWebSockets({
+        connections: [{ cluster: '', url, onMessage: onMessageA }],
+      })
+    );
+
+    await server.connected;
+    await server.send('not valid json');
+
+    await waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        'WebSocket message parse error:',
+        expect.any(SyntaxError)
+      );
+    });
+    expect(onMessageA).not.toHaveBeenCalled();
+
+    await server.send(JSON.stringify({ type: 'DELETED', object: { metadata: { uid: 'pod-c' } } }));
+
+    await waitFor(() => {
+      expect(onMessageA).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('keeps a shared websocket alive until the last listener unsubscribes', async () => {
     const url = 'api/v1/pods?watch=1&resourceVersion=3';
     const server = new WS(`${BASE_WS_URL}${url}`);

--- a/frontend/src/lib/k8s/api/v2/webSocket.ts
+++ b/frontend/src/lib/k8s/api/v2/webSocket.ts
@@ -127,7 +127,13 @@ export async function openWebSocket<T>(
   const socket = new WebSocket(makeUrl([getBaseWsUrl(), ...path], {}), protocols);
   socket.binaryType = 'arraybuffer';
   socket.addEventListener('message', (body: MessageEvent) => {
-    const data = type === 'json' ? JSON.parse(body.data) : body.data;
+    let data;
+    try {
+      data = type === 'json' ? JSON.parse(body.data) : body.data;
+    } catch (error) {
+      console.error('WebSocket message parse error:', error);
+      return;
+    }
     const callbacks = listeners.get(connectionKey) ?? [onMessage];
     callbacks.forEach(callback => {
       try {


### PR DESCRIPTION
## Summary

createWebSocket's message listener parsed every incoming frame with no error handling, so a non-JSON frame threw uncaught inside the listener instead of being handled. The callback dispatch two lines below is already wrapped in try/catch, and the equivalent handler in multiplexer.ts (handleWebSocketMessage) guards its own JSON.parse too — this path was the odd one out.

This wraps the parse in try/catch, logs the error, and returns early on failure, matching multiplexer.ts's pattern.

## Related Issue

Fixes #7101

## Changes

- Wrapped the JSON.parse in createWebSocket's message listener (frontend/src/lib/k8s/api/v2/webSocket.ts) in try/catch, logging and returning early on a malformed frame
- Added a regression test that sends a malformed frame and checks the connection keeps delivering subsequent valid messages instead of the listener staying broken

## Steps to Test

1. Run `npx vitest run src/lib/k8s/api/v2/webSocket.test.ts` from frontend/
2. Confirm the new "drops a malformed frame instead of throwing, and keeps delivering later messages" test passes
3. Or manually: open a WebSocket connection through this path and have the server send a non-JSON frame — confirm it's logged and skipped instead of throwing uncaught, and later valid messages still arrive

## Screenshots (if applicable)


## Notes for the Reviewer

- This mirrors the existing guard pattern already used in multiplexer.ts's handleWebSocketMessage, so behavior stays consistent between the two WebSocket paths.
