### PR TITLE
frontend: ShowHideLabel: Fix aria attributes

### DIFF
--- a/frontend/.axe-storybook-baseline.test-a11y.json
+++ b/frontend/.axe-storybook-baseline.test-a11y.json
@@ -48,8 +48,6 @@
     "common/ReleaseNotes/ReleaseNotes/Default": ["heading-order"],
     "common/ReleaseNotes/ReleaseNotesModal/Show": ["heading-order", "scrollable-region-focusable"],
     "Resource/RestartMultipleButton/Menu Button Style": ["aria-required-parent"],
-    "common/ShowHideLabel/Basic": ["aria-allowed-attr"],
-    "common/ShowHideLabel/Expanded": ["aria-allowed-attr"],
     "GlobalSearch/Basic Example": ["color-contrast"],
     "Settings/PodDebugSettings/Default": ["label-title-only"],
     "Settings/PodDebugSettings/Disabled": ["label-title-only"],

--- a/frontend/src/components/common/ShowHideLabel/ShowHideLabel.tsx
+++ b/frontend/src/components/common/ShowHideLabel/ShowHideLabel.tsx
@@ -53,25 +53,24 @@ export default function ShowHideLabel(props: ShowHideLabelProps) {
   }
 
   return (
-    <Box display={expanded ? 'block' : 'flex'}>
+    <Box display="block">
       <span id={labelIdOrRandom} style={{ wordBreak: 'break-all', whiteSpace: 'normal' }}>
         {actualText}
-        {needsButton && (
-          <>
-            {!expanded && '…'}
-            <IconButton
-              aria-controls={labelIdOrRandom}
-              aria-expanded={expanded}
-              sx={{ display: 'inline' }}
-              onClick={() => setExpanded(expandedVal => !expandedVal)}
-              size="small"
-              aria-label={expanded ? t('translation|Collapse') : t('translation|Expand')}
-            >
-              <Icon icon={expanded ? 'mdi:menu-up' : 'mdi:menu-down'} />
-            </IconButton>
-          </>
-        )}
+        {!expanded && needsButton && '…'}
       </span>
+
+      {needsButton && (
+        <IconButton
+          aria-controls={labelIdOrRandom}
+          aria-expanded={expanded}
+          sx={{ display: 'inline' }}
+          onClick={() => setExpanded(expandedVal => !expandedVal)}
+          size="small"
+          aria-label={expanded ? t('translation|Collapse') : t('translation|Expand')}
+        >
+          <Icon icon={expanded ? 'mdi:menu-up' : 'mdi:menu-down'} />
+        </IconButton>
+      )}
     </Box>
   );
 }

--- a/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.Basic.stories.storyshot
+++ b/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.Basic.stories.storyshot
@@ -4,7 +4,7 @@
       class="MuiBox-root css-1v5z18m"
     >
       <div
-        class="MuiBox-root css-k008qs"
+        class="MuiBox-root css-13o7eu2"
       >
         <span
           id="label-id"
@@ -12,19 +12,19 @@
         >
           This is a placeholder label text that is many characters long. It is meant to be used as a temporary label for a UI element until the actual label is available. The text is long enough to fill up the space allocated for the label and provide a realistic pr
           …
-          <button
-            aria-controls="label-id"
-            aria-expanded="false"
-            aria-label="Expand"
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-z81te2-MuiButtonBase-root-MuiIconButton-root"
-            tabindex="0"
-            type="button"
-          >
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
-          </button>
         </span>
+        <button
+          aria-controls="label-id"
+          aria-expanded="false"
+          aria-label="Expand"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-z81te2-MuiButtonBase-root-MuiIconButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
       </div>
     </div>
   </div>

--- a/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.Expanded.stories.storyshot
+++ b/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.Expanded.stories.storyshot
@@ -11,19 +11,19 @@
           style="word-break: break-all; white-space: normal;"
         >
           This is a placeholder label text that is many characters long. It is meant to be used as a temporary label for a UI element until the actual label is available. The text is long enough to fill up the space allocated for the label and provide a realistic preview of how the label will look in the final UI. You can replace this text with the actual label text once it is available. This will ensure that the UI looks complete and professional even during the development phase. Thank you for using this placeholder text!
-          <button
-            aria-controls="my-label"
-            aria-expanded="true"
-            aria-label="Collapse"
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-z81te2-MuiButtonBase-root-MuiIconButton-root"
-            tabindex="0"
-            type="button"
-          >
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
-          </button>
         </span>
+        <button
+          aria-controls="my-label"
+          aria-expanded="true"
+          aria-label="Collapse"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-z81te2-MuiButtonBase-root-MuiIconButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
       </div>
     </div>
   </div>

--- a/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.ShortText.stories.storyshot
+++ b/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.ShortText.stories.storyshot
@@ -4,7 +4,7 @@
       class="MuiBox-root css-1v5z18m"
     >
       <div
-        class="MuiBox-root css-k008qs"
+        class="MuiBox-root css-13o7eu2"
       >
         <span
           id="my-label2"

--- a/frontend/src/components/common/__snapshots__/ObjectEventList.WithEvents.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ObjectEventList.WithEvents.stories.storyshot
@@ -125,7 +125,7 @@
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
                 >
                   <div
-                    class="MuiBox-root css-k008qs"
+                    class="MuiBox-root css-13o7eu2"
                   >
                     <span
                       id="event-uid-1"
@@ -169,7 +169,7 @@
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
                 >
                   <div
-                    class="MuiBox-root css-k008qs"
+                    class="MuiBox-root css-13o7eu2"
                   >
                     <span
                       id="event-uid-2"


### PR DESCRIPTION
## Summary

This PR fixes an accessibility issue in the ShowHideLabel component by moving the expand/collapse IconButton outside of the label element. The button now correctly controls the label text while keeping aria-expanded and aria-controls on the interactive element.

## Related Issue

Fixes #7194 

## Changes

- Updated ShowHideLabel to move the expand/collapse IconButton outside of the label <span>.
- Kept aria-expanded and aria-controls on the IconButton.
- Updated the ShowHideLabel Basic and Expanded Storybook snapshots to reflect the new DOM structure.

## Steps to Test

1) Navigate to the ShowHideLabel Storybook stories.
2) Open the Basic story and verify the long label is truncated with an expand button.
3) Click the expand button and verify the full label text is displayed.
4) Click the button again and verify the label collapses.
5) Open the Expanded story and verify the label is initially expanded and can be collapsed.
6) Verify the expand/collapse button has the appropriate aria-expanded and aria-controls attributes.

## Screenshots (if applicable)
N.A.

## Notes for the Reviewer
- The change is focused on the accessibility semantics and DOM structure of ShowHideLabel.
- The Storybook snapshots were updated to reflect the new element structure.
