### PR TITLE
frontend: ignore invalid plugin event resources

### DIFF
--- a/frontend/src/lib/k8s/event.ts
+++ b/frontend/src/lib/k8s/event.ts
@@ -181,7 +181,7 @@ class Event extends KubeObject<KubeEvent> {
     ];
     let objInstance: KubeObject | null = null;
     if (!!InvolvedObjectClass) {
-      objInstance = new InvolvedObjectClass(
+      const candidate = new InvolvedObjectClass(
         {
           kind: this.involvedObject.kind,
           metadata: {
@@ -193,6 +193,13 @@ class Event extends KubeObject<KubeEvent> {
         },
         this.cluster
       );
+
+      // Plugins can modify ResourceClasses at runtime, so validate the object before
+      // exposing it as a KubeObject. An incomplete implementation would otherwise crash
+      // consumers such as the cluster overview's event links.
+      if (candidate.metadata) {
+        objInstance = candidate;
+      }
     }
 
     return objInstance;

--- a/frontend/src/lib/k8s/index.test.ts
+++ b/frontend/src/lib/k8s/index.test.ts
@@ -22,6 +22,7 @@ import { createRouteURL } from '../router/createRouteURL';
 import { labelSelectorToQuery, ResourceClasses, useClustersVersion } from '.';
 import { clusterRequest } from './api/v1/clusterRequests';
 import { Cluster, LabelSelector } from './cluster';
+import type { KubeEvent } from './event';
 import { KubeObjectClass } from './KubeObject';
 import Namespace from './namespace';
 
@@ -48,6 +49,69 @@ const mockK8sObject = (className: string) => ({
     resourceVersion: '01',
     selfLink: 'http://localhost/api/v1/phony/01',
   },
+});
+
+describe('Event resource references', () => {
+  const pluginResourceKind = 'PluginResource';
+  const resourceClasses = ResourceClasses as Record<string, KubeObjectClass>;
+
+  afterEach(() => {
+    delete resourceClasses[pluginResourceKind];
+  });
+
+  test('Ignore registered resource classes that do not create valid KubeObjects', async () => {
+    class InvalidPluginResource {
+      static isNamespaced = true;
+      static detailsRoute = 'pluginresource';
+      jsonData: unknown;
+
+      constructor(jsonData: unknown) {
+        this.jsonData = jsonData;
+      }
+
+      getName() {
+        return 'plugin-resource';
+      }
+
+      getNamespace() {
+        return 'default';
+      }
+
+      _class() {
+        return InvalidPluginResource;
+      }
+    }
+
+    resourceClasses[pluginResourceKind] = InvalidPluginResource as unknown as KubeObjectClass;
+
+    const { default: Event } = await import('./event');
+    const event = new Event(
+      {
+        kind: 'Event',
+        type: 'Warning',
+        reason: 'InvalidPluginResource',
+        message: 'Plugin registered a class that does not implement the KubeObject contract',
+        metadata: {
+          name: 'invalid-plugin-resource',
+          namespace: 'default',
+          creationTimestamp: '2026-08-13T00:00:00Z',
+          uid: 'invalid-plugin-resource',
+        },
+        involvedObject: {
+          kind: pluginResourceKind,
+          namespace: 'default',
+          name: 'plugin-resource',
+          uid: 'plugin-resource',
+          apiVersion: 'example.com/v1',
+          resourceVersion: '1',
+          fieldPath: '',
+        },
+      } as KubeEvent,
+      'test-cluster'
+    );
+
+    expect(event.involvedObjectInstance).toBeNull();
+  });
 });
 
 describe('Class tests', () => {


### PR DESCRIPTION
## Summary

This PR fixes bug which is actually caused by using kubevirt plugin.  
But probably it is better to fix it in headlamp, because kubevirt plugin itself is not doing anything nefarious.  
Just returning some outdated objects.

## Related Issue

Fixes #7158

## Changes

- Fixed bug

## Steps to Test

1. Install kubevirt plugin.
2. Install kubevirt into a cluster.
3. Attempt to install bunch of vms, fail, create a lot of failure events. Not sure, maybe it will fail even if there will be only good events.
4. Open cluster in headlamp (desktop or mac)
5. Homepage of cluster does not fail anymore.

## There is no much screenshots
Just shows stack trace. With fix does not.

## Notes for the Reviewer

This was written by sol, apologies if this is not accepted.
