### PR TITLE
app: Resolve script path to file URL for compatibility

### DIFF
--- a/app/electron/runCmd.ts
+++ b/app/electron/runCmd.ts
@@ -19,6 +19,7 @@ import { BrowserWindow, dialog } from 'electron';
 import { IpcMainEvent } from 'electron/main';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
 import path from 'path';
 import i18n from './i18next.config';
 import { defaultPluginsDir, defaultUserPluginsDir } from './plugin-management';
@@ -368,7 +369,7 @@ export function runScript() {
     process.exit(1);
   }
 
-  import(scriptPath);
+  import(pathToFileURL(scriptPath).href);
 }
 
 /**


### PR DESCRIPTION
This PR fixes an issue when running scripts using `HEADLAMP_RUN_SCRIPT=true` on windows.
The import would fail on a windows path that start like "C:/..", requiring "file://" protocol to be used.
This PR resolves the path to the `file` protocol. Tested on windows and linux


### Steps to test on windows

1. Build app `cd app && npm run build`

3. Create a script inside plugins folder 

```powershell
$pluginDir = (Resolve-Path "app\dist\win-unpacked\resources\.plugins").Path
$script = Join-Path $pluginDir "run-script-test.js"

[IO.File]::WriteAllText($script, "console.log('HEADLAMP SCRIPT TEST PASSED');")
```

4. Run the script 

```powershell
$env:HEADLAMP_RUN_SCRIPT = "true"
& ".\app\dist\win-unpacked\Headlamp.exe" $script
```

*this PR was made with LLM assistance*
