### PR TITLE
frontend: Fix PersistentVolume list crash when capacity is missing

### DIFF
--- a/frontend/src/components/storage/VolumeList.stories.tsx
+++ b/frontend/src/components/storage/VolumeList.stories.tsx
@@ -17,8 +17,8 @@
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import { API_BASE, TestContext } from '../../test';
-import ListView from './ClassList';
 import { BASE_PV } from './storyHelper';
+import ListView from './VolumeList';
 
 export default {
   title: 'PersistentVolume/ListView',
@@ -44,10 +44,42 @@ Items.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get(`${API_BASE}/apis/storage.k8s.io/v1/storageclasses`, () =>
+        http.get(`${API_BASE}/api/v1/persistentvolumes`, () =>
           HttpResponse.json({
             kind: 'PersistentVolumeList',
             items: [BASE_PV],
+            metadata: {},
+          })
+        ),
+      ],
+    },
+  },
+};
+
+// `capacity` is optional in the Kubernetes API, so the Capacity column has to
+// tolerate a PersistentVolume that omits it.
+const PV_WITHOUT_CAPACITY = {
+  ...BASE_PV,
+  metadata: {
+    ...BASE_PV.metadata,
+    name: 'pv-without-capacity',
+    uid: 'abc-5678',
+  },
+  spec: {
+    ...BASE_PV.spec,
+    capacity: undefined,
+  },
+} as unknown as typeof BASE_PV;
+
+export const WithoutCapacity = Template.bind({});
+WithoutCapacity.parameters = {
+  msw: {
+    handlers: {
+      story: [
+        http.get(`${API_BASE}/api/v1/persistentvolumes`, () =>
+          HttpResponse.json({
+            kind: 'PersistentVolumeList',
+            items: [PV_WITHOUT_CAPACITY],
             metadata: {},
           })
         ),

--- a/frontend/src/components/storage/VolumeList.tsx
+++ b/frontend/src/components/storage/VolumeList.tsx
@@ -59,7 +59,7 @@ export default function VolumeList() {
         {
           id: 'capacity',
           label: t('Capacity'),
-          getValue: volume => volume.spec.capacity.storage,
+          getValue: volume => volume.spec?.capacity?.storage,
         },
         {
           id: 'accessModes',

--- a/frontend/src/components/storage/__snapshots__/VolumeList.WithoutCapacity.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeList.WithoutCapacity.stories.storyshot
@@ -739,7 +739,7 @@
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
                     href="/"
                   >
-                    my-pvc
+                    pv-without-capacity
                   </a>
                 </td>
                 <td
@@ -756,9 +756,7 @@
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1l0ciqb-MuiTableCell-root"
-                >
-                  8Gi
-                </td>
+                />
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1idyspx-MuiTableCell-root"
                 >


### PR DESCRIPTION
## What this PR does

The Capacity column in the PersistentVolume list read `volume.spec.capacity.storage` without guarding against a missing `capacity`. That field is optional in the Kubernetes API — `+optional` with `omitempty` on [`PersistentVolumeSpec`](https://github.com/kubernetes/api/blob/master/core/v1/types.go) — so a volume served without it made the list throw:

```
TypeError: Cannot read properties of undefined (reading 'storage')
```

`KubePersistentVolume` declares `spec.capacity` as required, which is why TypeScript did not flag the unguarded access.

## The change

```diff
-getValue: volume => volume.spec.capacity.storage,
+getValue: volume => volume.spec?.capacity?.storage,
```

This matches `spec?.capacity?.storage` in `VolumeDetails.tsx` and `status?.capacity?.storage` in `ClaimList.tsx`. The neighbouring Access Modes column in this same file was already guarded.

## Story fix

While adding coverage I found `VolumeList.stories.tsx` imported `ClassList` and served its fixture from the `storageclasses` endpoint, so it snapshotted the Storage Classes table instead of the volume list — `VolumeList` had no real coverage. The committed `VolumeList.Items.storyshot` contains a "Storage Classes" heading, which shows the story was never rendering this component.

This PR points the story at `VolumeList` and the `persistentvolumes` endpoint. The `Items` snapshot changes accordingly, and now reflects the actual volume list.

## Testing

Added a `WithoutCapacity` story covering a volume that omits `capacity`.

Verified it reproduces the bug: with the fix reverted, `WithoutCapacity` fails with the exact `TypeError` above while `Items` still passes. With the fix applied, both pass. Lint is clean.

Fixes #7262