### PR TITLE
frontend: Sidebar/SidebarItem: Fix list structure in Collapsed Section Header story

### DIFF
--- a/frontend/src/components/Sidebar/SidebarItem.tsx
+++ b/frontend/src/components/Sidebar/SidebarItem.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import Box from '@mui/material/Box';
 import Collapse from '@mui/material/Collapse';
 import Divider from '@mui/material/Divider';
 import List from '@mui/material/List';
@@ -102,15 +103,28 @@ const SidebarItemBase = memo((props: SidebarItemProps & { clusters?: string[] })
       theme.palette.getContrastText(theme.palette.sidebar.background);
 
     if (!fullWidth) {
+      // Render a plain <li> (via Box) so this stays a valid, unmodified
+      // list item for assistive tech. MUI's Divider always carries an
+      // implicit role="separator", so rendering the Divider itself as
+      // component="li" would produce <li role="separator">, which
+      // overrides the <li>'s native listitem semantics and breaks the
+      // surrounding <List>'s list structure. Nesting the Divider inside
+      // a role-free <li> keeps both the separator semantics and the
+      // list structure intact.
       return (
-        <Divider
+        <Box
           component="li"
-          sx={theme => ({
-            borderColor: alpha(sidebarColor(theme), 0.15),
+          sx={{
             listStyle: 'none',
-            margin: theme.spacing(1, 2),
-          })}
-        />
+            margin: theme => theme.spacing(1, 2),
+          }}
+        >
+          <Divider
+            sx={theme => ({
+              borderColor: alpha(sidebarColor(theme), 0.15),
+            })}
+          />
+        </Box>
       );
     }
 

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.CollapsedSectionHeader.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.CollapsedSectionHeader.stories.storyshot
@@ -8,9 +8,12 @@
         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
       >
         <li
-          class="MuiDivider-root MuiDivider-fullWidth css-lu63ml-MuiDivider-root"
-          role="separator"
-        />
+          class="MuiBox-root css-129d07s"
+        >
+          <hr
+            class="MuiDivider-root MuiDivider-fullWidth css-1tm7fe-MuiDivider-root"
+          />
+        </li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
## Summary

This PR fixes the accessibility list structure issue in the Collapsed Section Header Storybook story by ensuring the collapsed section header renders with valid list semantics.

## Related Issue

Fixes #7211  

## Changes

- Updated SidebarItem.tsx to render a proper role-free <li> wrapper for the collapsed section header.
- Nested the MUI Divider inside the <li> instead of rendering it directly as component="li".
- Preserved the Divider's separator styling and visual appearance.
- Prevented role="separator" from overriding the native <li> semantics.

## Steps to Test

1) Run Storybook with npm run storybook.
2) Navigate to SidebarItem → Collapsed Section Header.
3) Confirm entryType is subheader and fullWidth is false.
4) Verify the collapsed section header renders correctly.
5) Inspect the rendered DOM and confirm the previous role="separator" markup is no longer present.
6) Run the Storybook accessibility check and verify the list structure violation is resolved.

## Screenshots (if applicable)
N.A.

## Notes for the Reviewer
N.A.
