### PR TITLE
frontend: Guard storeClusterSettings against localStorage write failures

### DIFF
--- a/frontend/src/helpers/clusterSettings.test.ts
+++ b/frontend/src/helpers/clusterSettings.test.ts
@@ -83,6 +83,28 @@ describe('clusterSettings', () => {
       expect(localStorage.getItem('cluster_settings.prod')).toBe('{}');
       expect(loadClusterSettings('prod')).toEqual({});
     });
+
+    it('catches and logs error when localStorage.setItem throws', () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const originalSetItem = localStorage.setItem.bind(localStorage);
+      const setItemMock = vi.fn().mockImplementation(() => {
+        throw new Error('QuotaExceededError');
+      });
+      localStorage.setItem = setItemMock;
+
+      try {
+        storeClusterSettings('prod', { defaultNamespace: 'app' });
+
+        expect(setItemMock).toHaveBeenCalled();
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          'Failed to store cluster settings:',
+          'QuotaExceededError'
+        );
+      } finally {
+        localStorage.setItem = originalSetItem;
+        consoleErrorSpy.mockRestore();
+      }
+    });
   });
 
   describe('loadClusterSettings', () => {
@@ -123,32 +145,37 @@ describe('clusterSettings', () => {
 
       const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-      const result = loadClusterSettings('prod');
+      try {
+        const result = loadClusterSettings('prod');
 
-      expect(result).toEqual({});
-      expect(consoleWarnSpy).toHaveBeenCalled();
-      consoleWarnSpy.mockRestore();
+        expect(result).toEqual({});
+        expect(consoleWarnSpy).toHaveBeenCalled();
+      } finally {
+        consoleWarnSpy.mockRestore();
+      }
     });
 
     it('returns empty object and logs console warning when the stored payload is not an object', () => {
       const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-      // Test null
-      localStorage.setItem('cluster_settings.prod', 'null');
-      expect(loadClusterSettings('prod')).toEqual({});
-      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+      try {
+        // Test null
+        localStorage.setItem('cluster_settings.prod', 'null');
+        expect(loadClusterSettings('prod')).toEqual({});
+        expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
 
-      // Test array
-      localStorage.setItem('cluster_settings.prod', '[1, 2, 3]');
-      expect(loadClusterSettings('prod')).toEqual({});
-      expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+        // Test array
+        localStorage.setItem('cluster_settings.prod', '[1, 2, 3]');
+        expect(loadClusterSettings('prod')).toEqual({});
+        expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
 
-      // Test string
-      localStorage.setItem('cluster_settings.prod', '"some string"');
-      expect(loadClusterSettings('prod')).toEqual({});
-      expect(consoleWarnSpy).toHaveBeenCalledTimes(3);
-
-      consoleWarnSpy.mockRestore();
+        // Test string
+        localStorage.setItem('cluster_settings.prod', '"some string"');
+        expect(loadClusterSettings('prod')).toEqual({});
+        expect(consoleWarnSpy).toHaveBeenCalledTimes(3);
+      } finally {
+        consoleWarnSpy.mockRestore();
+      }
     });
   });
 });

--- a/frontend/src/helpers/clusterSettings.ts
+++ b/frontend/src/helpers/clusterSettings.ts
@@ -55,7 +55,14 @@ export function storeClusterSettings(clusterName: string, settings: ClusterSetti
   if (!clusterName) {
     return;
   }
-  localStorage.setItem(`cluster_settings.${clusterName}`, JSON.stringify(settings));
+  try {
+    localStorage.setItem(`cluster_settings.${clusterName}`, JSON.stringify(settings));
+  } catch (error) {
+    console.error(
+      'Failed to store cluster settings:',
+      error instanceof Error ? error.message : String(error)
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes #7265

## Summary
This PR adds defensive error handling to `storeClusterSettings`. It wraps `localStorage.setItem` in a `try/catch` block so that if the browser throws a `QuotaExceededError` (or any other storage exception), the application logs the error safely instead of crashing the settings panel with an uncaught exception.

*(Note: The read-path `JSON.parse` fixes originally intended for this PR have already been merged into `main` via commits 3c630c47 and 20ed7132, so this PR now focuses exclusively on securing the write-path).*

## Changes
- `clusterSettings.ts`: Wrap `localStorage.setItem` in a `try/catch` block. On failure, the error is logged to the console and the call becomes a safe no-op.
- `clusterSettings.test.ts`: Add tests for the new error-handling path and harden existing test spy teardown with `try/finally` blocks to prevent mock leakage.

## Steps to Test
1. Run `npm run frontend:test -- src/helpers/clusterSettings.test.ts`
2. Verify all tests pass, including the new tests covering `localStorage.setItem` exception handling.

## Notes for the Reviewer
- Purely defensive fix: no public API changes, no new dependencies.
- Follows the same defensive pattern as the accepted PR #6119 (`pluginConfigSlice` try/catch).