### PR TITLE
frontend: ResourceTableColumnChooser: Fix nested interactive elements and list structure

### DIFF
--- a/frontend/src/components/common/Resource/ResourceTableColumnChooser.test.tsx
+++ b/frontend/src/components/common/Resource/ResourceTableColumnChooser.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect, it, vi } from 'vitest';
+import { ResourceTableColumn } from './ResourceTable';
+import ColumnsPopup from './ResourceTableColumnChooser';
+
+const columns: ResourceTableColumn<any>[] = [
+  { id: 'name', label: 'Name', show: true, getValue: () => '' },
+  { id: 'status', label: 'Status', show: false, getValue: () => '' },
+];
+
+function renderPopup(onToggleColumn = vi.fn()) {
+  render(
+    <ColumnsPopup
+      columns={columns}
+      onToggleColumn={onToggleColumn}
+      onClose={vi.fn()}
+      anchorEl={document.body}
+    />
+  );
+  return onToggleColumn;
+}
+
+it('names each checkbox after its column and reflects its visibility', () => {
+  renderPopup();
+
+  expect(screen.getByRole('checkbox', { name: 'Name' })).toBeChecked();
+  expect(screen.getByRole('checkbox', { name: 'Status' })).not.toBeChecked();
+});
+
+it('has no interactive element nested inside another one', () => {
+  renderPopup();
+
+  for (const widget of screen.getAllByRole('checkbox')) {
+    expect(widget.closest('[role="button"], button')).toBeNull();
+  }
+});
+
+it('toggles the column when the label is clicked', async () => {
+  const onToggleColumn = renderPopup();
+
+  await userEvent.click(screen.getByText('Status'));
+
+  expect(onToggleColumn).toHaveBeenCalledWith([
+    expect.objectContaining({ id: 'name', show: true }),
+    expect.objectContaining({ id: 'status', show: true }),
+  ]);
+});

--- a/frontend/src/components/common/Resource/ResourceTableColumnChooser.test.tsx
+++ b/frontend/src/components/common/Resource/ResourceTableColumnChooser.test.tsx
@@ -52,6 +52,13 @@ it('has no interactive element nested inside another one', () => {
   }
 });
 
+it('puts only list items directly inside the list', () => {
+  renderPopup();
+
+  const list = screen.getByRole('list');
+  expect([...list.children].map(child => child.tagName)).toEqual(['LI', 'LI']);
+});
+
 it('toggles the column when the label is clicked', async () => {
   const onToggleColumn = renderPopup();
 

--- a/frontend/src/components/common/Resource/ResourceTableColumnChooser.tsx
+++ b/frontend/src/components/common/Resource/ResourceTableColumnChooser.tsx
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-import Box from '@mui/material/Box';
 import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
-import ListItemText from '@mui/material/ListItemText';
 import Popover from '@mui/material/Popover';
 import React from 'react';
 import { ResourceTableColumn } from './ResourceTable';
@@ -76,18 +75,19 @@ export default function ColumnsPopup<T>(props: ColumnsPopupProps<T>) {
           const labelId = `column-index-${index}`;
 
           return (
-            <ListItem key={labelId} dense button onClick={() => handleToggleColumn(index)}>
-              <Box>
-                <Checkbox
-                  edge="start"
-                  checked={column.show || column.show === undefined}
-                  tabIndex={-1}
-                  disableRipple
-                  color="default"
-                  inputProps={{ 'aria-labelledby': labelId }}
-                />
-              </Box>
-              <ListItemText id={labelId + '-label'} primary={column.label} />
+            <ListItem key={labelId} dense>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    edge="start"
+                    checked={column.show || column.show === undefined}
+                    onChange={() => handleToggleColumn(index)}
+                    disableRipple
+                    color="default"
+                  />
+                }
+                label={column.label}
+              />
             </ListItem>
           );
         })}

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTableColumnChooser.AllColumnsHidden.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTableColumnChooser.AllColumnsHidden.stories.storyshot
@@ -34,22 +34,18 @@
       <ul
         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
       >
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-0"
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -64,37 +60,25 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-0-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Name
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+          </label>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-1"
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -109,37 +93,25 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-1-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Namespace
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+          </label>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-2"
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -154,37 +126,25 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-2-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Age
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+          </label>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-3"
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -199,37 +159,25 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-3-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Status
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+          </label>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-4"
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -244,21 +192,13 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-4-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Labels
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
+          </label>
+        </li>
       </ul>
     </div>
     <div

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTableColumnChooser.AllColumnsVisible.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTableColumnChooser.AllColumnsVisible.stories.storyshot
@@ -34,23 +34,19 @@
       <ul
         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
       >
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-0"
                 checked=""
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -65,38 +61,26 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-0-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Name
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+          </label>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-1"
                 checked=""
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -111,38 +95,26 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-1-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Namespace
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+          </label>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-2"
                 checked=""
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -157,38 +129,26 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-2-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Age
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+          </label>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-3"
                 checked=""
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -203,38 +163,26 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-3-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Status
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+          </label>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-4"
                 checked=""
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -249,21 +197,13 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-4-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Labels
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
+          </label>
+        </li>
       </ul>
     </div>
     <div

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTableColumnChooser.Default.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTableColumnChooser.Default.stories.storyshot
@@ -34,23 +34,19 @@
       <ul
         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
       >
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-0"
                 checked=""
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -65,38 +61,26 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-0-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Name
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+          </label>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-1"
                 checked=""
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -111,38 +95,26 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-1-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Namespace
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+          </label>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-2"
                 checked=""
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -157,37 +129,25 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-2-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Age
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+          </label>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-3"
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -202,37 +162,25 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-3-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Status
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+          </label>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-4"
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -247,21 +195,13 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-4-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Labels
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
+          </label>
+        </li>
       </ul>
     </div>
     <div

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTableColumnChooser.ManyColumns.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTableColumnChooser.ManyColumns.stories.storyshot
@@ -34,23 +34,19 @@
       <ul
         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
       >
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-0"
                 checked=""
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -65,38 +61,26 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-0-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Name
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+          </label>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-1"
                 checked=""
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -111,38 +95,26 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-1-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Namespace
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+          </label>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-2"
                 checked=""
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -157,38 +129,26 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-2-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Age
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+          </label>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-3"
                 checked=""
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -203,37 +163,25 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-3-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Status
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+          </label>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-4"
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -248,37 +196,25 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-4-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Ready
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+          </label>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-5"
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -293,37 +229,25 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-5-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Restarts
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+          </label>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-6"
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -338,37 +262,25 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-6-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Node
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+          </label>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-7"
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -383,37 +295,25 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-7-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               IP
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+          </label>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-8"
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -428,37 +328,25 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-8-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Labels
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
-        <div
-          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
-          role="button"
-          tabindex="0"
+          </label>
+        </li>
+        <li
+          class="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-2scn94-MuiListItem-root"
         >
-          <div
-            class="MuiBox-root css-0"
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
           >
             <span
               class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xlumq2-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
             >
               <input
-                aria-labelledby="column-index-9"
                 class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                 data-indeterminate="false"
-                tabindex="-1"
                 type="checkbox"
               />
               <svg
@@ -473,21 +361,13 @@
                 />
               </svg>
             </span>
-          </div>
-          <div
-            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-            id="column-index-9-label"
-          >
             <span
-              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
             >
               Annotations
             </span>
-          </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </div>
+          </label>
+        </li>
       </ul>
     </div>
     <div


### PR DESCRIPTION
Fixes #7213
Fixes #7212
Fixes #7201

Each row was a `ListItem button`, which MUI renders as a `<div role="button">` wrapping a checkbox input. That is two violations at once: a nested interactive element, and a `<ul>` whose direct children are divs instead of `<li>`. Both were flagged by axe in the Default, All Columns Visible, All Columns Hidden and Many Columns stories.

Replaced the button ListItem + Checkbox pair with a plain `ListItem` containing a `FormControlLabel`, so each row is a real `<li>` and the checkbox is the only widget, named by the column label. This also fixes the broken `aria-labelledby` (it pointed at `column-index-N`, while the text had id `column-index-N-label`), which left the checkboxes unnamed (#7201).

Added tests covering accessible names, no nested widgets, list structure, and label-click toggling. Storyshots updated.
