### PR TITLE
frontend: Deployments: Fix Pods column sort with no available replicas

### DIFF
--- a/frontend/src/components/deployments/List.tsx
+++ b/frontend/src/components/deployments/List.tsx
@@ -21,6 +21,7 @@ import Deployment from '../../lib/k8s/deployment';
 import { StatusLabel } from '../common/Label';
 import ResourceListView from '../common/Resource/ResourceListView';
 import LightTooltip from '../common/Tooltip/TooltipLight';
+import { sortByPods } from './sortByPods';
 
 export default function DeploymentsList() {
   const { t } = useTranslation(['glossary', 'translation']);
@@ -29,18 +30,6 @@ export default function DeploymentsList() {
     const { replicas, availableReplicas } = deployment.status;
 
     return `${availableReplicas || 0}/${replicas || 0}`;
-  }
-
-  function sortByPods(d1: Deployment, d2: Deployment) {
-    const { replicas: r1, availableReplicas: avail1 } = d1.status;
-    const { replicas: r2, availableReplicas: avail2 } = d2.status;
-
-    const availSorted = avail1 - avail2;
-    if (availSorted === 0) {
-      return r1 - r2;
-    }
-
-    return availSorted;
   }
 
   function renderConditions(deployment: Deployment) {
@@ -94,7 +83,7 @@ export default function DeploymentsList() {
           id: 'pods',
           label: t('Pods'),
           disableFiltering: true,
-          getValue: deployment => deployment.status.availableReplicas,
+          getValue: deployment => deployment.status.availableReplicas ?? 0,
           render: deployment => renderPods(deployment),
           sort: sortByPods,
           gridTemplate: 'min-content',

--- a/frontend/src/components/deployments/sortByPods.test.ts
+++ b/frontend/src/components/deployments/sortByPods.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type Deployment from '../../lib/k8s/deployment';
+import { sortByPods } from './sortByPods';
+
+function makeDeployment(name: string, status: object) {
+  return { metadata: { name }, status } as Deployment;
+}
+
+describe('sortByPods', () => {
+  // The API omits replicas and availableReplicas when they are zero.
+  const deployments = [
+    makeDeployment('available-3-of-3', { replicas: 3, availableReplicas: 3 }),
+    makeDeployment('scaled-to-zero', {}),
+    makeDeployment('unavailable-0-of-2', { replicas: 2 }),
+    makeDeployment('partial-1-of-2', { replicas: 2, availableReplicas: 1 }),
+  ];
+
+  const namesInOrder = (list: Deployment[]) => [...list].sort(sortByPods).map(d => d.metadata.name);
+
+  it('sorts deployments without available replicas by their replica count', () => {
+    expect(namesInOrder(deployments)).toEqual([
+      'scaled-to-zero',
+      'unavailable-0-of-2',
+      'partial-1-of-2',
+      'available-3-of-3',
+    ]);
+  });
+
+  it('gives the same order no matter the initial one', () => {
+    expect(namesInOrder([...deployments].reverse())).toEqual(namesInOrder(deployments));
+  });
+});

--- a/frontend/src/components/deployments/sortByPods.ts
+++ b/frontend/src/components/deployments/sortByPods.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type Deployment from '../../lib/k8s/deployment';
+
+/**
+ * Compares deployments by their available and total replicas, as shown in the Pods column.
+ *
+ * The API omits replicas and availableReplicas when they are zero, so they are treated
+ * as such here. Subtracting them directly would give NaN and leave those rows in an
+ * arbitrary order.
+ */
+export function sortByPods(d1: Deployment, d2: Deployment) {
+  const { replicas: r1, availableReplicas: avail1 } = d1.status;
+  const { replicas: r2, availableReplicas: avail2 } = d2.status;
+
+  const availSorted = (avail1 ?? 0) - (avail2 ?? 0);
+  if (availSorted === 0) {
+    return (r1 ?? 0) - (r2 ?? 0);
+  }
+
+  return availSorted;
+}


### PR DESCRIPTION
Fixes #7117

Kubernetes omits `status.availableReplicas` and `status.replicas` when they are zero, so the Pods comparator returned `NaN` and those rows landed in an arbitrary order. Falls back to 0, matching the renderer and the ReplicaSet/StatefulSet lists.

Moved the comparator into `sortByPods.ts` with a unit test; `getValue` gets the same fallback so empty cells don't export/search as blank.