### PR TITLE
frontend: ShowHideLabel: fix phantom collapse button on short text

### DIFF
--- a/frontend/src/components/common/ShowHideLabel/ShowHideLabel.stories.tsx
+++ b/frontend/src/components/common/ShowHideLabel/ShowHideLabel.stories.tsx
@@ -56,3 +56,10 @@ ShortText.args = {
   children: 'Short text',
   labelId: 'my-label2',
 };
+
+export const ExpandedShortText = Template.bind({});
+ExpandedShortText.args = {
+  children: 'Short text',
+  show: true,
+  labelId: 'my-label3',
+};

--- a/frontend/src/components/common/ShowHideLabel/ShowHideLabel.test.tsx
+++ b/frontend/src/components/common/ShowHideLabel/ShowHideLabel.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import ShowHideLabel from './ShowHideLabel';
+
+describe('ShowHideLabel', () => {
+  it('does not render a toggle button for short text', () => {
+    render(<ShowHideLabel maxChars={20}>Short text</ShowHideLabel>);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('does not render a toggle button for short text even when initialized expanded', () => {
+    // Regression test: needsButton used to be computed as unconditionally true
+    // whenever expanded was true, so show={true} on text that never needed
+    // truncating rendered a Collapse button that vanished (rather than toggled
+    // back to Expand) the moment it was clicked.
+    render(
+      <ShowHideLabel show maxChars={20}>
+        Short text
+      </ShowHideLabel>
+    );
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders a toggle button and expands/collapses long text on click', () => {
+    const longText = 'a'.repeat(30);
+    render(<ShowHideLabel maxChars={20}>{longText}</ShowHideLabel>);
+
+    const button = screen.getByRole('button', { name: /expand/i });
+    expect(button).toBeInTheDocument();
+    expect(screen.getByText(longText.slice(0, 20), { exact: false })).toBeInTheDocument();
+
+    fireEvent.click(button);
+    expect(screen.getByRole('button', { name: /collapse/i })).toBeInTheDocument();
+    expect(screen.getByText(longText)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /collapse/i }));
+    expect(screen.getByRole('button', { name: /expand/i })).toBeInTheDocument();
+  });
+
+  it('keeps the toggle button visible after expanding long text initialized with show', () => {
+    const longText = 'a'.repeat(30);
+    render(
+      <ShowHideLabel show maxChars={20}>
+        {longText}
+      </ShowHideLabel>
+    );
+
+    expect(screen.getByRole('button', { name: /collapse/i })).toBeInTheDocument();
+    expect(screen.getByText(longText)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/common/ShowHideLabel/ShowHideLabel.tsx
+++ b/frontend/src/components/common/ShowHideLabel/ShowHideLabel.tsx
@@ -41,11 +41,13 @@ export default function ShowHideLabel(props: ShowHideLabelProps) {
       return ['', false];
     }
 
+    const isLong = children.length > maxChars;
+
     if (expanded) {
-      return [children, true];
+      return [children, isLong];
     }
 
-    return [children.substr(0, maxChars), children.length > maxChars];
+    return [children.substr(0, maxChars), isLong];
   }, [children, expanded, maxChars]);
 
   if (!children) {

--- a/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.ExpandedShortText.stories.storyshot
+++ b/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.ExpandedShortText.stories.storyshot
@@ -1,0 +1,18 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-1v5z18m"
+    >
+      <div
+        class="MuiBox-root css-13o7eu2"
+      >
+        <span
+          id="my-label3"
+          style="word-break: break-all; white-space: normal;"
+        >
+          Short text
+        </span>
+      </div>
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
## Summary

Fixes a phantom collapse button in `ShowHideLabel`: initializing the component with `show={true}` on text shorter than `maxChars` rendered a Collapse button that never should have appeared, and clicking it made the button vanish entirely instead of toggling back to Expand.

Fixes #7270

## Root cause

`needsButton` was unconditionally `true` whenever `expanded` was `true`:

```tsx
if (expanded) {
  return [children, true];
}
```

So `<ShowHideLabel show={true}>Short text</ShowHideLabel>` rendered a button even though the text never needed truncating. Clicking it flipped `expanded` to `false`, which recomputed `needsButton` as `children.length > maxChars` (false for short text), so the button disappeared instead of behaving like a toggle.

## Fix

`needsButton` is now derived solely from whether the text actually exceeds `maxChars`, independent of `expanded`.

## Testing

- Added a unit test file (`ShowHideLabel.test.tsx`) covering: no button for short text, no button for short text initialized expanded (the regression case), toggle behavior for long text, and toggle staying visible for long text initialized expanded.
- Added a new `ExpandedShortText` story/storyshot to cover this case visually.
- Verified all existing ShowHideLabel snapshots are unaffected.
