### PR TITLE
0063: app: electron: Configure update checks from product metadata

### DIFF
--- a/app/e2e-tests/playwright.electron.config.ts
+++ b/app/e2e-tests/playwright.electron.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
     'clusterAutoConnect.spec.ts',
     'pluginSecureStorage.spec.ts',
     'listenerCleanup.spec.ts',
+    'updateChecks.spec.ts',
   ],
   timeout: 60 * 1000,
   expect: {

--- a/app/e2e-tests/tests/updateChecks.spec.ts
+++ b/app/e2e-tests/tests/updateChecks.spec.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { _electron, ElectronApplication, Page } from 'playwright';
+
+/** Configuration sent by the Electron main process to the renderer. */
+interface AppConfig {
+  /** Whether the renderer should check for application updates. */
+  checkForUpdates: boolean;
+}
+
+/** Electron IPC methods exposed to the renderer by the preload script. */
+interface DesktopApi {
+  /** Registers a listener for an allowed IPC channel. */
+  receive(channel: string, listener: (config: AppConfig) => void): (() => void) | undefined;
+  /** Sends a message on an allowed IPC channel. */
+  send(channel: string): void;
+}
+
+const electronExecutable = process.platform === 'win32' ? 'electron.cmd' : 'electron';
+const electronPath = path.resolve(__dirname, `../../node_modules/.bin/${electronExecutable}`);
+const appPath = path.resolve(__dirname, '../../');
+const manifestPath = path.join(appPath, 'app-build-manifest.json');
+
+let electronApp: ElectronApplication;
+let electronPage: Page;
+let originalManifest: string;
+
+test.describe('update check configuration', () => {
+  test.beforeAll(async () => {
+    originalManifest = fs.readFileSync(manifestPath, 'utf8');
+    fs.writeFileSync(
+      manifestPath,
+      JSON.stringify({ ...JSON.parse(originalManifest), checkForUpdates: false }, null, 2) + '\n'
+    );
+
+    const electronEnvironment = { ...process.env };
+    delete electronEnvironment.ELECTRON_RUN_AS_NODE;
+
+    electronApp = await _electron.launch({
+      cwd: appPath,
+      executablePath: electronPath,
+      args: ['.'],
+      env: {
+        ...electronEnvironment,
+        ELECTRON_DEV: 'true',
+        // The opposite of the manifest value, so the assertion only passes when
+        // product metadata takes precedence over the environment.
+        HEADLAMP_CHECK_FOR_UPDATES: 'true',
+        NODE_ENV: 'development',
+      },
+    });
+    electronPage = await electronApp.firstWindow();
+    await electronPage.waitForLoadState('load');
+  });
+
+  test.afterAll(async () => {
+    await electronApp?.close();
+    fs.writeFileSync(manifestPath, originalManifest);
+  });
+
+  test('sends disabled update checks to the renderer', async () => {
+    const appConfig = await electronPage.evaluate(() => {
+      const desktopApi = (window as Window & { desktopApi: DesktopApi }).desktopApi;
+
+      return new Promise<AppConfig>(resolve => {
+        const unsubscribe = desktopApi.receive('appConfig', config => {
+          unsubscribe?.();
+          resolve(config);
+        });
+        desktopApi.send('appConfig');
+      });
+    });
+
+    expect(appConfig.checkForUpdates).toBe(false);
+  });
+});

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -70,6 +70,7 @@ import {
 import { setupSecureStorageHandlers } from './secureStorage';
 import { loadSettings, SETTINGS_PATH } from './settings';
 import { getShellEnv } from './shellEnv';
+import { shouldCheckForAppUpdates } from './shouldCheckForAppUpdates';
 import {
   cleanupHeadlampTray,
   createHeadlampTray,
@@ -202,11 +203,11 @@ let actualPort = defaultPort; // Will be updated when backend starts
 const MAX_PORT_ATTEMPTS = Math.abs(Number(process.env.HEADLAMP_MAX_PORT_ATTEMPTS) || 100); // Maximum number of ports to try
 
 const useExternalServer = process.env.EXTERNAL_SERVER || false;
-const shouldCheckForUpdates = process.env.HEADLAMP_CHECK_FOR_UPDATES !== 'false';
 const legalDocumentsResourcePath = getLegalDocumentsResourcePath(isDev, process.resourcesPath);
 const appBuildManifestPath = path.join(legalDocumentsResourcePath, 'app-build-manifest.json');
 const legalDocuments = loadLegalDocuments(appBuildManifestPath);
 const protocolScheme = readProtocolScheme(appBuildManifestPath);
+const shouldCheckForUpdates = shouldCheckForAppUpdates(appBuildManifestPath);
 
 // make it global so that it doesn't get garbage collected
 let mainWindow: BrowserWindow | null;

--- a/app/electron/shouldCheckForAppUpdates.test.ts
+++ b/app/electron/shouldCheckForAppUpdates.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { shouldCheckForAppUpdates } from './shouldCheckForAppUpdates';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+/** Writes an application build manifest to a fresh temporary directory. */
+function writeManifest(contents: string): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-update-check-'));
+  temporaryDirectories.push(directory);
+  const manifestPath = path.join(directory, 'app-build-manifest.json');
+  fs.writeFileSync(manifestPath, contents);
+  return manifestPath;
+}
+
+describe('shouldCheckForAppUpdates', () => {
+  it('enables update checks by default', () => {
+    expect(shouldCheckForAppUpdates('/path/that/does/not/exist', {})).toBe(true);
+  });
+
+  it('uses the environment setting when product metadata is unavailable', () => {
+    expect(
+      shouldCheckForAppUpdates('/path/that/does/not/exist', { HEADLAMP_CHECK_FOR_UPDATES: 'false' })
+    ).toBe(false);
+  });
+
+  it('prefers packaged product metadata over the environment', () => {
+    const manifestPath = writeManifest(JSON.stringify({ checkForUpdates: false }));
+
+    expect(shouldCheckForAppUpdates(manifestPath, { HEADLAMP_CHECK_FOR_UPDATES: 'true' })).toBe(
+      false
+    );
+  });
+
+  it('enables update checks when product metadata opts in', () => {
+    const manifestPath = writeManifest(JSON.stringify({ checkForUpdates: true }));
+
+    expect(shouldCheckForAppUpdates(manifestPath, { HEADLAMP_CHECK_FOR_UPDATES: 'false' })).toBe(
+      true
+    );
+  });
+
+  it('ignores non-boolean product metadata', () => {
+    const manifestPath = writeManifest(JSON.stringify({ checkForUpdates: 'false' }));
+
+    expect(shouldCheckForAppUpdates(manifestPath, {})).toBe(true);
+  });
+
+  it('ignores a manifest that is not an object', () => {
+    const manifestPath = writeManifest(JSON.stringify(null));
+
+    expect(shouldCheckForAppUpdates(manifestPath, { HEADLAMP_CHECK_FOR_UPDATES: 'false' })).toBe(
+      false
+    );
+  });
+
+  it('falls back to the environment when the manifest is invalid', () => {
+    const manifestPath = writeManifest('invalid json');
+
+    expect(shouldCheckForAppUpdates(manifestPath, { HEADLAMP_CHECK_FOR_UPDATES: 'false' })).toBe(
+      false
+    );
+  });
+});

--- a/app/electron/shouldCheckForAppUpdates.ts
+++ b/app/electron/shouldCheckForAppUpdates.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'node:fs';
+
+/**
+ * Resolves whether application update checks are enabled.
+ *
+ * Product metadata takes precedence over the environment setting when it
+ * provides a boolean value. Missing or invalid metadata falls back to the
+ * existing `HEADLAMP_CHECK_FOR_UPDATES` behavior.
+ *
+ * @param manifestPath - Path to the application build manifest JSON file.
+ * @param environment - Environment variables used as a configuration fallback.
+ * @returns Whether the application should check for updates.
+ */
+export function shouldCheckForAppUpdates(
+  manifestPath: string,
+  environment: NodeJS.ProcessEnv = process.env
+): boolean {
+  let buildManifest: unknown = {};
+  try {
+    buildManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  } catch {
+    // Fall back to the environment when product metadata is unavailable.
+  }
+
+  if (typeof buildManifest === 'object' && buildManifest !== null) {
+    const configuredValue = (buildManifest as { checkForUpdates?: unknown }).checkForUpdates;
+    if (typeof configuredValue === 'boolean') {
+      return configuredValue;
+    }
+  }
+
+  return environment.HEADLAMP_CHECK_FOR_UPDATES !== 'false';
+}


### PR DESCRIPTION
## Summary

- Read `checkForUpdates` from the packaged `app-build-manifest.json`.
- Keep `HEADLAMP_CHECK_FOR_UPDATES` as the fallback when product metadata does
  not provide a boolean setting.
- Verify the renderer receives disabled update checks through Electron IPC.

## Improvements over the existing behavior

Downstream builds can now configure update checks when packaging the product
instead of requiring a runtime environment variable. Invalid or unavailable
product metadata continues to fall back to the existing environment behavior,
and update checks remain enabled by default.

The upstreamed commit also adds TSDoc for the new helper contract, focused unit
coverage for metadata precedence, invalid values, valid manifest reads, and read
failures, plus an Electron end-to-end test for the renderer-facing IPC contract.

## Testing

- `cd app && npm test`: 19 files and 256 tests passed.
- `cd app && npm run tsc`: passed.
- `cd app/e2e-tests && npm run test-app -- updateChecks.spec.ts`: 1 passed.
- Focused V8 coverage for `electron/shouldCheckForAppUpdates.ts`: 100% branches, statements,
  functions, and lines.

## Provenance

- Original PR: https://github.com/Azure/aks-desktop/pull/823.
- Azure patch-retention commit: Azure/aks-desktop@387eb27e3f586211610dda61949255e7264a9c95.
- Patch 0063 upstream transformation SHA: `1e400e7906f3fa1b99e3ee2dc3de08dd536c2358`.
- Patch 0063 integration transformation SHA: `d9f438255fa449ed28bcfc9221fd734b7cf6f660`.
- Related tracking issue: Azure/aks-desktop#153.
- Related Headlamp product metadata work: #6831 and #7252.

The transformation SHAs are retained in the patch headers but are not reachable
from current Azure repository refs. No separate Azure feature PR was found;
https://github.com/Azure/aks-desktop/pull/823 is the source PR for the retained
patch.

The feature commit preserves Oleksandr Dubenko as the original author and keeps
the original author date. René Dudfield is included as co-author.

## Screenshots

Not applicable. This changes packaged Electron configuration and has no visual
UI difference.

Assisted by copilot.
