### PR TITLE
frontend: Table: Restore dropdown filter options on large lists

### DIFF
--- a/frontend/src/components/common/Table/Table.facetedFilterOptions.test.tsx
+++ b/frontend/src/components/common/Table/Table.facetedFilterOptions.test.tsx
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Regression cover for the undocumented MRT behaviors getDropdownFacetedUniqueValues in
+ * Table.tsx relies on: a caller-provided getFacetedUniqueValues wins over MRT's
+ * `enableFacetedValues ? ... : undefined`, and the dropdown pipeline reads faceted values
+ * even while faceting is off. These tests run against the real material-react-table;
+ * Table.test.tsx mocks it away and would not notice an MRT upgrade breaking either
+ * behavior. Without these, the select filters would go back to empty dropdowns on
+ * large lists.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { createMuiTheme } from '../../../lib/themes';
+import Table, { TableColumn } from './Table';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}));
+
+vi.mock('../../../lib/useShortcut', () => ({ useShortcut: vi.fn() }));
+vi.mock('../../../lib/util', () => ({
+  useURLState: (_key: string, options: { defaultValue: number }) => [options.defaultValue, vi.fn()],
+}));
+vi.mock('../../../helpers/tablesRowsPerPage', () => ({
+  getTablesRowsPerPage: () => 10,
+  setTablesRowsPerPage: vi.fn(),
+}));
+vi.mock('../../App/Settings/hook', () => ({ useSettings: () => [10] }));
+vi.mock('../../resourceMap/useQueryParamsState', () => ({
+  useQueryParamsState: (_key: string, initialValue: unknown) => [initialValue, vi.fn()],
+}));
+
+const theme = createMuiTheme({ base: 'light', name: 'light' });
+
+interface Row {
+  status: string;
+  tier: string;
+}
+
+/** Enough rows that ResourceTable-style callers turn faceted values off. */
+const largeData: Row[] = Array.from({ length: 501 }, (_, index) => ({
+  status: index % 2 === 0 ? 'Running' : 'Completed',
+  tier: index % 2 === 0 ? 'gold' : 'silver',
+}));
+
+function renderTable({
+  columns,
+  data,
+  initialState,
+}: {
+  columns: TableColumn<Row>[];
+  data: Row[];
+  initialState?: object;
+}) {
+  return render(
+    <ThemeProvider theme={theme}>
+      <Table<Row>
+        columns={columns}
+        data={data}
+        enableFacetedValues={data.length <= 500}
+        initialState={{ showColumnFilters: true, ...initialState }}
+      />
+    </ThemeProvider>
+  );
+}
+
+/** Opens the nth select-filter dropdown in the table head and returns its listbox. */
+function openDropdown(index = 0) {
+  // The page-size selector is a combobox too, so only take the ones in the table head.
+  const combobox = screen.getAllByRole('combobox').filter(el => el.closest('th') !== null)[index];
+  expect(combobox).toBeDefined();
+  fireEvent.mouseDown(combobox);
+  return screen.getByRole('listbox');
+}
+
+const statusColumn: TableColumn<Row> = {
+  id: 'status',
+  header: 'Status',
+  filterVariant: 'multi-select',
+  accessorFn: row => row.status,
+};
+
+describe('Table select filter options with real MRT', () => {
+  it('fills the dropdown with value counts although faceted values are disabled', () => {
+    renderTable({ columns: [statusColumn], data: largeData });
+
+    const listbox = openDropdown();
+    expect(within(listbox).getByRole('option', { name: /Completed \(250\)/ })).toBeInTheDocument();
+    expect(within(listbox).getByRole('option', { name: /Running \(251\)/ })).toBeInTheDocument();
+  });
+
+  it('filters the rows when a dropdown option is selected', async () => {
+    renderTable({ columns: [statusColumn], data: largeData });
+
+    const listbox = openDropdown();
+    fireEvent.click(within(listbox).getByRole('option', { name: /Completed/ }));
+    // Close the menu, MUI's modal hides the table from the accessibility tree while open.
+    fireEvent.keyDown(listbox, { key: 'Escape' });
+
+    // MRT debounces filter updates, so wait for the rows to settle.
+    await waitFor(() => {
+      const cells = screen.getAllByRole('cell').map(cell => cell.textContent);
+      expect(cells.length).toBeGreaterThan(0);
+      expect(cells.every(cell => cell === 'Completed')).toBe(true);
+    });
+  });
+
+  it('serves only the most frequent options for a column past the cap', () => {
+    const data: Row[] = [
+      ...Array.from({ length: 500 }, () => ({ status: 'common', tier: 'gold' })),
+      ...Array.from({ length: 1000 }, (_, index) => ({ status: `rare-${index}`, tier: 'gold' })),
+    ];
+    renderTable({ columns: [statusColumn], data });
+
+    const listbox = openDropdown();
+    // Plain DOM queries: computing accessible names for 1000 options is too slow for jsdom.
+    // The "value (count)" shape also drops MRT's placeholder item.
+    const options = Array.from(listbox.querySelectorAll('[role="option"]'), o =>
+      o.textContent?.trim()
+    ).filter(text => / \(\d+\)$/.test(text ?? ''));
+    // 1001 distinct values, truncated to the MAX_FILTER_OPTIONS most frequent.
+    expect(options).toHaveLength(1000);
+    expect(options).toContain('common (500)');
+    expect(options).not.toContain('rare-999 (1)');
+  });
+
+  it('does not walk the rows of non-dropdown columns', () => {
+    const accessorFn = vi.fn((row: Row) => row.tier);
+    renderTable({
+      columns: [statusColumn, { id: 'tier', header: 'Tier', accessorFn }],
+      data: largeData,
+    });
+
+    openDropdown();
+    // Only the visible page's cells read the text column, not the faceted walk.
+    expect(accessorFn.mock.calls.length).toBeLessThan(100);
+  });
+
+  it('prefers caller-provided filterSelectOptions over the computed values', () => {
+    renderTable({
+      columns: [{ ...statusColumn, filterSelectOptions: ['custom-a', 'custom-b'] }],
+      data: largeData,
+    });
+
+    const listbox = openDropdown();
+    expect(within(listbox).getByRole('option', { name: /custom-a/ })).toBeInTheDocument();
+    expect(within(listbox).queryByRole('option', { name: /Running/ })).toBeNull();
+  });
+
+  it('keeps the full faceting contract for non-dropdown columns while faceting is on', () => {
+    let uniqueCount = -1;
+    renderTable({
+      columns: [
+        statusColumn,
+        {
+          id: 'tier',
+          header: 'Tier',
+          accessorFn: row => row.tier,
+          // A custom filter reading the faceted values directly, like a plugin could.
+          Filter: ({ column }) => {
+            uniqueCount = column.getFacetedUniqueValues().size;
+            return null;
+          },
+        },
+      ],
+      data: largeData.slice(0, 100),
+    });
+
+    // Faceting is on, so a text column still gets its full unique-value map.
+    expect(uniqueCount).toBe(2);
+  });
+
+  it('keeps small-list options narrowing with other active filters', () => {
+    const tierColumn: TableColumn<Row> = {
+      id: 'tier',
+      header: 'Tier',
+      filterVariant: 'multi-select',
+      accessorFn: row => row.tier,
+    };
+    renderTable({
+      columns: [statusColumn, tierColumn],
+      data: largeData.slice(0, 100),
+      initialState: { columnFilters: [{ id: 'status', value: ['Running'] }] },
+    });
+
+    // Faceting is on, so the tier options should only reflect the Running rows.
+    const listbox = openDropdown(1);
+    expect(within(listbox).getByRole('option', { name: /gold \(50\)/ })).toBeInTheDocument();
+    expect(within(listbox).queryByRole('option', { name: /silver/ })).toBeNull();
+  });
+});

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -174,6 +174,74 @@ const StyledBody = styled('tbody')({ display: 'contents' });
 const DEFAULT_MIN_COLUMN_WIDTH = 100;
 
 /**
+ * Upper bound for the options served to a single select filter. MRT renders one
+ * unvirtualized menu item per option, so a column with more distinct values serves
+ * only its most frequent ones instead of freezing the tab on every open.
+ */
+const MAX_FILTER_OPTIONS = 1000;
+
+const EMPTY_FACETED_VALUES = new Map<any, number>();
+
+/** The filter variants whose UI is a dropdown that MRT feeds from the faceted values. */
+const DROPDOWN_FILTER_VARIANTS: readonly string[] = ['select', 'multi-select', 'autocomplete'];
+
+/**
+ * MRT sources the select-filter dropdown options from the column's faceted unique
+ * values, but installs no implementation when `enableFacetedValues` is off, which
+ * callers do on large datasets, because TanStack's default builds a unique-value map
+ * for every column, high-cardinality ones included. This implementation is installed
+ * only while faceting is off, walks just the columns whose filter renders a dropdown
+ * and serves an empty map for the rest, so the dropdowns keep their options at any
+ * size while the memory guard keeps covering the columns it exists for. With
+ * faceting on, MRT's native implementation stays in place for every column.
+ *
+ * It relies on two undocumented MRT behaviors, pinned in
+ * Table.facetedFilterOptions.test.tsx: a caller-provided implementation wins over
+ * MRT's own `enableFacetedValues ? ... : undefined`, and the dropdown pipeline reads
+ * faceted values regardless of that flag. With faceting off, TanStack backs
+ * `getFacetedRowModel()` with the pre-filtered rows, so the options are then a
+ * superset that does not narrow with other active filters.
+ */
+const getDropdownFacetedUniqueValues: NonNullable<
+  MaterialTableOptions<Record<string, any>>['getFacetedUniqueValues']
+> = (table, columnId) => {
+  // TanStack creates one closure per column, so caching on the row-model identity
+  // recomputes exactly when the column's rows change, like TanStack's default does.
+  let cachedRows: unknown;
+  let cachedValues = EMPTY_FACETED_VALUES;
+  return () => {
+    const column = table.getColumn(columnId);
+    const columnDef = column?.columnDef as TableColumn<Record<string, any>> | undefined;
+    if (
+      !column ||
+      !DROPDOWN_FILTER_VARIANTS.includes(columnDef?.filterVariant ?? '') ||
+      // MRT prefers caller-provided options, so the walk would go unused.
+      columnDef?.filterSelectOptions
+    ) {
+      return EMPTY_FACETED_VALUES;
+    }
+    const { flatRows } = column.getFacetedRowModel();
+    if (flatRows === cachedRows) {
+      return cachedValues;
+    }
+    const values = new Map<any, number>();
+    for (const row of flatRows) {
+      for (const value of row.getUniqueValues(columnId)) {
+        values.set(value, (values.get(value) ?? 0) + 1);
+      }
+    }
+    cachedRows = flatRows;
+    cachedValues = values;
+    if (values.size > MAX_FILTER_OPTIONS) {
+      // Keep the most frequent values so the dropdown stays useful past the cap.
+      const byCount = Array.from(values).sort(([, a], [, b]) => b - a);
+      cachedValues = new Map(byCount.slice(0, MAX_FILTER_OPTIONS));
+    }
+    return cachedValues;
+  };
+};
+
+/**
  * Tracks the current width of an element using a ResizeObserver.
  * Returns 0 until the element has been measured.
  */
@@ -361,6 +429,17 @@ export default function Table<RowItem extends Record<string, any>>({
     ...tableProps,
     columns: tableColumns ?? [],
     data: tableData,
+    // The key must be absent, not undefined, with faceting on: MRT applies caller options
+    // over its own wiring even when they are undefined, which would drop TanStack's
+    // default and its full faceting contract. A caller-provided implementation is
+    // already in the tableProps spread.
+    ...(tableProps.enableFacetedValues || tableProps.getFacetedUniqueValues
+      ? {}
+      : {
+          // The implementation only reads generic column metadata, so the erased row type is safe.
+          getFacetedUniqueValues:
+            getDropdownFacetedUniqueValues as MaterialTableOptions<RowItem>['getFacetedUniqueValues'],
+        }),
     enablePagination: tableData.length > rowsPerPageOptions[0],
     enableDensityToggle: tableProps.enableDensityToggle ?? false,
     enableFullScreenToggle: tableProps.enableFullScreenToggle ?? false,


### PR DESCRIPTION
### Problem

On lists with more than 500 rows the select filter dropdowns (Namespace, Kind, plugin-added ones) open empty, so big lists can't be filtered.

We disable faceted values above 500 rows because TanStack's default builds a unique-value map for every column, which was OOMing the browser on big pod lists (#5660). But MRT also populates the select filter dropdowns from faceted values, so those went empty too.

### Solution

While faceting is off, give Table its own `getFacetedUniqueValues` that only computes values for dropdown columns (select / multi-select / autocomplete) and returns an empty map for everything else. With faceting on, MRT keeps its native implementation for every column. High-cardinality columns like Name stay excluded, which is what the 500-row guard was really for.

- a column with more than 1000 distinct values serves only its most frequent ones, MRT renders the menu unvirtualized. Rare values stay reachable through the search box; a searchable or virtualized filter menu would be an MRT-level follow-up
- caller `getFacetedUniqueValues` / `filterSelectOptions` still take precedence
- small tables untouched, options still narrow when other filters are active

This relies on two undocumented MRT behaviors: our option overrides the `enableFacetedValues` wiring, and the dropdowns read faceted values even with faceting off. `Table.facetedFilterOptions.test.tsx` pins both against the real MRT so we notice if an upgrade changes them.

### Note

The first version of this PR only fixed the Namespace column via `filterSelectOptions` in ResourceTable. #7486 (@srebb) rightly pointed out that was incomplete, so I reworked it to fix all select filters in Table instead, using the mechanism found there. Credit to them for the diagnosis.



