### PR TITLE
backend: k8cache: Prevent cache poisoning during slow repopulations

### DIFF
--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -27,6 +27,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
@@ -79,18 +80,36 @@ func HandleNonGETCacheInvalidation(k8scache cache.Cache[string], w http.Response
 	DeleteKeys(key, k8scache)
 
 	freshURL := *r.URL
+	freshHeader := r.Header.Clone()
 
-	freshReq, err := http.NewRequestWithContext(r.Context(), http.MethodGet, freshURL.String(), nil) //nolint:gosec
+	next.ServeHTTP(w, r)
+
+	// Use context.WithoutCancel(r.Context()) instead of r.Context() so the cache repopulation
+	// request is not cancelled if the client disconnects before the fresh GET
+	// completes, while preserving request-scoped variables like mux route values.
+	// We wrap it in a finite timeout to prevent unresponsive upstream servers
+	// from leaking goroutines.
+	detachedCtx := context.WithoutCancel(r.Context())
+	timeoutCtx, timeoutCancel := context.WithTimeout(detachedCtx, 60*time.Second)
+
+	defer timeoutCancel()
+
+	freshReq, err := http.NewRequestWithContext( //nolint:gosec
+		timeoutCtx, http.MethodGet, freshURL.String(), nil,
+	)
 	if err != nil {
 		return err
 	}
 
-	freshReq.Header = r.Header.Clone()
-	next.ServeHTTP(w, r)
+	freshReq.Header = freshHeader
 
 	rr := httptest.NewRecorder()
 	freshRcw := NewResponseCapture(rr)
 	next.ServeHTTP(freshRcw, freshReq)
+
+	if timeoutCtx.Err() != nil {
+		return timeoutCtx.Err()
+	}
 
 	if err := StoreK8sResponseInCache(k8scache, freshReq.URL, freshRcw, key); err != nil {
 		return err

--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -98,7 +98,8 @@ func HandleNonGETCacheInvalidation(k8scache cache.Cache[string], w http.Response
 		timeoutCtx, http.MethodGet, freshURL.String(), nil,
 	)
 	if err != nil {
-		return err
+		logger.Log(logger.LevelWarn, nil, err, "could not create repopulation request")
+		return ErrHandled
 	}
 
 	freshReq.Header = freshHeader
@@ -108,11 +109,13 @@ func HandleNonGETCacheInvalidation(k8scache cache.Cache[string], w http.Response
 	next.ServeHTTP(freshRcw, freshReq)
 
 	if timeoutCtx.Err() != nil {
-		return timeoutCtx.Err()
+		logger.Log(logger.LevelWarn, nil, timeoutCtx.Err(), "cache repopulation request timed out")
+		return ErrHandled
 	}
 
 	if err := StoreK8sResponseInCache(k8scache, freshReq.URL, freshRcw, key); err != nil {
-		return err
+		logger.Log(logger.LevelWarn, nil, err, "failed to store repopulated response in cache")
+		return ErrHandled
 	}
 
 	return ErrHandled

--- a/backend/pkg/k8cache/cacheInvalidation_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_test.go
@@ -735,6 +735,56 @@ func TestHandleNonGETCacheInvalidation_PostOnResourceNamedVersion(t *testing.T) 
 	assert.NotContains(t, cachedValue, "stale")
 }
 
+// TestHandleNonGETCacheInvalidation_CachePopulatedAfterClientDisconnect is a
+// regression test for the bug where using r.Context() for the fresh-GET caused
+// the cache repopulation to be cancelled when the client disconnected, leaving
+// the cache permanently empty (cache poisoning on disconnect).
+//
+// The test cancels the request context *before* calling HandleNonGETCacheInvalidation
+// to simulate a client that disconnects immediately after sending the mutating
+// request. The fix (context.WithoutCancel(r.Context())) means the cache must
+// still be populated with the fresh response regardless of the client's context state.
+func TestHandleNonGETCacheInvalidation_CachePopulatedAfterClientDisconnect(t *testing.T) {
+	mockCache := NewMockCache()
+	targetURL := &url.URL{Path: "/clusters/kind/api/v1/namespaces/default/pods"}
+	cacheKey, err := k8cache.GenerateKey(targetURL, "ctx")
+	require.NoError(t, err)
+
+	// Seed an existing stale entry so we can confirm it is replaced.
+	require.NoError(t, mockCache.Set(context.Background(), cacheKey, `{"body":"stale"}`))
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method == http.MethodGet {
+			require.NoError(t, req.Context().Err(), "fresh GET context should not be cancelled")
+			vars := mux.Vars(req)
+			require.Equal(t, "test-cluster", vars["clusterName"], "fresh GET should preserve mux variables")
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"kind":"PodList","fresh":true}`))
+	})
+
+	// Simulate a client that has already disconnected: create a cancelled context.
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately — context.Err() is non-nil from here on
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(cancelledCtx, http.MethodPost, targetURL.String(), nil)
+	r = mux.SetURLVars(r, map[string]string{"clusterName": "test-cluster"})
+	r.URL = targetURL
+
+	err = k8cache.HandleNonGETCacheInvalidation(mockCache, w, r, next, "ctx")
+	assert.ErrorIs(t, err, k8cache.ErrHandled)
+
+	// The cache must contain the fresh data even though the client context was
+	// already cancelled. Before the fix this would fail because the fresh GET
+	// would be aborted along with the client context.
+	cachedValue, err := mockCache.Get(context.Background(), cacheKey)
+	require.NoError(t, err, "cache must be populated after client disconnect")
+	assert.Contains(t, cachedValue, "PodList", "cache must hold fresh response, not empty or stale data")
+	assert.NotContains(t, cachedValue, "stale")
+}
+
 var filterImportantResourcesTests = []struct {
 	name  string
 	input []schema.GroupVersionResource


### PR DESCRIPTION
### Summary
`HandleNonGETCacheInvalidation` used `r.Context()` to create the fresh GET request that repopulates the cache after a mutating request (POST/PUT/DELETE). When the client disconnected before that fresh GET completed, `r.Context()` was cancelled, aborting the repopulation. This left the cache permanently empty (the stale entry had already been purged by `DeleteKeys`), causing a cache miss storm and potentially serving stale data to subsequent requests.

### Related Issue
Fixes #7256

### Changes
- **`cacheInvalidation.go`**: Replaced `r.Context()` with `context.WithoutCancel(r.Context())` wrapped in a 60-second timeout. This decouples the cache repopulation from the client's connection lifetime while preserving request-scoped variables (like mux routes). Also added a check to skip cache writes if the 60-second timeout expires, preventing truncated bodies from poisoning the cache.
- **`cacheInvalidation_test.go`**: Added regression test `TestHandleNonGETCacheInvalidation_CachePopulatedAfterClientDisconnect` that cancels the request context before calling the function and asserts the cache is still populated correctly.

### Steps to Test
1. Make any mutating request (POST/DELETE) against a cached resource endpoint.
2. Immediately close the browser tab / drop the connection before the response returns.
3. Make a subsequent GET to the same resource — verify it returns fresh data and does not hit a cache miss storm.
4. Run the new regression test: `cd backend && go test ./pkg/k8cache/... -run TestHandleNonGETCacheInvalidation_CachePopulatedAfterClientDisconnect -v`

### Notes for the Reviewer
- `context.WithoutCancel` combined with a 60-second timeout is used instead of `context.Background()` to ensure request-bound variables aren't lost, while still protecting against both client disconnects and unresponsive upstream servers.
- No new dependencies introduced.