### PR TITLE
frontend: Activity: improve small-screen wrapping

### DIFF
--- a/frontend/src/components/activity/Activity.stories.tsx
+++ b/frontend/src/components/activity/Activity.stories.tsx
@@ -16,11 +16,24 @@
 
 import { Box } from '@mui/material';
 import { Meta, StoryFn } from '@storybook/react';
+import { useEffect } from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import store from '../../redux/stores/store';
 import { ActivitiesRenderer, Activity } from './Activity';
 import { activitySlice } from './activitySlice';
+
+const activityStoryIds = ['1', '2', 'long-1', 'long-2', 'short-1'];
+
+function ActivityStoryCleanup({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    return () => {
+      resetActivities(activityStoryIds);
+    };
+  }, []);
+
+  return <>{children}</>;
+}
 
 export default {
   title: 'Activity',
@@ -52,7 +65,9 @@ export default {
                 gridRow: '1/2',
               }}
             ></Box>
-            <Story />
+            <ActivityStoryCleanup>
+              <Story />
+            </ActivityStoryCleanup>
           </Box>
         </MemoryRouter>
       </Provider>
@@ -68,7 +83,15 @@ const makeActivity = (activity: Partial<Activity>): Activity => ({
   ...activity,
 });
 
+function resetActivities(ids: string[]) {
+  ids.forEach(id => {
+    store.dispatch(activitySlice.actions.close(id));
+  });
+}
+
 function setupActivities(activities: Activity[]) {
+  resetActivities(activities.map(activity => activity.id));
+
   activities.forEach(activity => {
     store.dispatch(activitySlice.actions.launchActivity(activity));
   });
@@ -84,8 +107,35 @@ export const Basic: StoryFn = () => {
 };
 
 export const EmptyBar: StoryFn = () => {
-  store.dispatch(activitySlice.actions.close('1'));
-  store.dispatch(activitySlice.actions.close('2'));
+  resetActivities(activityStoryIds);
+
+  return <ActivitiesRenderer />;
+};
+
+export const ResponsiveContent: StoryFn = () => {
+  setupActivities([
+    makeActivity({
+      id: 'long-1',
+      location: 'window',
+      cluster: 'docker-desktop-development-cluster-with-a-very-long-name',
+      title: 'Pod metrics collector for a very long deployment name in the activity view',
+      content: 'Long content',
+    }),
+    makeActivity({
+      id: 'long-2',
+      location: 'window',
+      cluster: 'prod-eu-west-1-internal-observability',
+      title: 'SomeAreVeryLongAndMightLookDifferent resource details and live logs',
+      content: 'Second long content',
+    }),
+    makeActivity({
+      id: 'short-1',
+      location: 'window',
+      cluster: 'dev',
+      title: 'Pod',
+      content: 'Short content',
+    }),
+  ]);
 
   return <ActivitiesRenderer />;
 };

--- a/frontend/src/components/activity/Activity.tsx
+++ b/frontend/src/components/activity/Activity.tsx
@@ -244,10 +244,12 @@ export function SingleActivityRenderer({
       const rows = 5;
       const gapPx = 20;
       const box = container.getBoundingClientRect();
-      const x = (box.width / cols) * (index % 3) + gapPx;
-      const y = (box.height / rows) * Math.floor(index / 3) + gapPx;
-      const width = box.width / cols - gapPx * (cols - 2);
-      const height = box.height / rows - gapPx * (rows - 2);
+      const row = Math.floor(index / cols);
+      const col = index % cols;
+      const width = (box.width - gapPx * (cols + 1)) / cols;
+      const height = Math.min(172, (box.height - gapPx * (rows + 1)) / rows);
+      const x = gapPx + col * (width + gapPx);
+      const y = gapPx + row * (height + gapPx);
 
       oldTranslation = activity.style.transform ?? '';
       oldHeight = activity.style.height;
@@ -391,16 +393,29 @@ export function SingleActivityRenderer({
           {isOverview && (
             <Box
               sx={{
-                fontSize: '18px',
+                fontSize: '1rem',
                 display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                padding: 1,
-                gap: 1,
+                flexDirection: 'column',
+                alignItems: 'stretch',
+                justifyContent: 'flex-start',
+                padding: 2,
+                gap: 1.5,
                 height: '100%',
               }}
             >
-              <Box sx={{ width: '48px', height: '48px', flexShrink: 0 }}>{icon}</Box> {title}
+              <Box sx={{ width: '48px', height: '48px', flexShrink: 0 }}>{icon}</Box>
+              <Box
+                sx={{
+                  flex: 1,
+                  minHeight: 0,
+                  overflow: 'hidden',
+                  overflowWrap: 'anywhere',
+                  lineHeight: 1.4,
+                }}
+                title={typeof title === 'string' ? title : undefined}
+              >
+                {title}
+              </Box>
             </Box>
           )}
           <>
@@ -428,15 +443,17 @@ export function SingleActivityRenderer({
             >
               {!hideTitleInHeader && (
                 <>
-                  <Box sx={{ width: '18px', height: '18px' }}>{icon}</Box>
+                  <Box sx={{ width: '18px', height: '18px', flexShrink: 0 }}>{icon}</Box>
                   <Typography
                     color="textSecondary"
                     fontSize={14}
                     sx={{
-                      maxWidth: 'calc(45% - 60px)',
+                      maxWidth: { xs: '100px', sm: '160px', md: 'calc(45% - 60px)' },
+                      minWidth: 0,
                       whiteSpace: 'nowrap',
                       textOverflow: 'ellipsis',
                       overflow: 'hidden',
+                      flexShrink: 1,
                     }}
                     title={typeof title === 'string' ? title : undefined}
                   >
@@ -455,10 +472,25 @@ export function SingleActivityRenderer({
                     gap: 0.25,
                     paddingX: 0.5,
                     color: theme.palette.text.secondary,
+                    maxWidth: { xs: '100px', sm: '160px', md: 'none' },
+                    minWidth: 0,
                   })}
                 >
-                  <Icon icon="mdi:hexagon-multiple-outline" />
-                  {cluster}
+                  <Icon icon="mdi:hexagon-multiple-outline" style={{ flexShrink: 0 }} />
+                  <Box
+                    component="span"
+                    sx={{
+                      display: 'block',
+                      flex: 1,
+                      minWidth: 0,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                    title={cluster}
+                  >
+                    {cluster}
+                  </Box>
                 </Box>
               )}
               {!isOverview && (
@@ -1133,9 +1165,9 @@ export const ActivityBar = React.memo(function ({
         paddingLeft: 1,
         zIndex: 10,
         position: 'relative',
-        alignItems: 'center',
+        alignItems: 'stretch',
         display: 'flex',
-        minHeight: '56px',
+        minHeight: { xs: '88px', sm: '76px', md: '64px' },
         overflowX: 'auto',
         scrollbarWidth: 'thin',
       })}
@@ -1153,17 +1185,19 @@ export const ActivityBar = React.memo(function ({
             borderTop: 0,
             borderColor: lastElement === it.id ? theme.palette.divider : 'transparent',
             background: lastElement === it.id ? theme.palette.background.default : 'transparent',
+            flexShrink: 0,
           })}
         >
           <Button
             sx={theme => ({
               height: '100%',
-              padding: '0px 5px 0 10px',
-              lineHeight: 1,
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
+              minHeight: { xs: '80px', sm: '68px', md: '56px' },
+              minWidth: { xs: '180px', sm: '220px', md: '260px' },
+              maxWidth: { xs: '180px', sm: '220px', md: '260px' },
+              padding: '8px 8px 8px 10px',
+              lineHeight: 1.25,
               justifyContent: 'start',
+              alignItems: 'stretch',
               color: theme.palette.text.primary,
             })}
             onClick={() => {
@@ -1176,9 +1210,6 @@ export const ActivityBar = React.memo(function ({
               }
             }}
           >
-            <Box sx={{ width: '22px', height: '22px', flexShrink: 0, marginRight: 1 }}>
-              {it.icon}
-            </Box>
             <Box
               sx={{
                 marginRight: 'auto',
@@ -1186,19 +1217,51 @@ export const ActivityBar = React.memo(function ({
                 flexDirection: 'column',
                 alignItems: 'flex-start',
                 gap: 0.5,
-                overflow: 'hidden',
+                minWidth: 0,
+                flex: 1,
               }}
             >
               {it.cluster && (
-                <Box sx={theme => ({ color: theme.palette.text.secondary })}>{it.cluster}</Box>
+                <Box
+                  sx={theme => ({
+                    color: theme.palette.text.secondary,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    width: '100%',
+                    minWidth: 0,
+                  })}
+                >
+                  <Box sx={{ width: '22px', height: '22px', flexShrink: 0 }}>{it.icon}</Box>
+                  <Box
+                    sx={{
+                      flex: 1,
+                      minWidth: 0,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                    title={it.cluster}
+                  >
+                    {it.cluster}
+                  </Box>
+                </Box>
+              )}
+              {!it.cluster && (
+                <Box sx={{ width: '22px', height: '22px', flexShrink: 0 }}>{it.icon}</Box>
               )}
               <Box
                 sx={{
-                  whiteSpace: 'nowrap',
                   overflow: 'hidden',
-                  textOverflow: 'ellipsis',
+                  display: '-webkit-box',
+                  WebkitBoxOrient: 'vertical',
+                  WebkitLineClamp: 2,
                   fontStyle: it.temporary ? 'italic' : undefined,
+                  overflowWrap: 'anywhere',
+                  width: '100%',
+                  lineHeight: 1.3,
                 }}
+                title={typeof it.title === 'string' ? it.title : undefined}
               >
                 {it.title ?? 'Something'}
               </Box>

--- a/frontend/src/components/activity/__snapshots__/Activity.ResponsiveContent.stories.storyshot
+++ b/frontend/src/components/activity/__snapshots__/Activity.ResponsiveContent.stories.storyshot
@@ -11,6 +11,7 @@
         class="MuiBox-root css-11hh78l"
       />
       <div
+        aria-label="Pod metrics collector for a very long deployment name in the activity view"
         class="MuiBox-root css-3xoqkk"
         role="complementary"
       >
@@ -25,10 +26,23 @@
             />
             <p
               class="MuiTypography-root MuiTypography-body1 css-1bfo8fe-MuiTypography-root"
-            />
+              title="Pod metrics collector for a very long deployment name in the activity view"
+            >
+              Pod metrics collector for a very long deployment name in the activity view
+            </p>
             <div
               class="MuiBox-root css-1po99kh"
             />
+            <div
+              class="MuiBox-root css-117i2fq"
+            >
+              <span
+                class="MuiBox-root css-1yu1mww"
+                title="docker-desktop-development-cluster-with-a-very-long-name"
+              >
+                docker-desktop-development-cluster-with-a-very-long-name
+              </span>
+            </div>
             <button
               aria-expanded="false"
               aria-haspopup="menu"
@@ -65,11 +79,12 @@
           <div
             class="MuiBox-root css-wqatdk"
           >
-            Left
+            Long content
           </div>
         </div>
       </div>
       <div
+        aria-label="SomeAreVeryLongAndMightLookDifferent resource details and live logs"
         class="MuiBox-root css-3xoqkk"
         role="complementary"
       >
@@ -84,10 +99,96 @@
             />
             <p
               class="MuiTypography-root MuiTypography-body1 css-1bfo8fe-MuiTypography-root"
-            />
+              title="SomeAreVeryLongAndMightLookDifferent resource details and live logs"
+            >
+              SomeAreVeryLongAndMightLookDifferent resource details and live logs
+            </p>
             <div
               class="MuiBox-root css-1po99kh"
             />
+            <div
+              class="MuiBox-root css-117i2fq"
+            >
+              <span
+                class="MuiBox-root css-1yu1mww"
+                title="prod-eu-west-1-internal-observability"
+              >
+                prod-eu-west-1-internal-observability
+              </span>
+            </div>
+            <button
+              aria-expanded="false"
+              aria-haspopup="menu"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
+              tabindex="0"
+              title="Window"
+              type="button"
+            >
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
+              tabindex="0"
+              title="Minimize"
+              type="button"
+            >
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
+              tabindex="0"
+              title="Close"
+              type="button"
+            >
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
+          </div>
+          <div
+            class="MuiBox-root css-wqatdk"
+          >
+            Second long content
+          </div>
+        </div>
+      </div>
+      <div
+        aria-label="Pod"
+        class="MuiBox-root css-3xoqkk"
+        role="complementary"
+      >
+        <div
+          class="MuiBox-root css-1j4p9ms"
+        >
+          <div
+            class="MuiBox-root css-ha4r1w"
+          >
+            <div
+              class="MuiBox-root css-1ww6zew"
+            />
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1bfo8fe-MuiTypography-root"
+              title="Pod"
+            >
+              Pod
+            </p>
+            <div
+              class="MuiBox-root css-1po99kh"
+            />
+            <div
+              class="MuiBox-root css-117i2fq"
+            >
+              <span
+                class="MuiBox-root css-1yu1mww"
+                title="dev"
+              >
+                dev
+              </span>
+            </div>
             <button
               aria-expanded="false"
               aria-haspopup="menu"
@@ -133,7 +234,7 @@
           <div
             class="MuiBox-root css-wqatdk"
           >
-            Right
+            Short content
           </div>
         </div>
       </div>
@@ -152,12 +253,23 @@
               class="MuiBox-root css-1aihc2e"
             >
               <div
-                class="MuiBox-root css-14itjq4"
-              />
+                class="MuiBox-root css-12dbwng"
+              >
+                <div
+                  class="MuiBox-root css-14itjq4"
+                />
+                <div
+                  class="MuiBox-root css-asfkam"
+                  title="dev"
+                >
+                  dev
+                </div>
+              </div>
               <div
                 class="MuiBox-root css-r1zxuf"
+                title="Pod"
               >
-                Something
+                Pod
               </div>
             </div>
             <span
@@ -187,12 +299,69 @@
               class="MuiBox-root css-1aihc2e"
             >
               <div
-                class="MuiBox-root css-14itjq4"
-              />
+                class="MuiBox-root css-12dbwng"
+              >
+                <div
+                  class="MuiBox-root css-14itjq4"
+                />
+                <div
+                  class="MuiBox-root css-asfkam"
+                  title="prod-eu-west-1-internal-observability"
+                >
+                  prod-eu-west-1-internal-observability
+                </div>
+              </div>
               <div
                 class="MuiBox-root css-r1zxuf"
+                title="SomeAreVeryLongAndMightLookDifferent resource details and live logs"
               >
-                Something
+                SomeAreVeryLongAndMightLookDifferent resource details and live logs
+              </div>
+            </div>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            aria-label="Close"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-182yqqz-MuiButtonBase-root-MuiIconButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+        <div
+          class="MuiBox-root css-1oygo4f"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-yxr1gy-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <div
+              class="MuiBox-root css-1aihc2e"
+            >
+              <div
+                class="MuiBox-root css-12dbwng"
+              >
+                <div
+                  class="MuiBox-root css-14itjq4"
+                />
+                <div
+                  class="MuiBox-root css-asfkam"
+                  title="docker-desktop-development-cluster-with-a-very-long-name"
+                >
+                  docker-desktop-development-cluster-with-a-very-long-name
+                </div>
+              </div>
+              <div
+                class="MuiBox-root css-r1zxuf"
+                title="Pod metrics collector for a very long deployment name in the activity view"
+              >
+                Pod metrics collector for a very long deployment name in the activity view
               </div>
             </div>
             <span


### PR DESCRIPTION
## Summary

This PR revives and rebases the work from #4473 on top of the current `main` branch.
It keeps the Activity panel readable on small screens by giving overview tiles and
activity-bar entries more vertical room instead of shrinking text.

## Related Issue

Fixes #4472
Supersedes #4473

## Changes

- Increase overview tile sizing and allow titles to wrap at the normal body-text size
- Rework activity-bar items so the icon shares a row with the cluster name and the title
  gets an extra wrapped line on narrow widths
- Keep header truncation constrained to the narrow header areas and preserve native tooltips
- Add a Storybook state covering long and short cluster/title values, plus updated snapshots

## Steps to Test

1. Run `npm run frontend:lint`
2. Run `npm run frontend:tsc`
3. Run `cd frontend && npx vitest run src/storybook.test.tsx -u --testNamePattern "Activity"`
4. Open the Activity view on a narrow viewport and verify overview cards and taskbar items stay readable without reducing text size

## Screenshots (if applicable)

Both taken from the real running app (a local pod named `pod-metrics-collector-for-a-very-long-deployment-name` in a namespace named `prod-eu-west-1-internal-observability`, terminal activity opened, viewport narrowed to 380px).

Before : the cluster name wraps and overlaps the header controls, and the taskbar entry has no width limit so its title runs off the edge instead of wrapping.
<img width="380" height="640" alt="Before: cluster name wrapping into the header controls and the taskbar title running off the edge unclamped" src="https://raw.githubusercontent.com/rootp1/headlamp/rootp1/pr-7146-screenshots/pr-7146-before.png" />

After : the header stays compact and the taskbar entry wraps the title onto a second line within its fixed width.
<img width="380" height="640" alt="After: header staying compact and the taskbar title wrapped onto two lines within a fixed width" src="https://raw.githubusercontent.com/rootp1/headlamp/rootp1/pr-7146-screenshots/pr-7146-after.png" />

## Notes for the Reviewer

- This follows the earlier review feedback from `@illume` by preferring wrapping and extra vertical space over aggressive truncation.
- The commit author remains `greedy-wudpeckr`, with `rootp1` added as co-author for the rebased follow-up.
