### PR TITLE
frontend: Translate hardcoded aria-labels for i18n/a11y

### DIFF
--- a/frontend/src/components/common/Resource/DryRunPreviewDialog.tsx
+++ b/frontend/src/components/common/Resource/DryRunPreviewDialog.tsx
@@ -105,7 +105,12 @@ export default function DryRunPreviewDialog(props: DryRunPreviewDialogProps) {
         </Box>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} aria-label="close-button" color="secondary" variant="contained">
+        <Button
+          onClick={onClose}
+          aria-label={t('translation|Close')}
+          color="secondary"
+          variant="contained"
+        >
           {t('translation|Close')}
         </Button>
       </DialogActions>

--- a/frontend/src/components/common/Resource/__snapshots__/DryRunPreviewDialog.LargeYaml.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/DryRunPreviewDialog.LargeYaml.stories.storyshot
@@ -128,7 +128,7 @@
           class="MuiDialogActions-root MuiDialogActions-spacing css-knqc4i-MuiDialogActions-root"
         >
           <button
-            aria-label="close-button"
+            aria-label="Close"
             class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation css-14f6w6s-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"

--- a/frontend/src/components/common/Resource/__snapshots__/DryRunPreviewDialog.Open.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/DryRunPreviewDialog.Open.stories.storyshot
@@ -128,7 +128,7 @@
           class="MuiDialogActions-root MuiDialogActions-spacing css-knqc4i-MuiDialogActions-root"
         >
           <button
-            aria-label="close-button"
+            aria-label="Close"
             class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation css-14f6w6s-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"

--- a/frontend/src/components/namespace/CreateNamespaceButton.stories.tsx
+++ b/frontend/src/components/namespace/CreateNamespaceButton.stories.tsx
@@ -47,7 +47,9 @@ export const OkayName: StoryObj = {
   play: async () => {
     await userEvent.click(screen.getByLabelText('Create'));
 
-    await waitFor(() => expect(screen.getByLabelText('Dialog')).toBeVisible());
+    await waitFor(() =>
+      expect(screen.getByRole('dialog', { name: 'Create Namespace' })).toBeVisible()
+    );
 
     await waitFor(() => userEvent.type(screen.getByRole('textbox'), 'okay-name'), {
       timeout: 5000,
@@ -63,7 +65,9 @@ export const EmptyName: StoryObj = {
   play: async () => {
     await userEvent.click(screen.getByLabelText('Create'));
 
-    await waitFor(() => expect(screen.getByLabelText('Dialog')).toBeVisible());
+    await waitFor(() =>
+      expect(screen.getByRole('dialog', { name: 'Create Namespace' })).toBeVisible()
+    );
 
     await waitFor(() => userEvent.type(screen.getByRole('textbox'), ' '), { timeout: 5000 });
 
@@ -81,7 +85,9 @@ export const NotValidName: StoryObj = {
   play: async () => {
     await userEvent.click(screen.getByLabelText('Create'));
 
-    await waitFor(() => expect(screen.getByLabelText('Dialog')).toBeVisible());
+    await waitFor(() =>
+      expect(screen.getByRole('dialog', { name: 'Create Namespace' })).toBeVisible()
+    );
 
     await waitFor(() => userEvent.type(screen.getByRole('textbox'), 'not-valid-name-'), {
       timeout: 5000,
@@ -102,7 +108,9 @@ export const NotValidNameLong: StoryObj = {
     const longName = 'w'.repeat(64);
     await userEvent.click(screen.getByLabelText('Create'));
 
-    await waitFor(() => expect(screen.getByLabelText('Dialog')).toBeVisible());
+    await waitFor(() =>
+      expect(screen.getByRole('dialog', { name: 'Create Namespace' })).toBeVisible()
+    );
 
     await waitFor(() => userEvent.type(screen.getByRole('textbox'), longName), { timeout: 10000 });
 
@@ -128,7 +136,9 @@ export const NamespaceAlreadyExists: StoryObj = {
   play: async () => {
     await userEvent.click(screen.getByLabelText('Create'));
 
-    await waitFor(() => expect(screen.getByLabelText('Dialog')).toBeVisible());
+    await waitFor(() =>
+      expect(screen.getByRole('dialog', { name: 'Create Namespace' })).toBeVisible()
+    );
 
     await waitFor(() => userEvent.type(screen.getByRole('textbox'), 'existing-namespace'), {
       timeout: 5000,

--- a/frontend/src/components/namespace/CreateNamespaceButton.tsx
+++ b/frontend/src/components/namespace/CreateNamespaceButton.tsx
@@ -123,14 +123,18 @@ export default function CreateNamespaceButton() {
         }}
       />
 
-      <Dialog aria-label="Dialog" open={namespaceDialogOpen} onClose={handleClose}>
+      <Dialog
+        aria-label={t('translation|Create Namespace')}
+        open={namespaceDialogOpen}
+        onClose={handleClose}
+      >
         <DialogTitle>{t('translation|Create Namespace')}</DialogTitle>
         <DialogContent>
           <Box component="form" style={{ width: '20vw', maxWidth: '20vw' }}>
             <TextField
               margin="dense"
               id="name"
-              aria-label="Name"
+              aria-label={t('translation|Name')}
               label={t('translation|Name')}
               type="text"
               error={!isValidNamespaceName && namespaceName.length > 0}


### PR DESCRIPTION
## Summary

This PR fixes an accessibility and internationalization bug by replacing hardcoded English `aria-label` attributes with translated strings using the `react-i18next` hook (`t()`).

## Related Issue

Fixes #7285  

## Changes

- Updated `frontend/src/components/common/Resource/DryRunPreviewDialog.tsx` to use `t('translation|Close')` instead of hardcoded `"close-button"`.
- Updated `frontend/src/components/namespace/CreateNamespaceButton.tsx` to use `t('translation|Dialog')` and `t('translation|Name')` instead of hardcoded strings.
- Updated Storybook snapshots to reflect the new accessibility labels.

## Steps to Test

1. Apply the PR and run `npm start` in the `frontend` folder.
2. Ensure you are using a screen reader (or inspect the DOM using DevTools).
3. Open the "Create Namespace" dialog and verify the inputs and dialog have the properly translated `aria-label` attributes.
4. Open the "Dry Run" preview dialog and ensure the close button uses the properly translated `aria-label` attribute.
5. Alternatively, run `npm run frontend:test` to verify that the updated Storybook tests pass successfully.

## Notes for the Reviewer

- This PR directly touches the i18n layer to improve screen reader support for non-English users. 
