### PR TITLE
fix(frontend): LogsButton: Preserve cluster context for related pods

### DIFF
--- a/frontend/src/components/common/Resource/LogsButton.test.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.test.tsx
@@ -35,10 +35,12 @@ const {
 } = vi.hoisted(() => {
   class MockKubeObject {
     jsonData: any;
+    _cluster: string;
     static kind = '';
     static apiGroupName = '';
-    constructor(data: any) {
+    constructor(data: any, cluster: string = '') {
       this.jsonData = data;
+      this._cluster = cluster;
     }
     get kind() {
       return this.jsonData?.kind;
@@ -59,7 +61,7 @@ const {
       return this.jsonData?.status;
     }
     get cluster() {
-      return '';
+      return this._cluster;
     }
     getName() {
       return this.jsonData?.metadata?.name ?? '';
@@ -953,5 +955,33 @@ describe('LogsButton', () => {
     // 5. Verify the hook state reflects the unchecked INFO severity
     // (default was ['error', 'warn', 'info'], so unchecking INFO leaves ['error', 'warn'])
     expect(result.current[0]).toEqual(['error', 'warn']);
+  });
+
+  it('retains workload cluster context when fetching and retrieving logs for related pods', async () => {
+    mockClusterFetch.mockResolvedValue({
+      json: async () => ({ items: [mockPodData] }),
+    });
+
+    let podInstance: any;
+    Pod.prototype.getLogs = vi.fn(function (this: any) {
+      podInstance = this;
+      return () => {};
+    }) as any;
+
+    const workloadData = { ...deploymentData, cluster: 'cluster-B' };
+    const workload = new Deployment(workloadData as any, 'cluster-B');
+
+    render(
+      <TestContext>
+        <LogsButton item={workload} />
+      </TestContext>
+    );
+
+    fireEvent.click(screen.getByLabelText('translation|Show logs'));
+    const activityContent = mockActivityLaunch.mock.calls[0][0].content;
+    render(<TestContext>{activityContent}</TestContext>);
+
+    await waitFor(() => expect(podInstance).toBeDefined());
+    expect(podInstance.cluster).toBe('cluster-B');
   });
 });

--- a/frontend/src/components/common/Resource/LogsButton.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.tsx
@@ -189,7 +189,7 @@ export function WorkloadLogs({ item }: WorkloadLogsProps) {
           throw new Error(t('translation|Invalid response from server'));
         }
 
-        return response.items.map((podData: any) => new Pod(podData));
+        return response.items.map((podData: any) => new Pod(podData, item.cluster));
       } catch (error) {
         console.error('Error in getRelatedPods:', error);
         throw new Error(


### PR DESCRIPTION
## Summary

Fixes #7222

`LogsButton` correctly fetches related Pods using the workload's cluster, but the cluster context was lost when constructing the `Pod` objects.

Previously, related Pods were created with:

```ts
new Pod(podData)
```

When no cluster was provided, the Pod could fall back to the current UI cluster. In a multi-cluster view, this could cause log requests for a workload from another cluster to target the wrong cluster.

This change preserves the workload's cluster when constructing related Pods:

```ts
new Pod(podData, item.cluster)
```

## Testing

- Added a regression test covering cluster context preservation for related Pods.
- `npx vitest run src/components/common/Resource/LogsButton.test.tsx` — 14/14 passed
- `npm run lint` — passed