### PR TITLE
frontend: Add Node Shell "Chroot to host" option

### DIFF
--- a/frontend/src/components/App/Settings/NodeShellSettings.stories.tsx
+++ b/frontend/src/components/App/Settings/NodeShellSettings.stories.tsx
@@ -68,6 +68,7 @@ Default.args = {
   clusterSettings: {
     nodeShellTerminal: {
       isEnabled: true,
+      chrootHostRoot: true,
       namespace: 'kube-system',
       linuxImage: 'busybox:1.28',
     },

--- a/frontend/src/components/App/Settings/NodeShellSettings.tsx
+++ b/frontend/src/components/App/Settings/NodeShellSettings.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Typography } from '@mui/material';
+import { Icon } from '@iconify/react';
+import { IconButton, Tooltip, Typography } from '@mui/material';
 import Switch from '@mui/material/Switch';
 import TextField from '@mui/material/TextField';
 import React from 'react';
@@ -46,10 +47,12 @@ export default function NodeShellSettings(props: SettingsProps) {
     DEFAULT_NODE_SHELL_NAMESPACE;
 
   const nodeShellLabelID = 'node-shell-enabled-label';
+  const chrootHostRootLabelID = 'node-shell-chroot-host-root-label';
 
   const namespace = clusterSettings.nodeShellTerminal?.namespace ?? '';
   const image = clusterSettings.nodeShellTerminal?.linuxImage ?? '';
   const isEnabled = clusterSettings.nodeShellTerminal?.isEnabled ?? true;
+  const chrootHostRoot = clusterSettings.nodeShellTerminal?.chrootHostRoot ?? false;
 
   const [namespaceInput, setNamespaceInput] = React.useState(namespace);
   React.useEffect(() => {
@@ -79,6 +82,34 @@ export default function NodeShellSettings(props: SettingsProps) {
                 inputProps={{ 'aria-labelledby': nodeShellLabelID }}
                 checked={isEnabled}
                 onChange={e => updateNodeShell({ isEnabled: e.target.checked })}
+              />
+            ),
+          },
+          {
+            name: (
+              <>
+                <Typography id={chrootHostRootLabelID} display="inline">
+                  Chroot to host
+                </Typography>
+                <Tooltip
+                  describeChild
+                  title={t('translation|Start the Node Shell with chroot /host.')}
+                >
+                  <IconButton
+                    aria-label={t('translation|Chroot to host')}
+                    size="small"
+                    sx={{ ml: 0.5, p: 0, verticalAlign: 'middle' }}
+                  >
+                    <Icon icon="mdi:information-outline" />
+                  </IconButton>
+                </Tooltip>
+              </>
+            ),
+            value: (
+              <Switch
+                inputProps={{ 'aria-labelledby': chrootHostRootLabelID }}
+                checked={chrootHostRoot}
+                onChange={e => updateNodeShell({ chrootHostRoot: e.target.checked })}
               />
             ),
           },

--- a/frontend/src/components/App/Settings/__snapshots__/NodeShellSettings.Default.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/NodeShellSettings.Default.stories.storyshot
@@ -69,6 +69,55 @@
           <dt
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
           >
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1os2m0i-MuiTypography-root"
+              id="node-shell-chroot-host-root-label"
+            >
+              Chroot to host
+            </p>
+            <button
+              aria-label="Chroot to host"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-w2d4tr-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              tabindex="0"
+              title="Start the Node Shell with chroot /host."
+              type="button"
+            >
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
+          </dt>
+          <dd
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+          >
+            <span
+              class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
+            >
+              <span
+                class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary Mui-checked PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary Mui-checked Mui-checked css-po6g13-MuiButtonBase-root-MuiSwitchBase-root-MuiSwitch-switchBase"
+              >
+                <input
+                  aria-labelledby="node-shell-chroot-host-root-label"
+                  checked=""
+                  class="PrivateSwitchBase-input MuiSwitch-input css-1p3z7et-MuiSwitchBase-root"
+                  type="checkbox"
+                />
+                <span
+                  class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
+                />
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </span>
+              <span
+                class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
+              />
+            </span>
+          </dd>
+          <dt
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+          >
             Linux Image
           </dt>
           <dd

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.Default.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.Default.stories.storyshot
@@ -389,6 +389,54 @@
           <dt
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
           >
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1os2m0i-MuiTypography-root"
+              id="node-shell-chroot-host-root-label"
+            >
+              Chroot to host
+            </p>
+            <button
+              aria-label="Chroot to host"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-w2d4tr-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              tabindex="0"
+              title="Start the Node Shell with chroot /host."
+              type="button"
+            >
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
+          </dt>
+          <dd
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+          >
+            <span
+              class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
+            >
+              <span
+                class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-po6g13-MuiButtonBase-root-MuiSwitchBase-root-MuiSwitch-switchBase"
+              >
+                <input
+                  aria-labelledby="node-shell-chroot-host-root-label"
+                  class="PrivateSwitchBase-input MuiSwitch-input css-1p3z7et-MuiSwitchBase-root"
+                  type="checkbox"
+                />
+                <span
+                  class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
+                />
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </span>
+              <span
+                class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
+              />
+            </span>
+          </dd>
+          <dt
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+          >
             Linux Image
           </dt>
           <dd

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.DynamicCluster.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.DynamicCluster.stories.storyshot
@@ -434,6 +434,54 @@
           <dt
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
           >
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1os2m0i-MuiTypography-root"
+              id="node-shell-chroot-host-root-label"
+            >
+              Chroot to host
+            </p>
+            <button
+              aria-label="Chroot to host"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-w2d4tr-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              tabindex="0"
+              title="Start the Node Shell with chroot /host."
+              type="button"
+            >
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
+          </dt>
+          <dd
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+          >
+            <span
+              class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
+            >
+              <span
+                class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-po6g13-MuiButtonBase-root-MuiSwitchBase-root-MuiSwitch-switchBase"
+              >
+                <input
+                  aria-labelledby="node-shell-chroot-host-root-label"
+                  class="PrivateSwitchBase-input MuiSwitch-input css-1p3z7et-MuiSwitchBase-root"
+                  type="checkbox"
+                />
+                <span
+                  class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
+                />
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </span>
+              <span
+                class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
+              />
+            </span>
+          </dd>
+          <dt
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+          >
             Linux Image
           </dt>
           <dd

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.MultipleAllowedNamespaces.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.MultipleAllowedNamespaces.stories.storyshot
@@ -522,6 +522,54 @@
           <dt
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
           >
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1os2m0i-MuiTypography-root"
+              id="node-shell-chroot-host-root-label"
+            >
+              Chroot to host
+            </p>
+            <button
+              aria-label="Chroot to host"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-w2d4tr-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              tabindex="0"
+              title="Start the Node Shell with chroot /host."
+              type="button"
+            >
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
+          </dt>
+          <dd
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+          >
+            <span
+              class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
+            >
+              <span
+                class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-po6g13-MuiButtonBase-root-MuiSwitchBase-root-MuiSwitch-switchBase"
+              >
+                <input
+                  aria-labelledby="node-shell-chroot-host-root-label"
+                  class="PrivateSwitchBase-input MuiSwitch-input css-1p3z7et-MuiSwitchBase-root"
+                  type="checkbox"
+                />
+                <span
+                  class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
+                />
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </span>
+              <span
+                class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
+              />
+            </span>
+          </dd>
+          <dt
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+          >
             Linux Image
           </dt>
           <dd

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.NamespaceValidation.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.NamespaceValidation.stories.storyshot
@@ -434,6 +434,54 @@
           <dt
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
           >
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1os2m0i-MuiTypography-root"
+              id="node-shell-chroot-host-root-label"
+            >
+              Chroot to host
+            </p>
+            <button
+              aria-label="Chroot to host"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-w2d4tr-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              tabindex="0"
+              title="Start the Node Shell with chroot /host."
+              type="button"
+            >
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
+          </dt>
+          <dd
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+          >
+            <span
+              class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
+            >
+              <span
+                class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-po6g13-MuiButtonBase-root-MuiSwitchBase-root-MuiSwitch-switchBase"
+              >
+                <input
+                  aria-labelledby="node-shell-chroot-host-root-label"
+                  class="PrivateSwitchBase-input MuiSwitch-input css-1p3z7et-MuiSwitchBase-root"
+                  type="checkbox"
+                />
+                <span
+                  class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
+                />
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </span>
+              <span
+                class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
+              />
+            </span>
+          </dd>
+          <dt
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+          >
             Linux Image
           </dt>
           <dd

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.WithAppearance.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.WithAppearance.stories.storyshot
@@ -412,6 +412,54 @@
           <dt
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
           >
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1os2m0i-MuiTypography-root"
+              id="node-shell-chroot-host-root-label"
+            >
+              Chroot to host
+            </p>
+            <button
+              aria-label="Chroot to host"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-w2d4tr-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              tabindex="0"
+              title="Start the Node Shell with chroot /host."
+              type="button"
+            >
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
+          </dt>
+          <dd
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+          >
+            <span
+              class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
+            >
+              <span
+                class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-po6g13-MuiButtonBase-root-MuiSwitchBase-root-MuiSwitch-switchBase"
+              >
+                <input
+                  aria-labelledby="node-shell-chroot-host-root-label"
+                  class="PrivateSwitchBase-input MuiSwitch-input css-1p3z7et-MuiSwitchBase-root"
+                  type="checkbox"
+                />
+                <span
+                  class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
+                />
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </span>
+              <span
+                class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
+              />
+            </span>
+          </dd>
+          <dt
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+          >
             Linux Image
           </dt>
           <dd

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.WithSavedSettings.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.WithSavedSettings.stories.storyshot
@@ -479,6 +479,54 @@
           <dt
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
           >
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1os2m0i-MuiTypography-root"
+              id="node-shell-chroot-host-root-label"
+            >
+              Chroot to host
+            </p>
+            <button
+              aria-label="Chroot to host"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-w2d4tr-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              tabindex="0"
+              title="Start the Node Shell with chroot /host."
+              type="button"
+            >
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
+          </dt>
+          <dd
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+          >
+            <span
+              class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
+            >
+              <span
+                class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-po6g13-MuiButtonBase-root-MuiSwitchBase-root-MuiSwitch-switchBase"
+              >
+                <input
+                  aria-labelledby="node-shell-chroot-host-root-label"
+                  class="PrivateSwitchBase-input MuiSwitch-input css-1p3z7et-MuiSwitchBase-root"
+                  type="checkbox"
+                />
+                <span
+                  class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
+                />
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </span>
+              <span
+                class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
+              />
+            </span>
+          </dd>
+          <dt
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+          >
             Linux Image
           </dt>
           <dd

--- a/frontend/src/components/node/NodeShellTerminal.test.ts
+++ b/frontend/src/components/node/NodeShellTerminal.test.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getNodeShellCommand } from './NodeShellTerminal';
+
+describe('getNodeShellCommand', () => {
+  it('keeps the existing shell command when host chroot is disabled', () => {
+    expect(getNodeShellCommand()).toEqual(['sh']);
+    expect(getNodeShellCommand(false)).toEqual(['sh']);
+  });
+
+  it('starts chroot at the host root when enabled', () => {
+    expect(getNodeShellCommand(true)).toEqual(['chroot', '/host']);
+  });
+});

--- a/frontend/src/components/node/NodeShellTerminal.tsx
+++ b/frontend/src/components/node/NodeShellTerminal.tsx
@@ -94,6 +94,10 @@ const shellPod = (
   } as unknown as KubePod;
 };
 
+export function getNodeShellCommand(chrootHostRoot?: boolean): string[] {
+  return chrootHostRoot ? ['chroot', '/host'] : ['sh'];
+}
+
 function uniqueString() {
   const alphabet = '23456789abcdefghjkmnpqrstuvwxyz';
   let res = '';
@@ -130,7 +134,13 @@ async function shell(
   const linuxImage = config?.linuxImage || defaultImage || DEFAULT_NODE_SHELL_LINUX_IMAGE;
   const namespace = config?.namespace || defaultNamespace || DEFAULT_NODE_SHELL_NAMESPACE;
   const podName = `node-debugger-${item.getName()}-${uniqueString()}`;
-  const kubePod = shellPod(podName, namespace, item.getName(), linuxImage);
+  const kubePod = shellPod(
+    podName,
+    namespace,
+    item.getName(),
+    linuxImage,
+    getNodeShellCommand(config?.chrootHostRoot)
+  );
   try {
     await apply(kubePod, cluster);
   } catch (e) {

--- a/frontend/src/helpers/clusterSettings.test.ts
+++ b/frontend/src/helpers/clusterSettings.test.ts
@@ -39,6 +39,7 @@ describe('clusterSettings', () => {
           linuxImage: 'alpine:latest',
           namespace: 'kube-system',
           isEnabled: true,
+          chrootHostRoot: true,
         },
         podDebugTerminal: {
           debugImage: 'busybox:1.36',

--- a/frontend/src/helpers/clusterSettings.ts
+++ b/frontend/src/helpers/clusterSettings.ts
@@ -28,6 +28,7 @@ export interface ClusterSettings {
     linuxImage?: string;
     namespace?: string;
     isEnabled?: boolean;
+    chrootHostRoot?: boolean;
   };
   podDebugTerminal?: {
     debugImage?: string;


### PR DESCRIPTION
## Summary

This PR adds an optional per-cluster Node Shell setting to start the shell with `chroot /host`.

## Related Issue

https://github.com/kubernetes-sigs/headlamp/issues/7228

## Changes

- Added a `Chroot to host` toggle under Node Shell Settings.
- Added a tooltip explaining that the option starts Node Shell with `chroot /host`.
- Persisted the setting in cluster settings.
- Kept Pod Debug behavior unchanged.
- Added tests and updated Storybook snapshots.

## Steps to Test

1. Open **Settings → Cluster → Node Shell Settings**.
2. Enable **Chroot to host**.
3. Verify the tooltip on the information icon.
4. Open a Node Shell and verify it starts through `chroot /host`.
5. Disable the option and verify the existing `sh` behavior remains unchanged.

## Screenshots (if applicable)

<img width="1560" height="694" alt="auto-chroot" src="https://github.com/user-attachments/assets/2c7bfc58-50bc-42fd-baad-e2a0acd18290" />

## Notes for the Reviewer

The implementation intentionally uses `['chroot', '/host']` without an explicit shell, preserving the host image's default shell behavior.

## Validation

- `npm run frontend:test`
- `npm run frontend:build`
- `npm run frontend:tsc`
- `npm run frontend:lint`