### PR TITLE
Fix color contrast of Surge Node chip in UpgradeVisualizationPanel

### DIFF
--- a/frontend/src/components/node/UpgradeVisualizationPanel.tsx
+++ b/frontend/src/components/node/UpgradeVisualizationPanel.tsx
@@ -17,7 +17,7 @@
 import { Icon } from '@iconify/react';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
-import { green } from '@mui/material/colors';
+import { blue, green } from '@mui/material/colors';
 import Paper from '@mui/material/Paper';
 import Step from '@mui/material/Step';
 import StepConnector, { stepConnectorClasses } from '@mui/material/StepConnector';
@@ -77,6 +77,7 @@ function formatTimestamp(ts: string): string {
 }
 
 const successBgColor = green[800]; // #2e7d32 — dark green, works in both modes
+const surgeBgColor = blue[800]; // #1565c0 — dark blue, sufficient contrast for white text in both modes
 
 function useActiveBgColor() {
   const theme = useTheme();
@@ -266,7 +267,13 @@ function NodeIdleRow({ state, node }: { state: NodeUpgradeState; node: Node | un
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
         <Typography variant="subtitle2">{state.nodeName}</Typography>
         {isReady && <Chip label={t('Ready')} size="small" color="success" variant="outlined" />}
-        {state.isSurge && <Chip label={t('Surge Node')} size="small" color="info" />}
+        {state.isSurge && (
+          <Chip
+            label={t('Surge Node')}
+            size="small"
+            sx={{ backgroundColor: surgeBgColor, color: '#fff' }}
+          />
+        )}
       </Box>
       {version && (
         <Typography variant="body2" sx={{ color: 'primary.main', fontWeight: 500 }}>

--- a/frontend/src/components/node/__snapshots__/UpgradeVisualizationPanel.Upgrading.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/UpgradeVisualizationPanel.Upgrading.stories.storyshot
@@ -224,7 +224,7 @@
               </span>
             </div>
             <div
-              class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-1qavl4s-MuiChip-root"
+              class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-lsd13o-MuiChip-root"
             >
               <span
                 class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"


### PR DESCRIPTION
## Summary
The "Surge Node" chip in `UpgradeVisualizationPanel` used a filled `color="info"` MUI Chip — white text on a light blue background. That combination only achieves a ~3.9:1 contrast ratio, which fails the WCAG AA minimum (4.5:1) for text at this size. This surfaced as a Storybook accessibility failure in the `Upgrading` story, the only fixture where a node is marked as a surge node.

## Related Issue
Fixes #7172

## Changes
- Added a `surgeBgColor` constant (`blue[800]`, `#1565c0`) to `UpgradeVisualizationPanel.tsx`, following the same pattern already used for `successBgColor` (a fixed dark shade chosen to keep sufficient contrast in both light and dark theme modes).
- Replaced the Surge Node chip's `color="info"` with an explicit `sx={{ backgroundColor: surgeBgColor, color: '#fff' }}`, raising contrast to ~5.7:1.

## Steps to Test
1. Run Storybook: `npm run storybook` (from `frontend/`)
2. Navigate to `node/UpgradeVisualizationPanel` → `Upgrading`
3. Confirm the "Surge Node" chip renders with a dark blue background and white text, and passes a contrast check (e.g. via the Storybook a11y addon or a manual contrast checker)

## Screenshots
Before
<img width="1372" height="552" alt="Screenshot 2026-08-15 190130" src="https://github.com/user-attachments/assets/360de77f-b03a-4027-91df-77470551d913" />

After
<img width="1375" height="570" alt="image" src="https://github.com/user-attachments/assets/df6bc519-a421-45cd-871f-7056ca790978" />


## Notes for the Reviewer
No layout changes — only the color of the one Chip. `AllIdle` story is unaffected since no node is marked as a surge node without upgrade events.