### PR TITLE
0034: frontend: themes: Improve dark-theme warning alert contrast

### DIFF
--- a/e2e-tests/tests/podsPage.spec.ts
+++ b/e2e-tests/tests/podsPage.spec.ts
@@ -196,6 +196,10 @@ test('warns and preserves edits when a pod is modified externally', async ({ pag
   const tempDirectory = await mkdtemp(join(tmpdir(), 'headlamp-e2e-'));
   const kubeconfig = join(tempDirectory, 'kubeconfig');
 
+  await page.addInitScript(() => {
+    window.localStorage.setItem('headlampThemePreference', 'Dark');
+  });
+
   try {
     const { stdout } = await execFileAsync('kind', ['get', 'kubeconfig', '--name', 'test']);
     await writeFile(kubeconfig, stdout);
@@ -252,11 +256,12 @@ test('warns and preserves edits when a pod is modified externally', async ({ pag
       '--overwrite'
     );
 
-    await expect(
-      page.getByText(
-        'This resource was modified while you were editing. Your changes may conflict with the latest version.'
-      )
-    ).toBeVisible({ timeout: 15000 });
+    const warningAlert = page.getByRole('alert').filter({
+      hasText:
+        'This resource was modified while you were editing. Your changes may conflict with the latest version.',
+    });
+    await expect(warningAlert).toBeVisible({ timeout: 15000 });
+    await expect(warningAlert).toHaveClass(/MuiAlert-standardWarning/);
     await expect(editor).toHaveValue(editedYaml);
   } finally {
     await kubectl(

--- a/frontend/src/lib/themes.test.ts
+++ b/frontend/src/lib/themes.test.ts
@@ -35,6 +35,18 @@ describe('themes.ts', () => {
       expect(theme.palette.background.default).toBe('#1f1f1f');
     });
 
+    it('should keep warning alerts readable in the dark theme', () => {
+      const theme = createMuiTheme({ base: 'dark', name: 'Dark Theme' });
+
+      expect(theme.components?.MuiAlert?.styleOverrides?.standardWarning).toEqual({
+        backgroundColor: 'rgba(255, 152, 0, 0.12)',
+        color: '#fff3e0',
+        '& .MuiAlert-icon': {
+          color: '#ffb74d',
+        },
+      });
+    });
+
     it('should set searchHint defaults for light and dark themes', () => {
       const lightTheme = createMuiTheme({ base: 'light', name: 'Light Theme' });
       const darkTheme = createMuiTheme({ base: 'dark', name: 'Dark Theme' });

--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -534,6 +534,17 @@ export function createMuiTheme(currentTheme: AppTheme) {
             underline: 'hover' as 'always' | 'hover' | 'none',
           },
         },
+        MuiAlert: {
+          styleOverrides: {
+            standardWarning: {
+              backgroundColor: 'rgba(255, 152, 0, 0.12)',
+              color: orange[50],
+              '& .MuiAlert-icon': {
+                color: orange[300],
+              },
+            },
+          },
+        },
         MuiSwitch: {
           styleOverrides: {
             root: {


### PR DESCRIPTION
## Summary

Improve the contrast of standard warning alerts in Headlamp's dark theme by
setting explicit background, text, and icon colors.

Add regression coverage for the generated MUI theme and exercise a real warning
alert in Headlamp's dark theme through the existing pod edit-conflict e2e flow.

## Related Work

- Original change: [Azure/aks-desktop#454](https://github.com/Azure/aks-desktop/pull/454)
- Original commit: [`6c8f0018f71a9e91faad3f872c5f9aa7034995a4`](https://github.com/Azure/aks-desktop/commit/6c8f0018f71a9e91faad3f872c5f9aa7034995a4)
- Rebasing source commit: [`0570f3a314184796634c1676bbcdaf4ab9b16b57`](https://github.com/Azure/aks-desktop/commit/0570f3a314184796634c1676bbcdaf4ab9b16b57)
- Retained patch commit: `b6fa2371d832c2b85bf752d4ede3c3b57527c886`
- Patch-series PR: [Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823)
- Related downstream issue: [Azure/aks-desktop#153](https://github.com/Azure/aks-desktop/issues/153)

## Changes

- Override dark-theme `MuiAlert` standard warning colors.
- Add a focused unit regression test for the generated warning styles.
- Run the existing pod edit-conflict warning flow in the dark theme and verify
  that it renders the standard warning alert variant.

## Improvements Over Existing Changes

- Adds e2e coverage that was not present in the original Azure change.
- Retains the focused unit regression test from patch 0034 on current Headlamp
  main.
- Verifies `frontend/src/lib/themes.ts` at 91.48% branch coverage, above the
  requested 80% threshold.
- Keeps the e2e coverage in a separate commit before the visual implementation
  commit for easier review.

## Testing

- `npx vitest run src/lib/themes.test.ts --coverage --coverage.include=src/lib/themes.ts --coverage.reporter=text`
  - 22 tests passed
  - 91.48% branch coverage for `themes.ts`
- `npm run tsc`
- `npx prettier --config package.json --check src/lib/themes.ts src/lib/themes.test.ts ../e2e-tests/tests/podsPage.spec.ts`
- `npx playwright test tests/podsPage.spec.ts --list`
  - 5 tests discovered with no TypeScript or configuration errors

The live-cluster Playwright test was not run locally because Docker was stopped
and no `HEADLAMP_TEST_URL` or `HEADLAMP_TEST_TOKEN` was configured.

## Screenshots

### Original screenshots

Original dark-theme warning alert screenshots from
[Azure/aks-desktop#454](https://github.com/Azure/aks-desktop/pull/454):

| Before | After |
| --- | --- |
| ![Warning alert before the contrast change](https://github.com/user-attachments/assets/044116c6-7899-4217-95b8-00b8c2e1871e) | ![Warning alert after the contrast change](https://github.com/user-attachments/assets/dd504ac0-c924-45a7-9db7-f439535d2bd3) |

### Fresh captures

New captures rendered with Headlamp's real dark `createMuiTheme` and MUI
`Alert`. The baseline uses upstream commit `d48d9abbf`; the updated capture uses
this PR's commit `168201dc1`.

| New baseline capture | New PR capture |
| --- | --- |
| ![New baseline capture showing low-contrast dark-theme warning text](https://raw.githubusercontent.com/illume/headlamp/9c286a482ce71b2885b6e5a78b709b20140a5f48/pr-screenshots/7247/dark-alert-before.png) | ![New PR capture showing readable dark-theme warning text](https://raw.githubusercontent.com/illume/headlamp/9c286a482ce71b2885b6e5a78b709b20140a5f48/pr-screenshots/7247/dark-alert-after.png) |

## Notes for the Reviewer

The implementation commit preserves the original author and author date and
adds René Dudfield as co-author.

Assisted by copilot
