### PR TITLE
frontend: Dialog: Fix aria-dialog-name by forwarding aria-label to Paper

### DIFF
--- a/frontend/.axe-storybook-baseline.test-a11y.json
+++ b/frontend/.axe-storybook-baseline.test-a11y.json
@@ -23,7 +23,6 @@
     "TopBar/With Email Only": ["color-contrast"],
     "TopBar/Undefined Data": ["color-contrast"],
     "TopBar/Empty User Info": ["color-contrast"],
-    "TopBar/Version Dialog": ["aria-dialog-name"],
     "AuthToken/Show Error": ["empty-heading"],
     "AuthToken/Show Actions": ["empty-heading"],
     "Activity/Basic": ["landmark-unique"],
@@ -57,7 +56,6 @@
     "project/NewProjectPopup/With Existing Projects (for duplicate name testing)": [
       "heading-order"
     ],
-    "Settings/PodDebugSettings/Version Dialog": ["aria-dialog-name"],
     "Settings/NumRowsInput/Default": ["aria-input-field-name"],
     "Settings/SettingsCluster/Default": ["heading-order", "label-title-only"],
     "Settings/SettingsCluster/With Saved Settings": ["heading-order", "label-title-only"],
@@ -125,7 +123,6 @@
     "pvc/CreatePVCForm/Static Provisioning": ["label"],
     "pvc/CreatePVCForm/With Storage Class And Volume Name": ["label"],
     "pvc/CreatePVCForm/Read Write Many": ["label"],
-    "pvc/CreatePVCForm/Multiple Access Modes": ["label"],
-    "Version Dialog/Version Dialog": ["aria-dialog-name"]
+    "pvc/CreatePVCForm/Multiple Access Modes": ["label"]
   }
 }

--- a/frontend/src/components/App/__snapshots__/VersionDialog.VersionDialog.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/VersionDialog.VersionDialog.stories.storyshot
@@ -3,7 +3,6 @@
     aria-hidden="true"
   />
   <div
-    aria-label="Version information"
     class="MuiDialog-root MuiModal-root css-zw3mfo-MuiModal-root-MuiDialog-root"
     role="presentation"
     style="z-index: 1900;"

--- a/frontend/src/components/common/Dialog.tsx
+++ b/frontend/src/components/common/Dialog.tsx
@@ -144,13 +144,27 @@ export function Dialog(props: DialogProps) {
   const titleId = titleProps?.id || generatedId;
   const dialogAriaProps = title ? { 'aria-labelledby': titleId } : {};
 
+  // Forward aria-label to PaperProps when there is no title, since MUI v5 Dialog
+  // root has role="presentation" and the Paper child has role="dialog".
+  // Merge theme defaults (variant/elevation from themes.ts) so passing an
+  // explicit PaperProps here does not silently drop them.
+  const { 'aria-label': ariaLabel, PaperProps: existingPaperProps, ...restOther } = other;
+  const themePaperProps = theme.components?.MuiDialog?.defaultProps?.PaperProps ?? {};
+  const paperProps =
+    !title && ariaLabel
+      ? { PaperProps: { ...themePaperProps, ...existingPaperProps, 'aria-label': ariaLabel } }
+      : existingPaperProps
+      ? { PaperProps: { ...themePaperProps, ...existingPaperProps } }
+      : {};
+
   return (
     <MuiDialog
       maxWidth="lg"
       scroll="paper"
       fullWidth
       {...dialogAriaProps}
-      {...other}
+      {...restOther}
+      {...paperProps}
       fullScreen={fullScreen}
     >
       {(!!title || withFullScreen) && (


### PR DESCRIPTION
## Summary

The Dialog component was forwarding aria-label to the MUI Dialog root element, which has role="presentation". The actual role="dialog" is on the inner Paper element, so axe could not find an accessible name for the dialog.

This change extracts aria-label from the props and forwards it to the Paper element via PaperProps, ensuring the dialog accessible name is on the element with role="dialog".

## Related Issue

Fixes #7178

## Changes

- Extract aria-label from other props in Dialog and forward it to PaperProps
- Remove aria-label from the root element to avoid duplication
- Removed 3 aria-dialog-name entries from the a11y baseline:
  - TopBar/Version Dialog
  - Settings/PodDebugSettings/Version Dialog
  - Version Dialog/Version Dialog

## Steps to Test

1. Run cd frontend && npm run test:a11y — the 3 Version Dialog stories no longer report aria-dialog-name
2. Run npm run frontend:test — all storyshots pass
3. Open Storybook, navigate to Version Dialog, verify the dialog still renders correctly