### PR TITLE
frontend: Fix Events table crash when event has no source

### DIFF
--- a/frontend/src/components/common/ObjectEventList.stories.tsx
+++ b/frontend/src/components/common/ObjectEventList.stories.tsx
@@ -47,6 +47,17 @@ const mockOwnerObjectNoEvents = new KubeObject({
   },
 });
 
+const mockOwnerObjectSourcelessEvents = new KubeObject({
+  kind: 'Pod',
+  apiVersion: 'v1',
+  metadata: {
+    name: 'test-pod-sourceless-events',
+    namespace: 'default',
+    uid: 'owner-pod-uid-789',
+    creationTimestamp: getTestDate().toISOString(),
+  },
+});
+
 const mockEvents: KubeEvent[] = [
   {
     kind: 'Event',
@@ -102,6 +113,62 @@ const mockEvents: KubeEvent[] = [
   },
 ];
 
+// Events created through the events.k8s.io API have no `source` field, so the
+// From column has to tolerate it being absent.
+const mockSourcelessEvents: KubeEvent[] = [
+  {
+    kind: 'Event',
+    apiVersion: 'v1',
+    metadata: {
+      name: 'event3.789',
+      namespace: 'default',
+      uid: 'event-uid-3',
+      creationTimestamp: new Date(getTestDate().getTime() - 3 * 60 * 1000).toISOString(),
+    },
+    involvedObject: {
+      kind: 'Pod',
+      namespace: 'default',
+      name: 'test-pod-sourceless-events',
+      uid: 'owner-pod-uid-789',
+      apiVersion: 'v1',
+      resourceVersion: '1',
+      fieldPath: '',
+    },
+    reason: 'Scheduled',
+    message: 'Successfully assigned default/test-pod-sourceless-events to worker-node-1',
+    firstTimestamp: new Date(getTestDate().getTime() - 3 * 60 * 1000).toISOString(),
+    lastTimestamp: new Date(getTestDate().getTime() - 3 * 60 * 1000).toISOString(),
+    count: 1,
+    type: 'Normal',
+  },
+  {
+    kind: 'Event',
+    apiVersion: 'v1',
+    metadata: {
+      name: 'event4.101',
+      namespace: 'default',
+      uid: 'event-uid-4',
+      creationTimestamp: new Date(getTestDate().getTime() - 1 * 60 * 1000).toISOString(),
+    },
+    involvedObject: {
+      kind: 'Pod',
+      namespace: 'default',
+      name: 'test-pod-sourceless-events',
+      uid: 'owner-pod-uid-789',
+      apiVersion: 'v1',
+      resourceVersion: '1',
+      fieldPath: '',
+    },
+    reason: 'Pulled',
+    message: 'Container image "nginx:latest" already present on machine',
+    source: {},
+    firstTimestamp: new Date(getTestDate().getTime() - 1 * 60 * 1000).toISOString(),
+    lastTimestamp: new Date(getTestDate().getTime() - 1 * 60 * 1000).toISOString(),
+    count: 1,
+    type: 'Normal',
+  },
+];
+
 export default {
   title: 'common/ObjectEventList',
   component: ObjectEventList,
@@ -143,6 +210,22 @@ export default {
             ) {
               return HttpResponse.json({ kind: 'EventList', items: [], metadata: {} });
             }
+            if (
+              reqNamespace === mockOwnerObjectSourcelessEvents.metadata.namespace &&
+              fieldSelector &&
+              fieldSelector.includes(
+                `involvedObject.kind=${mockOwnerObjectSourcelessEvents.kind}`
+              ) &&
+              fieldSelector.includes(
+                `involvedObject.name=${mockOwnerObjectSourcelessEvents.metadata.name}`
+              )
+            ) {
+              return HttpResponse.json({
+                kind: 'EventList',
+                items: mockSourcelessEvents,
+                metadata: {},
+              });
+            }
             return HttpResponse.json({ kind: 'EventList', items: [], metadata: {} });
           }),
         ],
@@ -170,6 +253,12 @@ NoEventsForObject.args = {
   object: mockOwnerObjectNoEvents,
 };
 NoEventsForObject.storyName = 'No Events for an Object';
+
+export const EventsWithoutSource = Template.bind({});
+EventsWithoutSource.args = {
+  object: mockOwnerObjectSourcelessEvents,
+};
+EventsWithoutSource.storyName = 'Events Without a Source';
 
 export const ErrorFetching = Template.bind({});
 ErrorFetching.args = {

--- a/frontend/src/components/common/ObjectEventList.tsx
+++ b/frontend/src/components/common/ObjectEventList.tsx
@@ -130,7 +130,7 @@ export default function ObjectEventList(props: ObjectEventListProps) {
           {
             label: t('From'),
             getter: item => {
-              return item.source.component;
+              return item.source?.component ?? '';
             },
           },
           {

--- a/frontend/src/components/common/__snapshots__/ObjectEventList.EventsWithoutSource.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ObjectEventList.EventsWithoutSource.stories.storyshot
@@ -1,0 +1,196 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-j1fy4m"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiBox-root css-70qvj9"
+          >
+            <h2
+              class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+            >
+              Events
+            </h2>
+            <div
+              class="MuiBox-root css-ldp2l3"
+            >
+              <button
+                aria-label="Events lifetime information"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1txv3mw"
+      >
+        <div
+          aria-atomic="true"
+          aria-live="polite"
+          class="MuiBox-root css-ty8jgw"
+          role="status"
+        />
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-onzayo-MuiPaper-root-MuiTableContainer-root"
+          tabindex="0"
+        >
+          <table
+            class="MuiTable-root css-r7i92b-MuiTable-root"
+          >
+            <thead
+              class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+            >
+              <tr
+                class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+              >
+                <th
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                  scope="col"
+                >
+                  Type
+                </th>
+                <th
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                  scope="col"
+                >
+                  Reason
+                </th>
+                <th
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                  scope="col"
+                >
+                  From
+                </th>
+                <th
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                  scope="col"
+                >
+                  Message
+                </th>
+                <th
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-d9iroo-MuiTableCell-root"
+                  scope="col"
+                >
+                  Age
+                  <button
+                    aria-label="Sort ascending"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+            >
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  Normal
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  Scheduled
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                />
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <div
+                    class="MuiBox-root css-k008qs"
+                  >
+                    <span
+                      id="event-uid-3"
+                      style="word-break: break-all; white-space: normal;"
+                    >
+                      Successfully assigned default/test-pod-sourceless-events to worker-node-1
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <p
+                    aria-label="2024-02-14T23:57:00.000Z"
+                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    data-mui-internal-clone-element="true"
+                  >
+                    90d
+                  </p>
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  Normal
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  Pulled
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                />
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <div
+                    class="MuiBox-root css-k008qs"
+                  >
+                    <span
+                      id="event-uid-4"
+                      style="word-break: break-all; white-space: normal;"
+                    >
+                      Container image "nginx:latest" already present on machine
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <p
+                    aria-label="2024-02-14T23:59:00.000Z"
+                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    data-mui-internal-clone-element="true"
+                  >
+                    90d
+                  </p>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
## What this PR does

The `From` column in `ObjectEventList` read `item.source.component` without guarding against a missing `source`. Kubernetes omits that field on events created through the `events.k8s.io` API, so the Events section on resource detail pages threw:

```
TypeError: Cannot read properties of undefined (reading 'component')
```

`source` is not declared on the `KubeEvent` interface — it resolves through the `[otherProps: string]: any` index signature — so TypeScript did not flag the unguarded access.

## The change

```diff
-return item.source.component;
+return item.source?.component ?? '';
```

This matches the existing `event.source?.host ?? ''` usage in `cluster/Overview.tsx`.

## Testing

Added an `EventsWithoutSource` story covering both an event that omits `source` entirely and one whose `source` has no `component`.

Verified the story actually reproduces the bug: with the fix reverted, `EventsWithoutSource` fails with the exact `TypeError` from the issue while the other three `ObjectEventList` stories pass. With the fix applied, all 4 pass. Lint and typecheck are clean.

Fixes #5823