### PR TITLE
frontend: show all node capacity/allocatable keys, not just a hardcoded list

### DIFF
--- a/frontend/src/components/node/Details.tsx
+++ b/frontend/src/components/node/Details.tsx
@@ -349,10 +349,11 @@ export default function NodeDetails(props: { name?: string; cluster?: string }) 
           if (!item) return [];
           const roles = item.getRoles();
           const nodePool = item.getNodePool();
-          // The keys of interest are reported by the API in kebab-case.
-          const reportedKeys = ['cpu', 'memory', 'pods', 'ephemeral-storage'];
+          // Show every resource the API reports (cpu, memory, pods, ephemeral-storage,
+          // hugepages-*, extended resources like nvidia.com/gpu, etc.), not just a
+          // fixed subset, so device/GPU/hugepage capacity isn't silently hidden.
           const pickResources = (res: { [key: string]: string } = {}) =>
-            Object.fromEntries(reportedKeys.filter(key => res[key]).map(key => [key, res[key]]));
+            Object.fromEntries(Object.entries(res).filter(([, value]) => !!value));
           const capacity = pickResources(item.status?.capacity);
           const allocatable = pickResources(item.status?.allocatable);
 

--- a/frontend/src/components/node/__snapshots__/Details.Default.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/Details.Default.stories.storyshot
@@ -880,17 +880,27 @@
                         <p
                           class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
                         >
+                          ephemeral-storage: 50000000Ki
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          hugepages-1Gi: 0
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          hugepages-2Mi: 0
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
                           memory: 8000000Ki
                         </p>
                         <p
                           class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
                         >
                           pods: 110
-                        </p>
-                        <p
-                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
-                        >
-                          ephemeral-storage: 50000000Ki
                         </p>
                       </div>
                     </div>
@@ -917,17 +927,27 @@
                         <p
                           class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
                         >
+                          ephemeral-storage: 50000000Ki
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          hugepages-1Gi: 0
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          hugepages-2Mi: 0
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
                           memory: 8000000Ki
                         </p>
                         <p
                           class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
                         >
                           pods: 110
-                        </p>
-                        <p
-                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
-                        >
-                          ephemeral-storage: 50000000Ki
                         </p>
                       </div>
                     </div>

--- a/frontend/src/components/node/__snapshots__/Details.NoMetrics.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/Details.NoMetrics.stories.storyshot
@@ -880,17 +880,27 @@
                         <p
                           class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
                         >
+                          ephemeral-storage: 50000000Ki
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          hugepages-1Gi: 0
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          hugepages-2Mi: 0
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
                           memory: 8000000Ki
                         </p>
                         <p
                           class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
                         >
                           pods: 110
-                        </p>
-                        <p
-                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
-                        >
-                          ephemeral-storage: 50000000Ki
                         </p>
                       </div>
                     </div>
@@ -917,17 +927,27 @@
                         <p
                           class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
                         >
+                          ephemeral-storage: 50000000Ki
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          hugepages-1Gi: 0
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          hugepages-2Mi: 0
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
                           memory: 8000000Ki
                         </p>
                         <p
                           class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
                         >
                           pods: 110
-                        </p>
-                        <p
-                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
-                        >
-                          ephemeral-storage: 50000000Ki
                         </p>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary

This PR fixes a bug where Node Details' "Capacity" and "Allocatable" sections only showed a hardcoded set of resource keys, hiding hugepages and extended resources like GPUs.

## Related Issue

Fixes #7244

## Changes

- Fixed Node Details `Capacity`/`Allocatable` sections filtering resources through a hardcoded 4-key list (`cpu`, `memory`, `pods`, `ephemeral-storage`)
- Replaced it with a generic filter that shows every non-empty key reported by `status.capacity`/`status.allocatable`, so hugepages (`hugepages-2Mi`, `hugepages-1Gi`) and extended resources like GPUs (`nvidia.com/gpu`, `amd.com/gpu`) are no longer silently dropped

## Steps to Test

1. Open a node whose `status.capacity`/`status.allocatable` has a key outside `cpu`, `memory`, `pods`, `ephemeral-storage` (e.g. a node with hugepages or GPU resources)
2. Go to that node's Details page in Headlamp
3. Check the "Capacity" and "Allocatable" sections — all reported keys should now be visible, not just the previous 4

## Screenshots (if applicable)

N/A (type/data-only change)



