### PR TITLE
app: Fix headlamp:// deep links

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -60,7 +60,12 @@ import {
   PluginManager,
   setAppConfigDirName,
 } from './plugin-management';
-import { findProtocolUrl, isProtocolUrl, readProtocolScheme } from './protocol';
+import {
+  findProtocolUrl,
+  getRouteFromProtocolUrl,
+  isProtocolUrl,
+  readProtocolScheme,
+} from './protocol';
 import {
   addRunCmdConsent,
   environmentOverrides,
@@ -1365,17 +1370,6 @@ function startElectron() {
   const pendingProtocolUrls: string[] = [];
 
   function routeProtocolUrl(protocolUrl: string) {
-    let urlObj: URL;
-    try {
-      urlObj = new URL(protocolUrl);
-    } catch {
-      dialog.showErrorBox(
-        i18n.t('Invalid URL'),
-        i18n.t('Application opened with an invalid URL: {{ url }}', { url: protocolUrl })
-      );
-      return;
-    }
-
     if (!isProtocolUrl(protocolUrl, protocolScheme)) {
       dialog.showErrorBox(
         i18n.t('Invalid URL'),
@@ -1392,10 +1386,13 @@ function startElectron() {
     if (mainWindow.isMinimized()) {
       mainWindow.restore();
     }
+    if (!mainWindow.isVisible()) {
+      mainWindow.show();
+    }
     mainWindow.focus();
 
     const baseUrl = startUrl.endsWith('/') ? startUrl.slice(0, -1) : startUrl;
-    mainWindow.loadURL(baseUrl + '#' + urlObj.hostname + urlObj.search);
+    mainWindow.loadURL(baseUrl + '#' + getRouteFromProtocolUrl(protocolUrl));
   }
 
   function routeProtocolUrlFromCommandLine(commandLine: readonly string[]) {

--- a/app/electron/protocol.test.ts
+++ b/app/electron/protocol.test.ts
@@ -18,7 +18,13 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { findProtocolUrl, getProtocolScheme, isProtocolUrl, readProtocolScheme } from './protocol';
+import {
+  findProtocolUrl,
+  getProtocolScheme,
+  getRouteFromProtocolUrl,
+  isProtocolUrl,
+  readProtocolScheme,
+} from './protocol';
 
 /**
  * Builds a manifest whose product metadata declares the given protocol schemes.
@@ -121,6 +127,16 @@ describe('isProtocolUrl', () => {
   ])('rejects malformed URLs, other protocols, and hostless URLs: %s', value => {
     expect(isProtocolUrl(value, 'my-desktop')).toBe(false);
   });
+
+  // Routing uses only host, path, and query, so a URL whose authority carries
+  // credentials or a port would navigate somewhere other than what it displays.
+  it.each([
+    'my-desktop://user:pass@cluster/pods',
+    'my-desktop://user@cluster/pods',
+    'my-desktop://cluster:123/pods',
+  ])('rejects URLs with credentials or a port: %s', value => {
+    expect(isProtocolUrl(value, 'my-desktop')).toBe(false);
+  });
 });
 
 describe('findProtocolUrl', () => {
@@ -134,5 +150,21 @@ describe('findProtocolUrl', () => {
     expect(
       findProtocolUrl(['electron', '.', 'not a URL', 'headlamp://cluster'], 'my-desktop')
     ).toBeUndefined();
+  });
+});
+
+describe('getRouteFromProtocolUrl', () => {
+  it('keeps the path segments after the host', () => {
+    expect(getRouteFromProtocolUrl('headlamp://c/mycluster/pods')).toBe('c/mycluster/pods');
+  });
+
+  it('keeps the query string', () => {
+    expect(getRouteFromProtocolUrl('headlamp://c/mycluster/pods?namespace=kube-system')).toBe(
+      'c/mycluster/pods?namespace=kube-system'
+    );
+  });
+
+  it('routes host-only URLs unchanged', () => {
+    expect(getRouteFromProtocolUrl('headlamp://cluster?name=local')).toBe('cluster?name=local');
   });
 });

--- a/app/electron/protocol.ts
+++ b/app/electron/protocol.ts
@@ -77,14 +77,26 @@ export function readProtocolScheme(manifestPath: string): string {
  * from the host component, so an empty host would silently navigate to the
  * app root instead of the requested route.
  *
+ * URLs carrying credentials or a port are rejected too. Routing only uses the
+ * host, path, and query, so `headlamp://user:pass@c/pods` would silently drop
+ * the userinfo and navigate to `c/pods` — the visible authority would not be
+ * the one that was acted on. Rejecting keeps a crafted link from looking like
+ * it points somewhere it does not.
+ *
  * @param value - Candidate deep-link URL.
  * @param protocolScheme - Expected protocol scheme without a trailing colon.
- * @returns Whether the URL uses the configured protocol scheme and has a host.
+ * @returns Whether the URL uses the configured protocol scheme and has a bare host.
  */
 export function isProtocolUrl(value: string, protocolScheme: string): boolean {
   try {
     const url = new URL(value);
-    return url.protocol === `${protocolScheme}:` && url.hostname !== '';
+    return (
+      url.protocol === `${protocolScheme}:` &&
+      url.hostname !== '' &&
+      url.username === '' &&
+      url.password === '' &&
+      url.port === ''
+    );
   } catch {
     return false;
   }
@@ -102,4 +114,21 @@ export function findProtocolUrl(
   protocolScheme: string
 ): string | undefined {
   return commandLine.find(value => isProtocolUrl(value, protocolScheme));
+}
+
+/**
+ * Builds the in-app hash route a protocol URL points to.
+ *
+ * Custom protocol URLs carry their first path segment in the URL host:
+ * `headlamp://c/mycluster/pods` parses with hostname `c` and pathname
+ * `/mycluster/pods`. The route keeps both parts and the query string, so that
+ * example maps to `c/mycluster/pods`. The renderer's hash history normalizes
+ * the leading slash.
+ *
+ * @param protocolUrl - A URL already validated with {@link isProtocolUrl}.
+ * @returns The hash route, without the leading `#`.
+ */
+export function getRouteFromProtocolUrl(protocolUrl: string): string {
+  const url = new URL(protocolUrl);
+  return `${url.hostname}${url.pathname}${url.search}`;
 }


### PR DESCRIPTION
## Summary

Make `headlamp://` deep links work: keep the full URL path, and handle the command-line delivery Windows and Linux use.

## Related Issue

Fixes #7217

## Changes

- Rebuild the route from the URL host, path, and query in a new pure helper (`app/electron/protocol.ts`), so `headlamp://c/minikube/pods/default/my-pod` navigates to `#/c/minikube/pods/default/my-pod` instead of `#c`. Non-`headlamp:` schemes and URLs with credentials or ports are rejected.
- Handle protocol URLs passed on the command line: on cold start via `process.argv` and while running via the `second-instance` arguments, which is how Windows and Linux deliver them.
- Register a single `open-url` listener at bootstrap instead of inside `createWindow`, which re-registered the listener on every window re-creation and missed cold-start events on macOS; early URLs are stored until the window exists.
- Unit tests for the URL-to-route mapping and the argv scan.

## Steps to Test

1. `cd app && npm test` — the new `electron/protocol.test.ts` covers the mapping (12 tests).
2. Build the desktop app, then:
   - macOS: `open "headlamp://c/<cluster>/pods"` — the app opens/focuses on that cluster's Pods page. Before this change it landed on `#c`.
   - Windows/Linux: launch the app (or a second instance while it runs) with `headlamp://c/<cluster>/pods` as an argument — it navigates to that page. Before this change nothing happened.
3. `headlamp://plugins` still works and now lands on the proper `#/plugins` route.

## Screenshots (if applicable)

Not applicable — no UI changes, only navigation behavior.

## Notes for the Reviewer

- The scheme was already registered via the electron-builder `protocols` config, but nothing in the repo emits such links yet; this makes the registered scheme actually usable (e.g. pasting a link into a browser or runbook).
- Related to the hardening asked for in #6765: navigation stays confined to `startUrl + '#' + route`, and the helper validates the URL before any navigation.
