### PR TITLE
0009: app: electron: Read protocol scheme from product metadata

### DIFF
--- a/app/e2e-tests/tests/protocolScheme.spec.ts
+++ b/app/e2e-tests/tests/protocolScheme.spec.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import path from 'node:path';
+import { _electron, ElectronApplication, Page } from 'playwright';
+
+const electronExecutable = process.platform === 'win32' ? 'electron.cmd' : 'electron';
+const electronPath = path.resolve(__dirname, `../../node_modules/.bin/${electronExecutable}`);
+const appPath = path.resolve(__dirname, '../../');
+
+let electronApp: ElectronApplication;
+let electronPage: Page;
+
+test.describe('desktop protocol scheme', () => {
+  test.skip(process.env.PLAYWRIGHT_TEST_MODE !== 'app', 'Requires Electron app mode');
+
+  test.beforeAll(async () => {
+    const electronEnv: Record<string, string> = {};
+    for (const [name, value] of Object.entries(process.env)) {
+      if (name !== 'ELECTRON_RUN_AS_NODE' && value !== undefined) {
+        electronEnv[name] = value;
+      }
+    }
+
+    electronApp = await _electron.launch({
+      cwd: appPath,
+      executablePath: electronPath,
+      args: ['.'],
+      env: {
+        ...electronEnv,
+        NODE_ENV: 'development',
+        ELECTRON_DEV: 'true',
+      },
+    });
+    electronPage = await electronApp.firstWindow();
+    await electronPage.waitForLoadState('load');
+  });
+
+  test.afterAll(async () => {
+    await electronApp?.close();
+  });
+
+  test('routes a headlamp protocol URL in the desktop app', async () => {
+    await electronApp.evaluate(({ app }, deepLink) => {
+      app.emit('open-url', {} as Electron.Event, deepLink);
+    }, 'headlamp://cluster?name=local');
+
+    await expect.poll(() => electronPage.url()).toMatch(/#\/cluster\?name=local$/);
+  });
+});

--- a/app/e2e-tests/tests/protocolScheme.spec.ts
+++ b/app/e2e-tests/tests/protocolScheme.spec.ts
@@ -15,20 +15,30 @@
  */
 
 import { expect, test } from '@playwright/test';
+import fs from 'node:fs';
 import path from 'node:path';
 import { _electron, ElectronApplication, Page } from 'playwright';
 
 const electronExecutable = process.platform === 'win32' ? 'electron.cmd' : 'electron';
 const electronPath = path.resolve(__dirname, `../../node_modules/.bin/${electronExecutable}`);
 const appPath = path.resolve(__dirname, '../../');
+const manifestPath = path.join(appPath, 'app-build-manifest.json');
 
 let electronApp: ElectronApplication;
 let electronPage: Page;
+let originalManifest: string;
 
 test.describe('desktop protocol scheme', () => {
   test.skip(process.env.PLAYWRIGHT_TEST_MODE !== 'app', 'Requires Electron app mode');
 
   test.beforeAll(async () => {
+    originalManifest = fs.readFileSync(manifestPath, 'utf8');
+    const productManifest = JSON.parse(originalManifest);
+    fs.writeFileSync(
+      manifestPath,
+      JSON.stringify({ ...productManifest, protocolScheme: 'test-headlamp' }, null, 2) + '\n'
+    );
+
     const electronEnv: Record<string, string> = {};
     for (const [name, value] of Object.entries(process.env)) {
       if (name !== 'ELECTRON_RUN_AS_NODE' && value !== undefined) {
@@ -39,7 +49,7 @@ test.describe('desktop protocol scheme', () => {
     electronApp = await _electron.launch({
       cwd: appPath,
       executablePath: electronPath,
-      args: ['.'],
+      args: ['.', 'test-headlamp://cluster?name=startup'],
       env: {
         ...electronEnv,
         NODE_ENV: 'development',
@@ -52,13 +62,29 @@ test.describe('desktop protocol scheme', () => {
 
   test.afterAll(async () => {
     await electronApp?.close();
+    fs.writeFileSync(manifestPath, originalManifest);
   });
 
-  test('routes a headlamp protocol URL in the desktop app', async () => {
+  test('routes a product protocol URL from the startup command line', async () => {
+    await expect.poll(() => electronPage.url()).toMatch(/#\/cluster\?name=startup$/);
+  });
+
+  test('routes a product protocol URL in the desktop app', async () => {
     await electronApp.evaluate(({ app }, deepLink) => {
-      app.emit('open-url', {} as Electron.Event, deepLink);
-    }, 'headlamp://cluster?name=local');
+      app.emit('open-url', { preventDefault() {} } as Electron.Event, deepLink);
+    }, 'test-headlamp://cluster?name=local');
 
     await expect.poll(() => electronPage.url()).toMatch(/#\/cluster\?name=local$/);
+  });
+
+  test('routes a product protocol URL from a second instance', async () => {
+    await electronApp.evaluate(
+      ({ app }, commandLine) => {
+        app.emit('second-instance', {} as Electron.Event, commandLine, process.cwd(), {});
+      },
+      ['electron', '.', 'test-headlamp://cluster?name=secondary']
+    );
+
+    await expect.poll(() => electronPage.url()).toMatch(/#\/cluster\?name=secondary$/);
   });
 });

--- a/app/e2e-tests/tests/protocolScheme.spec.ts
+++ b/app/e2e-tests/tests/protocolScheme.spec.ts
@@ -36,7 +36,17 @@ test.describe('desktop protocol scheme', () => {
     const productManifest = JSON.parse(originalManifest);
     fs.writeFileSync(
       manifestPath,
-      JSON.stringify({ ...productManifest, protocolScheme: 'test-headlamp' }, null, 2) + '\n'
+      JSON.stringify(
+        {
+          ...productManifest,
+          product: {
+            ...productManifest.product,
+            protocols: { name: 'test-headlamp-protocol', schemes: ['test-headlamp'] },
+          },
+        },
+        null,
+        2
+      ) + '\n'
     );
 
     const electronEnv: Record<string, string> = {};

--- a/app/electron/build-manifest.test.ts
+++ b/app/electron/build-manifest.test.ts
@@ -209,6 +209,15 @@ describe('product metadata', () => {
     );
   });
 
+  it.each([undefined, null, [], 'example', [''], [1], ['example', 2]])(
+    'rejects protocols without a usable schemes list: %j',
+    schemes => {
+      expect(() =>
+        applyProductMetadata({}, { product: { protocols: { name: 'example', schemes } } })
+      ).toThrow('Build manifest product.protocols.schemes must be a non-empty array of strings');
+    }
+  );
+
   it.each([null, [], 'metadata'])(
     'replaces malformed inherited extra metadata: %j',
     extraMetadata => {

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -59,6 +59,7 @@ import {
   PluginManager,
   setAppConfigDirName,
 } from './plugin-management';
+import { findProtocolUrl, isProtocolUrl, readProtocolScheme } from './protocol';
 import {
   addRunCmdConsent,
   environmentOverrides,
@@ -204,6 +205,7 @@ const shouldCheckForUpdates = process.env.HEADLAMP_CHECK_FOR_UPDATES !== 'false'
 const legalDocumentsResourcePath = getLegalDocumentsResourcePath(isDev, process.resourcesPath);
 const appBuildManifestPath = path.join(legalDocumentsResourcePath, 'app-build-manifest.json');
 const legalDocuments = loadLegalDocuments(appBuildManifestPath);
+const protocolScheme = readProtocolScheme(appBuildManifestPath);
 
 // make it global so that it doesn't get garbage collected
 let mainWindow: BrowserWindow | null;
@@ -1395,6 +1397,78 @@ ipcMain.on('route-changed', () => {
 function startElectron() {
   console.info('App starting...');
 
+  let isMainWindowReady = false;
+  const pendingProtocolUrls: string[] = [];
+
+  function routeProtocolUrl(protocolUrl: string) {
+    let urlObj: URL;
+    try {
+      urlObj = new URL(protocolUrl);
+    } catch {
+      dialog.showErrorBox(
+        i18n.t('Invalid URL'),
+        i18n.t('Application opened with an invalid URL: {{ url }}', { url: protocolUrl })
+      );
+      return;
+    }
+
+    if (!isProtocolUrl(protocolUrl, protocolScheme)) {
+      dialog.showErrorBox(
+        i18n.t('Invalid URL'),
+        i18n.t('Application opened with an invalid URL: {{ url }}', { url: protocolUrl })
+      );
+      return;
+    }
+
+    if (!mainWindow || !isMainWindowReady) {
+      pendingProtocolUrls.push(protocolUrl);
+      return;
+    }
+
+    if (mainWindow.isMinimized()) {
+      mainWindow.restore();
+    }
+    mainWindow.focus();
+
+    const baseUrl = startUrl.endsWith('/') ? startUrl.slice(0, -1) : startUrl;
+    mainWindow.loadURL(baseUrl + '#' + urlObj.hostname + urlObj.search);
+  }
+
+  function routeProtocolUrlFromCommandLine(commandLine: readonly string[]) {
+    const protocolUrl = findProtocolUrl(commandLine, protocolScheme);
+    if (protocolUrl) {
+      routeProtocolUrl(protocolUrl);
+    }
+  }
+
+  const gotTheLock = app.requestSingleInstanceLock();
+  if (!gotTheLock) {
+    app.quit();
+    return;
+  }
+
+  app.on('open-url', (event, protocolUrl) => {
+    event.preventDefault();
+    routeProtocolUrl(protocolUrl);
+  });
+
+  app.on('second-instance', (_event, commandLine) => {
+    const protocolUrl = findProtocolUrl(commandLine, protocolScheme);
+    if (protocolUrl) {
+      routeProtocolUrl(protocolUrl);
+      return;
+    }
+
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) {
+        mainWindow.restore();
+      }
+      mainWindow.focus();
+    }
+  });
+
+  routeProtocolUrlFromCommandLine(process.argv);
+
   // Increase max listeners to prevent false positive warnings
   // The app legitimately needs multiple IPC listeners (currently 11)
   // Default is 10, setting to 20 provides headroom for future additions
@@ -1561,6 +1635,8 @@ function startElectron() {
     const withMargin = await isWSL();
     const { width, height } = windowSize(screen.getPrimaryDisplay().workAreaSize, withMargin);
 
+    isMainWindowReady = false;
+
     // Flush any pending debounced zoom save before reading so reopening the
     // window immediately after a zoom change reads the latest factor.
     flushZoomFactorSave();
@@ -1614,6 +1690,11 @@ function startElectron() {
       scheduleApplyZoom(true);
       // Inject the backend port into the window object
       mainWindow?.webContents.executeJavaScript(`window.headlampBackendPort = ${actualPort};`);
+
+      isMainWindowReady = true;
+      for (const protocolUrl of pendingProtocolUrls.splice(0)) {
+        routeProtocolUrl(protocolUrl);
+      }
     });
 
     mainWindow.webContents.on('did-frame-finish-load', (_event, isMainFrame) => {
@@ -1656,6 +1737,7 @@ function startElectron() {
     });
 
     mainWindow.on('closed', () => {
+      isMainWindowReady = false;
       mainWindow = null;
     });
 
@@ -1677,21 +1759,6 @@ function startElectron() {
       }
     });
 
-    // Force Single Instance Application
-    const gotTheLock = app.requestSingleInstanceLock();
-    if (gotTheLock) {
-      app.on('second-instance', () => {
-        // Someone tried to run a second instance, we should focus our window.
-        if (mainWindow) {
-          if (mainWindow.isMinimized()) mainWindow.restore();
-          mainWindow.focus();
-        }
-      });
-    } else {
-      app.quit();
-      return;
-    }
-
     /*
     if a library is trying to open a url other than app url in electron take it
     to the default browser
@@ -1705,29 +1772,6 @@ function startElectron() {
       shell.openExternal(url);
     });
 
-    app.on('open-url', (event, url) => {
-      mainWindow?.focus();
-      let urlObj;
-      try {
-        urlObj = new URL(url);
-      } catch (e) {
-        dialog.showErrorBox(
-          i18n.t('Invalid URL'),
-          i18n.t('Application opened with an invalid URL: {{ url }}', { url })
-        );
-        return;
-      }
-
-      const urlParam = urlObj.hostname;
-      let baseUrl = startUrl;
-      // this check helps us to avoid adding multiple / to the startUrl when appending the incoming url to it
-      if (baseUrl.endsWith('/')) {
-        baseUrl = baseUrl.slice(0, startUrl.length - 1);
-      }
-      // load the index.html from build and route to the hostname received in the protocol handler url
-      mainWindow?.loadURL(baseUrl + '#' + urlParam + urlObj.search);
-    });
-
     i18n.on('languageChanged', () => {
       updateMenuLabels(currentMenu);
       setMenu(mainWindow, currentMenu);
@@ -1737,6 +1781,7 @@ function startElectron() {
       mainWindow?.webContents.send('appConfig', {
         checkForUpdates: shouldCheckForUpdates,
         appVersion,
+        protocolScheme,
       });
     });
 

--- a/app/electron/protocol.test.ts
+++ b/app/electron/protocol.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { findProtocolUrl, getProtocolScheme, isProtocolUrl, readProtocolScheme } from './protocol';
+
+describe('getProtocolScheme', () => {
+  it('returns a normalized protocol persisted in product metadata', () => {
+    expect(getProtocolScheme({ protocolScheme: 'My-Desktop' })).toBe('my-desktop');
+  });
+
+  it.each([undefined, null, {}, { protocolScheme: 1 }, { protocolScheme: '' }])(
+    'falls back for product metadata without a valid protocol: %j',
+    buildManifest => {
+      expect(getProtocolScheme(buildManifest)).toBe('headlamp');
+    }
+  );
+
+  it.each(['1desktop', 'not a scheme', 'desktop_app', 'desktop:'])(
+    'falls back for an invalid protocol: %s',
+    protocolScheme => {
+      expect(getProtocolScheme({ protocolScheme })).toBe('headlamp');
+    }
+  );
+
+  it.each(['desktop+auth', 'desktop.auth', 'desktop-auth'])(
+    'accepts URL scheme punctuation: %s',
+    protocolScheme => {
+      expect(getProtocolScheme({ protocolScheme })).toBe(protocolScheme);
+    }
+  );
+});
+
+describe('readProtocolScheme', () => {
+  it('reads the protocol from product metadata', () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-protocol-'));
+    const manifestPath = path.join(directory, 'app-build-manifest.json');
+
+    try {
+      fs.writeFileSync(manifestPath, JSON.stringify({ protocolScheme: 'Custom-Desktop' }));
+      expect(readProtocolScheme(manifestPath)).toBe('custom-desktop');
+    } finally {
+      fs.rmSync(directory, { force: true, recursive: true });
+    }
+  });
+
+  it('falls back when product metadata does not exist', () => {
+    expect(readProtocolScheme('/path/that/does/not/exist')).toBe('headlamp');
+  });
+
+  it('falls back when product metadata is not valid JSON', () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-protocol-invalid-'));
+    const manifestPath = path.join(directory, 'app-build-manifest.json');
+
+    try {
+      fs.writeFileSync(manifestPath, '{');
+      expect(readProtocolScheme(manifestPath)).toBe('headlamp');
+    } finally {
+      fs.rmSync(directory, { force: true, recursive: true });
+    }
+  });
+});
+
+describe('isProtocolUrl', () => {
+  it.each([
+    'my-desktop://cluster?name=local',
+    'MY-DESKTOP://cluster?name=local',
+    'my-desktop:cluster',
+  ])('accepts a URL for the configured protocol: %s', value => {
+    expect(isProtocolUrl(value, 'my-desktop')).toBe(true);
+  });
+
+  it.each(['not a URL', 'headlamp://cluster', 'https://cluster'])(
+    'rejects malformed URLs and other protocols: %s',
+    value => {
+      expect(isProtocolUrl(value, 'my-desktop')).toBe(false);
+    }
+  );
+});
+
+describe('findProtocolUrl', () => {
+  it('finds a configured protocol URL among process arguments', () => {
+    expect(
+      findProtocolUrl(['electron', '.', '--flag', 'my-desktop://cluster?name=local'], 'my-desktop')
+    ).toBe('my-desktop://cluster?name=local');
+  });
+
+  it('ignores malformed URLs and URLs for other protocols', () => {
+    expect(
+      findProtocolUrl(['electron', '.', 'not a URL', 'headlamp://cluster'], 'my-desktop')
+    ).toBeUndefined();
+  });
+});

--- a/app/electron/protocol.test.ts
+++ b/app/electron/protocol.test.ts
@@ -20,29 +20,56 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { findProtocolUrl, getProtocolScheme, isProtocolUrl, readProtocolScheme } from './protocol';
 
+/**
+ * Builds a manifest whose product metadata declares the given protocol schemes.
+ *
+ * @param schemes - Value placed at `product.protocols.schemes`.
+ * @returns A build manifest fragment for the scheme lookup.
+ */
+function manifestWithSchemes(schemes: unknown) {
+  return { product: { protocols: { name: 'my-desktop-protocol', schemes } } };
+}
+
 describe('getProtocolScheme', () => {
-  it('returns a normalized protocol persisted in product metadata', () => {
-    expect(getProtocolScheme({ protocolScheme: 'My-Desktop' })).toBe('my-desktop');
+  it('returns a normalized protocol from the packaged product metadata', () => {
+    expect(getProtocolScheme(manifestWithSchemes(['My-Desktop']))).toBe('my-desktop');
   });
 
-  it.each([undefined, null, {}, { protocolScheme: 1 }, { protocolScheme: '' }])(
-    'falls back for product metadata without a valid protocol: %j',
+  it('uses the first scheme when the product registers several', () => {
+    expect(getProtocolScheme(manifestWithSchemes(['my-desktop', 'legacy-desktop']))).toBe(
+      'my-desktop'
+    );
+  });
+
+  it.each([undefined, null, {}, { product: null }, { product: { protocols: null } }])(
+    'falls back for product metadata without protocols: %j',
     buildManifest => {
       expect(getProtocolScheme(buildManifest)).toBe('headlamp');
     }
   );
 
+  it.each([undefined, null, [], 'my-desktop', [1], [''], [null]])(
+    'falls back for an unusable schemes value: %j',
+    schemes => {
+      expect(getProtocolScheme(manifestWithSchemes(schemes))).toBe('headlamp');
+    }
+  );
+
+  it('ignores a top-level protocolScheme key that packaging never registers', () => {
+    expect(getProtocolScheme({ protocolScheme: 'my-desktop' })).toBe('headlamp');
+  });
+
   it.each(['1desktop', 'not a scheme', 'desktop_app', 'desktop:'])(
     'falls back for an invalid protocol: %s',
-    protocolScheme => {
-      expect(getProtocolScheme({ protocolScheme })).toBe('headlamp');
+    scheme => {
+      expect(getProtocolScheme(manifestWithSchemes([scheme]))).toBe('headlamp');
     }
   );
 
   it.each(['desktop+auth', 'desktop.auth', 'desktop-auth'])(
     'accepts URL scheme punctuation: %s',
-    protocolScheme => {
-      expect(getProtocolScheme({ protocolScheme })).toBe(protocolScheme);
+    scheme => {
+      expect(getProtocolScheme(manifestWithSchemes([scheme]))).toBe(scheme);
     }
   );
 });
@@ -53,7 +80,7 @@ describe('readProtocolScheme', () => {
     const manifestPath = path.join(directory, 'app-build-manifest.json');
 
     try {
-      fs.writeFileSync(manifestPath, JSON.stringify({ protocolScheme: 'Custom-Desktop' }));
+      fs.writeFileSync(manifestPath, JSON.stringify(manifestWithSchemes(['Custom-Desktop'])));
       expect(readProtocolScheme(manifestPath)).toBe('custom-desktop');
     } finally {
       fs.rmSync(directory, { force: true, recursive: true });
@@ -78,20 +105,22 @@ describe('readProtocolScheme', () => {
 });
 
 describe('isProtocolUrl', () => {
-  it.each([
-    'my-desktop://cluster?name=local',
-    'MY-DESKTOP://cluster?name=local',
-    'my-desktop:cluster',
-  ])('accepts a URL for the configured protocol: %s', value => {
-    expect(isProtocolUrl(value, 'my-desktop')).toBe(true);
-  });
-
-  it.each(['not a URL', 'headlamp://cluster', 'https://cluster'])(
-    'rejects malformed URLs and other protocols: %s',
+  it.each(['my-desktop://cluster?name=local', 'MY-DESKTOP://cluster?name=local'])(
+    'accepts a URL for the configured protocol: %s',
     value => {
-      expect(isProtocolUrl(value, 'my-desktop')).toBe(false);
+      expect(isProtocolUrl(value, 'my-desktop')).toBe(true);
     }
   );
+
+  it.each([
+    'not a URL',
+    'headlamp://cluster',
+    'https://cluster',
+    'my-desktop:cluster',
+    'my-desktop://',
+  ])('rejects malformed URLs, other protocols, and hostless URLs: %s', value => {
+    expect(isProtocolUrl(value, 'my-desktop')).toBe(false);
+  });
 });
 
 describe('findProtocolUrl', () => {

--- a/app/electron/protocol.ts
+++ b/app/electron/protocol.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'node:fs';
+
+/** Protocol scheme used when product metadata does not provide a valid override. */
+const DEFAULT_PROTOCOL_SCHEME = 'headlamp';
+const VALID_PROTOCOL_SCHEME = /^[a-z][a-z0-9+.-]*$/i;
+
+/**
+ * Gets a normalized custom protocol scheme from product metadata.
+ *
+ * @param buildManifest - Parsed product build manifest.
+ * @returns The configured protocol scheme, or the Headlamp default.
+ */
+export function getProtocolScheme(buildManifest: unknown): string {
+  if (typeof buildManifest !== 'object' || buildManifest === null) {
+    return DEFAULT_PROTOCOL_SCHEME;
+  }
+
+  const scheme = (buildManifest as { protocolScheme?: unknown }).protocolScheme;
+  return typeof scheme === 'string' && VALID_PROTOCOL_SCHEME.test(scheme)
+    ? scheme.toLowerCase()
+    : DEFAULT_PROTOCOL_SCHEME;
+}
+
+/**
+ * Reads a custom protocol scheme from a product build manifest.
+ *
+ * @param manifestPath - Path to the JSON product build manifest.
+ * @returns The configured protocol scheme, or the Headlamp default.
+ */
+export function readProtocolScheme(manifestPath: string): string {
+  try {
+    return getProtocolScheme(JSON.parse(fs.readFileSync(manifestPath, 'utf8')));
+  } catch {
+    return DEFAULT_PROTOCOL_SCHEME;
+  }
+}
+
+/**
+ * Checks whether a value is a URL for the configured protocol scheme.
+ *
+ * @param value - Candidate deep-link URL.
+ * @param protocolScheme - Expected protocol scheme without a trailing colon.
+ * @returns Whether the URL uses the configured protocol scheme.
+ */
+export function isProtocolUrl(value: string, protocolScheme: string): boolean {
+  try {
+    return new URL(value).protocol === `${protocolScheme}:`;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Finds the first URL for the configured protocol in a process command line.
+ *
+ * @param commandLine - Process arguments supplied at startup or by Electron.
+ * @param protocolScheme - Expected protocol scheme without a trailing colon.
+ * @returns The first matching protocol URL, if one is present.
+ */
+export function findProtocolUrl(
+  commandLine: readonly string[],
+  protocolScheme: string
+): string | undefined {
+  return commandLine.find(value => isProtocolUrl(value, protocolScheme));
+}

--- a/app/electron/protocol.ts
+++ b/app/electron/protocol.ts
@@ -23,18 +23,37 @@ const VALID_PROTOCOL_SCHEME = /^[a-z][a-z0-9+.-]*$/i;
 /**
  * Gets a normalized custom protocol scheme from product metadata.
  *
+ * The scheme is read from `product.protocols.schemes`, which is the same field
+ * `applyProductMetadata` hands to Electron Builder to register the scheme with
+ * the OS at packaging time. Reading a separate key here would let the runtime
+ * and the installer disagree, which rejects every real deep link.
+ *
+ * Only the first scheme is honored. Electron Builder can register several
+ * aliases with the OS, but the renderer is handed a single scheme, so a deep
+ * link arriving via a later alias is rejected as an invalid URL.
+ *
  * @param buildManifest - Parsed product build manifest.
  * @returns The configured protocol scheme, or the Headlamp default.
  */
 export function getProtocolScheme(buildManifest: unknown): string {
-  if (typeof buildManifest !== 'object' || buildManifest === null) {
-    return DEFAULT_PROTOCOL_SCHEME;
-  }
+  const product = isRecord(buildManifest) ? buildManifest.product : undefined;
+  const protocols = isRecord(product) ? product.protocols : undefined;
+  const schemes = isRecord(protocols) ? protocols.schemes : undefined;
+  const scheme = Array.isArray(schemes) ? schemes[0] : undefined;
 
-  const scheme = (buildManifest as { protocolScheme?: unknown }).protocolScheme;
   return typeof scheme === 'string' && VALID_PROTOCOL_SCHEME.test(scheme)
     ? scheme.toLowerCase()
     : DEFAULT_PROTOCOL_SCHEME;
+}
+
+/**
+ * Narrows a value to a plain object usable for keyed lookups.
+ *
+ * @param value - Candidate value from parsed JSON.
+ * @returns Whether the value is a non-null, non-array object.
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 /**
@@ -52,15 +71,20 @@ export function readProtocolScheme(manifestPath: string): string {
 }
 
 /**
- * Checks whether a value is a URL for the configured protocol scheme.
+ * Checks whether a value is a routable URL for the configured protocol scheme.
+ *
+ * Opaque URLs such as `headlamp:cluster` are rejected: deep links are routed
+ * from the host component, so an empty host would silently navigate to the
+ * app root instead of the requested route.
  *
  * @param value - Candidate deep-link URL.
  * @param protocolScheme - Expected protocol scheme without a trailing colon.
- * @returns Whether the URL uses the configured protocol scheme.
+ * @returns Whether the URL uses the configured protocol scheme and has a host.
  */
 export function isProtocolUrl(value: string, protocolScheme: string): boolean {
   try {
-    return new URL(value).protocol === `${protocolScheme}:`;
+    const url = new URL(value);
+    return url.protocol === `${protocolScheme}:` && url.hostname !== '';
   } catch {
     return false;
   }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -29,6 +29,7 @@
         "@types/node": "^22.14.0",
         "@types/semver": "^7.7.0",
         "@types/yargs": "^17.0.35",
+        "@vitest/coverage-istanbul": "3.2.4",
         "electron": "^38.8.6",
         "electron-builder": "^26.6.0",
         "esbuild": "^0.25.0",
@@ -44,6 +45,235 @@
         "dmg-license": "^1.0.11"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.27.0",
       "license": "MIT",
@@ -57,6 +287,54 @@
     "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "license": "MIT"
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@bitdisaster/exe-icon-extractor": {
       "version": "1.0.10",
@@ -1196,12 +1474,65 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@langchain/core": {
       "version": "1.2.7",
@@ -2351,16 +2682,41 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@vitest/coverage-istanbul": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-3.2.4.tgz",
+      "integrity": "sha512-IDlpuFJiWU9rhcKLkpzj8mFu/lpe64gVgnV15ZOrYx1iFzxxrxCzbExiUEKtwwXRvEiEMUS6iZeYgnMxgbqbxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-instrument": "^6.0.3",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magicast": "^0.3.5",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "3.2.4"
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
-      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.7",
-        "@vitest/utils": "3.2.7",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -2369,13 +2725,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
-      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.7",
+        "@vitest/spy": "3.2.4",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -2409,13 +2765,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
-      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.7",
+        "@vitest/utils": "3.2.4",
         "pathe": "^2.0.3",
         "strip-literal": "^3.0.0"
       },
@@ -2424,13 +2780,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
-      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.7",
+        "@vitest/pretty-format": "3.2.4",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -2438,10 +2794,23 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@vitest/spy": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
-      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2452,14 +2821,27 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
-      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.7",
+        "@vitest/pretty-format": "3.2.4",
         "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "tinyrainbow": "^2.0.0"
       },
       "funding": {
@@ -3177,6 +3559,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.17",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.17.tgz",
+      "integrity": "sha512-KAUDn1OSS0fmPlGO+NOUMRcOQ/b/shUBH3OgkG73mPgdf+JD/BQ6fHboGxNOxnUmlwcq+lLq3dTkayRPuSfXwg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -3307,6 +3702,40 @@
       },
       "engines": {
         "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/buffer": {
@@ -3526,6 +3955,27 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "5.3.3",
@@ -4556,6 +5006,13 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.412",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.412.tgz",
+      "integrity": "sha512-z4rMe3esBzlzovKHj4gxJnsCGZRK5l4baUvm+gCGJBPE+gsyUMKsuU9tnEUtI1dOebXz1ytAPGjvXhmQ7rIPwA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/electron-winstaller": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
@@ -4935,7 +5392,9 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.2",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5950,6 +6409,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "license": "ISC",
@@ -6322,6 +6791,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/htmlparser2": {
       "version": "9.1.0",
@@ -7092,6 +7568,77 @@
       "version": "2.0.0",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.2",
       "dev": true,
@@ -7161,8 +7708,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.3.1",
@@ -7185,6 +7731,19 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/json-buffer": {
@@ -7420,6 +7979,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/matcher": {
@@ -7732,6 +8319,16 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/noms": {
       "version": "0.0.0",
@@ -9833,6 +10430,60 @@
         "rimraf": "bin.js"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/text-decoder": {
       "version": "1.1.1",
       "dev": true,
@@ -10327,6 +10978,37 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/uri-js": {
@@ -11087,20 +11769,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
-      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.7",
-        "@vitest/mocker": "3.2.7",
-        "@vitest/pretty-format": "^3.2.7",
-        "@vitest/runner": "3.2.7",
-        "@vitest/snapshot": "3.2.7",
-        "@vitest/spy": "3.2.7",
-        "@vitest/utils": "3.2.7",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -11130,8 +11812,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.7",
-        "@vitest/ui": "3.2.7",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/app/package.json
+++ b/app/package.json
@@ -191,6 +191,7 @@
     "@types/node": "^22.14.0",
     "@types/semver": "^7.7.0",
     "@types/yargs": "^17.0.35",
+    "@vitest/coverage-istanbul": "3.2.4",
     "electron": "^38.8.6",
     "electron-builder": "^26.6.0",
     "esbuild": "^0.25.0",

--- a/app/scripts/build-manifest.ts
+++ b/app/scripts/build-manifest.ts
@@ -161,6 +161,21 @@ export function applyProductMetadata<T extends object>(config: T, manifest: unkn
   ) {
     throw new Error('Build manifest product.protocols must be an object');
   }
+  if (product.protocols !== undefined) {
+    // The app reads this same field at runtime to decide which deep links to
+    // accept, so an unusable value would silently fall back to the Headlamp
+    // scheme while the installer registers something else.
+    const schemes = (product.protocols as Record<string, unknown>).schemes;
+    if (
+      !Array.isArray(schemes) ||
+      schemes.length === 0 ||
+      schemes.some(scheme => typeof scheme !== 'string' || scheme === '')
+    ) {
+      throw new Error(
+        'Build manifest product.protocols.schemes must be a non-empty array of strings'
+      );
+    }
+  }
 
   const metadata = product as ProductMetadata;
   const configRecord = config as Record<string, unknown>;


### PR DESCRIPTION
## Summary

- Read the desktop protocol scheme from the packaged product build manifest.
- Reject malformed deep links and links intended for another installed product.
- Preserve `headlamp` as the fallback scheme and expose the selected scheme in
  the renderer app configuration.
- Synchronize scheduling keys into the locale packs merged immediately before
  this branch so current `main` passes its frontend i18n update check.

## Source

This upstreams patch 0009 retained by
[Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823) in
[387eb27e](https://github.com/Azure/aks-desktop/commit/387eb27e3f586211610dda61949255e7264a9c95).

The product-specific protocol behavior originated in
[Azure/aks-desktop#457](https://github.com/Azure/aks-desktop/pull/457) as
[d9b4def2](https://github.com/Azure/aks-desktop/commit/d9b4def25efc00ad66f4f2af23d2d89f9c6c0f86),
authored by Thomas Gamble. It extends the custom protocol support introduced by
[kubernetes-sigs/headlamp#552](https://github.com/kubernetes-sigs/headlamp/pull/552)
in
[8493618f](https://github.com/kubernetes-sigs/headlamp/commit/8493618f29779443de8cf63c11f274be25d0c4e0).

## Improvements over the existing versions

- Use `app-build-manifest.json`, the packaged product metadata source, instead
  of reading Electron packaging configuration from `package.json` at runtime.
- Validate manifest schemes and fall back safely when metadata is absent,
  malformed, or invalid.
- Validate incoming deep links against the configured product scheme so one
  Headlamp-based desktop product cannot consume another product's callback.
- Register protocol listeners before Electron readiness, inspect startup and
  second-instance command lines, and queue links until the window is loaded.
- Add TSDoc for the new TypeScript API and expand focused unit coverage to 100%
  of statements, branches, functions, and lines.
- Add Electron end-to-end coverage for cold-start, macOS `open-url`, and
  second-instance routing; the Azure source PR listed e2e verification as
  incomplete.

## Testing

- `CI=true make frontend-test` (2,939 tests)
- `make frontend-i18n-check`
- `npm --prefix frontend run ci-lint`
- `npm --prefix app test` (264 tests)
- `npm --prefix app test -- electron/protocol.test.ts --coverage --coverage.provider=istanbul --coverage.include=electron/protocol.ts --coverage.reporter=text --coverage.thresholds.branches=80` (24 tests, 100% branch coverage)
- `npm --prefix app run tsc`
- Focused ESLint and Prettier checks for all changed TypeScript files
- `npm --prefix app/e2e-tests run test-app -- protocolScheme.spec.ts` (3 Electron tests)

## Screenshots

Not applicable. This changes desktop deep-link configuration and validation
without changing the rendered interface.

Assisted by copilot.