### PR TITLE
0019: frontend: Clean up desktop IPC listeners

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -47,6 +47,13 @@ jobs:
     - name: App linux
       run: |
         make app-linux
+    - name: Install desktop e2e dependencies
+      run: |
+        cd app/e2e-tests
+        npm ci
+        npx playwright install --with-deps chromium
+    - name: Test desktop listener cleanup
+      run: xvfb-run --auto-servernum npm run app:test:e2e -- tests/listenerCleanup.spec.ts
     - name: Verify Linux build
       run: npm run app:verify-build-linux
     - name: Start Minikube

--- a/app/e2e-tests/README.md
+++ b/app/e2e-tests/README.md
@@ -1,13 +1,12 @@
 # e2e tests for the desktop (Electron) app
 
 These are the Playwright tests for the desktop app, driven via
-`npm run test-app`, which launches the real Electron app against a real
-minikube cluster. The web-mode tests for in-cluster Headlamp live in the
-top-level `e2e-tests` directory.
+`npm run test-app`, which launches the real Electron app. The web-mode tests for
+in-cluster Headlamp live in the top-level `e2e-tests` directory.
 
 ## Prerequisites
 
-A running minikube cluster named `minikube`:
+The cluster workflow specs need a running minikube cluster named `minikube`:
 
 ```bash
 minikube start
@@ -17,7 +16,10 @@ kubectl config current-context   # should print: minikube
 The name matters. `clusterRename.spec.ts` expects a cluster called `minikube`,
 and `clusterAutoConnect.spec.ts` shells out to `minikube` directly to create and
 delete its own throwaway profile, so `minikube` and `kubectl` must both be on
-`PATH`.
+`PATH`. `listenerCleanup.spec.ts` does not require minikube.
+
+`listenerCleanup.spec.ts` runs `gh --version`, so the GitHub CLI must also be
+installed and available on `PATH`.
 
 App mode runs the app from source rather than from a packaged build, so the
 things the app loads in dev mode have to exist first:

--- a/app/e2e-tests/package-lock.json
+++ b/app/e2e-tests/package-lock.json
@@ -11,7 +11,8 @@
       "devDependencies": {
         "@axe-core/playwright": "^4.10.1",
         "@playwright/test": "^1.48.1",
-        "@types/node": "^22.7.5"
+        "@types/node": "^22.7.5",
+        "esbuild": "^0.25.12"
       }
     },
     "node_modules/@axe-core/playwright": {
@@ -25,6 +26,448 @@
       },
       "peerDependencies": {
         "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha1-gPy+NhMOWLdnBRHoiLjoiiWe12w=",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha1-MAcSEB9/UPHSYnoWLm4JsQm2dno=",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha1-iqSWX40KeYLcIXNL9mATI6Ztp1I=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha1-h9+ycWEgK9yVjvSLthsJx1j67hY=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha1-eRl4mOwf90XSHAceHHzDyALwwf0=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha1-FGQAqFYhM/RcTS6tzzfd0JcYB54=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha1-HF+bpyBuFY/SskxZ+i0si7R8oP4=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha1-6mMfSja+qsS5J5+g/MbKKerusrM=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha1-RSzWayCTLQi9xTqLYcDjC69DSLk=",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha1-4QZrzlg5TxsRQd7shVel8KIvWXc=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha1-sk+KzEW89UGSx/LzvhtT5lUer+A=",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha1-+c//p/yDIlcfvEyLMmjK8VvYGtA=",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha1-V1oUvXRkT/q4ka3H1+YNJ1KW8s0=",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha1-dbmccKlfvV93OddpK+/mBgFZGGk=",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha1-LjJZRAMhpE553fdTXDJQV9qHXNY=",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha1-F2dsq7/lko2lsqDW311YzQjbJmM=",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha1-BYN3VoXKggZtBMNQfwlSTTzXowY=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha1-8ExAScsuJS/paxb+2Q9wdGsT9KQ=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha1-d9oNCg2CbXySHuo9QCklSLJYoHY=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha1-Ypb1hnrt7yioGyKrIAnHhqlS3M0=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha1-+NIzAzYOJ7Fs8GWyO7/0PBQUJnk=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha1-SeC3aHRKOSS+DX/ZfdbOmykj2I0=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha1-pu19Z3jWflKMgfsWWyP0kRubE9Y=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha1-msFMN44bZTrxfQjn0840yu9YcyM=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha1-kYlC3LuzXMFPyjmvuRteaj0Scmc=",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha1-m9rYF2vngRrRSNH4dyNZBB9GxsU=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@playwright/test": {
@@ -61,6 +504,48 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha1-l6HQQfSrAML84vg40rmWmi0ql6U=",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/fsevents": {

--- a/app/e2e-tests/package.json
+++ b/app/e2e-tests/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.10.1",
     "@playwright/test": "^1.48.1",
-    "@types/node": "^22.7.5"
+    "@types/node": "^22.7.5",
+    "esbuild": "^0.25.12"
   }
 }

--- a/app/e2e-tests/playwright.electron.config.ts
+++ b/app/e2e-tests/playwright.electron.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
     'namespaces.spec.ts',
     'clusterAutoConnect.spec.ts',
     'pluginSecureStorage.spec.ts',
+    'listenerCleanup.spec.ts',
   ],
   timeout: 60 * 1000,
   expect: {

--- a/app/e2e-tests/tests/listenerCleanup.spec.ts
+++ b/app/e2e-tests/tests/listenerCleanup.spec.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import path from 'path';
+import { _electron, ElectronApplication, Page } from 'playwright';
+
+const electronExecutable = process.platform === 'win32' ? 'electron.cmd' : 'electron';
+const electronPath = path.resolve(__dirname, `../../node_modules/.bin/${electronExecutable}`);
+const appPath = path.resolve(__dirname, '../../');
+
+let electronApp: ElectronApplication;
+let electronPage: Page;
+
+test.describe('desktop listener cleanup', () => {
+  test.beforeAll(async () => {
+    electronApp = await _electron.launch({
+      cwd: appPath,
+      executablePath: electronPath,
+      args: ['.'],
+      env: {
+        ...process.env,
+        NODE_ENV: 'development',
+        ELECTRON_DEV: 'true',
+      },
+    });
+    electronPage = await electronApp.firstWindow();
+    await electronPage.waitForLoadState('load');
+  });
+
+  test.afterAll(async () => {
+    await electronApp?.close();
+  });
+
+  test('stops delivering IPC events after unsubscribe', async () => {
+    await electronPage.evaluate(() => {
+      const desktopApi = (window as any).desktopApi;
+      (window as any).listenerCleanupEvents = [];
+      (window as any).unsubscribeCommand = desktopApi.receive(
+        'command-stdout',
+        (commandId: string, data: string) => {
+          (window as any).listenerCleanupEvents.push(`${commandId}:${data}`);
+        }
+      );
+      (window as any).unsubscribeMarker = desktopApi.receive('command-stderr', () => {
+        (window as any).listenerCleanupMarker = true;
+      });
+    });
+
+    await electronApp.evaluate(({ BrowserWindow }) => {
+      BrowserWindow.getAllWindows()[0].webContents.send('command-stdout', 'test-command', 'before');
+    });
+    await expect
+      .poll(() => electronPage.evaluate(() => (window as any).listenerCleanupEvents))
+      .toEqual(['test-command:before']);
+
+    await electronPage.evaluate(() => (window as any).unsubscribeCommand());
+    await electronApp.evaluate(({ BrowserWindow }) => {
+      const window = BrowserWindow.getAllWindows()[0];
+      window.webContents.send('command-stdout', 'test-command', 'after');
+      window.webContents.send('command-stderr', 'marker');
+    });
+    await expect
+      .poll(() => electronPage.evaluate(() => (window as any).listenerCleanupMarker))
+      .toBe(true);
+
+    await expect(
+      electronPage.evaluate(() => (window as any).listenerCleanupEvents)
+    ).resolves.toEqual(['test-command:before']);
+    await electronPage.evaluate(() => (window as any).unsubscribeMarker());
+  });
+});

--- a/app/e2e-tests/tests/listenerCleanup.spec.ts
+++ b/app/e2e-tests/tests/listenerCleanup.spec.ts
@@ -15,22 +15,53 @@
  */
 
 import { expect, test } from '@playwright/test';
+import { build } from 'esbuild';
+import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { _electron, ElectronApplication, Page } from 'playwright';
 
 const electronExecutable = process.platform === 'win32' ? 'electron.cmd' : 'electron';
 const electronPath = path.resolve(__dirname, `../../node_modules/.bin/${electronExecutable}`);
 const appPath = path.resolve(__dirname, '../../');
+const runCommandPath = path.resolve(
+  __dirname,
+  '../../../frontend/src/components/App/runCommand.ts'
+);
 
 let electronApp: ElectronApplication;
 let electronPage: Page;
+let userDataDirectory: string;
+
+/**
+ * Persists consent for the command used by the Electron test.
+ *
+ * @param allowed - Whether `gh --version` is allowed to run.
+ */
+async function setCommandConsent(allowed: boolean): Promise<void> {
+  const settingsDirectory = await electronApp.evaluate(({ app }) => app.getPath('userData'));
+  fs.mkdirSync(settingsDirectory, { recursive: true });
+  fs.writeFileSync(
+    path.join(settingsDirectory, 'settings.json'),
+    JSON.stringify({ confirmedCommands: { 'gh --version': allowed } })
+  );
+}
 
 test.describe('desktop listener cleanup', () => {
   test.beforeAll(async () => {
+    const bundle = await build({
+      entryPoints: [runCommandPath],
+      bundle: true,
+      format: 'iife',
+      globalName: 'RunCommandModule',
+      platform: 'browser',
+      write: false,
+    });
+    userDataDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-listener-e2e-'));
     electronApp = await _electron.launch({
       cwd: appPath,
       executablePath: electronPath,
-      args: ['.'],
+      args: ['.', `--user-data-dir=${userDataDirectory}`],
       env: {
         ...process.env,
         NODE_ENV: 'development',
@@ -39,47 +70,89 @@ test.describe('desktop listener cleanup', () => {
     });
     electronPage = await electronApp.firstWindow();
     await electronPage.waitForLoadState('load');
+    await electronPage.addInitScript(() => {
+      (window as any).desktopApi.receive(
+        'plugin-permission-secrets',
+        (secrets: Record<string, number>) => {
+          (window as any).listenerCleanupPermissionSecrets = secrets;
+        }
+      );
+    });
+    await electronPage.reload({ waitUntil: 'load' });
+    await expect
+      .poll(() =>
+        electronPage.evaluate(() => Boolean((window as any).listenerCleanupPermissionSecrets))
+      )
+      .toBe(true);
+    await electronPage.addScriptTag({ content: bundle.outputFiles[0].text });
+    await electronPage.evaluate(() => {
+      (window as any).runE2ECommand = async () => {
+        const desktopApi = (window as any).desktopApi;
+        const permissionSecrets = (window as any).listenerCleanupPermissionSecrets;
+        const removedChannels: string[] = [];
+        const receive = (
+          channel: string,
+          listener: (commandId: string, data: string | number) => void
+        ) => {
+          const unsubscribe = desktopApi.receive(channel, listener);
+          return () => {
+            removedChannels.push(channel);
+            unsubscribe?.();
+          };
+        };
+        const commandProcess = (window as any).RunCommandModule.runCommand(
+          'gh',
+          ['--version'],
+          {},
+          permissionSecrets,
+          desktopApi.send,
+          receive
+        );
+
+        return await new Promise((resolve, reject) => {
+          const stdout: string[] = [];
+          const stderr: string[] = [];
+          const timeout = window.setTimeout(
+            () => reject(new Error('Timed out waiting for command-exit')),
+            10000
+          );
+          commandProcess.stdout.on('data', (data: string) => stdout.push(data));
+          commandProcess.stderr.on('data', (data: string) => stderr.push(data));
+          commandProcess.on('exit', (code: number | null) => {
+            window.clearTimeout(timeout);
+            resolve({ code, stdout, stderr, removedChannels });
+          });
+        });
+      };
+    });
   });
 
   test.afterAll(async () => {
     await electronApp?.close();
+    fs.rmSync(userDataDirectory, { force: true, recursive: true });
   });
 
-  test('stops delivering IPC events after unsubscribe', async () => {
-    await electronPage.evaluate(() => {
-      const desktopApi = (window as any).desktopApi;
-      (window as any).listenerCleanupEvents = [];
-      (window as any).unsubscribeCommand = desktopApi.receive(
-        'command-stdout',
-        (commandId: string, data: string) => {
-          (window as any).listenerCleanupEvents.push(`${commandId}:${data}`);
-        }
-      );
-      (window as any).unsubscribeMarker = desktopApi.receive('command-stderr', () => {
-        (window as any).listenerCleanupMarker = true;
-      });
-    });
+  test('delivers complete command output before cleaning up listeners', async () => {
+    await setCommandConsent(true);
 
-    await electronApp.evaluate(({ BrowserWindow }) => {
-      BrowserWindow.getAllWindows()[0].webContents.send('command-stdout', 'test-command', 'before');
-    });
-    await expect
-      .poll(() => electronPage.evaluate(() => (window as any).listenerCleanupEvents))
-      .toEqual(['test-command:before']);
+    const result = await electronPage.evaluate(() => (window as any).runE2ECommand());
 
-    await electronPage.evaluate(() => (window as any).unsubscribeCommand());
-    await electronApp.evaluate(({ BrowserWindow }) => {
-      const window = BrowserWindow.getAllWindows()[0];
-      window.webContents.send('command-stdout', 'test-command', 'after');
-      window.webContents.send('command-stderr', 'marker');
-    });
-    await expect
-      .poll(() => electronPage.evaluate(() => (window as any).listenerCleanupMarker))
-      .toBe(true);
+    expect(result.code).toBe(0);
+    expect(result.stdout.join('')).toContain('gh version');
+    expect(result.stderr).toEqual([]);
+    expect(result.removedChannels).toEqual(['command-stdout', 'command-stderr', 'command-exit']);
+  });
 
-    await expect(
-      electronPage.evaluate(() => (window as any).listenerCleanupEvents)
-    ).resolves.toEqual(['test-command:before']);
-    await electronPage.evaluate(() => (window as any).unsubscribeMarker());
+  test('cleans up listeners when command consent is denied', async () => {
+    await setCommandConsent(false);
+
+    const result = await electronPage.evaluate(() => (window as any).runE2ECommand());
+
+    expect(result).toEqual({
+      code: -1,
+      stdout: [],
+      stderr: [],
+      removedChannels: ['command-stdout', 'command-stderr', 'command-exit'],
+    });
   });
 });

--- a/app/electron/runCmd.test.ts
+++ b/app/electron/runCmd.test.ts
@@ -162,6 +162,14 @@ describe('validateCommandData', () => {
     expect(validateCommandData('string' as any)[0]).toBe(false);
   });
 
+  it('returns false if id is missing, empty, or not a string', () => {
+    expect(validateCommandData({ command: 'gh', args: [], options: {} })[0]).toBe(false);
+    expect(validateCommandData({ id: '', command: 'gh', args: [], options: {} })[0]).toBe(false);
+    expect(validateCommandData({ id: 1 as any, command: 'gh', args: [], options: {} })[0]).toBe(
+      false
+    );
+  });
+
   it('returns false if command is missing or not a string', () => {
     expect(validateCommandData({ args: [], options: {}, permissionSecrets: {} })[0]).toBe(false);
     expect(
@@ -246,6 +254,7 @@ describe('validateCommandData', () => {
   it('returns true for valid minikube command', () => {
     expect(
       validateCommandData({
+        id: 'test-id',
         command: 'minikube',
         args: [],
         options: {},
@@ -257,6 +266,7 @@ describe('validateCommandData', () => {
   it('returns true for valid az command', () => {
     expect(
       validateCommandData({
+        id: 'test-id',
         command: 'az',
         args: ['arg1'],
         options: {},
@@ -268,6 +278,7 @@ describe('validateCommandData', () => {
   it('returns true for valid scriptjs command', () => {
     expect(
       validateCommandData({
+        id: 'test-id',
         command: 'scriptjs',
         args: ['myscript.js'],
         options: {},
@@ -327,6 +338,77 @@ describe('handleRunCommand', () => {
 
     expect(sentMessages).toContainEqual(['command-stderr', 'test-id', 'spawn error']);
     expect(sentMessages).toContainEqual(['command-exit', 'test-id', -1]);
+
+    childEmitter.emit('close', null);
+    expect(sentMessages.filter(([channel]) => channel === 'command-exit')).toHaveLength(1);
+  });
+
+  it('reports exit only after stdout and stderr close', async () => {
+    const eventData = {
+      id: 'test-id',
+      command: 'gh',
+      args: ['auth', 'token'],
+      options: {},
+      permissionSecrets: { 'runCmd-gh': 99 },
+    };
+
+    await handleRunCommand(fakeEvent, eventData, { id: 1 } as any, { 'runCmd-gh': 99 });
+
+    childEmitter.emit('exit', 0);
+    childEmitter.stdout.emit('data', 'final output');
+    childEmitter.stderr.emit('data', 'final warning');
+
+    expect(sentMessages).toEqual([
+      ['command-stdout', 'test-id', 'final output'],
+      ['command-stderr', 'test-id', 'final warning'],
+    ]);
+
+    childEmitter.emit('close', 0);
+    expect(sentMessages.at(-1)).toEqual(['command-exit', 'test-id', 0]);
+  });
+
+  it.each([
+    ['missing window', { id: 'test-id' }, null, { 'runCmd-gh': 99 }],
+    [
+      'invalid command data',
+      { id: 'test-id', command: 'invalid', args: [], options: {}, permissionSecrets: {} },
+      { id: 1 },
+      {},
+    ],
+    [
+      'invalid permission secret',
+      {
+        id: 'test-id',
+        command: 'gh',
+        args: ['auth', 'token'],
+        options: {},
+        permissionSecrets: { 'runCmd-gh': 1 },
+      },
+      { id: 1 },
+      { 'runCmd-gh': 99 },
+    ],
+  ])('reports a rejected exit for %s', async (_name, data, window, secrets) => {
+    await handleRunCommand(fakeEvent, data as any, window as any, secrets);
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(sentMessages).toEqual([['command-exit', 'test-id', -1]]);
+  });
+
+  it('reports a rejected exit when command consent was denied previously', async () => {
+    const { loadSettings } = await import('./settings');
+    vi.mocked(loadSettings).mockReturnValueOnce({ confirmedCommands: { 'gh auth': false } });
+    const eventData = {
+      id: 'test-id',
+      command: 'gh',
+      args: ['auth', 'token'],
+      options: {},
+      permissionSecrets: { 'runCmd-gh': 99 },
+    };
+
+    await handleRunCommand(fakeEvent, eventData, { id: 1 } as any, { 'runCmd-gh': 99 });
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(sentMessages).toEqual([['command-exit', 'test-id', -1]]);
   });
 
   it('reports synchronous spawn errors without rejecting', async () => {

--- a/app/electron/runCmd.ts
+++ b/app/electron/runCmd.ts
@@ -281,13 +281,22 @@ export async function handleRunCommand(
   mainWindow: BrowserWindow | null,
   permissionSecrets: Record<string, number>
 ): Promise<void> {
+  const commandId = typeof eventData?.id === 'string' ? eventData.id : undefined;
+  const sendRejectedExit = () => {
+    if (commandId) {
+      event.sender.send('command-exit', commandId, -1);
+    }
+  };
+
   if (mainWindow === null) {
     console.error('Main window is null, cannot run command');
+    sendRejectedExit();
     return;
   }
   const [isValid, errorMessage] = validateCommandData(eventData);
   if (!isValid) {
     console.error(errorMessage);
+    sendRejectedExit();
     return;
   }
   const commandData = eventData as CommandData;
@@ -295,10 +304,12 @@ export async function handleRunCommand(
   const [permissionsValid, permissionError] = checkPermissionSecret(commandData, permissionSecrets);
   if (!permissionsValid) {
     console.error(permissionError);
+    sendRejectedExit();
     return;
   }
 
   if (!checkCommandConsent(commandData.command, commandData.args, mainWindow)) {
+    sendRejectedExit();
     return;
   }
 
@@ -345,13 +356,22 @@ export async function handleRunCommand(
     event.sender.send('command-stderr', commandData.id, data.toString());
   });
 
+  let terminalEventSent = false;
+  const sendTerminalEvent = (code: number | null) => {
+    if (terminalEventSent) {
+      return;
+    }
+    terminalEventSent = true;
+    event.sender.send('command-exit', commandData.id, code);
+  };
+
   child.on('error', (err: Error) => {
     event.sender.send('command-stderr', commandData.id, err.message);
-    event.sender.send('command-exit', commandData.id, -1);
+    sendTerminalEvent(-1);
   });
 
-  child.on('exit', (code: number | null) => {
-    event.sender.send('command-exit', commandData.id, code);
+  child.on('close', (code: number | null) => {
+    sendTerminalEvent(code);
   });
 }
 
@@ -448,6 +468,9 @@ type CommandDataPartial = Partial<CommandData>;
 export function validateCommandData(eventData: CommandDataPartial): [boolean, string] {
   if (!eventData || typeof eventData !== 'object' || eventData === null) {
     return [false, `Invalid eventData data received: ${eventData}`];
+  }
+  if (typeof eventData.id !== 'string' || !eventData.id) {
+    return [false, `Invalid eventData.id: ${eventData.id}`];
   }
   if (typeof eventData.command !== 'string' || !eventData.command) {
     return [false, `Invalid eventData.command: ${eventData.command}`];

--- a/frontend/src/components/App/pluginManager.test.ts
+++ b/frontend/src/components/App/pluginManager.test.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PluginManager } from './pluginManager';
+
+describe('PluginManager', () => {
+  let handleResponse: (response: string) => void;
+  const send = vi.fn();
+  const removeListener = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    send.mockReset();
+    removeListener.mockReset();
+    window.desktopApi = {
+      platform: 'darwin',
+      send,
+      receive: vi.fn((_channel, listener) => {
+        handleResponse = listener;
+      }),
+      removeListener,
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each([
+    ['install', ['operation-1', 'example', 'https://example.com/plugin'], 'INSTALL'],
+    ['update', ['operation-1', 'example'], 'UPDATE'],
+    ['uninstall', ['operation-1', 'example'], 'UNINSTALL'],
+    ['cancel', ['operation-1'], 'CANCEL'],
+  ] as const)('sends the %s request', (method, args, action) => {
+    PluginManager[method](...(args as any));
+
+    expect(send).toHaveBeenCalledOnce();
+    expect(send).toHaveBeenCalledWith(
+      'plugin-manager',
+      expect.stringContaining(`"action":"${action}"`)
+    );
+  });
+
+  it('returns installed plugins from a list response', async () => {
+    const response = PluginManager.list();
+
+    handleResponse(
+      JSON.stringify({
+        type: 'success',
+        message: 'done',
+        identifier: 'list-plugins',
+        data: { example: { version: '1.0.0' } },
+      })
+    );
+
+    await expect(response).resolves.toEqual({ example: { version: '1.0.0' } });
+  });
+
+  it('rejects an error list response', async () => {
+    const response = PluginManager.list();
+
+    handleResponse(
+      JSON.stringify({ type: 'error', message: 'list failed', identifier: 'list-plugins' })
+    );
+
+    await expect(response).rejects.toThrow('list failed');
+  });
+
+  it('removes its listener after receiving the matching response', async () => {
+    const response = PluginManager.getStatus('operation-1');
+
+    handleResponse(JSON.stringify({ type: 'success', message: 'done', identifier: 'operation-1' }));
+
+    await expect(response).resolves.toMatchObject({ identifier: 'operation-1' });
+    expect(removeListener).toHaveBeenCalledOnce();
+    expect(removeListener).toHaveBeenCalledWith('plugin-manager', handleResponse);
+  });
+
+  it('removes its listener after malformed JSON', async () => {
+    const response = PluginManager.getStatus('operation-1');
+
+    handleResponse('{');
+
+    await expect(response).rejects.toBeInstanceOf(SyntaxError);
+    expect(removeListener).toHaveBeenCalledOnce();
+  });
+
+  it('removes its listener after the response limit', async () => {
+    const response = PluginManager.getStatus('operation-1');
+
+    for (let index = 0; index < 10; index++) {
+      handleResponse(
+        JSON.stringify({ type: 'progress', message: 'working', identifier: `other-${index}` })
+      );
+    }
+
+    await expect(response).rejects.toThrow('Message limit exceeded');
+    expect(removeListener).toHaveBeenCalledOnce();
+  });
+
+  it('removes its listener after timing out', async () => {
+    const response = PluginManager.getStatus('operation-1');
+    const rejection = expect(response).rejects.toThrow('Timeout exceeded');
+
+    await vi.advanceTimersByTimeAsync(10000);
+
+    await rejection;
+    expect(removeListener).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/components/App/pluginManager.test.ts
+++ b/frontend/src/components/App/pluginManager.test.ts
@@ -20,18 +20,24 @@ import { PluginManager } from './pluginManager';
 describe('PluginManager', () => {
   let handleResponse: (response: string) => void;
   const send = vi.fn();
+  const receive = vi.fn();
+  const unsubscribe = vi.fn();
   const removeListener = vi.fn();
 
   beforeEach(() => {
     vi.useFakeTimers();
     send.mockReset();
+    receive.mockReset();
+    receive.mockImplementation((_channel, listener) => {
+      handleResponse = listener;
+      return unsubscribe;
+    });
+    unsubscribe.mockReset();
     removeListener.mockReset();
     window.desktopApi = {
       platform: 'darwin',
       send,
-      receive: vi.fn((_channel, listener) => {
-        handleResponse = listener;
-      }),
+      receive,
       removeListener,
     };
   });
@@ -41,12 +47,16 @@ describe('PluginManager', () => {
   });
 
   it.each([
-    ['install', ['operation-1', 'example', 'https://example.com/plugin'], 'INSTALL'],
-    ['update', ['operation-1', 'example'], 'UPDATE'],
-    ['uninstall', ['operation-1', 'example'], 'UNINSTALL'],
-    ['cancel', ['operation-1'], 'CANCEL'],
-  ] as const)('sends the %s request', (method, args, action) => {
-    PluginManager[method](...(args as any));
+    [
+      'install',
+      () => PluginManager.install('operation-1', 'example', 'https://example.com/plugin'),
+      'INSTALL',
+    ],
+    ['update', () => PluginManager.update('operation-1', 'example'), 'UPDATE'],
+    ['uninstall', () => PluginManager.uninstall('operation-1', 'example'), 'UNINSTALL'],
+    ['cancel', () => PluginManager.cancel('operation-1'), 'CANCEL'],
+  ] as const)('sends the %s request', (_method, invoke, action) => {
+    invoke();
 
     expect(send).toHaveBeenCalledOnce();
     expect(send).toHaveBeenCalledWith(
@@ -80,26 +90,37 @@ describe('PluginManager', () => {
     await expect(response).rejects.toThrow('list failed');
   });
 
-  it('removes its listener after receiving the matching response', async () => {
+  it('unsubscribes after receiving the matching response', async () => {
     const response = PluginManager.getStatus('operation-1');
 
     handleResponse(JSON.stringify({ type: 'success', message: 'done', identifier: 'operation-1' }));
 
     await expect(response).resolves.toMatchObject({ identifier: 'operation-1' });
-    expect(removeListener).toHaveBeenCalledOnce();
-    expect(removeListener).toHaveBeenCalledWith('plugin-manager', handleResponse);
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(removeListener).not.toHaveBeenCalled();
   });
 
-  it('removes its listener after malformed JSON', async () => {
+  it('unsubscribes after malformed JSON', async () => {
     const response = PluginManager.getStatus('operation-1');
 
     handleResponse('{');
 
     await expect(response).rejects.toBeInstanceOf(SyntaxError);
-    expect(removeListener).toHaveBeenCalledOnce();
+    expect(unsubscribe).toHaveBeenCalledOnce();
   });
 
-  it('removes its listener after the response limit', async () => {
+  it('rejects malformed JSON when receive returns no unsubscribe function', async () => {
+    receive.mockImplementationOnce((_channel, listener) => {
+      handleResponse = listener;
+    });
+    const response = PluginManager.getStatus('operation-1');
+
+    handleResponse('{');
+
+    await expect(response).rejects.toBeInstanceOf(SyntaxError);
+  });
+
+  it('unsubscribes after the response limit', async () => {
     const response = PluginManager.getStatus('operation-1');
 
     for (let index = 0; index < 10; index++) {
@@ -109,16 +130,28 @@ describe('PluginManager', () => {
     }
 
     await expect(response).rejects.toThrow('Message limit exceeded');
-    expect(removeListener).toHaveBeenCalledOnce();
+    expect(unsubscribe).toHaveBeenCalledOnce();
   });
 
-  it('removes its listener after timing out', async () => {
+  it('unsubscribes after timing out', async () => {
     const response = PluginManager.getStatus('operation-1');
     const rejection = expect(response).rejects.toThrow('Timeout exceeded');
 
     await vi.advanceTimersByTimeAsync(10000);
 
     await rejection;
-    expect(removeListener).toHaveBeenCalledOnce();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it('rejects after timing out when receive returns no unsubscribe function', async () => {
+    receive.mockImplementationOnce((_channel, listener) => {
+      handleResponse = listener;
+    });
+    const response = PluginManager.getStatus('operation-1');
+    const rejection = expect(response).rejects.toThrow('Timeout exceeded');
+
+    await vi.advanceTimersByTimeAsync(10000);
+
+    await rejection;
   });
 });

--- a/frontend/src/components/App/pluginManager.ts
+++ b/frontend/src/components/App/pluginManager.ts
@@ -55,27 +55,27 @@ export class PluginManager {
           parsedResponse = JSON.parse(response);
         } catch (error) {
           clearTimeout(timeoutId);
-          window.desktopApi.removeListener('plugin-manager', handleResponse);
+          unsubscribe?.();
           reject(error);
           return;
         }
 
         if (parsedResponse.identifier === identifier) {
           clearTimeout(timeoutId);
-          window.desktopApi.removeListener('plugin-manager', handleResponse);
+          unsubscribe?.();
           resolve(parsedResponse);
         } else if (++count >= waitCount) {
           clearTimeout(timeoutId);
-          window.desktopApi.removeListener('plugin-manager', handleResponse);
+          unsubscribe?.();
           reject(new Error('Message limit exceeded without a matching response'));
         }
       };
 
-      window.desktopApi.receive('plugin-manager', handleResponse);
+      const unsubscribe = window.desktopApi.receive('plugin-manager', handleResponse);
 
       // Add a timeout to ensure the promise is rejected if no response is received within a reasonable time
       const timeoutId = setTimeout(() => {
-        window.desktopApi.removeListener('plugin-manager', handleResponse);
+        unsubscribe?.();
         reject(new Error('Timeout exceeded without a matching response'));
       }, 10000);
     });

--- a/frontend/src/components/App/runCommand.test.ts
+++ b/frontend/src/components/App/runCommand.test.ts
@@ -80,4 +80,48 @@ describe('runCommand', () => {
     expect(exit).toHaveBeenCalledOnce();
     expect(exit).toHaveBeenCalledWith(0);
   });
+
+  it('removes command listeners after the matching command exits', () => {
+    const listeners = new Map<string, (id: string, data: string | number) => void>();
+    const removers = new Map<string, ReturnType<typeof vi.fn>>();
+    const send = vi.fn();
+    const receive = vi.fn(
+      (channel: string, listener: (id: string, data: string | number) => void) => {
+        const remove = vi.fn();
+        listeners.set(channel, listener);
+        removers.set(channel, remove);
+        return remove;
+      }
+    );
+
+    runCommand('gh', ['auth', 'status'], {}, {}, send, receive);
+    const commandId = send.mock.calls[0][1].id;
+
+    listeners.get('command-exit')?.(commandId, 0);
+
+    expect([...removers.values()]).toHaveLength(3);
+    for (const remove of removers.values()) {
+      expect(remove).toHaveBeenCalledOnce();
+    }
+  });
+
+  it('keeps listeners for another command exit', () => {
+    const listeners = new Map<string, (id: string, data: string | number) => void>();
+    const removers: Array<ReturnType<typeof vi.fn>> = [];
+    const receive = vi.fn(
+      (channel: string, listener: (id: string, data: string | number) => void) => {
+        const remove = vi.fn();
+        listeners.set(channel, listener);
+        removers.push(remove);
+        return remove;
+      }
+    );
+
+    runCommand('gh', ['auth', 'status'], {}, {}, vi.fn(), receive);
+    listeners.get('command-exit')?.('another-command', 0);
+
+    for (const remove of removers) {
+      expect(remove).not.toHaveBeenCalled();
+    }
+  });
 });

--- a/frontend/src/components/App/runCommand.test.ts
+++ b/frontend/src/components/App/runCommand.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { runCommand } from './runCommand';
+
+describe('runCommand', () => {
+  beforeEach(() => {
+    window.desktopApi = { platform: 'darwin' };
+  });
+
+  it('requires Headlamp app mode', () => {
+    Reflect.set(window, 'desktopApi', undefined);
+
+    expect(() => runCommand('gh', [], {}, {}, vi.fn(), vi.fn())).toThrow(
+      'runCommand only works in Headlamp app mode.'
+    );
+  });
+
+  it('requires the private IPC dependencies', () => {
+    expect(() => runCommand('gh', [], {})).toThrow('Do not use runCommand directly.');
+  });
+
+  it('sends the command and forwards events for its command ID', () => {
+    const listeners = new Map<string, (id: string, data: string | number) => void>();
+    const send = vi.fn();
+    const receive = vi.fn(
+      (channel: string, listener: (id: string, data: string | number) => void) => {
+        listeners.set(channel, listener);
+      }
+    );
+    const command = runCommand(
+      'gh',
+      ['auth', 'status'],
+      { cwd: '/tmp' },
+      { TOKEN: 7 },
+      send,
+      receive
+    );
+    const commandId = send.mock.calls[0][1].id;
+    const stdout = vi.fn();
+    const stderr = vi.fn();
+    const exit = vi.fn();
+
+    command.stdout.on('data', stdout);
+    command.stderr.on('data', stderr);
+    command.on('exit', exit);
+
+    listeners.get('command-stdout')?.('another-command', 'ignored');
+    listeners.get('command-stderr')?.('another-command', 'ignored');
+    listeners.get('command-exit')?.('another-command', 1);
+    listeners.get('command-stdout')?.(commandId, 'output');
+    listeners.get('command-stderr')?.(commandId, 'warning');
+    listeners.get('command-exit')?.(commandId, 0);
+
+    expect(send).toHaveBeenCalledWith('run-command', {
+      id: commandId,
+      command: 'gh',
+      args: ['auth', 'status'],
+      options: { cwd: '/tmp' },
+      permissionSecrets: { TOKEN: 7 },
+    });
+    expect(stdout).toHaveBeenCalledOnce();
+    expect(stdout).toHaveBeenCalledWith('output');
+    expect(stderr).toHaveBeenCalledOnce();
+    expect(stderr).toHaveBeenCalledWith('warning');
+    expect(exit).toHaveBeenCalledOnce();
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+});

--- a/frontend/src/components/App/runCommand.ts
+++ b/frontend/src/components/App/runCommand.ts
@@ -65,7 +65,7 @@ export function runCommand(
   desktopApiReceive?: (
     channel: string,
     listener: (cmdId: string, data: string | number) => void
-  ) => void
+  ) => (() => void) | void
 ): {
   stdout: { on: (event: string, listener: (chunk: any) => void) => void };
   stderr: { on: (event: string, listener: (chunk: any) => void) => void };
@@ -87,24 +87,34 @@ export function runCommand(
   const id = `${new Date().getTime()}-${Math.random().toString(36)}`;
 
   const stdout = new EventTarget();
-  desktopApiReceive('command-stdout', (cmdId: string, data: string | number) => {
-    if (cmdId === id) {
-      const event = new CustomEvent('data', { detail: data });
-      stdout.dispatchEvent(event);
+  const removeStdout = desktopApiReceive(
+    'command-stdout',
+    (cmdId: string, data: string | number) => {
+      if (cmdId === id) {
+        const event = new CustomEvent('data', { detail: data });
+        stdout.dispatchEvent(event);
+      }
     }
-  });
+  );
 
   const stderr = new EventTarget();
-  desktopApiReceive('command-stderr', (cmdId: string, data: string | number) => {
-    if (cmdId === id) {
-      const event = new CustomEvent('data', { detail: data });
-      stderr.dispatchEvent(event);
+  const removeStderr = desktopApiReceive(
+    'command-stderr',
+    (cmdId: string, data: string | number) => {
+      if (cmdId === id) {
+        const event = new CustomEvent('data', { detail: data });
+        stderr.dispatchEvent(event);
+      }
     }
-  });
+  );
 
   const exit = new EventTarget();
-  desktopApiReceive('command-exit', (cmdId: string, code: string | number) => {
+  const removeExit = desktopApiReceive('command-exit', (cmdId: string, code: string | number) => {
     if (cmdId === id) {
+      removeStdout?.();
+      removeStderr?.();
+      removeExit?.();
+
       const event = new CustomEvent('exit', { detail: code });
       exit.dispatchEvent(event);
     }


### PR DESCRIPTION
## Summary

- release `runCommand` IPC subscriptions when the matching command exits
- use the exact preload unsubscribe callback for all `PluginManager` completion paths
- wait for drained command output and terminate rejected commands consistently
- add focused unit and Electron end-to-end coverage for listener cleanup

## Source

This upstreams patch 0019 from Azure/aks-desktop#823:
https://github.com/Azure/aks-desktop/pull/823

The original downstream change was Azure/aks-desktop#394:
https://github.com/Azure/aks-desktop/pull/394

Original combined commit:
`e4798768d9995204e2ad32da138b11f094640828`

PR 823 split that change into these reviewable patch commits:

- `48e4e03806152cf2aa527147e9a4105150b6b082` for `runCommand`
- `eeba14bd5891ad62b791d001883ce66810d527d3` for `PluginManager`

The functional commits retain Tejhan Diallo as author and preserve the original
March 12, 2026 author and commit date. René Dudfield is included as co-author.

## Improvements over the existing change

- adds baseline tests before the production commits, keeping the stack bisectable
- expands unit coverage to every branch in both changed files
- verifies command event forwarding and unrelated command filtering
- covers all plugin response outcomes and public request methods
- waits for the child `close` event so trailing stdout and stderr are not dropped
- emits one terminal event for validation, permission, and consent rejection
- tolerates preload shims that do not return an unsubscribe callback
- exercises the real `runCommand` path across the Electron preload boundary
- enforces the focused Electron test in the Linux app workflow
- splits the original combined change into focused `runCommand` and
  `PluginManager` commits

## Testing

- `npx vitest run src/components/App/runCommand.test.ts src/components/App/pluginManager.test.ts --coverage.enabled --coverage.provider=istanbul --coverage.reporter=text --coverage.include=src/components/App/runCommand.ts --coverage.include=src/components/App/pluginManager.ts`
  - 17 tests passed
  - 100% branch coverage for `runCommand.ts`
  - 100% branch coverage for `pluginManager.ts`
- `npx vitest run electron/runCmd.test.ts`
  - 39 tests passed
- frontend and app `npm run tsc`
- focused ESLint and Prettier checks for all changed files
- `playwright test --config=playwright.electron.config.ts tests/listenerCleanup.spec.ts`
  - 2 Electron e2e tests passed
  - verifies complete output before cleanup and consent-denied cleanup

## Screenshots

Not applicable. This change only affects IPC listener lifecycle and has no visual
change.

Assisted by copilot.
