### PR TITLE
frontend: Multiplexer: Pause background Kubernetes watches on hidden tab

### DIFF
--- a/frontend/src/lib/k8s/api/v2/multiplexer.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.ts
@@ -49,6 +49,12 @@ export const WebSocketManager = {
   /** Map to track pending unsubscribe operations for debouncing */
   pendingUnsubscribes: new Map<string, NodeJS.Timeout>(),
 
+  /** Flag to track if the WebSocket is intentionally suspended due to tab visibility */
+  suspended: false,
+
+  /** Timer for debouncing suspension when tab is hidden */
+  suspendTimer: null as NodeJS.Timeout | null,
+
   /**
    * Creates a unique key for identifying WebSocket subscriptions
    * @param clusterId - Cluster identifier
@@ -156,6 +162,28 @@ export const WebSocketManager = {
       };
       socket.send(JSON.stringify(requestMsg));
     });
+  },
+
+  /**
+   * Suspend all active watches by closing the WebSocket connection.
+   * Does not clear active subscriptions so they can be resumed later.
+   */
+  suspendAll(): void {
+    if (this.socketMultiplexer && this.socketMultiplexer.readyState === WebSocket.OPEN) {
+      this.socketMultiplexer.close();
+    }
+    this.suspended = true;
+  },
+
+  /**
+   * Resume all active watches by reconnecting the WebSocket.
+   */
+  resumeAll(): void {
+    this.suspended = false;
+    if (this.activeSubscriptions.size > 0) {
+      // Re-connect and resubscribe if there are active subscriptions
+      this.connect().catch(err => console.error('Failed to resume WebSocket subscriptions:', err));
+    }
   },
 
   /**
@@ -557,4 +585,25 @@ export interface WebSocketMessage {
    * - COMPLETE: Server indicates the watch request has completed (e.g., due to timeout or error)
    */
   type: 'REQUEST' | 'CLOSE' | 'COMPLETE';
+}
+
+// Add visibility change listener to pause background watches
+if (typeof document !== 'undefined') {
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') {
+      // Set a grace period of 30 seconds before suspending
+      WebSocketManager.suspendTimer = setTimeout(() => {
+        WebSocketManager.suspendAll();
+      }, 30000);
+    } else {
+      // Tab is visible again
+      if (WebSocketManager.suspendTimer) {
+        clearTimeout(WebSocketManager.suspendTimer);
+        WebSocketManager.suspendTimer = null;
+      }
+      if (WebSocketManager.suspended) {
+        WebSocketManager.resumeAll();
+      }
+    }
+  });
 }

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -317,7 +317,19 @@ function useWatchKubeObjectListsMultiplexed<K extends KubeObject>({
         parsedUrl.pathname,
         parsedUrl.search.slice(1),
         update => handleUpdate(update, cluster, namespace),
-        error => console.error(`WebSocket subscription error for cluster ${cluster}:`, error)
+        error => {
+          console.error(`WebSocket subscription error for cluster ${cluster}:`, error);
+          if (error.message.includes('410') || error.message.toLowerCase().includes('gone')) {
+            const queryKey = kubeObjectListQuery<K>(
+              kubeObjectClass,
+              endpoint,
+              namespace,
+              cluster,
+              stableQueryParams ?? {}
+            ).queryKey;
+            client.invalidateQueries({ queryKey });
+          }
+        }
       ).then(
         cleanup => cleanups.push(cleanup),
         error => {
@@ -336,7 +348,7 @@ function useWatchKubeObjectListsMultiplexed<K extends KubeObject>({
     return () => {
       cleanups.forEach(cleanup => cleanup());
     };
-  }, [connections, enabled, endpoint, handleUpdate]);
+  }, [connections, enabled, endpoint, handleUpdate, client, kubeObjectClass, stableQueryParams]);
 }
 
 /**


### PR DESCRIPTION
## What this PR does

Pauses background Kubernetes resource watches when the browser tab is hidden.

- Suspends multiplexed WebSocket watches when the tab becomes hidden.
- Resumes watches when the tab becomes visible again.
- Uses a 30-second grace period before suspending watches.
- Handles `410 Gone` errors by invalidating the relevant React Query caches so watches can recover correctly.

## Why

Headlamp continues maintaining Kubernetes resource watches while the browser tab is not visible. Pausing these watches reduces unnecessary browser and Kubernetes API activity when the user is working in another tab.

## Steps to test

1. Open Headlamp with resources that use Kubernetes watches.
2. Switch to another browser tab.
3. Wait for the 30-second grace period.
4. Verify that the background watches are suspended.
5. Return to the Headlamp tab.
6. Verify that the watches resume and resource data continues updating.
7. Run the relevant frontend tests and verify they pass.

Fixes #7139