### PR TITLE
backend: Fix port-forward goroutine leak on pod deletion

### DIFF
--- a/backend/pkg/portforward/handler.go
+++ b/backend/pkg/portforward/handler.go
@@ -216,7 +216,7 @@ func StartPortForward(kubeConfigStore kubeconfig.ContextStore, cache cache.Cache
 		token, _ = auth.GetTokenFromCookie(r, requestClusterName)
 	}
 
-	err = startPortForward(kContext, cache, p, token, contextKey, requestClusterName)
+	err = startPortForward(r.Context(), kContext, cache, p, token, contextKey, requestClusterName)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "starting portforward")
 
@@ -411,6 +411,7 @@ func safeCloseChan(ch chan struct{}) {
 // to stop by closing its stopChan and updates its status in the cache.
 // It stops when the associated port-forward's closeChan is closed.
 func monitorPodAndManagePortForward(
+	ctx context.Context,
 	clientset *kubernetes.Clientset,
 	cache cache.Cache[interface{}],
 	pfDetails *portForward,
@@ -422,6 +423,14 @@ func monitorPodAndManagePortForward(
 
 	for {
 		select {
+		case <-ctx.Done():
+			logger.Log(logger.LevelInfo, logParams, nil, "Pod monitor stopping: request context canceled.")
+
+			pfSnapshot := pfDetails.setStatusAndSnapshot(STOPPED, "request context canceled")
+			portforwardstore(cache, pfSnapshot)
+			safeCloseChan(pfDetails.closeChan)
+
+			return
 		case <-ticker.C:
 			err := checkIfPodIsRunning(clientset, pfDetails.Namespace, pfDetails.Pod)
 			if err != nil {
@@ -597,6 +606,7 @@ func forwardPortsAsync(
 // then handles its readiness, and if ready, starts another goroutine to
 // monitor the target pod's status.
 func runAndMonitorPortForward(
+	ctx context.Context,
 	clientset *kubernetes.Clientset,
 	cache cache.Cache[interface{}],
 	pfDetails *portForward,
@@ -616,14 +626,14 @@ func runAndMonitorPortForward(
 		return err
 	}
 
-	go monitorPodAndManagePortForward(clientset, cache, pfDetails)
+	go monitorPodAndManagePortForward(ctx, clientset, cache, pfDetails)
 
 	return nil
 }
 
 // startPortForward starts a port forward. This is the internal function that was refactored.
 // It sets up Kubernetes clients, initializes the port forwarder, and manages its lifecycle.
-func startPortForward(kContext *kubeconfig.Context, cache cache.Cache[interface{}],
+func startPortForward(ctx context.Context, kContext *kubeconfig.Context, cache cache.Cache[interface{}],
 	p portForwardRequest, token string, clusterName string, requestClusterName string,
 ) error {
 	clientset, rConf, err := getKubeClientAndConfig(kContext, token)
@@ -671,7 +681,7 @@ func startPortForward(kContext *kubeconfig.Context, cache cache.Cache[interface{
 		Error:            "",
 	}
 
-	return runAndMonitorPortForward(clientset, cache, pfDetails, forwarder, readyChan, errOut)
+	return runAndMonitorPortForward(ctx, clientset, cache, pfDetails, forwarder, readyChan, errOut)
 }
 
 func checkIfPodIsRunning(clientset *kubernetes.Clientset, namespace string, pod string) error {


### PR DESCRIPTION
## Summary

This PR fixes **Issue #6** (goroutine leaks during port-forwarding) by tying the background pod monitoring to the actual HTTP request connection. 

## Changes

- **Updated `handler.go`:** Passed the HTTP `r.Context()` down into the background goroutine.
- **Fixed Goroutine Leak:** Added a `<-ctx.Done()` listener. Now, if the HTTP connection suddenly drops, the background monitor immediately and safely shuts down and cleans up resources instead of running indefinitely.

## Steps to Test

1. Start up the backend server locally.
2. Trigger a port-forward request to a running pod.
3. Abruptly kill the HTTP connection (e.g., close the tab or kill the client request).
4. Check the backend logs/goroutines to confirm the port-forward monitor cleanly stopped and didn't leave a ghost process running.


## Notes for the Reviewer

- The fix is strictly contained to the `backend/pkg/portforward/handler.go` file. It cleanly cascades the request context down to `monitorPodAndManagePortForward` to ensure proper garbage collection.