### PR TITLE
frontend: ClusterChooserPopup: Name the cluster listbox

### DIFF
--- a/frontend/src/components/cluster/ClusterChooserPopup.test.tsx
+++ b/frontend/src/components/cluster/ClusterChooserPopup.test.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import ClusterChooserPopup from './ClusterChooserPopup';
+
+// ClusterChooserPopup transitively pulls in k8s resource classes which have a
+// circular dependency that breaks module initialisation in the test
+// environment. Mock the two hooks it needs from there.
+vi.mock('../../lib/k8s', () => ({
+  useClustersConf: () => ({ cluster0: { name: 'cluster0' }, cluster1: { name: 'cluster1' } }),
+  useSelectedClusters: () => ['cluster0'],
+}));
+
+it('names the cluster listbox after the filter field', () => {
+  render(
+    <TestContext routerMap={{ cluster: 'cluster0' }} urlPrefix="/c">
+      <ClusterChooserPopup anchor={document.body} />
+    </TestContext>
+  );
+
+  expect(screen.getByRole('listbox', { name: 'Choose cluster' })).toBeInTheDocument();
+});

--- a/frontend/src/components/cluster/ClusterChooserPopup.tsx
+++ b/frontend/src/components/cluster/ClusterChooserPopup.tsx
@@ -260,7 +260,7 @@ function ClusterChooserPopup(props: ChooserPopupPros) {
       <Box p={2} pb={1}>
         <TextField
           label={t('Choose cluster')}
-          id="filled-size-small"
+          id="cluster-chooser-filter"
           placeholder={t('translation|Name')}
           variant="outlined"
           size="small"
@@ -278,6 +278,9 @@ function ClusterChooserPopup(props: ChooserPopupPros) {
         <MenuList
           id="cluster-chooser-list"
           role="listbox"
+          // A listbox is an ARIA input field, so it needs its own name: reuse
+          // the filter field's label.
+          aria-labelledby="cluster-chooser-filter-label"
           tabIndex={0}
           sx={{
             width: '280px',

--- a/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.NoClustersButRecent.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.NoClustersButRecent.stories.storyshot
@@ -33,8 +33,8 @@
           <label
             class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1f7ywh2-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="filled-size-small"
-            id="filled-size-small-label"
+            for="cluster-chooser-filter"
+            id="cluster-chooser-filter-label"
           >
             Choose cluster
           </label>
@@ -46,7 +46,7 @@
             <input
               aria-invalid="false"
               class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="filled-size-small"
+              id="cluster-chooser-filter"
               placeholder="Name"
               type="text"
               value=""
@@ -66,6 +66,7 @@
           </div>
         </div>
         <ul
+          aria-labelledby="cluster-chooser-filter-label"
           class="MuiList-root MuiList-padding MuiList-dense css-1k1lw4j-MuiList-root"
           id="cluster-chooser-list"
           role="listbox"

--- a/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.NoRecentClusters.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.NoRecentClusters.stories.storyshot
@@ -33,8 +33,8 @@
           <label
             class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1f7ywh2-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="filled-size-small"
-            id="filled-size-small-label"
+            for="cluster-chooser-filter"
+            id="cluster-chooser-filter-label"
           >
             Choose cluster
           </label>
@@ -46,7 +46,7 @@
             <input
               aria-invalid="false"
               class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="filled-size-small"
+              id="cluster-chooser-filter"
               placeholder="Name"
               type="text"
               value=""
@@ -66,6 +66,7 @@
           </div>
         </div>
         <ul
+          aria-labelledby="cluster-chooser-filter-label"
           class="MuiList-root MuiList-padding MuiList-dense css-1k1lw4j-MuiList-root"
           id="cluster-chooser-list"
           role="listbox"

--- a/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.Normal.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.Normal.stories.storyshot
@@ -33,8 +33,8 @@
           <label
             class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1f7ywh2-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="filled-size-small"
-            id="filled-size-small-label"
+            for="cluster-chooser-filter"
+            id="cluster-chooser-filter-label"
           >
             Choose cluster
           </label>
@@ -46,7 +46,7 @@
             <input
               aria-invalid="false"
               class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="filled-size-small"
+              id="cluster-chooser-filter"
               placeholder="Name"
               type="text"
               value=""
@@ -66,6 +66,7 @@
           </div>
         </div>
         <ul
+          aria-labelledby="cluster-chooser-filter-label"
           class="MuiList-root MuiList-padding MuiList-dense css-1k1lw4j-MuiList-root"
           id="cluster-chooser-list"
           role="listbox"

--- a/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.Scrollbar.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.Scrollbar.stories.storyshot
@@ -33,8 +33,8 @@
           <label
             class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1f7ywh2-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="filled-size-small"
-            id="filled-size-small-label"
+            for="cluster-chooser-filter"
+            id="cluster-chooser-filter-label"
           >
             Choose cluster
           </label>
@@ -46,7 +46,7 @@
             <input
               aria-invalid="false"
               class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="filled-size-small"
+              id="cluster-chooser-filter"
               placeholder="Name"
               type="text"
               value=""
@@ -66,6 +66,7 @@
           </div>
         </div>
         <ul
+          aria-labelledby="cluster-chooser-filter-label"
           class="MuiList-root MuiList-padding MuiList-dense css-1k1lw4j-MuiList-root"
           id="cluster-chooser-list"
           role="listbox"


### PR DESCRIPTION
The cluster list has `role="listbox"` but no accessible name, so screen readers announce an unlabelled input field.

Point `aria-labelledby` at the filter field's label and give that field a meaningful id (was `filled-size-small`, a leftover from an MUI example).

Test asserts the listbox is reachable by its name; storyshots updated.

Fixes #7195
