### PR TITLE
frontend: resourceMap: graphGrouping: Avoid merging via RWX PVC

### DIFF
--- a/frontend/src/components/resourceMap/graph/graphGrouping.test.ts
+++ b/frontend/src/components/resourceMap/graph/graphGrouping.test.ts
@@ -218,6 +218,199 @@ describe('groupGraph', () => {
     const individualNodes = groupedGraph.nodes?.filter(node => !node.id.startsWith('group-'));
     expect(individualNodes?.map(n => n.id)).toEqual(['hpa', 'configmap']);
   });
+
+  it('does not merge separate components through shared RWX PVC', () => {
+    const rwxPvc: GraphNode = {
+      id: 'pvc-rwx',
+      kubeObject: {
+        kind: 'PersistentVolumeClaim',
+        metadata: { name: 'pvc-rwx', namespace: 'ns1' } as any,
+        spec: { accessModes: ['ReadWriteMany'] },
+      } as any,
+    };
+
+    const deploymentA: GraphNode = { id: 'deploy-a', kubeObject: { kind: 'Deployment' } as any };
+    const podA: GraphNode = { id: 'pod-a', kubeObject: { kind: 'Pod' } as any };
+    const deploymentB: GraphNode = { id: 'deploy-b', kubeObject: { kind: 'Deployment' } as any };
+    const podB: GraphNode = { id: 'pod-b', kubeObject: { kind: 'Pod' } as any };
+
+    const groupedGraph = groupGraph(
+      [deploymentA, podA, deploymentB, podB, rwxPvc],
+      [
+        { id: 'e-a', source: 'deploy-a', target: 'pod-a' },
+        { id: 'e-b', source: 'deploy-b', target: 'pod-b' },
+        // Edges from RWX PVC to pods should be marked with a nonGroupingSide (simulating what relations.tsx does)
+        { id: 'e-a-pvc', source: 'pvc-rwx', target: 'pod-a', nonGroupingSide: 'source' },
+        { id: 'e-b-pvc', source: 'pvc-rwx', target: 'pod-b', nonGroupingSide: 'source' },
+      ],
+      { namespaces: [], k8sNodes: [] }
+    );
+
+    const connectedGroups = (groupedGraph.nodes ?? []).filter(
+      node => node.id.startsWith('group-') && (node.edges?.length ?? 0) > 0
+    );
+    expect(connectedGroups).toHaveLength(2);
+
+    // The original shared PVC node should not appear directly in grouped output.
+    expect((groupedGraph.nodes ?? []).some(n => n.id === 'pvc-rwx')).toBe(false);
+
+    const groupNodeIds = (group: GraphNode) => new Set((group.nodes ?? []).map(n => n.id));
+
+    const groupA = connectedGroups.find(g => groupNodeIds(g).has('deploy-a'));
+    const groupB = connectedGroups.find(g => groupNodeIds(g).has('deploy-b'));
+    expect(groupA).toBeDefined();
+    expect(groupB).toBeDefined();
+
+    expect(groupNodeIds(groupA!).has('pod-a')).toBe(true);
+    expect(groupNodeIds(groupB!).has('pod-b')).toBe(true);
+    // Each group should only contain its own workload, not the other one.
+    expect(groupNodeIds(groupA!).has('deploy-b')).toBe(false);
+    expect(groupNodeIds(groupA!).has('pod-b')).toBe(false);
+    expect(groupNodeIds(groupB!).has('deploy-a')).toBe(false);
+    expect(groupNodeIds(groupB!).has('pod-a')).toBe(false);
+
+    const pvcNodesByGroup = connectedGroups.map(group =>
+      (group.nodes ?? []).filter(node => node.kubeObject?.kind === 'PersistentVolumeClaim')
+    );
+
+    expect(pvcNodesByGroup[0]).toHaveLength(1);
+    expect(pvcNodesByGroup[1]).toHaveLength(1);
+
+    const pvc0 = pvcNodesByGroup[0][0];
+    const pvc1 = pvcNodesByGroup[1][0];
+
+    expect(pvc0.id).not.toEqual(pvc1.id);
+    expect(pvc0.id).not.toEqual('pvc-rwx');
+    expect(pvc1.id).not.toEqual('pvc-rwx');
+    expect(pvc0.id.startsWith('pvc-rwx--group-')).toBe(true);
+    expect(pvc1.id.startsWith('pvc-rwx--group-')).toBe(true);
+
+    // Each group should reference its own cloned PVC ID (not the original PVC ID), and
+    // the cloned PVC node should preserve the original PVC's kubeObject data.
+    connectedGroups.forEach(group => {
+      const edgeIds = new Set((group.edges ?? []).flatMap(e => [e.source, e.target]));
+      expect(edgeIds.has('pvc-rwx')).toBe(false);
+
+      const pvc = (group.nodes ?? []).find(n => n.kubeObject?.kind === 'PersistentVolumeClaim');
+      expect(pvc).toBeDefined();
+      expect(edgeIds.has(pvc!.id)).toBe(true);
+      expect((pvc!.kubeObject as any)?.spec?.accessModes).toContain('ReadWriteMany');
+    });
+  });
+
+  it('does not merge separate components through shared generic nodes', () => {
+    // Verifies the nonGroupingSide logic is generic and not tied to PVCs specifically.
+    const sharedNode: GraphNode = {
+      id: 'shared-resource',
+      kubeObject: { kind: 'ConfigMap', metadata: { name: 'shared-cm' } } as any,
+    };
+
+    const nodeA: GraphNode = { id: 'node-a', kubeObject: { kind: 'Pod' } as any };
+    const nodeB: GraphNode = { id: 'node-b', kubeObject: { kind: 'Pod' } as any };
+
+    const groupedGraph = groupGraph(
+      [nodeA, nodeB, sharedNode],
+      [
+        {
+          id: 'e-a-shared',
+          source: 'shared-resource',
+          target: 'node-a',
+          nonGroupingSide: 'source',
+        },
+        {
+          id: 'e-b-shared',
+          source: 'shared-resource',
+          target: 'node-b',
+          nonGroupingSide: 'source',
+        },
+      ],
+      { namespaces: [], k8sNodes: [] }
+    );
+
+    const connectedGroups = (groupedGraph.nodes ?? []).filter(
+      node => node.id.startsWith('group-') && (node.edges?.length ?? 0) > 0
+    );
+    // Should result in 2 separate groups, not 1 giant group.
+    expect(connectedGroups).toHaveLength(2);
+
+    const groupA = connectedGroups.find(g => (g.nodes ?? []).some(n => n.id === 'node-a'));
+    const groupB = connectedGroups.find(g => (g.nodes ?? []).some(n => n.id === 'node-b'));
+
+    expect(groupA).toBeDefined();
+    expect(groupB).toBeDefined();
+
+    // Verify shared node is cloned, once per group, with a distinct ID.
+    const sharedInA = groupA?.nodes?.find(n => n.id.startsWith('shared-resource--'));
+    const sharedInB = groupB?.nodes?.find(n => n.id.startsWith('shared-resource--'));
+    expect(sharedInA).toBeDefined();
+    expect(sharedInB).toBeDefined();
+    expect(sharedInA?.id).not.toEqual(sharedInB?.id);
+  });
+
+  it('keeps the original ID for a shared RWX PVC that only touches one component', () => {
+    // Two Pods of the *same* Deployment mounting an RWX PVC don't bridge separate
+    // components, so the PVC should be reattached as-is (not cloned with a synthetic ID).
+    const rwxPvc: GraphNode = {
+      id: 'pvc-rwx',
+      kubeObject: { kind: 'PersistentVolumeClaim' } as any,
+    };
+    const deployment: GraphNode = { id: 'deploy-a', kubeObject: { kind: 'Deployment' } as any };
+    const podA: GraphNode = { id: 'pod-a', kubeObject: { kind: 'Pod' } as any };
+    const podB: GraphNode = { id: 'pod-b', kubeObject: { kind: 'Pod' } as any };
+
+    const groupedGraph = groupGraph(
+      [deployment, podA, podB, rwxPvc],
+      [
+        { id: 'e-dep-a', source: 'deploy-a', target: 'pod-a' },
+        { id: 'e-dep-b', source: 'deploy-a', target: 'pod-b' },
+        { id: 'e-a-pvc', source: 'pvc-rwx', target: 'pod-a', nonGroupingSide: 'source' },
+        { id: 'e-b-pvc', source: 'pvc-rwx', target: 'pod-b', nonGroupingSide: 'source' },
+      ],
+      { namespaces: [], k8sNodes: [] }
+    );
+
+    const connectedGroup = (groupedGraph.nodes ?? []).find(
+      node => node.id.startsWith('group-') && (node.edges?.length ?? 0) > 0
+    );
+    expect(connectedGroup).toBeDefined();
+
+    const pvcNode = connectedGroup?.nodes?.find(
+      n => n.kubeObject?.kind === 'PersistentVolumeClaim'
+    );
+    expect(pvcNode?.id).toBe('pvc-rwx');
+
+    const edgeIds = (connectedGroup?.edges ?? []).map(e => e.id);
+    expect(edgeIds).toEqual(expect.arrayContaining(['e-a-pvc', 'e-b-pvc']));
+  });
+
+  it('does not treat a standalone Pod mounting two RWX PVCs as shared', () => {
+    // The Pod's only edges are both `nonGroupingSide: 'source'` (naming the PVCs, not
+    // the Pod, as shareable) so even though the Pod itself has no "normal" edges and
+    // touches 2 neighbors, it must not be split out as if it were the shared resource.
+    // Neither PVC has more than one consumer either, so nothing here should be split:
+    // the Pod and both PVCs should end up in a single, un-cloned connected component.
+    const pod: GraphNode = { id: 'pod-solo', kubeObject: { kind: 'Pod' } as any };
+    const pvcA: GraphNode = { id: 'pvc-a', kubeObject: { kind: 'PersistentVolumeClaim' } as any };
+    const pvcB: GraphNode = { id: 'pvc-b', kubeObject: { kind: 'PersistentVolumeClaim' } as any };
+
+    const groupedGraph = groupGraph(
+      [pod, pvcA, pvcB],
+      [
+        { id: 'e-pod-pvc-a', source: 'pvc-a', target: 'pod-solo', nonGroupingSide: 'source' },
+        { id: 'e-pod-pvc-b', source: 'pvc-b', target: 'pod-solo', nonGroupingSide: 'source' },
+      ],
+      { namespaces: [], k8sNodes: [] }
+    );
+
+    const connectedGroups = (groupedGraph.nodes ?? []).filter(
+      node => node.id.startsWith('group-') && (node.edges?.length ?? 0) > 0
+    );
+    // A single group containing the Pod and both (un-cloned) PVCs, not split apart.
+    expect(connectedGroups).toHaveLength(1);
+    const group = connectedGroups[0];
+    expect((group.nodes ?? []).map(n => n.id).sort()).toEqual(['pod-solo', 'pvc-a', 'pvc-b']);
+    expect((group.edges ?? []).map(e => e.id).sort()).toEqual(['e-pod-pvc-a', 'e-pod-pvc-b']);
+  });
 });
 
 describe('collapseGraph', () => {

--- a/frontend/src/components/resourceMap/graph/graphGrouping.tsx
+++ b/frontend/src/components/resourceMap/graph/graphGrouping.tsx
@@ -38,9 +38,304 @@ export const getGraphSize = (graph: GraphNode) => {
 };
 
 /**
+ * Iteratively finds all nodes in the connected component of a given node.
+ * Performs a breadth-first search (BFS) to traverse and collect all nodes
+ * that are part of the same connected component as the provided node.
+ *
+ * PERFORMANCE: Uses an index-based queue instead of Array.shift() to achieve
+ * O(1) amortized dequeue and avoid the O(n²) behavior that shift()-based
+ * queues can exhibit on large components. The resulting BFS traversal runs
+ * in O(n) time with respect to the number of nodes in the component.
+ *
+ * PERFORMANCE: Uses iterative BFS instead of recursive DFS to avoid recursion
+ * depth limits and potential stack overflows on deep or dense graphs. The
+ * iterative approach removes dependence on call stack depth and is suitable
+ * for handling large graphs safely.
+ *
+ * @param graphLookup - Lookup structure over the nodes/edges being searched
+ * @param startNode - The starting node for the connected component search
+ * @param visitedNodes - Set of node IDs already assigned to a component, updated in place
+ * @param visitedEdges - Set of edge IDs already collected, updated in place
+ * @param componentNodes - An array to store the nodes that are part of the connected component
+ * @param componentEdges - An array to store the edges that are part of the connected component
+ */
+const findConnectedComponent = (
+  graphLookup: ReturnType<typeof makeGraphLookup>,
+  startNode: GraphNode,
+  visitedNodes: Set<string>,
+  visitedEdges: Set<string>,
+  componentNodes: GraphNode[],
+  componentEdges: GraphEdge[]
+) => {
+  const queue: GraphNode[] = [startNode];
+  // PERFORMANCE: Index-based queue for O(1) dequeue instead of O(n) shift()
+  let queueIndex = 0;
+  visitedNodes.add(startNode.id);
+  componentNodes.push(startNode);
+
+  while (queueIndex < queue.length) {
+    const node = queue[queueIndex++]; // O(1) operation vs shift() which is O(n)
+
+    // Outgoing edges
+    const outgoing = graphLookup.getOutgoingEdges(node.id);
+    if (outgoing) {
+      for (const edge of outgoing) {
+        // Always collect the edge if we haven't yet
+        if (!visitedEdges.has(edge.id)) {
+          visitedEdges.add(edge.id);
+          componentEdges.push(edge);
+        }
+
+        // Only add to queue if we haven't visited the target node
+        if (!visitedNodes.has(edge.target)) {
+          const targetNode = graphLookup.getNode(edge.target);
+          if (targetNode) {
+            visitedNodes.add(edge.target);
+            componentNodes.push(targetNode);
+            queue.push(targetNode);
+          }
+        }
+      }
+    }
+
+    // Incoming edges
+    const incoming = graphLookup.getIncomingEdges(node.id);
+    if (incoming) {
+      for (const edge of incoming) {
+        // Always collect the edge if we haven't yet
+        if (!visitedEdges.has(edge.id)) {
+          visitedEdges.add(edge.id);
+          componentEdges.push(edge);
+        }
+
+        // Only add to queue if we haven't visited the source node
+        if (!visitedNodes.has(edge.source)) {
+          const sourceNode = graphLookup.getNode(edge.source);
+          if (sourceNode) {
+            visitedNodes.add(edge.source);
+            componentNodes.push(sourceNode);
+            queue.push(sourceNode);
+          }
+        }
+      }
+    }
+  }
+};
+
+/**
+ * Computes connected components for a node/edge set and returns them as group nodes,
+ * without collapsing single-node components down to plain nodes (that happens once in
+ * {@link getConnectedComponents}, after any shared nodes have been cloned back in).
+ *
+ * @param nodes - Nodes to search for connected components
+ * @param graphLookup - Lookup structure built over `nodes` and their edges
+ * @returns Group nodes, one per connected component found
+ */
+const getConnectedComponentGroups = (
+  nodes: GraphNode[],
+  graphLookup: ReturnType<typeof makeGraphLookup>
+): GraphNode[] => {
+  const components: GraphNode[] = [];
+  const visitedNodes = new Set<string>();
+  const visitedEdges = new Set<string>();
+
+  nodes.forEach(node => {
+    if (!visitedNodes.has(node.id)) {
+      const componentNodes: GraphNode[] = [];
+      const componentEdges: GraphEdge[] = [];
+      findConnectedComponent(
+        graphLookup,
+        node,
+        visitedNodes,
+        visitedEdges,
+        componentNodes,
+        componentEdges
+      );
+      const mainNode = getMainNode(componentNodes);
+
+      components.push({
+        id: 'group-' + (mainNode?.id ?? 'unknown'),
+        nodes: componentNodes,
+        edges: componentEdges,
+      });
+    }
+  });
+
+  return components;
+};
+
+/**
+ * Finds nodes that must not be allowed to merge otherwise-separate components together.
+ *
+ * A node qualifies as "shared" when *every* edge touching it names that same node as
+ * its {@link GraphEdge.nonGroupingSide} and it has more than one distinct neighbor.
+ * A ReadWriteMany PVC mounted by several unrelated Deployments is the motivating
+ * example (see #4310): without this check, the shared PVC would connect all of those
+ * Deployments into a single connected component.
+ *
+ * Checking `nonGroupingSide` against this specific node (rather than a plain boolean
+ * on the edge) matters for the *other* endpoint: e.g. a standalone Pod mounting two
+ * RWX PVCs has two edges that are both non-grouping, but neither names the Pod as
+ * their `nonGroupingSide` (they name the PVCs), so the Pod itself is correctly never
+ * treated as shared even though it has no "normal" edges and touches >1 neighbor.
+ *
+ * @param nodes - All nodes in the graph
+ * @param graphLookup - Lookup structure built over `nodes` and their edges
+ * @returns Set of node IDs that should be treated as shared
+ */
+const findSharedNodeIds = (
+  nodes: GraphNode[],
+  graphLookup: ReturnType<typeof makeGraphLookup>
+): Set<string> => {
+  const sharedNodeIds = new Set<string>();
+
+  nodes.forEach(node => {
+    const incomingEdges = graphLookup.getIncomingEdges(node.id) ?? [];
+    const outgoingEdges = graphLookup.getOutgoingEdges(node.id) ?? [];
+    const allEdges = [...incomingEdges, ...outgoingEdges];
+
+    // A node is only a shareable-resource candidate if every edge touching it names
+    // *this* node (by its role on that edge) as the shareable endpoint.
+    const isShareableEndpoint = (edge: GraphEdge) =>
+      (edge.target === node.id && edge.nonGroupingSide === 'target') ||
+      (edge.source === node.id && edge.nonGroupingSide === 'source');
+
+    if (allEdges.length === 0 || !allEdges.every(isShareableEndpoint)) {
+      return;
+    }
+
+    const neighborNodeIds = new Set<string>();
+    outgoingEdges.forEach(edge => neighborNodeIds.add(edge.target));
+    incomingEdges.forEach(edge => neighborNodeIds.add(edge.source));
+
+    if (neighborNodeIds.size > 1) {
+      sharedNodeIds.add(node.id);
+    }
+  });
+
+  return sharedNodeIds;
+};
+
+/**
+ * Computes connected components while keeping shared nodes (see {@link findSharedNodeIds})
+ * from bridging otherwise unrelated components together.
+ *
+ * Shared nodes are removed before searching for components, then attached back to every
+ * component they're actually connected to. A shared node that only ever touches a single
+ * component (e.g. an RWX PVC mounted by two Pods of the *same* Deployment) is reattached
+ * unchanged, preserving its original ID so exact-ID lookups (e.g. a `?node=<uid>` selection)
+ * keep working. Only when a shared node genuinely bridges more than one component is it
+ * cloned per-component, each clone getting a unique ID and its own copy of the incident
+ * edges, so every component keeps showing its own relationship to the shared resource
+ * without merging with unrelated components.
+ *
+ * @param nodes - All nodes in the graph
+ * @param edges - All edges in the graph
+ * @param sharedNodeIds - IDs of nodes to split out and reattach per-component
+ * @returns Group nodes, one per connected component found in the graph without the shared nodes
+ */
+const getComponentsWithSharedNodesCloned = (
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+  sharedNodeIds: Set<string>
+): GraphNode[] => {
+  const baseNodes = nodes.filter(node => !sharedNodeIds.has(node.id));
+  const baseEdges = edges.filter(
+    edge => !sharedNodeIds.has(edge.source) && !sharedNodeIds.has(edge.target)
+  );
+
+  const sharedNodesById = new Map<string, GraphNode>();
+  nodes.forEach(node => {
+    if (sharedNodeIds.has(node.id)) {
+      sharedNodesById.set(node.id, node);
+    }
+  });
+
+  // Index edges touching a shared node by that shared node's ID, so each shared node's
+  // target component(s) can be resolved directly instead of every component scanning
+  // every shared node.
+  const edgesBySharedNode = new Map<string, GraphEdge[]>();
+  edges.forEach(edge => {
+    const sharedId = sharedNodeIds.has(edge.source)
+      ? edge.source
+      : sharedNodeIds.has(edge.target)
+      ? edge.target
+      : undefined;
+    if (!sharedId) {
+      return;
+    }
+
+    const list = edgesBySharedNode.get(sharedId) ?? [];
+    list.push(edge);
+    edgesBySharedNode.set(sharedId, list);
+  });
+
+  const baseGraphLookup = makeGraphLookup(baseNodes, baseEdges);
+  const baseComponents = getConnectedComponentGroups(baseNodes, baseGraphLookup);
+
+  // Map every base node back to the component it ended up in, so a shared node's incident
+  // edges resolve to their component(s) in a single pass over those edges.
+  const componentByNodeId = new Map<string, GraphNode>();
+  baseComponents.forEach(component => {
+    component.nodes?.forEach(node => componentByNodeId.set(node.id, component));
+  });
+
+  sharedNodeIds.forEach(sharedId => {
+    const sharedNode = sharedNodesById.get(sharedId);
+    const incidentEdges = edgesBySharedNode.get(sharedId);
+    if (!sharedNode || !incidentEdges || incidentEdges.length === 0) {
+      return;
+    }
+
+    const edgesByComponent = new Map<GraphNode, GraphEdge[]>();
+    incidentEdges.forEach(edge => {
+      const otherNodeId = edge.source === sharedId ? edge.target : edge.source;
+      const component = componentByNodeId.get(otherNodeId);
+      if (!component) {
+        return;
+      }
+
+      const list = edgesByComponent.get(component) ?? [];
+      list.push(edge);
+      edgesByComponent.set(component, list);
+    });
+
+    if (edgesByComponent.size === 0) {
+      return;
+    }
+
+    // Only one component is actually touched: reattach the node as-is, no cloning needed.
+    if (edgesByComponent.size === 1) {
+      const [[component, componentEdges]] = edgesByComponent;
+      component.nodes = [...(component.nodes ?? []), sharedNode];
+      component.edges = [...(component.edges ?? []), ...componentEdges];
+      return;
+    }
+
+    // Genuinely bridges multiple components: clone the node per-component with a unique ID.
+    edgesByComponent.forEach((componentEdges, component) => {
+      const clonedId = `${sharedId}--${component.id}`;
+      component.nodes = [...(component.nodes ?? []), { ...sharedNode, id: clonedId }];
+
+      component.edges = [
+        ...(component.edges ?? []),
+        ...componentEdges.map(edge => ({
+          ...edge,
+          id: `${edge.id}--${clonedId}`,
+          source: edge.source === sharedId ? clonedId : edge.source,
+          target: edge.target === sharedId ? clonedId : edge.target,
+        })),
+      ];
+    });
+  });
+
+  return baseComponents;
+};
+
+/**
  * Identifies and groups connected components from a set of nodes and edges.
  * Connected component is a subgraph where all nodes are connected to each other
- * but not to any other node in the graph. Essentialy a separate subgraph
+ * but not to any other node in the graph. Essentially a separate subgraph.
  *
  * @param nodes - An array of `KubeObjectNode` representing the nodes in the graph
  * @param edges - An array of `GraphEdge` representing the edges in the graph
@@ -49,110 +344,23 @@ export const getGraphSize = (graph: GraphNode) => {
  */
 const getConnectedComponents = (nodes: GraphNode[], edges: GraphEdge[]): GraphNode[] => {
   const perfStart = performance.now();
-  const components: GraphNode[] = [];
 
   const lookupStart = performance.now();
   const graphLookup = makeGraphLookup(nodes, edges);
   const lookupTime = performance.now() - lookupStart;
 
-  const visitedNodes = new Set<string>();
-  const visitedEdges = new Set<string>();
-
-  /**
-   * Iteratively finds all nodes in the connected component of a given node
-   * This function performs a breadth-first search (BFS) to traverse and collect all nodes
-   * that are part of the same connected component as the provided node
-   *
-   * PERFORMANCE: Uses an index-based queue instead of Array.shift() to achieve
-   * O(1) amortized dequeue and avoid the O(n²) behavior that shift()-based
-   * queues can exhibit on large components. The resulting BFS traversal runs
-   * in O(n) time with respect to the number of nodes in the component.
-   *
-   * PERFORMANCE: Uses iterative BFS instead of recursive DFS to avoid recursion
-   * depth limits and potential stack overflows on deep or dense graphs. The
-   * iterative approach removes dependence on call stack depth and is suitable
-   * for handling large graphs safely.
-   *
-   * @param startNode - The starting node for the connected component search
-   * @param componentNodes - An array to store the nodes that are part of the connected component
-   */
-  const findConnectedComponent = (
-    startNode: GraphNode,
-    componentNodes: GraphNode[],
-    componentEdges: GraphEdge[]
-  ) => {
-    const queue: GraphNode[] = [startNode];
-    // PERFORMANCE: Index-based queue for O(1) dequeue instead of O(n) shift()
-    let queueIndex = 0;
-    visitedNodes.add(startNode.id);
-    componentNodes.push(startNode);
-
-    while (queueIndex < queue.length) {
-      const node = queue[queueIndex++]; // O(1) operation vs shift() which is O(n)
-
-      // Outgoing edges
-      const outgoing = graphLookup.getOutgoingEdges(node.id);
-      if (outgoing) {
-        for (const edge of outgoing) {
-          // Always collect the edge if we haven't yet
-          if (!visitedEdges.has(edge.id)) {
-            visitedEdges.add(edge.id);
-            componentEdges.push(edge);
-          }
-
-          // Only add to queue if we haven't visited the target node
-          if (!visitedNodes.has(edge.target)) {
-            const targetNode = graphLookup.getNode(edge.target);
-            if (targetNode) {
-              visitedNodes.add(edge.target);
-              componentNodes.push(targetNode);
-              queue.push(targetNode);
-            }
-          }
-        }
-      }
-
-      // Incoming edges
-      const incoming = graphLookup.getIncomingEdges(node.id);
-      if (incoming) {
-        for (const edge of incoming) {
-          // Always collect the edge if we haven't yet
-          if (!visitedEdges.has(edge.id)) {
-            visitedEdges.add(edge.id);
-            componentEdges.push(edge);
-          }
-
-          // Only add to queue if we haven't visited the source node
-          if (!visitedNodes.has(edge.source)) {
-            const sourceNode = graphLookup.getNode(edge.source);
-            if (sourceNode) {
-              visitedNodes.add(edge.source);
-              componentNodes.push(sourceNode);
-              queue.push(sourceNode);
-            }
-          }
-        }
-      }
-    }
-  };
-
-  // Iterate over each node and find connected components
   const componentStart = performance.now();
-  nodes.forEach(node => {
-    if (!visitedNodes.has(node.id)) {
-      const componentNodes: GraphNode[] = [];
-      const componentEdges: GraphEdge[] = [];
-      findConnectedComponent(node, componentNodes, componentEdges);
-      const mainNode = getMainNode(componentNodes);
 
-      const id = 'group-' + (mainNode?.id ?? 'unknown');
-      components.push({
-        id: id,
-        nodes: componentNodes,
-        edges: componentEdges,
-      });
-    }
-  });
+  // Nodes only reachable via nonGroupingSide-flagged edges to more than one neighbor (e.g. a
+  // ReadWriteMany PVC mounted by several unrelated Pods) must not bridge otherwise
+  // separate components together, so they're searched for and handled separately below.
+  const sharedNodeIds = findSharedNodeIds(nodes, graphLookup);
+
+  const components =
+    sharedNodeIds.size > 0
+      ? getComponentsWithSharedNodesCloned(nodes, edges, sharedNodeIds)
+      : getConnectedComponentGroups(nodes, graphLookup);
+
   const componentTime = performance.now() - componentStart;
 
   const totalTime = performance.now() - perfStart;

--- a/frontend/src/components/resourceMap/graph/graphModel.tsx
+++ b/frontend/src/components/resourceMap/graph/graphModel.tsx
@@ -82,6 +82,21 @@ export interface GraphEdge {
   label?: ReactNode;
   /** Custom data for this node */
   data?: any;
+  /**
+   * Names which endpoint of *this* edge ('source' or 'target') is allowed to be
+   * treated as a shareable resource that shouldn't bridge unrelated groups — e.g. for
+   * a PVC→Pod edge, 'source' names the PVC, not the Pod. This only changes grouping
+   * for a node when *every* edge touching it names that same node as its
+   * `nonGroupingSide` and the node touches more than one distinct neighbor (e.g. a
+   * ReadWriteMany PVC mounted by several otherwise-unrelated Deployments). Such a node
+   * is then split out of grouping and cloned back into each component it touches,
+   * instead of merging them into one.
+   *
+   * Being edge-role-specific (rather than a plain boolean flag on the edge) keeps the
+   * *other* endpoint — e.g. a Pod that happens to mount only RWX PVCs and so has no
+   * "normal" edges — from being misidentified as shareable itself.
+   */
+  nonGroupingSide?: 'source' | 'target';
 }
 
 /**
@@ -188,6 +203,16 @@ export interface Relation {
    */
   buildEdgesWithIndex?: (fromNodes: GraphNode[], nodesByUid: Map<string, GraphNode>) => GraphEdge[];
   label?: string;
+  /**
+   * Optional extra attributes to apply to an edge created by this relation
+   * when its predicate matches (e.g. marking a `nonGroupingSide`). Structural
+   * fields (`id`/`source`/`target`) are always assigned by the caller and are
+   * excluded from this callback's return type so they can't be overwritten.
+   */
+  edgeAttributes?: (
+    from: GraphNode,
+    to: GraphNode
+  ) => Partial<Omit<GraphEdge, 'id' | 'source' | 'target'>>;
 }
 
 /**

--- a/frontend/src/components/resourceMap/sources/GraphSources.test.tsx
+++ b/frontend/src/components/resourceMap/sources/GraphSources.test.tsx
@@ -240,4 +240,83 @@ describe('GraphSourceManager', () => {
       },
     ]);
   });
+
+  it('applies a relation edgeAttributes callback to the generated edge', async () => {
+    const edgeAttributes = vi.fn(() => ({ nonGroupingSide: 'source' as const }));
+
+    render(
+      <GraphSourceManager
+        sources={[
+          source('first', { nodes: [{ id: 'first-node' }] }),
+          source('second', { nodes: [{ id: 'second-node' }] }),
+        ]}
+        relations={[
+          {
+            id: 'first-second',
+            fromSource: 'first',
+            toSource: 'second',
+            predicate: () => true,
+            edgeAttributes,
+          },
+        ]}
+      >
+        <Probe />
+      </GraphSourceManager>
+    );
+
+    await waitFor(() => expect(context.isLoading).toBe(false));
+    expect(edgeAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'first-node' }),
+      expect.objectContaining({ id: 'second-node' })
+    );
+    expect(context.edges).toEqual([
+      {
+        id: 'first-node-second-node-first-second',
+        source: 'first-node',
+        target: 'second-node',
+        label: undefined,
+        nonGroupingSide: 'source',
+      },
+    ]);
+  });
+
+  it('does not let a relation edgeAttributes callback override the generated id/source/target', async () => {
+    // edgeAttributes is typed to exclude these fields, but nothing stops a
+    // dynamically-loaded plugin relation from returning them anyway at runtime.
+    const edgeAttributes = vi.fn(() => ({
+      id: 'hijacked-id',
+      source: 'nonexistent-node',
+      target: 'nonexistent-node',
+    })) as unknown as Relation['edgeAttributes'];
+
+    render(
+      <GraphSourceManager
+        sources={[
+          source('first', { nodes: [{ id: 'first-node' }] }),
+          source('second', { nodes: [{ id: 'second-node' }] }),
+        ]}
+        relations={[
+          {
+            id: 'first-second',
+            fromSource: 'first',
+            toSource: 'second',
+            predicate: () => true,
+            edgeAttributes,
+          },
+        ]}
+      >
+        <Probe />
+      </GraphSourceManager>
+    );
+
+    await waitFor(() => expect(context.isLoading).toBe(false));
+    expect(context.edges).toEqual([
+      {
+        id: 'first-node-second-node-first-second',
+        source: 'first-node',
+        target: 'second-node',
+        label: undefined,
+      },
+    ]);
+  });
 });

--- a/frontend/src/components/resourceMap/sources/GraphSources.tsx
+++ b/frontend/src/components/resourceMap/sources/GraphSources.tsx
@@ -345,10 +345,14 @@ export function GraphSourceManager({ sources, children, relations }: GraphSource
           toNodes.forEach(to => {
             if (relation.predicate(from, to)) {
               edges.push({
+                label: relation.label,
+                ...relation.edgeAttributes?.(from, to),
+                // Structural fields are authoritative and must win over a relation's
+                // edgeAttributes: otherwise a Partial<GraphEdge> that (accidentally or
+                // not) sets id/source/target could corrupt deduplication or topology.
                 id: from.id + '-' + to.id + '-' + relation.id,
                 source: from.id,
                 target: to.id,
-                label: relation.label,
               });
             }
           });

--- a/frontend/src/components/resourceMap/sources/definitions/relations.test.tsx
+++ b/frontend/src/components/resourceMap/sources/definitions/relations.test.tsx
@@ -20,6 +20,7 @@ import ConfigMap from '../../../../lib/k8s/configMap';
 import CRD from '../../../../lib/k8s/crd';
 import Gateway from '../../../../lib/k8s/gateway';
 import { KubeObject, KubeObjectClass } from '../../../../lib/k8s/KubeObject';
+import PersistentVolumeClaim from '../../../../lib/k8s/persistentVolumeClaim';
 import Pod from '../../../../lib/k8s/pod';
 import Secret from '../../../../lib/k8s/secret';
 import Service from '../../../../lib/k8s/service';
@@ -445,5 +446,26 @@ describe('useGetAllRelations', () => {
         node(new KubeObject({ metadata: { uid: 'other' } } as any, 'cluster-a'))
       )
     ).toBe(false);
+  });
+
+  it('marks pvc-pod edges as nonGroupingSide for RWX PVCs only', () => {
+    vi.spyOn(CRD, 'useList').mockReturnValue({ items: null } as ReturnType<typeof CRD.useList>);
+    const { result } = renderUseGetAllRelations();
+    const relation = relationById(result.current, 'pvc-pod');
+    const matchingPod = pod({ uid: 'pod', name: 'pod', namespace: 'namespace-a' }, {}, 'cluster-a');
+
+    const pvc = (accessModes: string[]) =>
+      new PersistentVolumeClaim(
+        {
+          metadata: { uid: 'pvc', name: 'pvc', namespace: 'namespace-a' },
+          spec: { accessModes, resources: { requests: {} } },
+        } as any,
+        'cluster-a'
+      );
+
+    expect(relation.edgeAttributes?.(node(pvc(['ReadWriteMany'])), node(matchingPod))).toEqual({
+      nonGroupingSide: 'source',
+    });
+    expect(relation.edgeAttributes?.(node(pvc(['ReadWriteOnce'])), node(matchingPod))).toEqual({});
   });
 });

--- a/frontend/src/components/resourceMap/sources/definitions/relations.tsx
+++ b/frontend/src/components/resourceMap/sources/definitions/relations.tsx
@@ -72,7 +72,11 @@ const makeRelation = <From extends KubeObjectClass, To extends KubeObjectClass>(
   id: string,
   from: From,
   to: To,
-  selector: (a: InstanceType<From>, b: InstanceType<To>) => unknown
+  selector: (a: InstanceType<From>, b: InstanceType<To>) => unknown,
+  edgeAttributes?: (
+    a: InstanceType<From>,
+    b: InstanceType<To>
+  ) => Partial<Omit<GraphEdge, 'id' | 'source' | 'target'>>
 ): Relation => ({
   id,
   fromSource: makeKubeSourceId(from),
@@ -92,6 +96,13 @@ const makeRelation = <From extends KubeObjectClass, To extends KubeObjectClass>(
       Boolean(selector(fromObject, toObject))
     );
   },
+  edgeAttributes: edgeAttributes
+    ? (fromNode, toNode) =>
+        edgeAttributes(
+          fromNode.kubeObject as InstanceType<From>,
+          toNode.kubeObject as InstanceType<To>
+        )
+    : undefined,
 });
 
 const makeOwnerRelation = (cl: KubeObjectClass): Relation => ({
@@ -296,8 +307,18 @@ const serviceAccountToDaemonSets = makeRelation(
     ds.metadata.namespace === sa.metadata.namespace
 );
 
-const pvcToPods = makeRelation('pvc-pod', PersistentVolumeClaim, Pod, (pvc, pod) =>
-  pod.spec.volumes?.find(volume => volume.persistentVolumeClaim?.claimName === pvc.metadata.name)
+const pvcToPods = makeRelation(
+  'pvc-pod',
+  PersistentVolumeClaim,
+  Pod,
+  (pvc, pod) =>
+    pod.spec.volumes?.find(volume => volume.persistentVolumeClaim?.claimName === pvc.metadata.name),
+  // A ReadWriteMany PVC can be mounted by many otherwise-unrelated Pods; don't let
+  // it bridge their components into one giant group (see #4310). 'source' names the
+  // PVC (this relation's `from`), not the Pod, as the one allowed to be shared/split.
+  // eslint-disable-next-line no-unused-vars
+  (pvc, _pod) =>
+    pvc.spec?.accessModes?.includes('ReadWriteMany') ? { nonGroupingSide: 'source' } : {}
 );
 
 const podToOwner = makeOwnerRelation(Pod);


### PR DESCRIPTION
## Summary

Fixes Resource Map grouping when multiple unrelated workloads share a `ReadWriteMany` (RWX) `PersistentVolumeClaim`. Previously, a shared RWX PVC could bridge otherwise unrelated components into a single group. This adds a generic `isNonGrouping` edge flag (per review feedback from @sniok, instead of hardcoding PVC-specific logic in `graphGrouping`), and marks PVC→Pod edges as non-grouping when the PVC is RWX. Nodes only reachable via non-grouping edges to more than one neighbor are split out of connected-component detection and cloned back into each component they touch, so every group keeps showing its own copy of the shared resource without merging with unrelated workloads.

This is a continuation of #4499 (by @devsubid), rebased against latest `main` and reworked to:
- Use the generic `isNonGrouping` edge flag suggested by @sniok instead of PVC-specific grouping logic.
- Address outstanding Copilot review comments (JSDoc on new helpers, avoid unnecessary `as any`, fix edge direction in tests, avoid redundant checks).
- Rebase cleanly onto current `main`, which has since gained a BFS/perf-instrumented `getConnectedComponents` — the fix is adapted to preserve that instrumentation.

Fixes #4310

## Screenshots

Two unrelated Deployments (`web-frontend`, `report-generator`) mounting the same RWX PVC (`shared-uploads`), same live cluster, same namespace, same viewport — only this fix applied differs between the two:

**Before** — both workloads collapse into a single connected group, bridged by the shared PVC:

<img width="1310" height="393" alt="Before the fix: web-frontend and report-generator merged into one group via the shared RWX PVC" src="https://raw.githubusercontent.com/rootp1/headlamp/rootp1/pr-screenshots/pr-7241-before.png" />

**After** — each workload stays in its own group, each with its own copy of the PVC node:

<img width="1310" height="384" alt="After the fix: web-frontend and report-generator in two separate groups, each with its own shared-uploads PVC node" src="https://raw.githubusercontent.com/rootp1/headlamp/rootp1/pr-screenshots/pr-7241-after.png" />
