### PR TITLE
app: scripts: Copy plugin locales from tarballs

### DIFF
--- a/app/electron/build-manifest.test.ts
+++ b/app/electron/build-manifest.test.ts
@@ -816,6 +816,51 @@ describe('plugin archive integrity', () => {
     ).rejects.toThrow();
   });
 
+  it.each([
+    {
+      layout: 'current',
+      archiveRoot: 'plugin',
+      mainPath: 'plugin/main.js',
+      packageJsonPath: 'plugin/package.json',
+      translationPath: 'plugin/locales/fr/translation.json',
+    },
+    {
+      layout: 'legacy',
+      archiveRoot: 'package',
+      mainPath: 'package/dist/main.js',
+      packageJsonPath: 'package/package.json',
+      translationPath: 'package/dist/locales/fr/translation.json',
+    },
+  ])('copies plugin locales from the $layout archive layout', async archiveLayout => {
+    const sourceDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-tar-source-'));
+    const extractionDirectory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'headlamp-plugin-extraction-')
+    );
+    const pluginRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-plugin-root-'));
+    temporaryDirectories.push(sourceDirectory, extractionDirectory, pluginRoot);
+
+    for (const [relativePath, contents] of [
+      [archiveLayout.mainPath, 'main'],
+      [archiveLayout.packageJsonPath, '{}'],
+      [archiveLayout.translationPath, '{"hello":"bonjour"}'],
+    ]) {
+      const filePath = path.join(sourceDirectory, relativePath);
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, contents);
+    }
+    const archive = path.join(sourceDirectory, `${archiveLayout.layout}.tar.gz`);
+    await tar.c({ cwd: sourceDirectory, file: archive, gzip: true }, [archiveLayout.archiveRoot]);
+
+    await extractArchive('localized', archive, extractionDirectory, pluginRoot);
+
+    expect(
+      fs.readFileSync(
+        path.join(pluginRoot, 'localized', 'locales', 'fr', 'translation.json'),
+        'utf8'
+      )
+    ).toBe('{"hello":"bonjour"}');
+  });
+
   it('limits extracted entries and rejects symbolic links', async () => {
     const sourceDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-tar-source-'));
     const extractionDirectory = fs.mkdtempSync(

--- a/app/scripts/setup-plugins.ts
+++ b/app/scripts/setup-plugins.ts
@@ -359,6 +359,11 @@ export async function extractArchive(
       path.join(pluginFolder, 'package.json'),
       temporaryFolder
     );
+    copyExtractedDirectory(
+      path.join(path.dirname(mainLocation), 'locales'),
+      path.join(pluginFolder, 'locales'),
+      temporaryFolder
+    );
   } else if (fs.existsSync(path.join(temporaryFolder, 'package', 'dist'))) {
     copyExtractedRegularFile(
       path.join(temporaryFolder, 'package', 'dist', 'main.js'),
@@ -370,8 +375,40 @@ export async function extractArchive(
       path.join(pluginFolder, 'package.json'),
       temporaryFolder
     );
+    copyExtractedDirectory(
+      path.join(temporaryFolder, 'package', 'dist', 'locales'),
+      path.join(pluginFolder, 'locales'),
+      temporaryFolder
+    );
   } else {
     throw new Error(`Failed to find plugin content within archive: ${archivePath}`);
+  }
+}
+
+function copyExtractedDirectory(source: string, destination: string, extractionRoot: string): void {
+  if (!fs.existsSync(source)) return;
+
+  const realRoot = fs.realpathSync.native(extractionRoot);
+  const realSource = fs.realpathSync.native(source);
+  const relativeSource = path.relative(realRoot, realSource);
+  if (relativeSource.startsWith('..') || path.isAbsolute(relativeSource)) {
+    throw new Error(`Extracted plugin directory escapes extraction directory: ${source}`);
+  }
+  if (!fs.lstatSync(realSource).isDirectory()) {
+    throw new Error(`Extracted plugin directory must be a directory: ${source}`);
+  }
+
+  fs.mkdirSync(destination, { recursive: true });
+  for (const entry of fs.readdirSync(realSource, { withFileTypes: true })) {
+    const sourceEntry = path.join(realSource, entry.name);
+    const destinationEntry = path.join(destination, entry.name);
+    if (entry.isDirectory()) {
+      copyExtractedDirectory(sourceEntry, destinationEntry, extractionRoot);
+    } else if (entry.isFile()) {
+      copyExtractedRegularFile(sourceEntry, destinationEntry, extractionRoot);
+    } else {
+      throw new Error(`Extracted plugin directory contains an unsupported entry: ${sourceEntry}`);
+    }
   }
 }
 


### PR DESCRIPTION
Plugins installed via `app-build-manifest.json` can ship translations in a
`locales` folder, and Headlamp fetches
`<plugin>/locales/{lang}/translation.json` at runtime. Archive extraction only
copied `main.js` and `package.json`, so translations included in these archives
never reached the installed plugin directory.

Needed for https://github.com/Azure/aks-desktop/issues/515, which localizes the
bundled plugins.

### Changes

- Copy `locales` from extracted plugin archives for both current and legacy
  tarball layouts
- Preserve archive extraction safeguards while recursively copying locale
  directories and regular files
- Add regression coverage for both supported archive layouts

Stale locale files are handled by the existing staging workflow, which builds a
fresh plugin directory and atomically replaces the previous installation.

### Testing

- [x] `cd app && npm test -- electron/build-manifest.test.ts`
- [x] `cd app && npm run tsc`
- [x] Verified locale extraction for both current and legacy tarball layouts
- [x] Plugins without a `locales` directory remain unaffected