### PR TITLE
frontend: apply: Enforce strict field validation

### DIFF
--- a/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
+++ b/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
@@ -681,6 +681,7 @@ describe('apiProxy', () => {
     it('Successfully creates a new resource with POST', async () => {
       nock(baseApiUrl)
         .post(`/clusters/${clusterName}/api/v1/namespaces/${namespace}/configmaps`)
+        .query({ fieldValidation: 'Strict' })
         .reply(201, mockConfigMap);
 
       const response = await apiProxy.apply(mockConfigMap);
@@ -690,7 +691,7 @@ describe('apiProxy', () => {
     it('Successfully creates a new resource with POST dry-run query params', async () => {
       nock(baseApiUrl)
         .post(`/clusters/${clusterName}/api/v1/namespaces/${namespace}/configmaps`)
-        .query({ dryRun: 'All' })
+        .query({ dryRun: 'All', fieldValidation: 'Strict' })
         .reply(201, mockConfigMap);
 
       const response = await apiProxy.apply(mockConfigMap, undefined, { dryRun: true });
@@ -700,12 +701,14 @@ describe('apiProxy', () => {
     it('Successfully updates an existing resource with PUT', async () => {
       nock(baseApiUrl)
         .post(`/clusters/${clusterName}/api/v1/namespaces/${namespace}/configmaps`)
+        .query({ fieldValidation: 'Strict' })
         .reply(409, errorMessage);
 
       nock(baseApiUrl)
         .put(
           `/clusters/${clusterName}/api/v1/namespaces/${namespace}/configmaps/${mockConfigMap.metadata.name}`
         )
+        .query({ fieldValidation: 'Strict' })
         .reply(200, modifiedConfigMap);
 
       const response = await apiProxy.apply(mockConfigMap);
@@ -715,14 +718,14 @@ describe('apiProxy', () => {
     it('Successfully updates an existing resource with PUT dry-run query params', async () => {
       nock(baseApiUrl)
         .post(`/clusters/${clusterName}/api/v1/namespaces/${namespace}/configmaps`)
-        .query({ dryRun: 'All' })
+        .query({ dryRun: 'All', fieldValidation: 'Strict' })
         .reply(409, errorMessage);
 
       nock(baseApiUrl)
         .put(
           `/clusters/${clusterName}/api/v1/namespaces/${namespace}/configmaps/${mockConfigMap.metadata.name}`
         )
-        .query({ dryRun: 'All' })
+        .query({ dryRun: 'All', fieldValidation: 'Strict' })
         .reply(200, modifiedConfigMap);
 
       const response = await apiProxy.apply(mockConfigMap, undefined, { dryRun: true });
@@ -732,12 +735,14 @@ describe('apiProxy', () => {
     it('Successfully handles failing POST and PUT requests', async () => {
       nock(baseApiUrl)
         .post(`/clusters/${clusterName}/api/v1/namespaces/${namespace}/configmaps`)
+        .query({ fieldValidation: 'Strict' })
         .reply(409, errorMessage);
 
       nock(baseApiUrl)
         .put(
           `/clusters/${clusterName}/api/v1/namespaces/${namespace}/configmaps/${mockConfigMap.metadata.name}`
         )
+        .query({ fieldValidation: 'Strict' })
         .reply(500, errorResponse500);
 
       await expect(apiProxy.apply(mockConfigMap)).rejects.toThrow(errorResponse500.error);
@@ -751,6 +756,7 @@ describe('apiProxy', () => {
 
       nock(baseApiUrl)
         .post(`/clusters/${clusterName}/api/v1/namespaces/${namespace}/configmaps`)
+        .query({ fieldValidation: 'Strict' })
         .reply(201, mockConfigMap);
 
       const response = await apiProxy.apply(configMapWithoutNamespace);

--- a/frontend/src/lib/k8s/api/v1/factories.ts
+++ b/frontend/src/lib/k8s/api/v1/factories.ts
@@ -384,17 +384,35 @@ export function singleApiFactory<T extends KubeObjectInterface>(
     },
     get: (name, cb, errCb, queryParams, cluster) =>
       streamResult(url, name, cb, errCb, queryParams, cluster),
-    post: (body, queryParams, cluster) => post(url + asQuery(queryParams), body, true, { cluster }),
+    post: (body, queryParams, cluster) =>
+      post(url + asQuery({ fieldValidation: 'Strict', ...queryParams }), body, true, { cluster }),
     put: (body, queryParams, cluster) =>
-      put(`${url}/${body.metadata.name}` + asQuery(queryParams), body, true, { cluster }),
+      put(
+        `${url}/${body.metadata.name}` + asQuery({ fieldValidation: 'Strict', ...queryParams }),
+        body,
+        true,
+        {
+          cluster,
+        }
+      ),
     patch: (body, name, queryParams, cluster) =>
-      patch(`${url}/${name}` + asQuery({ ...queryParams, ...{ pretty: 'true' } }), body, true, {
-        cluster,
-      }),
+      patch(
+        `${url}/${name}` + asQuery({ fieldValidation: 'Strict', pretty: 'true', ...queryParams }),
+        body,
+        true,
+        {
+          cluster,
+        }
+      ),
     jsonPatch: (body, name, queryParams, cluster) =>
-      jsonPatch(`${url}/${name}` + asQuery({ ...queryParams, ...{ pretty: 'true' } }), body, true, {
-        cluster,
-      }),
+      jsonPatch(
+        `${url}/${name}` + asQuery({ fieldValidation: 'Strict', pretty: 'true', ...queryParams }),
+        body,
+        true,
+        {
+          cluster,
+        }
+      ),
     delete: (name, deleteParams, cluster) =>
       remove(`${url}/${name}` + asQuery(deleteParams), { cluster }),
     isNamespaced: false,
@@ -466,24 +484,32 @@ function simpleApiFactoryWithNamespace<T extends KubeObjectInterface>(
     get: (namespace, name, cb, errCb, queryParams, cluster) =>
       streamResult(url(namespace), name, cb, errCb, queryParams, cluster),
     post: (body, queryParams, cluster) =>
-      post(url(body.metadata?.namespace!) + asQuery(queryParams), body, true, { cluster }),
+      post(
+        url(body.metadata?.namespace!) + asQuery({ fieldValidation: 'Strict', ...queryParams }),
+        body,
+        true,
+        { cluster }
+      ),
     patch: (body, namespace, name, queryParams, cluster) =>
       patch(
-        `${url(namespace)}/${name}` + asQuery({ ...queryParams, ...{ pretty: 'true' } }),
+        `${url(namespace)}/${name}` +
+          asQuery({ fieldValidation: 'Strict', pretty: 'true', ...queryParams }),
         body,
         true,
         { cluster }
       ),
     jsonPatch: (body, namespace, name, queryParams, cluster) =>
       jsonPatch(
-        `${url(namespace)}/${name}` + asQuery({ ...queryParams, ...{ pretty: 'true' } }),
+        `${url(namespace)}/${name}` +
+          asQuery({ fieldValidation: 'Strict', pretty: 'true', ...queryParams }),
         body,
         true,
         { cluster }
       ),
     put: (body, queryParams, cluster) =>
       put(
-        `${url(body.metadata.namespace!)}/${body.metadata.name}` + asQuery(queryParams),
+        `${url(body.metadata.namespace!)}/${body.metadata.name}` +
+          asQuery({ fieldValidation: 'Strict', ...queryParams }),
         body,
         true,
         { cluster }

--- a/frontend/src/lib/k8s/api/v1/queryParameters.ts
+++ b/frontend/src/lib/k8s/api/v1/queryParameters.ts
@@ -124,4 +124,12 @@ export interface QueryParameters {
    * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes
    */
   watch?: string;
+  /**
+   * fieldValidation instructs the server on how to handle objects in the request
+   * (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are:
+   * - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23.
+   * - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+
+   * - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.
+   */
+  fieldValidation?: string;
 }

--- a/frontend/src/lib/k8s/api/v1/scaleApi.ts
+++ b/frontend/src/lib/k8s/api/v1/scaleApi.ts
@@ -48,7 +48,12 @@ export function apiScaleFactory(apiRoot: string, resource: string): ScaleApi {
     },
     put: (body: { metadata: KubeMetadata; spec: { replicas: number } }, clusterName?: string) => {
       const cluster = clusterName || getCluster() || '';
-      return put(url(body.metadata.namespace!, body.metadata.name), body, undefined, { cluster });
+      return put(
+        url(body.metadata.namespace!, body.metadata.name) + '?fieldValidation=Strict',
+        body,
+        undefined,
+        { cluster }
+      );
     },
     patch: (
       body: {
@@ -60,7 +65,12 @@ export function apiScaleFactory(apiRoot: string, resource: string): ScaleApi {
       clusterName?: string
     ) => {
       const cluster = clusterName || getCluster() || '';
-      return patch(url(metadata.namespace!, metadata.name), body, false, { cluster });
+      return patch(
+        url(metadata.namespace!, metadata.name) + '?fieldValidation=Strict',
+        body,
+        undefined,
+        { cluster }
+      );
     },
   };
 


### PR DESCRIPTION
## Summary

Enforces strict Kubernetes field validation for resource mutations so unknown or misspelled fields are rejected instead of being silently dropped.

## Related Issue

Related to #7147

## Changes

- Adds `fieldValidation=Strict` to resource mutation requests.
- Applies strict validation to create, update, and patch operations.
- Applies the validation to dry-run requests as well.
- Updates the relevant tests to verify that strict field validation is included.

## Why

Kubernetes can silently drop unknown fields when field validation is not explicitly set to `Strict`. This can cause a user's edit to appear successful even though a misspelled field was ignored.

Using strict validation makes the API server reject invalid fields and gives the user immediate feedback instead of silently losing the change.

## Steps to Test

1. Open a resource editor in Headlamp.
2. Add or rename a field to an invalid/unknown field.
3. Try a dry-run and verify that the request is rejected.
4. Try applying the invalid resource and verify that the request fails with a field validation error.
5. Verify that valid resource create/update/apply operations continue to work.
6. Run the relevant frontend tests and verify they pass.