### PR TITLE
0031: backend: Make backend application name configurable

### DIFF
--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -50,13 +50,14 @@ func main() {
 		return
 	}
 
-	conf, err := config.Parse(os.Args)
+	conf, err := config.ParseWithAppNameDefault(os.Args, kubeconfig.AppName)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "fetching config:%v")
 		os.Exit(1)
 	}
 
 	logger.Init(conf.LogLevel)
+	kubeconfig.AppName = conf.AppName
 
 	if conf.Version {
 		fmt.Printf("%s %s (%s/%s)\n", kubeconfig.AppName, kubeconfig.Version, runtime.GOOS, runtime.GOARCH)

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -37,6 +37,7 @@ const (
 
 type Config struct {
 	Version              bool   `koanf:"version"`
+	AppName              string `koanf:"app-name"`
 	InCluster            bool   `koanf:"in-cluster"`
 	InClusterContextName string `koanf:"in-cluster-context-name"`
 	DevMode              bool   `koanf:"dev"`
@@ -122,6 +123,10 @@ func (c *Config) warnRedundantThemeDefaults() {
 }
 
 func (c *Config) Validate() error {
+	if err := c.validateAppName(); err != nil {
+		return err
+	}
+
 	if !c.InCluster && !c.OidcUseCookie && (c.OidcClientID != "" || c.OidcClientSecret != "" || c.OidcIdpIssuerURL != "" ||
 		c.OidcValidatorClientID != "" || c.OidcValidatorIdpIssuerURL != "") {
 		return errors.New("oidc-client-id, oidc-client-secret, oidc-idp-issuer-url, " +
@@ -154,7 +159,6 @@ func (c *Config) Validate() error {
 	}
 
 	const oneYearInSeconds = 31536000
-
 	if c.SessionTTL > oneYearInSeconds {
 		return errors.New("session-ttl cannot be greater than 1 year")
 	}
@@ -178,6 +182,18 @@ func (c *Config) Validate() error {
 
 	if err := c.validateClusterInventory(); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// validateAppName ensures the application name is safe for use in Kubernetes User-Agent headers.
+func (c *Config) validateAppName() error {
+	for index := 0; index < len(c.AppName); index++ {
+		character := c.AppName[index]
+		if (character < ' ' && character != '\t') || character == 0x7f {
+			return errors.New("app-name contains invalid HTTP header characters")
+		}
 	}
 
 	return nil
@@ -407,9 +423,14 @@ func setMeDefaults(config *Config) {
 // the value of port will be 3456.
 
 func Parse(args []string) (*Config, error) {
+	return ParseWithAppNameDefault(args, "Headlamp")
+}
+
+// ParseWithAppNameDefault loads the config using appName as the application name default.
+func ParseWithAppNameDefault(args []string, appName string) (*Config, error) {
 	var config Config
 
-	f := flagset()
+	f := flagset(appName)
 
 	k := koanf.New(".")
 
@@ -526,10 +547,10 @@ func validateOpenBrowser(config *Config, explicitFlags map[string]bool) error {
 	return nil
 }
 
-func flagset() *flag.FlagSet {
+func flagset(appName string) *flag.FlagSet {
 	f := flag.NewFlagSet("config", flag.ContinueOnError)
 
-	addGeneralFlags(f)
+	addGeneralFlags(f, appName)
 	addOIDCFlags(f)
 	addProxyAuthFlags(f)
 	addTelemetryFlags(f)
@@ -538,8 +559,9 @@ func flagset() *flag.FlagSet {
 	return f
 }
 
-func addGeneralFlags(f *flag.FlagSet) {
+func addGeneralFlags(f *flag.FlagSet, appName string) {
 	f.Bool("version", false, "Print version information and exit")
+	f.String("app-name", appName, "Application name used in version output and Kubernetes User-Agent headers")
 	f.Bool("in-cluster", false, "Set when running from a k8s cluster")
 	f.String("in-cluster-context-name", "",
 		"Name to use for the in-cluster Kubernetes context. "+

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -132,6 +132,91 @@ func TestParseBasic(t *testing.T) {
 	}
 }
 
+func TestParseAppName(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		defaultAppName string
+		envValue       string
+		expected       string
+	}{
+		{
+			name:           "default",
+			defaultAppName: "Headlamp",
+			expected:       "Headlamp",
+		},
+		{
+			name:           "linker default",
+			defaultAppName: "Branded Headlamp",
+			expected:       "Branded Headlamp",
+		},
+		{
+			name:           "environment",
+			defaultAppName: "Branded Headlamp",
+			envValue:       "Environment Headlamp",
+			expected:       "Environment Headlamp",
+		},
+		{
+			name:           "flag overrides environment",
+			args:           []string{"headlamp-server", "--app-name=Flag Headlamp"},
+			defaultAppName: "Branded Headlamp",
+			envValue:       "Environment Headlamp",
+			expected:       "Flag Headlamp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue == "" {
+				require.NoError(t, os.Unsetenv("HEADLAMP_CONFIG_APP_NAME"))
+				t.Cleanup(func() {
+					_ = os.Unsetenv("HEADLAMP_CONFIG_APP_NAME")
+				})
+			} else {
+				t.Setenv("HEADLAMP_CONFIG_APP_NAME", tt.envValue)
+			}
+
+			conf, err := config.ParseWithAppNameDefault(tt.args, tt.defaultAppName)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, conf.AppName)
+		})
+	}
+}
+
+func TestParseInvalidAppName(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		envValue string
+	}{
+		{
+			name: "carriage return from flag",
+			args: []string{"headlamp-server", "--app-name=Headlamp\rInjected"},
+		},
+		{
+			name:     "line feed from environment",
+			args:     []string{"headlamp-server"},
+			envValue: "Headlamp\nInjected",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue == "" {
+				require.NoError(t, os.Unsetenv("HEADLAMP_CONFIG_APP_NAME"))
+				t.Cleanup(func() {
+					_ = os.Unsetenv("HEADLAMP_CONFIG_APP_NAME")
+				})
+			} else {
+				t.Setenv("HEADLAMP_CONFIG_APP_NAME", tt.envValue)
+			}
+
+			_, err := config.Parse(tt.args)
+			require.ErrorContains(t, err, "app-name contains invalid HTTP header characters")
+		})
+	}
+}
+
 var ParseWithEnvTests = []struct {
 	name   string
 	args   []string

--- a/e2e-tests/tests/backendAppName.spec.ts
+++ b/e2e-tests/tests/backendAppName.spec.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+/** Executes a command without invoking a shell. */
+const execFileAsync = promisify(execFile);
+
+test('backend uses the configured application name', async () => {
+  const appName = 'E2E Headlamp';
+  const tempDirectory = await mkdtemp(join(tmpdir(), 'headlamp-e2e-'));
+  const kubeconfig = join(tempDirectory, 'kubeconfig');
+
+  try {
+    const { stdout: kindKubeconfig } = await execFileAsync('kind', [
+      'get',
+      'kubeconfig',
+      '--name',
+      'test',
+    ]);
+    await writeFile(kubeconfig, kindKubeconfig);
+
+    const { stdout } = await execFileAsync('kubectl', [
+      '--kubeconfig',
+      kubeconfig,
+      '--context=kind-test',
+      'exec',
+      '--namespace=kube-system',
+      'deployment/headlamp',
+      '--',
+      'env',
+      `HEADLAMP_CONFIG_APP_NAME=${appName}`,
+      '/headlamp/headlamp-server',
+      '--version',
+    ]);
+
+    expect(stdout).toMatch(new RegExp(`^${appName} \\S+ \\(linux/\\S+\\)\\n$`));
+  } finally {
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Make the backend application name configurable with `--app-name` or
`HEADLAMP_CONFIG_APP_NAME` while retaining `Headlamp` as the default.

The configured name is used by `--version` output and Kubernetes User-Agent
headers, allowing branded distributions to avoid carrying a backend fork.

## Source provenance

- [Azure/aks-desktop#696](https://github.com/Azure/aks-desktop/pull/696)
  introduced the downstream `AKS-desktop` backend name in
  [commit 73e75e2](https://github.com/Azure/aks-desktop/commit/73e75e235685069724a63d72a18087865074a57c)
  by Oleksandr Dubenko.
- [Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823) carries
  the upstreamable change as patch 0031, generated
  from commit `3927ae61711b7118158946631b0179d18191782d` by Oleksandr Dubenko.
- The feature commit in this PR preserves the patch author's identity and author
  date and adds René Dudfield as co-author.

## Improvements over the existing changes

- Replaces the downstream hardcoded product name with reusable configuration.
- Preserves upstream behavior through the `Headlamp` default.
- Covers the default, environment, and explicit flag precedence paths.
- Adds a container-level e2e check against the packaged backend binary.
- Keeps implementation and tests in one independently testable commit.

## Testing

- `cd backend && go test ./...`
- `npm run backend:lint`
- `cd backend && go test -coverprofile=$TMPDIR/headlamp-0031.out ./pkg/config`
  reports 87.2% statement coverage. Go's built-in coverage does not report
  branch coverage; all application-name precedence decisions are covered.
- `cd e2e-tests && npx playwright test tests/backendAppName.spec.ts --list`
  discovers the new test. The live test runs in the existing kind-based
  container e2e workflow.

This is a backend-only configuration change with no visual difference, so
screenshots are not applicable.

Assisted by copilot.
