### PR TITLE
backend: config: Add auth-bypass-urls flag to allow configurable cach…

### DIFF
--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -74,6 +74,17 @@ func main() {
 		}()
 	}
 
+	if conf.AuthBypassURLs != "" {
+		urls := strings.Split(conf.AuthBypassURLs, ",")
+		var trimmedURLs []string
+		for _, u := range urls {
+			if trimmed := strings.TrimSpace(u); trimmed != "" {
+				trimmedURLs = append(trimmedURLs, trimmed)
+			}
+		}
+		k8cache.ExtraAuthBypassURLs = trimmedURLs
+	}
+
 	headlampConfig := createHeadlampConfig(conf)
 	StartHeadlampServer(headlampConfig)
 }

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -65,6 +65,7 @@ type Config struct {
 	NodeShellImage         string `koanf:"node-shell-image"`
 	NodeShellNamespace     string `koanf:"node-shell-namespace"`
 	ProxyURLs              string `koanf:"proxy-urls"`
+	AuthBypassURLs         string `koanf:"auth-bypass-urls"`
 
 	ClusterInventoryProviderFile          string        `koanf:"cluster-inventory-provider-file"`
 	ClusterInventoryLabelSelector         string        `koanf:"cluster-inventory-label-selector"`
@@ -571,6 +572,7 @@ func addGeneralFlags(f *flag.FlagSet) {
 	f.String("listen-addr", "", "Address to listen on; default is empty, which means listening to any address")
 	f.Uint("port", defaultPort, "Port to listen from")
 	f.String("proxy-urls", "", "Allow proxy requests to specified URLs")
+	f.String("auth-bypass-urls", "", "Comma-separated list of additional URLs to bypass cache authorization")
 	f.Bool("enable-helm", false, "Enable Helm operations")
 	f.Bool("enable-cluster-inventory", false,
 		"Enable experimental/alpha automatic discovery of clusters from ClusterProfile resources")

--- a/backend/pkg/k8cache/authErrResp.go
+++ b/backend/pkg/k8cache/authErrResp.go
@@ -30,6 +30,9 @@ type AuthErrResponse struct {
 	Code       int      `json:"code"`       // The HTTP status code, typically 403.
 }
 
+// ExtraAuthBypassURLs allows configuring additional URLs that bypass authorization.
+var ExtraAuthBypassURLs []string
+
 // IsAuthBypassURL returns true if the given URL path should be checked for authorization errors,
 // excluding known public, health-check, or self-subject review endpoints.
 func IsAuthBypassURL(urlPath string) bool {
@@ -39,6 +42,13 @@ func IsAuthBypassURL(urlPath string) bool {
 		isDirectOrProxiedEndpoint(urlPath, "healthz") ||
 		IsSelfSubjectReviewAPIPath(urlPath) {
 		return false
+	}
+
+	for _, bypass := range ExtraAuthBypassURLs {
+		bypass = strings.TrimLeft(bypass, "/")
+		if isDirectOrProxiedEndpoint(urlPath, bypass) {
+			return false
+		}
 	}
 
 	return true


### PR DESCRIPTION
**Title:** Fix: Make cache authorization bypass list configurable

**Description:**
Fixes the hardcoded cache authorization bypass list by adding a new `--auth-bypass-urls` flag.

**Changes:**
- Added `--auth-bypass-urls` flag to `config.go`.
- Updated `IsAuthBypassURL` in `authErrResp.go` to support custom endpoints.
- Parsed and passed the flag values to the cache on startup in `server.go`.

This allows users to easily add custom unauthenticated Kubernetes API endpoints without needing to modify source code.