### PR TITLE
frontend: router: Break self-referencing barrel import in getRoutePath

### DIFF
--- a/frontend/src/components/pod/kubeObjectImport.test.ts
+++ b/frontend/src/components/pod/kubeObjectImport.test.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import NetworkPolicy from '../../lib/k8s/networkpolicy';
+
+// Regression test for a circular import between KubeObject and the router: importing a
+// resource class from a components/ test file (i.e. before the k8s barrel has been touched
+// by anything else) used to crash with "Class extends value undefined is not a constructor
+// or null", because KubeObject.ts pulled in the router chain, which looped back into the
+// lib/k8s barrel before KubeObject itself had finished initializing.
+it('imports a resource class from a components/ test without crashing', () => {
+  expect(NetworkPolicy).toBeDefined();
+});

--- a/frontend/src/components/project/NewProjectPopup.test.tsx
+++ b/frontend/src/components/project/NewProjectPopup.test.tsx
@@ -77,6 +77,8 @@ vi.mock('@iconify/react', () => ({
   Icon: () => <span />,
 }));
 
+// Registers the app's routes (via setDefaultRoutes) so createRouteURL below has routes to resolve.
+import '../../lib/router';
 import { EventStatus, HeadlampEventType } from '../../redux/headlampEventSlice';
 import { recordHeadlampEvents, TestContext } from '../../test';
 import { NewProjectPopup } from './NewProjectPopup';

--- a/frontend/src/lib/k8s/index.test.ts
+++ b/frontend/src/lib/k8s/index.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+// Registers the app's routes (via setDefaultRoutes) so createRouteURL below has routes to resolve.
+import '../router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';

--- a/frontend/src/lib/router/index.tsx
+++ b/frontend/src/lib/router/index.tsx
@@ -16,7 +16,6 @@
 
 import React from 'react';
 import { useHistory } from 'react-router';
-import NotFoundComponent from '../../components/404';
 import AuthToken from '../../components/account/Auth';
 import AddCluster from '../../components/App/CreateCluster/AddCluster';
 import Home from '../../components/App/Home';
@@ -1091,14 +1090,4 @@ const defaultRoutes: { [routeName: string]: Route } = {
 
 setDefaultRoutes(defaultRoutes);
 
-// The NotFound route  needs to be considered always in the last place when used
-// with the router switch, as any routes added after this one will never be considered.
-// So we do not include it in the default routes in order to always "manually" consider it.
-export const NotFoundRoute = {
-  path: '*',
-  exact: true,
-  name: `Whoops! This page doesn't exist`,
-  component: () => <NotFoundComponent />,
-  sidebar: null,
-  noAuthRequired: true,
-};
+export { NotFoundRoute } from './notFoundRoute';

--- a/frontend/src/lib/router/notFoundRoute.tsx
+++ b/frontend/src/lib/router/notFoundRoute.tsx
@@ -14,18 +14,16 @@
  * limitations under the License.
  */
 
-import { getClusterPrefixedPath } from '../cluster';
-import { getRouteUseClusterURL } from './getRouteUseClusterURL';
-import { NotFoundRoute } from './notFoundRoute';
-import type { Route } from './Route';
+import NotFoundComponent from '../../components/404';
 
-export function getRoutePath(route: Route) {
-  if (route.path === NotFoundRoute.path) {
-    return route.path;
-  }
-  if (!getRouteUseClusterURL(route)) {
-    return route.path;
-  }
-
-  return getClusterPrefixedPath(route.path);
-}
+// The NotFound route needs to be considered always in the last place when used
+// with the router switch, as any routes added after this one will never be considered.
+// So we do not include it in the default routes in order to always "manually" consider it.
+export const NotFoundRoute = {
+  path: '*',
+  exact: true,
+  name: `Whoops! This page doesn't exist`,
+  component: () => <NotFoundComponent />,
+  sidebar: null,
+  noAuthRequired: true,
+};


### PR DESCRIPTION
## Summary

Fixes a circular import between `KubeObject` and the router that crashed component-level tests importing a resource class in isolation.

## Related Issue

Fixes #7102

## Changes

- Moved `NotFoundRoute` out of `lib/router/index.tsx` into its own file (`lib/router/notFoundRoute.tsx`) with no barrel dependency; `router/index.tsx` re-exports it so existing consumers are unaffected.
- Updated `getRoutePath.tsx` to import `NotFoundRoute` from the new file instead of `.` (the router barrel), which is what was pulling the entire router barrel — and transitively the k8s barrel — into `KubeObject.ts`'s own import chain.
- Updated `index.test.ts` and `NewProjectPopup.test.tsx` to explicitly import the router barrel, since they were relying on the old cycle to register default routes as a side effect.
- Added a regression test (`components/pod/kubeObjectImport.test.ts`) that imports a resource class from a `components/` test file, matching the original crash repro.

## Steps to Test

1. `git checkout frontend/fix-circular-import-kubeobject`
2. `cd frontend && npx vitest run src/components/pod/kubeObjectImport.test.ts` — passes.
3. Optionally revert the fix locally and rerun the same test — it fails with `TypeError: Class extends value undefined is not a constructor or null`.
4. Full suite: `npx vitest run` — 197 files / 2653 tests pass. Also ran `tsc --noEmit` and `eslint` clean on all touched files.

## Screenshots

N/A — non-visual fix.

## Notes for the Reviewer

The root cause: `getRoutePath.tsx` only needed `NotFoundRoute.path` (the literal `'*'` string) but imported it from the router's own barrel, which imports nearly every page component in the app, some of which pull in `lib/k8s`. Since `KubeObject.ts` imports `createRouteURL` (which reaches `getRoutePath.tsx`), any resource class loaded before `KubeObject.ts` finishes initializing could re-enter the k8s barrel mid-load and crash trying to build a class that extends a not-yet-defined `KubeObject`. This only ever showed up when a resource class or the barrel was imported directly by a test — the real app always survives because `RouteSwitcher` mounts and registers routes before anything else runs.
