### PR TITLE
frontend: KubeConfigLoader: Label the kubeconfig file input

### DIFF
--- a/frontend/src/components/cluster/KubeConfigLoader.test.tsx
+++ b/frontend/src/components/cluster/KubeConfigLoader.test.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect, it, vi } from 'vitest';
+import { createMuiTheme } from '../../lib/themes';
+import { TestContext } from '../../test';
+import { PureKubeConfigLoader, Step } from './KubeConfigLoader';
+
+// KubeConfigLoader transitively pulls in k8s resource classes which have a
+// circular dependency that breaks module initialisation in the test
+// environment. Mock the modules that trigger that chain.
+vi.mock('../../lib/k8s', () => ({ useClustersConf: vi.fn() }));
+vi.mock('../../lib/k8s/api/v1/clusterApi', () => ({ setCluster: vi.fn() }));
+
+function renderLoader() {
+  render(
+    <TestContext>
+      <ThemeProvider theme={createMuiTheme({ name: 'test' })}>
+        <PureKubeConfigLoader
+          step={Step.LoadKubeConfig}
+          fileContent={{ clusters: [], users: [], contexts: [], currentContext: '' }}
+          selectedClusters={[]}
+          onDrop={vi.fn()}
+          onCheckboxChange={vi.fn()}
+          onNext={vi.fn()}
+          onBack={vi.fn()}
+          onFinish={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      </ThemeProvider>
+    </TestContext>
+  );
+}
+
+it('names the kubeconfig file input', () => {
+  renderLoader();
+
+  expect(
+    screen.getByLabelText('Drag & drop or choose kubeconfig file here', { selector: 'input' })
+  ).toHaveAttribute('type', 'file');
+});
+
+it('opens the file dialog once when the choose file button is clicked', async () => {
+  const click = vi.spyOn(HTMLInputElement.prototype, 'click');
+  renderLoader();
+
+  // The tooltip gives the button its accessible name, so match on its text instead.
+  await userEvent.click(screen.getByText('Choose file'));
+
+  expect(click).toHaveBeenCalledTimes(1);
+  click.mockRestore();
+});

--- a/frontend/src/components/cluster/KubeConfigLoader.tsx
+++ b/frontend/src/components/cluster/KubeConfigLoader.tsx
@@ -166,7 +166,10 @@ export function PureKubeConfigLoader(props: PureKubeConfigLoaderProps) {
           <Box>
             <DropZoneBox border={1} borderColor="secondary.main" {...getRootProps()}>
               <FormControl>
-                <input {...getInputProps()} />
+                <input
+                  {...getInputProps()}
+                  aria-label={t('translation|Drag & drop or choose kubeconfig file here')}
+                />
                 <Tooltip
                   title={t('translation|Drag & drop or choose kubeconfig file here')}
                   placement="top"

--- a/frontend/src/components/cluster/KubeConfigLoader.tsx
+++ b/frontend/src/components/cluster/KubeConfigLoader.tsx
@@ -154,7 +154,7 @@ export function PureKubeConfigLoader(props: PureKubeConfigLoaderProps) {
   } = props;
   const { t } = useTranslation(['translation']);
 
-  const { getRootProps, getInputProps, open } = useDropzone({
+  const { getRootProps, getInputProps } = useDropzone({
     onDrop: (acceptedFiles: File[]) => onDrop(acceptedFiles),
     multiple: false,
   });
@@ -174,9 +174,9 @@ export function PureKubeConfigLoader(props: PureKubeConfigLoaderProps) {
                   title={t('translation|Drag & drop or choose kubeconfig file here')}
                   placement="top"
                 >
+                  {/* The dropzone root already opens the file dialog on click. */}
                   <Button
                     variant="contained"
-                    onClick={() => open}
                     startIcon={<InlineIcon icon="mdi:upload" width={32} />}
                   >
                     {t('translation|Choose file')}

--- a/frontend/src/components/cluster/__snapshots__/KubeConfigLoader.FileUpload.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/KubeConfigLoader.FileUpload.stories.storyshot
@@ -95,6 +95,7 @@
                   class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
                 >
                   <input
+                    aria-label="Drag & drop or choose kubeconfig file here"
                     style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
                     tabindex="-1"
                     type="file"

--- a/frontend/src/components/cluster/__snapshots__/KubeConfigLoader.InvalidYAMLError.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/KubeConfigLoader.InvalidYAMLError.stories.storyshot
@@ -101,6 +101,7 @@
                   class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
                 >
                   <input
+                    aria-label="Drag & drop or choose kubeconfig file here"
                     style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
                     tabindex="-1"
                     type="file"


### PR DESCRIPTION
The kubeconfig file input in `KubeConfigLoader` has no accessible name — the
`Choose file` tooltip sits on the button, not the input, so screen readers
announce an unlabelled file field in the File Upload and Invalid YAML Error
stories.

Also drops `onClick={() => open}` on the Choose file button: it evaluated
`open` and threw the result away, so it never did anything. The dropzone root
already opens the file dialog on click, and removing the dead handler avoids a
double-open if it were ever "fixed" to `open()`.

Fixes: https://github.com/kubernetes-sigs/headlamp/issues/7199

Changed:
- `frontend/src/components/cluster/KubeConfigLoader.tsx` — `aria-label` on the file input, drop the no-op handler
- `frontend/src/components/cluster/KubeConfigLoader.test.tsx` — new, covers both
- two `.storyshot` files — regenerated

How to test:
```
cd frontend
npx vitest run src/components/cluster/KubeConfigLoader.test.tsx
npx vitest run src/storybook.test.tsx -t "KubeConfigLoader"
```
