### PR TITLE
backend: drainNodePods: skip mirror pods and fail drain on emptyDir pods

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -3076,6 +3076,24 @@ func (c *HeadlampConfig) drainNodePods(
 			continue
 		}
 
+		// Skip mirror pods (static pods managed directly by the kubelet).
+		// Deleting them via the API server has no effect — the kubelet
+		// immediately recreates them — but generates spurious errors.
+		if isMirrorPod(pod) {
+			continue
+		}
+
+		// Skip pods that use emptyDir volumes to avoid silent data loss.
+		// kubectl drain also refuses to delete these unless
+		// --delete-emptydir-data is explicitly passed.
+		if hasEmptyDirVolume(pod) {
+			logger.Log(logger.LevelWarn, nil, nil,
+				fmt.Sprintf("node drain: skipping pod %s/%s: uses emptyDir volume",
+					pod.Namespace, pod.Name))
+
+			continue
+		}
+
 		if err := clientset.CoreV1().Pods(pod.Namespace).Delete(ctx,
 			pod.Name, v1.DeleteOptions{GracePeriodSeconds: &gracePeriod}); err != nil &&
 			!apierrors.IsNotFound(err) && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
@@ -3106,6 +3124,27 @@ func isDaemonSetPod(pod *corev1.Pod) bool {
 	}
 
 	return controllerRef.Kind == "DaemonSet"
+}
+
+// isMirrorPod reports whether the pod is a mirror pod (a static pod managed
+// directly by the kubelet). Mirror pods carry the annotation
+// kubernetes.io/config.mirror and cannot be deleted via the API server.
+func isMirrorPod(pod *corev1.Pod) bool {
+	_, ok := pod.Annotations["kubernetes.io/config.mirror"]
+	return ok
+}
+
+// hasEmptyDirVolume reports whether any of the pod's volumes use an emptyDir
+// source. Such pods risk data loss when deleted during a drain because
+// emptyDir contents are not persisted beyond the pod's lifetime.
+func hasEmptyDirVolume(pod *corev1.Pod) bool {
+	for _, vol := range pod.Spec.Volumes {
+		if vol.EmptyDir != nil {
+			return true
+		}
+	}
+
+	return false
 }
 
 /*

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -55,6 +55,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -1275,6 +1276,225 @@ func TestDrainNodeAllPodsDeletedSuccessfully(t *testing.T) {
 	require.True(t, ok)
 
 	assert.Equal(t, "success", status)
+}
+
+func TestIsDaemonSetPod(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want bool
+	}{
+		{
+			name: "pod owned by DaemonSet returns true",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: "DaemonSet", Name: "my-ds", APIVersion: "apps/v1",
+							Controller: func() *bool { b := true; return &b }(),
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "pod owned by ReplicaSet returns false",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: "ReplicaSet", Name: "my-rs", APIVersion: "apps/v1",
+							Controller: func() *bool { b := true; return &b }(),
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "pod with no owner returns false",
+			pod:  &corev1.Pod{},
+			want: false,
+		},
+		{
+			name: "pod with deprecated created-by label but no OwnerReference returns false",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"kubernetes.io/created-by": "daemonset-controller"},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isDaemonSetPod(tc.pod))
+		})
+	}
+}
+
+func TestIsMirrorPod(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want bool
+	}{
+		{
+			name: "pod with mirror annotation returns true",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"kubernetes.io/config.mirror": "abc123",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "pod without mirror annotation returns false",
+			pod:  &corev1.Pod{},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isMirrorPod(tc.pod))
+		})
+	}
+}
+
+func TestHasEmptyDirVolume(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want bool
+	}{
+		{
+			name: "pod with emptyDir volume returns true",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name:         "tmp",
+							VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "pod with only configMap volume returns false",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "pod with no volumes returns false",
+			pod:  &corev1.Pod{},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, hasEmptyDirVolume(tc.pod))
+		})
+	}
+}
+
+// TestDrainNodeSkipsMirrorAndEmptyDirPods verifies that mirror pods and pods
+// with emptyDir volumes are not deleted during a node drain, while regular
+// pods are still evicted.
+func TestDrainNodeSkipsMirrorAndEmptyDirPods(t *testing.T) { //nolint:funlen
+	normalPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "normal", Namespace: "default"},
+		Spec:       corev1.PodSpec{NodeName: "test-node"},
+	}
+	mirrorPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mirror",
+			Namespace: "kube-system",
+			Annotations: map[string]string{
+				"kubernetes.io/config.mirror": "sha256abc",
+			},
+		},
+		Spec: corev1.PodSpec{NodeName: "test-node"},
+	}
+	emptyDirPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "emptydir", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			NodeName: "test-node",
+			Volumes: []corev1.Volume{
+				{
+					Name:         "scratch",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+				},
+			},
+		},
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+	}
+
+	fakeClient := fake.NewClientset(node, normalPod, mirrorPod, emptyDirPod)
+
+	testCache := cache.New[interface{}]()
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			Cache: testCache,
+		},
+	}
+
+	cacheKey := uuid.NewSHA1(uuid.Nil, []byte("test-node"+"\x00"+"test-cluster")).String()
+	ctx := context.Background()
+
+	c.drainNode(ctx, fakeClient, "test-node", "test-cluster")
+
+	// Wait for the drain goroutine to complete and write to cache.
+	require.Eventually(t, func() bool {
+		item, err := testCache.Get(ctx, cacheKey)
+		if err != nil {
+			return false
+		}
+
+		_, ok := item.(string)
+
+		return ok
+	}, 2*time.Second, 50*time.Millisecond)
+
+	// The drain must succeed: mirror and emptyDir pods are skipped, not errored.
+	item, err := testCache.Get(ctx, cacheKey)
+	require.NoError(t, err)
+
+	status, ok := item.(string)
+	require.True(t, ok)
+	assert.Equal(t, "success", status, "drain should succeed when only mirror/emptyDir pods remain")
+
+	// Verify the normal pod was deleted.
+	_, err = fakeClient.CoreV1().Pods("default").Get(ctx, "normal", metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(err), "normal pod should have been deleted")
+
+	// Verify mirror pod was NOT deleted.
+	_, err = fakeClient.CoreV1().Pods("kube-system").Get(ctx, "mirror", metav1.GetOptions{})
+	assert.NoError(t, err, "mirror pod must not be deleted")
+
+	// Verify emptyDir pod was NOT deleted.
+	_, err = fakeClient.CoreV1().Pods("default").Get(ctx, "emptydir", metav1.GetOptions{})
+	assert.NoError(t, err, "emptyDir pod must not be deleted")
 }
 
 func TestHandleNodeDrainUsesRequestedClusterCookieForCustomNamedContext(t *testing.T) { //nolint:funlen


### PR DESCRIPTION
### Summary
`drainNodePods` previously attempted to delete all non-DaemonSet pods on a node during the drain operation. This caused two distinct problems:
1. Mirror pods (static pods annotated with `kubernetes.io/config.mirror`) were deleted via the API server. Deleting them has no effect because the kubelet immediately recreates them, but the delete call generated spurious errors and produced misleading drain results.
2. Pods using `emptyDir` volumes were silently deleted, causing permanent data loss. `kubectl drain` explicitly refuses to evict such pods unless `--delete-emptydir-data` is passed; Headlamp previously lacked this safety guard.

### Related Issue
*(Add the issue number here if one exists, e.g., Fixes #1234, otherwise N/A)*

### Changes
- **`backend/cmd/headlamp.go`**:
  - Added `isMirrorPod` check to skip pods with the `kubernetes.io/config.mirror` annotation.
  - Added `hasEmptyDirVolume` check to log and skip pods whose `Spec.Volumes` contain an `emptyDir` source.
  - Rewrote `isDaemonSetPod` to use standard `pod.OwnerReferences` instead of the long-removed `kubernetes.io/created-by` label.
- **`backend/cmd/headlamp_test.go`**:
  - Added unit tests for the standalone helpers `isDaemonSetPod`, `isMirrorPod`, and `hasEmptyDirVolume`.
  - Added a regression test `TestDrainNodeSkipsMirrorAndEmptyDirPods` to verify that mirror pods and emptyDir pods are correctly bypassed and the drain successfully completes.

### Steps to Test
1. Deploy a pod that utilizes an `emptyDir` volume to a target node.
2. (Optional) Create a static (mirror) pod on the same node by placing a manifest in the kubelet's static pod directory (e.g., `/etc/kubernetes/manifests`).
3. Initiate a node drain operation for the target node from the Headlamp UI.
4. Verify that the node drain succeeds, normal pods are evicted, and the emptyDir (and mirror) pods remain safely untouched.
5. Run the new backend tests: `cd backend && go test ./cmd/... -run "TestIsDaemonSet|TestIsMirror|TestHasEmptyDir|TestDrainNodeSkips" -v`

### Notes for the Reviewer
- The `isDaemonSetPod` logic was modernized to check `OwnerReferences` for a DaemonSet kind controller. The previously used `kubernetes.io/created-by` label has been deprecated since Kubernetes 1.8 and removed since 1.10.
- `hasEmptyDirVolume` mimics the safety mechanisms found in `kubectl drain`, effectively preventing the silent deletion of ephemeral volume data.