### PR TITLE
frontend: DropZoneBox: Fix aria-allowed-role in Upload Files story

### DIFF
--- a/frontend/.axe-storybook-baseline.test-a11y.json
+++ b/frontend/.axe-storybook-baseline.test-a11y.json
@@ -43,7 +43,6 @@
       "scrollable-region-focusable",
       "aria-input-field-name"
     ],
-    "DropZoneBox/Upload Files": ["aria-allowed-role"],
     "common/Loader/With Empty Title": ["aria-progressbar-name"],
     "common/ReleaseNotes/ReleaseNotes/Default": ["heading-order"],
     "common/ReleaseNotes/ReleaseNotesModal/Show": ["heading-order", "scrollable-region-focusable"],

--- a/frontend/src/components/common/DropZoneBox.stories.tsx
+++ b/frontend/src/components/common/DropZoneBox.stories.tsx
@@ -18,7 +18,6 @@ import { InlineIcon } from '@iconify/react';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import { Meta, StoryFn } from '@storybook/react';
-import React from 'react';
 import { DropZoneBox } from './DropZoneBox';
 
 export default {
@@ -29,19 +28,26 @@ export default {
 const Template: StoryFn<typeof DropZoneBox> = args => <DropZoneBox {...args} />;
 
 const UploadFilesContent = () => {
-  const fileInputRef = React.useRef<HTMLInputElement>(null);
   return (
     <>
       <Typography sx={{ m: 2 }}>{'Select a file or drag and drop here'}</Typography>
-      <input type="file" hidden ref={fileInputRef} />
-      <Button
-        variant="contained"
-        onClick={() => fileInputRef.current?.click()}
-        startIcon={<InlineIcon icon="mdi:upload" width={32} />}
-        sx={{ fontWeight: 500 }}
-      >
-        {'Select File'}
-      </Button>
+      <label>
+        <input type="file" hidden />
+        <Button
+          variant="contained"
+          component="span"
+          onKeyDown={event => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              event.currentTarget.click();
+            }
+          }}
+          startIcon={<InlineIcon icon="mdi:upload" width={32} />}
+          sx={{ fontWeight: 500 }}
+        >
+          {'Select File'}
+        </Button>
+      </label>
     </>
   );
 };

--- a/frontend/src/components/common/__snapshots__/DropZoneBox.UploadFiles.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/DropZoneBox.UploadFiles.stories.storyshot
@@ -8,23 +8,25 @@
       >
         Select a file or drag and drop here
       </p>
-      <input
-        hidden=""
-        type="file"
-      />
-      <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-17g4n8r-MuiButtonBase-root-MuiButton-root"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1d6wzja-MuiButton-startIcon"
+      <label>
+        <input
+          hidden=""
+          type="file"
         />
-        Select File
         <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
-      </button>
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-17g4n8r-MuiButtonBase-root-MuiButton-root"
+          role="button"
+          tabindex="0"
+        >
+          <span
+            class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1d6wzja-MuiButton-startIcon"
+          />
+          Select File
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </span>
+      </label>
     </div>
   </div>
 </body>


### PR DESCRIPTION
## Summary

The Upload Files story used a `Button` with `onClick` + `ref.click()` to trigger a hidden file input. This caused an `aria-allowed-role` violation because the button role was applied where a label association was more appropriate.

Replaced the `Button` + `ref.click()` pattern with a `<label>` wrapping the hidden input and a `Button` with `component="span"`, which is the correct semantic pattern for file upload triggers.

## Related Issue

Fixes #7187

## Changes

- Replaced `Button` + `useRef` + `ref.click()` with `<label>` + `<input>` + `Button component="span"`
- Removed unused `React` import
- Removed `DropZoneBox/Upload Files` from the a11y baseline

## Steps to Test

1. Run `cd frontend && npm run test:a11y` — `DropZoneBox/Upload Files` no longer reports `aria-allowed-role`
2. Run `npm run frontend:test` — all storyshots pass
3. Open Storybook, navigate to DropZoneBox → Upload Files, verify the Select File button still works