### PR TITLE
ci: workflow: Add helm e2e tests for plugin manager

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -13,6 +13,7 @@ on:
     - Dockerfile
     - Dockerfile.plugins
     - 'e2e-tests/**'
+    - 'charts/**'
   push:
     branches:
       - main
@@ -302,6 +303,49 @@ jobs:
           echo "❌ In-cluster API tests failed with exit code $EXIT_CODE"
           exit $EXIT_CODE
         fi
+    - name: Set up Helm
+      uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+      with:
+        version: v3.18.4
+    - name: Deploy Headlamp via Helm and run plugin manager tests
+      run: |
+        # The "test" context's kind-test cluster entry gets its server rewritten to the
+        # Headlamp NodePort service URL by the earlier "Run e2e tests" step, so it can no
+        # longer reach the real Kubernetes API server. Use "test2" instead, which is untouched.
+        kubectl config use-context test2
+        # HEADLAMP_TEST_TOKEN was minted against the "test" cluster's headlamp-admin service
+        # account, which the "test2" API server won't accept. Mint a token from test2's own
+        # headlamp-admin service account (bound to cluster-admin earlier in this workflow) instead.
+        HELM_TEST_TOKEN=$(kubectl create token headlamp-admin --duration 24h -n kube-system)
+        kubectl create namespace headlamp-helm --dry-run=client -o yaml | kubectl apply -f -
+        echo 'image:' > helm-values.yaml
+        echo '  registry: ghcr.io' >> helm-values.yaml
+        echo '  repository: headlamp-k8s/headlamp' >> helm-values.yaml
+        echo '  tag: latest' >> helm-values.yaml
+        echo '  pullPolicy: Never' >> helm-values.yaml
+        echo 'config:' >> helm-values.yaml
+        echo '  baseURL: "/headlamp-helm"' >> helm-values.yaml
+        echo '  watchPlugins: true' >> helm-values.yaml
+        echo 'service:' >> helm-values.yaml
+        echo '  type: NodePort' >> helm-values.yaml
+        echo 'pluginsManager:' >> helm-values.yaml
+        echo '  enabled: true' >> helm-values.yaml
+        echo '  configContent: |' >> helm-values.yaml
+        echo '    plugins:' >> helm-values.yaml
+        echo '      - name: flux' >> helm-values.yaml
+        echo '        source: https://artifacthub.io/packages/headlamp/headlamp-plugins/headlamp_flux' >> helm-values.yaml
+        # Use a release name distinct from "headlamp" so the chart's ClusterRoleBinding
+        # (named "<release>-admin") doesn't collide with the cluster-scoped
+        # "headlamp-admin" binding created earlier in this workflow for the e2e tests.
+        helm install headlamp-helm-e2e ./charts/headlamp --namespace headlamp-helm -f helm-values.yaml
+        echo "Waiting for headlamp helm deployment to be available..."
+        kubectl wait deployment -n headlamp-helm headlamp-helm-e2e --for condition=Available=True --timeout=120s
+        IP_ADDRESS=$(kubectl get nodes --context test2 -o=jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+        SERVICE_PORT=$(kubectl get services headlamp-helm-e2e -n headlamp-helm -o=jsonpath='{.spec.ports[0].nodePort}')
+        export SERVICE_URL="http://${IP_ADDRESS}:${SERVICE_PORT}/headlamp-helm"
+        echo "Helm Headlamp URL: $SERVICE_URL"
+        cd e2e-tests
+        HEADLAMP_TEST_URL=$SERVICE_URL HEADLAMP_TEST_TOKEN=$HELM_TEST_TOKEN HEADLAMP_TEST_HELM=true npx playwright test tests/helmPlugins.spec.ts
     # Clear disk space by removing unnecessary files, apt files and uninstall some playwright dependencies
     - name: Clear Disk Space
       if: steps.cache-image-restore2.outputs.cache-hit != 'true'

--- a/e2e-tests/tests/headlampPage.ts
+++ b/e2e-tests/tests/headlampPage.ts
@@ -139,6 +139,10 @@ export class HeadlampPage {
     }
   }
 
+  async tableContains(text: string | RegExp, options?: { timeout?: number }) {
+    await expect(this.page.locator('table')).toContainText(text, options);
+  }
+
   async clickOnPlugin(pluginName: string) {
     await this.page.click(`a:has-text("${pluginName}")`);
     await this.page.waitForLoadState('load');

--- a/e2e-tests/tests/helmPlugins.spec.ts
+++ b/e2e-tests/tests/helmPlugins.spec.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// <reference types="node" />
+import { expect, test } from '@playwright/test';
+import { HeadlampPage } from './headlampPage';
+
+let headlampPage: HeadlampPage;
+
+// Only run against the dedicated Helm deployment set up in CI. In the generic e2e run this
+// points at the ordinary kube-system instance, which never has the plugin installed, so skip it
+// there instead of letting it fail.
+const shouldRun = !!process.env.HEADLAMP_TEST_HELM;
+
+test.describe('Headlamp plugin manager via Helm', () => {
+  test.skip(!shouldRun, 'HEADLAMP_TEST_HELM is not set; skipping helm plugin manager test');
+
+  test.beforeEach(async ({ page }) => {
+    headlampPage = new HeadlampPage(page);
+
+    await headlampPage.navigateToCluster('main', process.env.HEADLAMP_TEST_TOKEN);
+  });
+
+  test('plugin manager should have installed plugins via helm', async ({ page }) => {
+    // Wait for plugins to be loaded.
+    // The plugin we are installing is 'Flux' via Helm.
+    // Give the plugin manager sidecar (npx download + Artifact Hub fetch/extract) and the
+    // repeated page reloads below plenty of time to complete.
+    test.setTimeout(300000);
+
+    await headlampPage.navigateTopage('/settings/plugins', /Plugins/);
+
+    // Plugins are only discovered once, on app boot, so a plugin the sidecar installs after the
+    // page has already loaded will not show up without a reload. Poll by reloading until it does.
+    await expect(async () => {
+      await page.reload();
+      await headlampPage.tableContains(/flux/i, { timeout: 5000 });
+    }).toPass({ timeout: 240000, intervals: [5000] });
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds Helm e2e tests for plugins repo plugins installed via Helm.

## Related Issue

Fixes #4058

## Changes

- added `e2e-tests/tests/helmPlugins.spec.ts` to verify plugins installed via Helm and Manager.
- added `tableContains` helper method to `e2e-tests/tests/headlampPage.ts` for table content assertions.
- Updated `.github/workflows/build-container.yml` to:
    - Set up Helm in the CI environment.
    - Deploy Headlamp using the local chart in a dedicated namespace (`headlamp-helm`).
    - Configure the Plugin Manager via Helm values to install the **Flux** plugin from Artifact Hub.
    - Execute the new e2e test against the Helm-installed instance.

## Steps to Test

1. Trigger the "Build Container and test" workflow in GitHub Actions.
2. In the `build discover and deploy` job, check the "Deploy Headlamp via Helm and run plugin manager tests" step.
3. Verify that the `helmPlugins.spec.ts` test passes, confirming that the Flux plugin is visible in the settings table.

## Notes for the Reviewer

- The test uses the **Flux** plugin from Artifact Hub as a stable, official reference for integration testing.
- I've used a **60-second timeout** for the plugin check in the e2e test. This is necessary because the Plugin Manager sidecar needs time to download, extract, and initialize the plugin after the pod starts.
- The Helm deployment uses a `NodePort` service and a custom `baseURL` (`/headlamp-helm`) to ensure routing works correctly in complex deployment scenarios.

This PR is rebuilt on top of the latest `main` and addresses the previous review feedback and merge conflicts from #4648.