### PR TITLE
frontend: k8s: Add generics to PUT requests

### DIFF
--- a/frontend/src/lib/k8s/api/v1/clusterRequests.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterRequests.ts
@@ -306,12 +306,12 @@ export function jsonPatch(
   return clusterRequest(url, opts);
 }
 
-export function put(
+export function put<T = KubeObjectInterface>(
   url: string,
-  json: Partial<KubeObjectInterface>,
+  json: Partial<T>,
   autoLogoutOnAuthError = true,
   requestOptions: ClusterRequestParams = {}
-) {
+): Promise<T> {
   const body = JSON.stringify(json);
   const { cluster: clusterName, ...restOptions } = requestOptions;
   const opts = {
@@ -332,4 +332,3 @@ export function remove(url: string, requestOptions: ClusterRequestParams = {}) {
   return clusterRequest(url, opts);
 }
 
-// @todo: apiEndpoint.put has a type of any, which needs improving.


### PR DESCRIPTION
Implement TypeScript generics for the `apiEndpoint.put` method so callers can specify the expected `KubeObject` return type and payload type. This ensures strict type safety when mutating Kubernetes resources.

## Summary

This PR addresses an open `@todo` in the Kubernetes API proxy (`clusterRequests.ts`) where the `put` method lacked strict TypeScript generics. It introduces generics (`<T>`) to the `put` payload and return type to match the implementation of `get`.

## Related Issue

Fixes #ISSUE_NUMBER  *(Note: Replace ISSUE_NUMBER if you opened an issue for this, otherwise you can remove this line)*

## Changes

- Added `<T = KubeObjectInterface>` generic to the `put` function in `frontend/src/lib/k8s/api/v1/clusterRequests.ts`.
- Removed the outdated `@todo: apiEndpoint.put has a type of any, which needs improving` comment.

## Steps to Test

1. Navigate to `frontend/src/lib/k8s/api/v1/clusterRequests.ts`.
2. Inspect the `put` method and verify it accepts `<T>` and returns `Promise<T>`.
3. Run the application (`npm start`).
4. Perform an edit on any resource in the dashboard (which triggers a `put` request) and verify it still applies changes successfully.

## Screenshots (if applicable)

*(N/A - This is a TypeScript typing enhancement)*

## Notes for the Reviewer

- Adding these generics is highly beneficial for the plugin ecosystem. Plugin developers (e.g. building a PipeCD integration) will now get full autocomplete and type-checking when issuing PUT requests through the Headlamp Kubernetes proxy.
