### PR TITLE
frontend: Settings: Add configuration export and import

### DIFF
--- a/frontend/src/components/App/Settings/Settings.tsx
+++ b/frontend/src/components/App/Settings/Settings.tsx
@@ -30,11 +30,11 @@ import ActionButton from '../../common/ActionButton';
 import NameValueTable from '../../common/NameValueTable';
 import SectionBox from '../../common/SectionBox';
 import TimezoneSelect from '../../common/TimezoneSelect';
-import { theme } from '../../TestHelpers/theme';
 import { setTheme, useAppThemes } from '../themeSlice';
 import DrawerModeSettings from './DrawerModeSettings';
 import { useSettings } from './hook';
 import NumRowsInput from './NumRowsInput';
+import SettingsExportImport from './SettingsExportImport';
 import { ShortcutsList } from './ShortcutsSettings';
 import { ThemePreview } from './ThemePreview';
 
@@ -258,7 +258,7 @@ export default function Settings() {
             </Typography>
           )}
           <Box
-            sx={{
+            sx={theme => ({
               display: 'grid',
               gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))',
               gap: 2,
@@ -269,7 +269,7 @@ export default function Settings() {
               },
               opacity: forceTheme ? 0.5 : 1,
               pointerEvents: forceTheme ? 'none' : 'auto',
-            }}
+            })}
           >
             {appThemes.map(it => (
               <Box
@@ -322,6 +322,7 @@ export default function Settings() {
           <ShortcutsList />
         </SectionBox>
       </Box>
+      <SettingsExportImport />
     </SectionBox>
   );
 }

--- a/frontend/src/components/App/Settings/SettingsExportImport.tsx
+++ b/frontend/src/components/App/Settings/SettingsExportImport.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import Typography from '@mui/material/Typography';
+import { useSnackbar } from 'notistack';
+import React, { useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { exportConfigurationToFile, importSettings } from '../../../helpers/settingsExportImport';
+import SectionBox from '../../common/SectionBox';
+
+export default function SettingsExportImport() {
+  const { t } = useTranslation(['translation']);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [openModal, setOpenModal] = useState(false);
+  const [importContent, setImportContent] = useState<string | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+  const { enqueueSnackbar } = useSnackbar();
+
+  const handleExport = () => {
+    exportConfigurationToFile();
+  };
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = e => {
+      const content = e.target?.result as string;
+      setImportContent(content);
+      setImportError(null);
+      setOpenModal(true);
+    };
+    reader.onerror = () => {
+      enqueueSnackbar(t('translation|Failed to read the file.'), { variant: 'error' });
+    };
+    reader.readAsText(file);
+    // Reset the input so the same file can be selected again
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const handleConfirmImport = () => {
+    if (importContent === null) return;
+
+    let settings;
+    try {
+      settings = JSON.parse(importContent);
+    } catch (e) {
+      setImportError(t('translation|Failed to parse the configuration file. It may be corrupted.'));
+      return;
+    }
+
+    try {
+      const success = importSettings(settings);
+
+      if (success) {
+        // Trigger a page reload to ensure all state is re-hydrated from localStorage
+        window.location.reload();
+      } else {
+        setImportError(t('translation|Invalid configuration file format.'));
+      }
+    } catch (e) {
+      setImportError(
+        t(
+          'translation|Failed to save configuration to local storage. Check your browser storage quota.'
+        )
+      );
+    }
+  };
+
+  const handleCloseModal = () => {
+    setOpenModal(false);
+    setImportContent(null);
+    setImportError(null);
+  };
+
+  return (
+    <Box sx={{ mt: 4 }}>
+      <SectionBox
+        title={t('translation|Export / Import Configuration')}
+        headerProps={{
+          headerStyle: 'subsection',
+        }}
+      >
+        <Typography variant="body2" sx={{ mb: 2, color: 'text.secondary' }}>
+          {t(
+            'translation|Export your current settings (including themes, tables, clusters, and shortcuts) to a file, or import an existing configuration.'
+          )}
+        </Typography>
+
+        <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
+          <Button variant="outlined" onClick={handleExport} color="primary">
+            {t('translation|Export Configuration')}
+          </Button>
+
+          <Button variant="outlined" onClick={() => fileInputRef.current?.click()} color="primary">
+            {t('translation|Import Configuration')}
+          </Button>
+          <input
+            type="file"
+            accept=".json"
+            style={{ display: 'none' }}
+            ref={fileInputRef}
+            onChange={handleFileChange}
+          />
+        </Box>
+      </SectionBox>
+
+      <Dialog open={openModal} onClose={handleCloseModal}>
+        <DialogTitle>{t('translation|Confirm Import')}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {t(
+              'translation|Importing a configuration will overwrite your existing local settings. Are you sure you want to proceed?'
+            )}
+          </DialogContentText>
+          {importError && (
+            <Typography color="error" sx={{ mt: 2 }}>
+              {importError}
+            </Typography>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseModal} color="primary">
+            {t('translation|Cancel')}
+          </Button>
+          <Button onClick={handleConfirmImport} color="error" variant="contained">
+            {t('translation|Import and Reload')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
@@ -817,6 +817,72 @@
             </div>
           </div>
         </div>
+        <div
+          class="MuiBox-root css-h5fkc8"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+                  >
+                    Export / Import Configuration
+                  </h2>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body2 css-1wgus3-MuiTypography-root"
+              >
+                Export your current settings (including themes, tables, clusters, and shortcuts) to a file, or import an existing configuration.
+              </p>
+              <div
+                class="MuiBox-root css-1r9i4v"
+              >
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1ftyvt9-MuiButtonBase-root-MuiButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  Export Configuration
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1ftyvt9-MuiButtonBase-root-MuiButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  Import Configuration
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+                <input
+                  accept=".json"
+                  style="display: none;"
+                  type="file"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/src/helpers/settingsExportImport.test.ts
+++ b/frontend/src/helpers/settingsExportImport.test.ts
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getExportSettings, importSettings } from './settingsExportImport';
+
+describe('settingsExportImport', () => {
+  beforeEach(() => {
+    localStorage.clear();
+
+    const mockStorage: Record<string, string> = {};
+    const originalSetItem = localStorage.setItem.bind(localStorage);
+    const originalRemoveItem = localStorage.removeItem.bind(localStorage);
+
+    vi.spyOn(localStorage, 'setItem').mockImplementation((k, v) => {
+      mockStorage[k] = String(v);
+      originalSetItem(k, v);
+    });
+
+    vi.spyOn(localStorage, 'removeItem').mockImplementation(k => {
+      delete mockStorage[k];
+      originalRemoveItem(k);
+    });
+
+    Object.defineProperty(localStorage, 'length', {
+      get: () => Object.keys(mockStorage).length,
+      configurable: true,
+    });
+    localStorage.key = (i: number) => Object.keys(mockStorage)[i] || null;
+  });
+
+  describe('getExportSettings', () => {
+    it('exports allowed keys including theme and namespace preferences', () => {
+      localStorage.setItem('settings', '{"theme":"dark"}');
+      localStorage.setItem('sidebar', '{"shrink":true}');
+      localStorage.setItem('cluster_settings.minikube', '{"namespace":"default"}');
+      localStorage.setItem('headlampThemePreference', 'light');
+      localStorage.setItem('cached-current-theme', 'custom-theme-name');
+      localStorage.setItem('headlamp-selected-namespace_minikube', 'kube-system');
+
+      const exported = getExportSettings();
+      expect(exported.version).toBe(1);
+      expect(exported.data['settings']).toBe('{"theme":"dark"}');
+      expect(exported.data['sidebar']).toBe('{"shrink":true}');
+      expect(exported.data['cluster_settings.minikube']).toBe('{"namespace":"default"}');
+      expect(exported.data['headlampThemePreference']).toBe('light');
+      expect(exported.data['cached-current-theme']).toBe('custom-theme-name');
+      expect(exported.data['headlamp-selected-namespace_minikube']).toBe('kube-system');
+    });
+
+    it('ignores non-allowed keys and pluginConfigs', () => {
+      localStorage.setItem('settings', '{"theme":"dark"}');
+      localStorage.setItem('headlamp-userId', 'user123');
+      localStorage.setItem('random-key', 'random-value');
+      localStorage.setItem('pluginConfigs', '{"secretToken":"12345"}');
+
+      const exported = getExportSettings();
+      expect(exported.data['settings']).toBe('{"theme":"dark"}');
+      expect(exported.data['headlamp-userId']).toBeUndefined();
+      expect(exported.data['random-key']).toBeUndefined();
+      expect(exported.data['pluginConfigs']).toBeUndefined();
+    });
+  });
+
+  describe('importSettings', () => {
+    it('imports allowed keys and ignores non-allowed keys', () => {
+      const payload = {
+        version: 1,
+        data: {
+          settings: '{"theme":"light"}',
+          'cluster_settings.prod': '{"namespace":"kube-system"}',
+          'random-key': 'value',
+        },
+      };
+
+      const result = importSettings(payload);
+      expect(result).toBe(true);
+
+      expect(localStorage.getItem('settings')).toBe('{"theme":"light"}');
+      expect(localStorage.getItem('cluster_settings.prod')).toBe('{"namespace":"kube-system"}');
+      expect(localStorage.getItem('random-key')).toBeNull();
+    });
+
+    it('replaces existing allowlisted keys not present in import', () => {
+      // Pre-populate with some allowlisted keys
+      localStorage.setItem('settings', '{"theme":"dark"}');
+      localStorage.setItem('sidebar', '{"shrink":true}');
+      localStorage.setItem('filter', '{"namespace":"default"}');
+
+      // Import with only 'settings' - sidebar and filter should be removed
+      const payload = {
+        version: 1,
+        data: {
+          settings: '{"theme":"light"}',
+        },
+      };
+
+      const result = importSettings(payload);
+      expect(result).toBe(true);
+
+      expect(localStorage.getItem('settings')).toBe('{"theme":"light"}');
+      expect(localStorage.getItem('sidebar')).toBeNull();
+      expect(localStorage.getItem('filter')).toBeNull();
+    });
+
+    it('preserves non-allowlisted keys during import', () => {
+      // Pre-populate with a non-allowlisted key
+      localStorage.setItem('headlamp-userId', 'user123');
+      localStorage.setItem('settings', '{"theme":"dark"}');
+
+      const payload = {
+        version: 1,
+        data: {
+          settings: '{"theme":"light"}',
+        },
+      };
+
+      importSettings(payload);
+
+      // Non-allowlisted key should remain untouched
+      expect(localStorage.getItem('headlamp-userId')).toBe('user123');
+      expect(localStorage.getItem('settings')).toBe('{"theme":"light"}');
+    });
+
+    it('round-trips theme preferences', () => {
+      localStorage.setItem('headlampThemePreference', 'dark');
+      localStorage.setItem('cached-current-theme', 'my-custom-theme');
+
+      const exported = getExportSettings();
+
+      // Clear and reimport
+      localStorage.clear();
+      const result = importSettings(exported);
+      expect(result).toBe(true);
+
+      expect(localStorage.getItem('headlampThemePreference')).toBe('dark');
+      expect(localStorage.getItem('cached-current-theme')).toBe('my-custom-theme');
+    });
+
+    it('rolls back to previous state if setItem throws an error', () => {
+      // Setup initial state
+      localStorage.setItem('settings', '{"theme":"dark"}');
+      localStorage.setItem('filter', 'my-filter');
+
+      const payload = {
+        version: 1,
+        data: {
+          settings: '{"theme":"light"}',
+          filter: 'new-filter',
+          sidebar: 'collapsed',
+        },
+      };
+
+      // Mock setItem to throw when setting 'sidebar'
+      const originalSetItem = localStorage.setItem.bind(localStorage);
+      const writtenKeys: string[] = [];
+      const setItemMock = vi.spyOn(localStorage, 'setItem').mockImplementation((key, value) => {
+        if (key === 'sidebar') {
+          throw new Error('Quota exceeded');
+        }
+        writtenKeys.push(key);
+        originalSetItem(key, value);
+      });
+
+      expect(() => importSettings(payload)).toThrowError('Quota exceeded');
+
+      // Verify the new keys were not persisted (or were removed)
+      expect(localStorage.getItem('sidebar')).toBeNull();
+
+      // Verify rollback to the initial state
+      expect(localStorage.getItem('settings')).toBe('{"theme":"dark"}');
+      expect(localStorage.getItem('filter')).toBe('my-filter');
+
+      setItemMock.mockRestore();
+    });
+
+    it('returns false for invalid payload', () => {
+      expect(importSettings(null as any)).toBe(false);
+      expect(importSettings({ version: 2, data: {} } as any)).toBe(false);
+      expect(importSettings({ version: 1, data: 'string' } as any)).toBe(false);
+    });
+
+    it('rejects data: null', () => {
+      expect(importSettings({ version: 1, data: null } as any)).toBe(false);
+    });
+
+    it('rejects data as an array', () => {
+      expect(importSettings({ version: 1, data: ['a', 'b'] } as any)).toBe(false);
+    });
+
+    it('rejects data with non-string values', () => {
+      expect(importSettings({ version: 1, data: { settings: 123 } } as any)).toBe(false);
+      expect(importSettings({ version: 1, data: { settings: true } } as any)).toBe(false);
+      expect(importSettings({ version: 1, data: { settings: { nested: 'obj' } } } as any)).toBe(
+        false
+      );
+    });
+  });
+});

--- a/frontend/src/helpers/settingsExportImport.ts
+++ b/frontend/src/helpers/settingsExportImport.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface ExportedSettings {
+  version: number;
+  data: Record<string, string>;
+}
+
+const EXPORT_VERSION = 1;
+
+const EXACT_KEYS_TO_EXPORT = [
+  'settings',
+  'keyboardShortcuts',
+  'filter',
+  'sidebar',
+  'recent_clusters',
+  'tables_rows_per_page',
+  'detailDrawerEnabled',
+  'headlampThemePreference',
+  'cached-current-theme',
+];
+
+const PREFIXES_TO_EXPORT = ['cluster_settings.', 'table_settings.', 'headlamp-selected-namespace_'];
+
+/**
+ * Determines whether a localStorage key should be included in the export.
+ */
+export function shouldExportKey(key: string): boolean {
+  if (EXACT_KEYS_TO_EXPORT.includes(key)) {
+    return true;
+  }
+  for (const prefix of PREFIXES_TO_EXPORT) {
+    if (key.startsWith(prefix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Exports all relevant configuration settings from localStorage into a JSON object.
+ */
+export function getExportSettings(): ExportedSettings {
+  const data: Record<string, string> = {};
+
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && shouldExportKey(key)) {
+      const value = localStorage.getItem(key);
+      if (value !== null) {
+        data[key] = value;
+      }
+    }
+  }
+
+  return {
+    version: EXPORT_VERSION,
+    data,
+  };
+}
+
+/**
+ * Triggers a download of the current settings configuration as a JSON file.
+ */
+export function exportConfigurationToFile() {
+  const settings = getExportSettings();
+  const blob = new Blob([JSON.stringify(settings, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `headlamp-config-${new Date().toISOString().split('T')[0]}.json`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Validates the structure of an imported settings payload.
+ * Rejects null, arrays, wrong version, and non-string data values.
+ */
+function isValidSettingsPayload(
+  settings: ExportedSettings
+): settings is ExportedSettings & { data: Record<string, string> } {
+  if (!settings || typeof settings !== 'object' || Array.isArray(settings)) {
+    return false;
+  }
+  if (settings.version !== EXPORT_VERSION) {
+    return false;
+  }
+  if (!settings.data || typeof settings.data !== 'object' || Array.isArray(settings.data)) {
+    return false;
+  }
+  // Verify all values are strings and valid JSON where applicable
+  for (const [key, value] of Object.entries(settings.data)) {
+    if (typeof value !== 'string') {
+      return false;
+    }
+    // Only validate keys we will actually import
+    if (!shouldExportKey(key)) {
+      continue;
+    }
+    // If it looks like a JSON object or array, ensure it is actually valid JSON
+    if (
+      (value.startsWith('{') && value.endsWith('}')) ||
+      (value.startsWith('[') && value.endsWith(']'))
+    ) {
+      try {
+        JSON.parse(value);
+      } catch (e) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+/**
+ * Imports configuration settings from a JSON object and saves them to localStorage.
+ * This replaces all existing allowlisted keys: keys present in the current storage
+ * but absent from the import will be removed so the import faithfully restores
+ * the source state.
+ */
+export function importSettings(settings: ExportedSettings): boolean {
+  if (!isValidSettingsPayload(settings)) {
+    return false;
+  }
+
+  // Snapshot existing allowlisted keys to enable rollback on failure
+  const snapshot: Record<string, string> = {};
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && shouldExportKey(key)) {
+      const val = localStorage.getItem(key);
+      if (val !== null) {
+        snapshot[key] = val;
+      }
+    }
+  }
+
+  // Identify new keys that are written during import so we can clean them up on failure
+  const writtenKeys: string[] = [];
+
+  try {
+    // Remove existing allowlisted keys so the import replaces rather than merges.
+    for (const key of Object.keys(snapshot)) {
+      localStorage.removeItem(key);
+    }
+
+    for (const [key, value] of Object.entries(settings.data)) {
+      if (shouldExportKey(key)) {
+        localStorage.setItem(key, value);
+        writtenKeys.push(key);
+      }
+    }
+    return true;
+  } catch (error) {
+    // Rollback: delete any keys written during the failed import
+    for (const key of writtenKeys) {
+      localStorage.removeItem(key);
+    }
+    // Restore the snapshotted keys
+    for (const [key, value] of Object.entries(snapshot)) {
+      try {
+        localStorage.setItem(key, value);
+      } catch (rollbackError) {
+        console.error('Failed to rollback settings during import error:', rollbackError);
+      }
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

Adds the ability to export and import Headlamp configuration settings as a JSON file, allowing users to back up and transfer their custom configuration across devices.

## Related Issue

Related to #7049

## Changes

- Adds `SettingsExportImport.tsx` to the General Settings view.
- Adds `getExportSettings` and `importSettings` utilities in `frontend/src/helpers/settingsExportImport.ts`.
- Exports only an allowlisted set of `localStorage` keys and prefixes.
- Adds a confirmation modal before importing settings.
- Adds unit tests covering allowed and disallowed settings.
- Reloads the page after a successful import so the updated configuration is loaded by the application.

## Steps to Test

1. Run Headlamp locally using `npm start`.
2. Change a few settings in the General Settings page.
3. Open the **Export / Import Configuration** section and click **Export Configuration**.
4. Verify that a JSON configuration file is downloaded.
5. Change or reset the settings.
6. Click **Import Configuration** and select the exported JSON file.
7. Confirm the import.
8. Verify that the previously exported settings are restored after the page reloads.

## Notes for Reviewers

- Exported settings are restricted to an explicit allowlist of `localStorage` keys and prefixes, such as `cluster_settings.` and `table_settings.`.
- Machine-specific or sensitive values such as `headlamp-userId` are not exported.
- The application reloads after import so Redux, React Query, and React contexts initialize using the imported configuration.