### PR TITLE
spa: Fix TestURLToRelAcceptsSafeRelativePath for Windows cross-platform compatibility

### DIFF
--- a/backend/pkg/spa/pathSafety_internal_test.go
+++ b/backend/pkg/spa/pathSafety_internal_test.go
@@ -1,6 +1,9 @@
 package spa
 
-import "testing"
+import (
+	"runtime"
+	"testing"
+)
 
 func TestURLToRelRejectsUnsafePaths(t *testing.T) {
 	tests := []struct {
@@ -27,7 +30,13 @@ func TestURLToRelAcceptsSafeRelativePath(t *testing.T) {
 		t.Fatalf("expected safe path to be accepted")
 	}
 
-	if rel != "headlamp/assets/main.js" {
+	// On Windows, filepath.FromSlash converts / to \
+	expected := "headlamp/assets/main.js"
+	if runtime.GOOS == "windows" {
+		expected = "headlamp\\assets\\main.js"
+	}
+
+	if rel != expected {
 		t.Fatalf("unexpected relative path: got %q", rel)
 	}
 }


### PR DESCRIPTION
## Summary
This PR fixes `TestURLToRelAcceptsSafeRelativePath` test failure on Windows by making the test expectation OS-aware using `runtime.GOOS`.

## Changes
- Fixed `backend/pkg/spa/pathSafety_internal_test.go` to handle Windows path separator conversion
- Added runtime import for OS detection
- Made test expect `"headlamp\\assets\\main.js"` on Windows and `"headlamp/assets/main.js"` on Linux/macOS

## Steps to Test
1. Run `go test -count=1 ./pkg/spa` on Windows
2. Verify `TestURLToRelAcceptsSafeRelativePath` passes

## Notes for the Reviewer
- This is a test-only change - no production code modified
- The `urlToRel` function correctly produces OS-specific paths via `filepath.FromSlash()` - the test expectation was written for Linux/macOS format only