### PR TITLE
frontend: pod/CreatePodForm: Add play functions with label assertions to stories

### DIFF
--- a/frontend/src/components/pod/CreatePodForm.stories.tsx
+++ b/frontend/src/components/pod/CreatePodForm.stories.tsx
@@ -15,6 +15,7 @@
  */
 
 import { Meta, StoryFn } from '@storybook/react';
+import { expect, waitFor, within } from 'storybook/test';
 import { TestContext } from '../../test';
 import CreatePodForm, { CreatePodFormProps } from './CreatePodForm';
 
@@ -33,11 +34,30 @@ export default {
 
 const Template: StoryFn<CreatePodFormProps> = args => <CreatePodForm {...args} />;
 
+/**
+ * Empty form — all fields start blank. Verifies that the Name field
+ * and Add container button are present and accessible.
+ */
 export const Empty = Template.bind({});
 Empty.args = {
   resource: {},
 };
+Empty.parameters = {
+  storyshots: { disable: true },
+};
+Empty.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  await waitFor(() => {
+    expect(canvas.getByLabelText('Name')).toBeInTheDocument();
+    expect(canvas.getByRole('button', { name: /Add container/i })).toBeInTheDocument();
+  });
+};
 
+/**
+ * Pre-filled form — metadata, one container, and an empty nodeName are
+ * pre-populated. Verifies that the Name, Container name, Container image,
+ * and Image pull policy fields are rendered with the correct values.
+ */
 export const Prefilled = Template.bind({});
 Prefilled.args = {
   resource: {
@@ -59,7 +79,23 @@ Prefilled.args = {
     },
   },
 };
+Prefilled.parameters = {
+  storyshots: { disable: true },
+};
+Prefilled.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  await waitFor(() => {
+    expect(canvas.getByLabelText('Name')).toHaveValue('my-nginx');
+    expect(canvas.getByLabelText('Container name')).toHaveValue('nginx');
+    expect(canvas.getByLabelText('Container image')).toHaveValue('nginx:1.27');
+    expect(canvas.getByLabelText('Image pull policy')).toBeInTheDocument();
+  });
+};
 
+/**
+ * Two containers — an app container and a sidecar. Verifies that both
+ * Container name and Container image labels appear twice (one per container).
+ */
 export const MultipleContainers = Template.bind({});
 MultipleContainers.args = {
   resource: {
@@ -82,7 +118,25 @@ MultipleContainers.args = {
     },
   },
 };
+MultipleContainers.parameters = {
+  storyshots: { disable: true },
+};
+MultipleContainers.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  await waitFor(() => {
+    const containerNames = canvas.getAllByLabelText('Container name');
+    expect(containerNames).toHaveLength(2);
+    expect(containerNames[0]).toHaveValue('app');
+    expect(containerNames[1]).toHaveValue('sidecar');
+    const containerImages = canvas.getAllByLabelText('Container image');
+    expect(containerImages).toHaveLength(2);
+  });
+};
 
+/**
+ * Pod pinned to a specific node via nodeName. Verifies that the Name field
+ * and the Node Name field both carry the correct pre-filled values.
+ */
 export const WithNodeName = Template.bind({});
 WithNodeName.args = {
   resource: {
@@ -99,4 +153,14 @@ WithNodeName.args = {
       nodeName: 'node-01',
     },
   },
+};
+WithNodeName.parameters = {
+  storyshots: { disable: true },
+};
+WithNodeName.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  await waitFor(() => {
+    expect(canvas.getByLabelText('Name')).toHaveValue('pinned-pod');
+    expect(canvas.getByLabelText('Node Name')).toHaveValue('node-01');
+  });
 };


### PR DESCRIPTION
## Summary

Adds Storybook `play` functions to the four `CreatePodForm` stories to verify that form elements carry correct accessible labels, resolving #7205.

## Related Issue

Fixes #7205

## Changes

- **Empty** – asserts that the `Name` field and the "Add container" button are present and accessible.
- **Prefilled** – asserts that `Name`, `Container name`, `Container image`, and `Image pull policy` fields render with the correct pre-filled values.
- **MultipleContainers** – asserts that `Container name` and `Container image` aria-labels each appear twice (once per container) with the right values.
- **WithNodeName** – asserts that the `Name` and `Node Name` fields carry their pre-filled values.

Each story also gets:
- A JSDoc description (matches the pattern used in `AuthToken.stories.tsx`).
- `parameters: { storyshots: { disable: true } }` so snapshot tests are not captured during async interactions.

## Steps to Test

1. `npm run frontend:storybook`
2. Open **pod/CreatePodForm** in Storybook.
3. Select each story — the Interactions panel should show all assertions passing.

## Notes for the Reviewer

The `play` functions use `within` + `getByLabelText` / `getAllByLabelText` to test the `aria-label` attributes that `CreateResourceForm` already sets on every text input (`inputProps={{ 'aria-label': field.label }}`). No production code was changed.
