### PR TITLE
frontend: Apply: Send fieldValidation=Strict on writes

### DIFF
--- a/docs/development/api/interfaces/lib_k8s_apiProxy.QueryParameters.md
+++ b/docs/development/api/interfaces/lib_k8s_apiProxy.QueryParameters.md
@@ -92,6 +92,24 @@ fieldSeletor restricts the list of returned objects by their fields. Defaults to
 
 ___
 
+### fieldValidation
+
+• `Optional` **fieldValidation**: `string`
+
+fieldValidation tells the apiserver how to treat unknown or duplicate fields in the
+request body. Can be 'Ignore', 'Warn' (apiserver default) or 'Strict'.
+
+With anything but 'Strict' those fields are dropped and only reported through response
+warning headers, so a typo silently does nothing.
+
+**`see`** https://kubernetes.io/docs/reference/using-api/api-concepts/#field-validation
+
+#### Defined in
+
+[lib/k8s/api/v1/queryParameters.ts:75](https://github.com/kubernetes-sigs/headlamp/blob/072d2509b/frontend/src/lib/k8s/api/v1/queryParameters.ts#L75)
+
+___
+
 ### labelSelector
 
 • `Optional` **labelSelector**: `string`

--- a/frontend/src/lib/k8s/KubeObject.test.ts
+++ b/frontend/src/lib/k8s/KubeObject.test.ts
@@ -44,6 +44,7 @@ vi.mock('./patchUtils', () => ({
 }));
 
 import { KubeObject } from './KubeObject';
+import { computePatchOperations, computeRawPatchCount } from './patchUtils';
 
 describe('KubeObject', () => {
   it('returns no API group when the class does not define an API version', () => {
@@ -61,5 +62,90 @@ describe('KubeObject', () => {
         new MyResource({ kind: 'MyResourceKind', metadata: { name: 'my-test-resource' } })
       )
     ).toBe(true);
+  });
+});
+
+describe('KubeObject write requests', () => {
+  // Every write must carry fieldValidation=Strict, otherwise the apiserver defaults to
+  // Warn and silently drops unknown fields, so a typo applies successfully and does
+  // nothing. See https://github.com/kubernetes-sigs/headlamp/issues/7147.
+  const STRICT = { fieldValidation: 'Strict' };
+  const original = { kind: 'X', apiVersion: 'v1', metadata: { name: 'n', namespace: 'ns' } } as any;
+  const modified = { ...original, spec: { replicas: 2 } };
+
+  beforeEach(() => {
+    vi.mocked(computePatchOperations).mockReturnValue([
+      { op: 'replace', path: '/spec/replicas', value: 2 },
+    ] as any);
+    vi.mocked(computeRawPatchCount).mockReturnValue(1);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('patchUpdate sends strict field validation for namespaced resources', () => {
+    const jsonPatch = vi.fn().mockResolvedValue({});
+    class Namespaced extends KubeObject {
+      static kind = 'Namespaced';
+      static isNamespaced = true;
+    }
+    Namespaced.apiEndpoint = { jsonPatch } as any;
+
+    new Namespaced(original, 'my-cluster').patchUpdate(original, modified);
+
+    expect(jsonPatch).toHaveBeenCalledWith(expect.anything(), 'ns', 'n', STRICT, 'my-cluster');
+  });
+
+  it('patchUpdate sends strict field validation for cluster-scoped resources', () => {
+    const jsonPatch = vi.fn().mockResolvedValue({});
+    class ClusterScoped extends KubeObject {
+      static kind = 'ClusterScoped';
+      static isNamespaced = false;
+    }
+    ClusterScoped.apiEndpoint = { jsonPatch } as any;
+
+    new ClusterScoped(original, 'my-cluster').patchUpdate(original, modified);
+
+    expect(jsonPatch).toHaveBeenCalledWith(expect.anything(), 'n', STRICT, 'my-cluster');
+  });
+
+  it('update sends strict field validation', () => {
+    const put = vi.fn().mockResolvedValue({});
+    class Puttable extends KubeObject {
+      static kind = 'Puttable';
+      static isNamespaced = true;
+    }
+    Puttable.apiEndpoint = { put } as any;
+
+    new Puttable(original, 'my-cluster').update(modified);
+
+    expect(put).toHaveBeenCalledWith(modified, STRICT, 'my-cluster');
+  });
+
+  it('static put sends strict field validation', () => {
+    const put = vi.fn().mockResolvedValue({});
+    class StaticPuttable extends KubeObject {
+      static kind = 'StaticPuttable';
+      static isNamespaced = true;
+    }
+    StaticPuttable.apiEndpoint = { put } as any;
+
+    StaticPuttable.put(modified);
+
+    expect(put).toHaveBeenCalledWith(modified, STRICT);
+  });
+
+  it('patch sends strict field validation', () => {
+    const patch = vi.fn().mockResolvedValue({});
+    class Patchable extends KubeObject {
+      static kind = 'Patchable';
+      static isNamespaced = true;
+    }
+    Patchable.apiEndpoint = { patch } as any;
+
+    new Patchable(original, 'my-cluster').patch({ spec: { replicas: 2 } } as any);
+
+    expect(patch).toHaveBeenCalledWith({ spec: { replicas: 2 } }, 'ns', 'n', STRICT, 'my-cluster');
   });
 });

--- a/frontend/src/lib/k8s/KubeObject.ts
+++ b/frontend/src/lib/k8s/KubeObject.ts
@@ -33,6 +33,7 @@ import type {
 import { apiFactory, apiFactoryWithNamespace } from './api/v1/factories';
 import { useConnectApi, useSelectedClusters } from './api/v1/hooks';
 import type { QueryParameters } from './api/v1/queryParameters';
+import { STRICT_FIELD_VALIDATION } from './api/v1/queryParameters';
 import type { ApiError } from './api/v2/ApiError';
 import { useKubeObject } from './api/v2/hooks';
 import { makeListRequests, useKubeObjectList } from './api/v2/useKubeObjectList';
@@ -521,7 +522,7 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
   }
 
   update(data: KubeObjectInterface) {
-    return this._class().apiEndpoint.put(data, {}, this._clusterName);
+    return this._class().apiEndpoint.put(data, STRICT_FIELD_VALIDATION, this._clusterName);
   }
 
   /**
@@ -560,20 +561,20 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
         filteredOps,
         this.getNamespace()!,
         this.getName(),
-        {},
+        STRICT_FIELD_VALIDATION,
         this._clusterName
       );
     }
     return (endpoint as ApiClient<KubeObjectInterface>).jsonPatch(
       filteredOps,
       this.getName(),
-      {},
+      STRICT_FIELD_VALIDATION,
       this._clusterName
     );
   }
 
   static put(data: KubeObjectInterface) {
-    return this.apiEndpoint.put(data);
+    return this.apiEndpoint.put(data, STRICT_FIELD_VALIDATION);
   }
 
   scale(numReplicas: number) {
@@ -615,7 +616,7 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
     args.push(this.getName());
 
     // @ts-ignore
-    return this._class().apiEndpoint.patch(...args, {}, this._clusterName);
+    return this._class().apiEndpoint.patch(...args, STRICT_FIELD_VALIDATION, this._clusterName);
   }
 
   /** Performs a request to check if the user has the given permission.

--- a/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
+++ b/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
@@ -681,6 +681,7 @@ describe('apiProxy', () => {
     it('Successfully creates a new resource with POST', async () => {
       nock(baseApiUrl)
         .post(`/clusters/${clusterName}/api/v1/namespaces/${namespace}/configmaps`)
+        .query({ fieldValidation: 'Strict' })
         .reply(201, mockConfigMap);
 
       const response = await apiProxy.apply(mockConfigMap);
@@ -690,7 +691,7 @@ describe('apiProxy', () => {
     it('Successfully creates a new resource with POST dry-run query params', async () => {
       nock(baseApiUrl)
         .post(`/clusters/${clusterName}/api/v1/namespaces/${namespace}/configmaps`)
-        .query({ dryRun: 'All' })
+        .query({ fieldValidation: 'Strict', dryRun: 'All' })
         .reply(201, mockConfigMap);
 
       const response = await apiProxy.apply(mockConfigMap, undefined, { dryRun: true });
@@ -700,12 +701,14 @@ describe('apiProxy', () => {
     it('Successfully updates an existing resource with PUT', async () => {
       nock(baseApiUrl)
         .post(`/clusters/${clusterName}/api/v1/namespaces/${namespace}/configmaps`)
+        .query({ fieldValidation: 'Strict' })
         .reply(409, errorMessage);
 
       nock(baseApiUrl)
         .put(
           `/clusters/${clusterName}/api/v1/namespaces/${namespace}/configmaps/${mockConfigMap.metadata.name}`
         )
+        .query({ fieldValidation: 'Strict' })
         .reply(200, modifiedConfigMap);
 
       const response = await apiProxy.apply(mockConfigMap);
@@ -715,14 +718,14 @@ describe('apiProxy', () => {
     it('Successfully updates an existing resource with PUT dry-run query params', async () => {
       nock(baseApiUrl)
         .post(`/clusters/${clusterName}/api/v1/namespaces/${namespace}/configmaps`)
-        .query({ dryRun: 'All' })
+        .query({ fieldValidation: 'Strict', dryRun: 'All' })
         .reply(409, errorMessage);
 
       nock(baseApiUrl)
         .put(
           `/clusters/${clusterName}/api/v1/namespaces/${namespace}/configmaps/${mockConfigMap.metadata.name}`
         )
-        .query({ dryRun: 'All' })
+        .query({ fieldValidation: 'Strict', dryRun: 'All' })
         .reply(200, modifiedConfigMap);
 
       const response = await apiProxy.apply(mockConfigMap, undefined, { dryRun: true });
@@ -732,15 +735,33 @@ describe('apiProxy', () => {
     it('Successfully handles failing POST and PUT requests', async () => {
       nock(baseApiUrl)
         .post(`/clusters/${clusterName}/api/v1/namespaces/${namespace}/configmaps`)
+        .query({ fieldValidation: 'Strict' })
         .reply(409, errorMessage);
 
       nock(baseApiUrl)
         .put(
           `/clusters/${clusterName}/api/v1/namespaces/${namespace}/configmaps/${mockConfigMap.metadata.name}`
         )
+        .query({ fieldValidation: 'Strict' })
         .reply(500, errorResponse500);
 
       await expect(apiProxy.apply(mockConfigMap)).rejects.toThrow(errorResponse500.error);
+    });
+
+    it('Sends fieldValidation=Strict so unknown fields are rejected, not dropped', async () => {
+      const strictError = {
+        kind: 'Status',
+        status: 'Failure',
+        message: 'strict decoding error: unknown field "spec.replics"',
+        code: 400,
+      };
+
+      nock(baseApiUrl)
+        .post(`/clusters/${clusterName}/api/v1/namespaces/${namespace}/configmaps`)
+        .query({ fieldValidation: 'Strict' })
+        .reply(400, strictError);
+
+      await expect(apiProxy.apply(mockConfigMap)).rejects.toThrow();
     });
 
     it('Successfully assigns default namespace if not given', async () => {
@@ -751,6 +772,7 @@ describe('apiProxy', () => {
 
       nock(baseApiUrl)
         .post(`/clusters/${clusterName}/api/v1/namespaces/${namespace}/configmaps`)
+        .query({ fieldValidation: 'Strict' })
         .reply(201, mockConfigMap);
 
       const response = await apiProxy.apply(configMapWithoutNamespace);

--- a/frontend/src/lib/k8s/api/v1/apply.ts
+++ b/frontend/src/lib/k8s/api/v1/apply.ts
@@ -21,6 +21,7 @@ import type { ApiError } from '../v2/ApiError';
 import { getClusterDefaultNamespace } from './clusterApi';
 import { resourceDefToApiFactory } from './factories';
 import type { QueryParameters } from './queryParameters';
+import { STRICT_FIELD_VALIDATION } from './queryParameters';
 
 export interface ApplyOptions {
   dryRun?: boolean;
@@ -77,7 +78,13 @@ export async function apply<T extends KubeObjectInterface>(
   }
 
   const resourceVersion = bodyToApply.metadata.resourceVersion;
-  const queryParams: QueryParameters = options.dryRun ? { dryRun: 'All' } : {};
+  // Strict makes the apiserver reject unknown or duplicate fields instead of silently
+  // dropping them, which is what kubectl does. Without it a typo like "replics" applies
+  // successfully and does nothing.
+  const queryParams: QueryParameters = { ...STRICT_FIELD_VALIDATION };
+  if (options.dryRun) {
+    queryParams.dryRun = 'All';
+  }
 
   try {
     delete bodyToApply.metadata.resourceVersion;

--- a/frontend/src/lib/k8s/api/v1/queryParameters.ts
+++ b/frontend/src/lib/k8s/api/v1/queryParameters.ts
@@ -18,6 +18,17 @@
 //        Because some only support some paramaters.
 
 /**
+ * Query parameters making the apiserver reject unknown or duplicate fields in a write
+ * request instead of silently dropping them. Shared by every write path so a typo can
+ * never apply successfully and do nothing.
+ *
+ * Spread it when the caller needs to add more parameters, it is frozen.
+ */
+export const STRICT_FIELD_VALIDATION: Readonly<QueryParameters> = Object.freeze({
+  fieldValidation: 'Strict',
+});
+
+/**
  * QueryParamaters is a map of query parameters for the Kubernetes API.
  */
 export interface QueryParameters {
@@ -52,6 +63,16 @@ export interface QueryParameters {
    * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#dry-run
    */
   dryRun?: string;
+  /**
+   * fieldValidation tells the apiserver how to treat unknown or duplicate fields in the
+   * request body. Can be 'Ignore', 'Warn' (apiserver default) or 'Strict'.
+   *
+   * With anything but 'Strict' those fields are dropped and only reported through response
+   * warning headers, so a typo silently does nothing.
+   *
+   * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#field-validation
+   */
+  fieldValidation?: string;
   /**
    * fieldSeletor restricts the list of returned objects by their fields. Defaults to everything.
    *


### PR DESCRIPTION
Fixes #7147

Headlamp never sent `fieldValidation`, so the apiserver defaulted to `Warn`: unknown or duplicate fields were silently dropped and the write returned 200. A typo like `replics: 3` in the editor "succeeded" and did nothing. Dry Run didn't catch it either, since it used the same default.

All write paths now send `fieldValidation=Strict`, matching kubectl:
- `apply()` (create/update, including dry run)
- `KubeObject.update()` (PUT)
- `KubeObject.patchUpdate()` (JSON Patch, namespaced and cluster-scoped) — the path the Edit button actually uses

Verified against a real cluster: a JSON Patch adding `/spec/replics` returns 200 with the field dropped without the parameter, and is rejected with it.

Tests: updated the existing apply tests for the new query and added one asserting the strict-decoding rejection, plus three in `KubeObject.test.ts` covering put and both patch shapes.