### PR TITLE
0049: frontend: Support distribution product versions

### DIFF
--- a/app/e2e-tests/tests/buildManifestProduct.spec.ts
+++ b/app/e2e-tests/tests/buildManifestProduct.spec.ts
@@ -22,6 +22,7 @@ import path from 'node:path';
 
 const appPath = path.resolve(__dirname, '../..');
 const frontendPath = path.resolve(appPath, '../frontend');
+const appVersion = JSON.parse(fs.readFileSync(path.join(appPath, 'package.json'), 'utf8')).version;
 
 test('custom product metadata reaches the Electron Builder configuration', () => {
   const manifestDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-product-manifest-'));
@@ -107,9 +108,10 @@ test('custom product metadata reaches the frontend environment', () => {
     );
 
     expect(env).toMatchObject({
-      REACT_APP_HEADLAMP_VERSION: '1.2.3=build',
+      REACT_APP_HEADLAMP_VERSION: appVersion,
       REACT_APP_HEADLAMP_GIT_VERSION: '0123456789abcdef=source',
       REACT_APP_HEADLAMP_PRODUCT_NAME: 'C# $HOME Desktop',
+      REACT_APP_HEADLAMP_PRODUCT_VERSION: '1.2.3=build',
     });
   } finally {
     fs.rmSync(manifestDirectory, { recursive: true, force: true });

--- a/e2e-tests/tests/headlamp.spec.ts
+++ b/e2e-tests/tests/headlamp.spec.ts
@@ -47,6 +47,19 @@ test('headlamp is there and so is minikube', async () => {
   await headlampPage.hasURLContaining(/.*test/);
 });
 
+test('version dialog shows Headlamp version information', async ({ page }) => {
+  await page.getByRole('button', { name: 'Account of current user' }).click();
+  await page
+    .locator('#primary-user-menu')
+    .getByText(/^Headlamp /)
+    .click();
+
+  const versionDialog = page.getByRole('dialog', { name: 'Headlamp' });
+  await expect(versionDialog).toBeVisible();
+  await expect(versionDialog.getByText('Version', { exact: true })).toBeVisible();
+  await expect(versionDialog.getByText('Git Commit', { exact: true })).toBeVisible();
+});
+
 test('main page should have Network tab', async () => {
   await headlampPage.hasNetworkTab();
   await headlampPage.a11y();

--- a/frontend/make-env.js
+++ b/frontend/make-env.js
@@ -51,7 +51,7 @@ function resolveBuildManifestPath(env = process.env) {
  * Validates product fields consumed by the frontend build.
  *
  * @param {unknown} manifest Parsed app build manifest.
- * @returns {ProductInfo} Validated product metadata or app package metadata.
+ * @returns {ProductInfo} Validated product metadata or an empty override.
  * @throws {TypeError} When the manifest, product, or consumed fields have an invalid shape.
  */
 function validateProductInfo(manifest) {
@@ -61,7 +61,7 @@ function validateProductInfo(manifest) {
 
   const product = manifest.product;
   if (product === undefined) {
-    return appInfo;
+    return {};
   }
   if (!product || typeof product !== 'object' || Array.isArray(product)) {
     throw new TypeError('Build manifest product must be an object');
@@ -78,14 +78,14 @@ function validateProductInfo(manifest) {
  * Reads product metadata from the selected app build manifest.
  *
  * @param {NodeJS.ProcessEnv} [env] Environment used to select a custom manifest.
- * @returns {ProductInfo} Product metadata from the selected manifest, or app package metadata
- * when the optional default manifest is absent or has no product override.
+ * @returns {ProductInfo} Product metadata from the selected manifest, or an empty override when
+ * the optional default manifest is absent or has no product metadata.
  * @throws {Error} When the configured manifest cannot be read or parsed as JSON.
  */
 function readProductInfo(env = process.env) {
   const manifestPath = resolveBuildManifestPath(env);
   if (!env.HEADLAMP_BUILD_MANIFEST && !fs.existsSync(manifestPath)) {
-    return appInfo;
+    return {};
   }
   return validateProductInfo(JSON.parse(fs.readFileSync(manifestPath, 'utf8')));
 }
@@ -108,11 +108,13 @@ function readGitVersion() {
 }
 
 const productInfo = readProductInfo();
+const productVersion = productInfo.version?.trim();
 
 const envContents = {
-  REACT_APP_HEADLAMP_VERSION: productInfo.version || appInfo.version,
+  REACT_APP_HEADLAMP_VERSION: appInfo.version,
   REACT_APP_HEADLAMP_GIT_VERSION: readGitVersion(),
   REACT_APP_HEADLAMP_PRODUCT_NAME: productInfo.productName || appInfo.productName,
+  ...(productVersion ? { REACT_APP_HEADLAMP_PRODUCT_VERSION: productVersion } : {}),
   REACT_APP_ENABLE_REACT_QUERY_DEVTOOLS: 'false',
   REACT_APP_HEADLAMP_SIDEBAR_DEFAULT_OPEN: 'true',
 };

--- a/frontend/src/components/App/TopBar.test.tsx
+++ b/frontend/src/components/App/TopBar.test.tsx
@@ -37,8 +37,8 @@ vi.mock('../../lib/k8s/api/v1/clusterApi', () => ({
 }));
 vi.mock('../../lib/auth', () => ({ logout: vi.fn() }));
 vi.mock('../../helpers/getProductInfo', () => ({
+  getDisplayVersion: vi.fn(() => '0.0.0'),
   getProductName: vi.fn(() => 'Headlamp'),
-  getVersion: vi.fn(() => ({ VERSION: '0.0.0' })),
 }));
 vi.mock('../../lib/router/createRouteURL', () => ({ createRouteURL: vi.fn(() => '/') }));
 vi.mock('../../redux/hooks', () => ({ useTypedSelector: vi.fn(() => undefined) }));

--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -33,7 +33,7 @@ import React, { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import { getProductName, getVersion } from '../../helpers/getProductInfo';
+import { getDisplayVersion, getProductName } from '../../helpers/getProductInfo';
 import { logout } from '../../lib/auth';
 import { useCluster, useClustersConf, useSelectedClusters } from '../../lib/k8s';
 import { ClusterUserInfo, getClusterUserInfo } from '../../lib/k8s/api/v1/clusterApi';
@@ -411,7 +411,7 @@ export const PureTopBar = memo(
             <Icon icon="mdi:information-outline" />
           </ListItemIcon>
           <ListItemText>
-            {getProductName()} {getVersion()['VERSION']}
+            {getProductName()} {getDisplayVersion()}
           </ListItemText>
         </MenuItem>
       </Menu>

--- a/frontend/src/components/App/VersionDialog.test.tsx
+++ b/frontend/src/components/App/VersionDialog.test.tsx
@@ -17,26 +17,42 @@
 import { ThemeProvider } from '@mui/material/styles';
 import { configureStore } from '@reduxjs/toolkit';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createMuiTheme } from '../../lib/themes';
 import uiReducer, { uiSlice } from '../../redux/uiSlice';
 import { TestContext } from '../../test';
 import VersionDialog from './VersionDialog';
 
+const { getProductName, getProductVersion, translate } = vi.hoisted(() => ({
+  getProductName: vi.fn<() => string | undefined>(() => 'Headlamp'),
+  getProductVersion: vi.fn<() => string | undefined>(),
+  translate: vi.fn((key: string, options?: { productName?: string }) =>
+    key
+      .split('|')
+      .at(-1)!
+      .replace('{{ productName }}', options?.productName || '')
+  ),
+}));
+
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key.split('|').pop() ?? key,
-  }),
+  useTranslation: () => ({ t: translate }),
 }));
 
 vi.mock('../../helpers/getProductInfo', () => ({
-  getProductName: () => 'Headlamp',
+  getProductName,
+  getProductVersion,
   getVersion: () => ({ VERSION: 'unused', GIT_VERSION: 'unused' }),
 }));
 
 const desktopApiBase = { platform: 'darwin' as NodeJS.Platform };
 
-function renderVersionDialog(useDefaultVersion = false) {
+function renderVersionDialog(
+  options: {
+    useDefaultVersion?: boolean;
+    productVersion?: string;
+  } = {}
+) {
+  const { useDefaultVersion = false, productVersion } = options;
   const store = configureStore({ reducer: { ui: uiReducer } });
   const theme = createMuiTheme({ name: 'Light', base: 'light' });
   store.dispatch(uiSlice.actions.setVersionDialogOpen(true));
@@ -48,6 +64,7 @@ function renderVersionDialog(useDefaultVersion = false) {
           getVersion={
             useDefaultVersion ? undefined : () => ({ VERSION: '1.2.3', GIT_VERSION: 'abc123' })
           }
+          getProductVersion={productVersion === undefined ? undefined : () => productVersion}
         />
       </ThemeProvider>
     </TestContext>
@@ -57,6 +74,12 @@ function renderVersionDialog(useDefaultVersion = false) {
 }
 
 describe('VersionDialog', () => {
+  beforeEach(() => {
+    getProductName.mockReturnValue('Headlamp');
+    getProductVersion.mockReturnValue(undefined);
+    translate.mockClear();
+  });
+
   afterEach(() => {
     window.desktopApi = { ...desktopApiBase };
   });
@@ -73,7 +96,7 @@ describe('VersionDialog', () => {
   });
 
   it('uses the product version provider by default', () => {
-    renderVersionDialog(true);
+    renderVersionDialog({ useDefaultVersion: true });
 
     expect(screen.getByRole('dialog', { name: 'Headlamp' })).toHaveTextContent('unused');
   });
@@ -98,5 +121,68 @@ describe('VersionDialog', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Close' }));
 
     expect(store.getState().ui.isVersionDialogOpen).toBe(false);
+  });
+
+  it('does not repeat a product version that matches the Headlamp version', () => {
+    renderVersionDialog({ productVersion: '1.2.3' });
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveTextContent('Version');
+    expect(dialog).not.toHaveTextContent('Headlamp Version');
+  });
+
+  it('does not show a whitespace-only product version', () => {
+    renderVersionDialog({ productVersion: ' \t\n' });
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveTextContent('Version');
+    expect(dialog).not.toHaveTextContent('Product Version');
+    expect(dialog).not.toHaveTextContent('Headlamp Version');
+  });
+
+  it('does not repeat a padded product version that matches the Headlamp version', () => {
+    renderVersionDialog({ productVersion: ' 1.2.3\t' });
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveTextContent('Version');
+    expect(dialog).not.toHaveTextContent('Product Version');
+    expect(dialog).not.toHaveTextContent('Headlamp Version');
+  });
+
+  it('shows distinct product and Headlamp versions', () => {
+    getProductName.mockReturnValue('AKS Desktop');
+
+    renderVersionDialog({ productVersion: '2.0.0' });
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveTextContent('AKS Desktop Version');
+    expect(dialog).toHaveTextContent('2.0.0');
+    expect(dialog).toHaveTextContent('Headlamp Version');
+    expect(dialog).toHaveTextContent('1.2.3');
+    expect(translate).toHaveBeenCalledWith('translation|{{ productName }} Version', {
+      productName: 'AKS Desktop',
+    });
+  });
+
+  it('distinguishes the product version when using the default product name', () => {
+    renderVersionDialog({ productVersion: '2.0.0' });
+
+    expect(screen.getByText('Product Version')).toBeVisible();
+    expect(screen.getByText('Headlamp Version')).toBeVisible();
+    expect(translate).toHaveBeenCalledWith('translation|{{ productName }} Version', {
+      productName: 'Product',
+    });
+  });
+
+  it('uses a generic label when the product name is unavailable', () => {
+    getProductName.mockReturnValue(undefined);
+
+    renderVersionDialog({ productVersion: '2.0.0' });
+
+    expect(screen.getByText('Product Version')).toBeVisible();
+    expect(translate).toHaveBeenCalledWith('translation|{{ productName }} Version', {
+      productName: 'Product',
+    });
+    expect(translate).toHaveBeenCalledWith('translation|Product');
   });
 });

--- a/frontend/src/components/App/VersionDialog.test.tsx
+++ b/frontend/src/components/App/VersionDialog.test.tsx
@@ -64,7 +64,11 @@ describe('VersionDialog', () => {
   it('shows version information without tabs in a browser host', () => {
     renderVersionDialog();
 
-    expect(screen.getByRole('dialog', { name: 'Headlamp' })).toHaveTextContent('1.2.3');
+    const dialog = screen.getByRole('dialog', { name: 'Headlamp' });
+    expect(dialog).toHaveTextContent('Version');
+    expect(dialog).toHaveTextContent('1.2.3');
+    expect(dialog).toHaveTextContent('Git Commit');
+    expect(dialog).toHaveTextContent('abc123');
     expect(screen.queryByRole('tab', { name: 'Legal' })).not.toBeInTheDocument();
   });
 

--- a/frontend/src/components/App/VersionDialog.tsx
+++ b/frontend/src/components/App/VersionDialog.tsx
@@ -17,7 +17,7 @@
 import DialogContent from '@mui/material/DialogContent';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
-import { getProductName, getVersion } from '../../helpers/getProductInfo';
+import { getProductName, getProductVersion, getVersion } from '../../helpers/getProductInfo';
 import { useTypedSelector } from '../../redux/hooks';
 import { uiSlice } from '../../redux/uiSlice';
 import { Dialog } from '../common/Dialog';
@@ -33,20 +33,18 @@ interface VersionInformation {
   GIT_VERSION: string;
 }
 
-/** Properties accepted by the Version dialog. */
-interface VersionDialogProps {
-  /** Optional version provider used by tests and embedding hosts. */
-  getVersion?: () => {
-    VERSION: string;
-    GIT_VERSION: string;
-  };
+export interface VersionDialogProps {
+  /** Overrides Headlamp version lookup, primarily for tests and stories. */
+  getVersion?: () => VersionInformation;
+  /** Overrides product distribution version lookup, primarily for tests and stories. */
+  getProductVersion?: typeof getProductVersion;
 }
 
 /**
- * Displays application version information and host-provided legal documents.
+ * Displays product, Headlamp, Git, and host-provided legal information.
  *
  * @param props - Version dialog dependencies.
- * @returns The application Version dialog.
+ * @returns The version information dialog.
  */
 export default function VersionDialog(props: VersionDialogProps) {
   const open = useTypedSelector(state => state.ui.isVersionDialogOpen);
@@ -55,28 +53,45 @@ export default function VersionDialog(props: VersionDialogProps) {
   const { VERSION, GIT_VERSION } = (
     props.getVersion ? props.getVersion() : getVersion()
   ) as VersionInformation;
-  const versionInformation = (
-    <NameValueTable
-      rows={[
-        {
-          name: t('translation|Version'),
-          value: VERSION,
-        },
-        {
-          name: t('Git Commit'),
-          value: GIT_VERSION,
-        },
-      ]}
-    />
-  );
+  const productVersion = (
+    props.getProductVersion ? props.getProductVersion() : getProductVersion()
+  )?.trim();
+  const showProductVersion = productVersion && productVersion !== VERSION;
+  const defaultProductName = t('translation|Product');
+  const productName = getProductName();
+  const productVersionName =
+    productName && productName !== 'Headlamp' ? productName : defaultProductName;
+  const rows = [
+    ...(showProductVersion
+      ? [
+          {
+            name: t('translation|{{ productName }} Version', {
+              productName: productVersionName,
+            }),
+            value: productVersion,
+          },
+        ]
+      : []),
+    {
+      name: showProductVersion
+        ? t('translation|{{ productName }} Version', { productName: 'Headlamp' })
+        : t('translation|Version'),
+      value: VERSION,
+    },
+    {
+      name: t('Git Commit'),
+      value: GIT_VERSION,
+    },
+  ];
+  const versionInformation = <NameValueTable rows={rows} />;
   const hasLegalDocuments = Boolean(window.desktopApi?.getLegalDocuments);
 
   return (
     <Dialog
-      maxWidth="sm"
+      maxWidth="md"
       open={open}
       onClose={() => dispatch(uiSlice.actions.setVersionDialogOpen(false))}
-      title={getProductName()}
+      title={productName}
       aria-label={t('translation|Version information')}
       // We want the dialog to show on top of the cluster chooser one if needed
       style={{ zIndex: 1900 }}

--- a/frontend/src/components/App/__snapshots__/VersionDialog.VersionDialog.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/VersionDialog.VersionDialog.stories.storyshot
@@ -25,7 +25,7 @@
     >
       <div
         aria-labelledby=":mock-test-id:"
-        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthSm MuiDialog-paperFullWidth css-1ehm288-MuiPaper-root-MuiDialog-paper"
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthMd MuiDialog-paperFullWidth css-1uqdd3t-MuiPaper-root-MuiDialog-paper"
         role="dialog"
       >
         <h2

--- a/frontend/src/helpers/getProductInfo.test.ts
+++ b/frontend/src/helpers/getProductInfo.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getDisplayVersion, getProductName, getProductVersion } from './getProductInfo';
+
+describe('getProductName', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns the configured product name', () => {
+    vi.stubEnv('REACT_APP_HEADLAMP_PRODUCT_NAME', 'AKS Desktop');
+
+    expect(getProductName()).toBe('AKS Desktop');
+  });
+});
+
+describe('getProductVersion', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns the configured product version', () => {
+    vi.stubEnv('REACT_APP_HEADLAMP_PRODUCT_VERSION', '1.2.3');
+
+    expect(getProductVersion()).toBe('1.2.3');
+  });
+
+  it('returns undefined when no product version is configured', () => {
+    expect(getProductVersion()).toBeUndefined();
+  });
+});
+
+describe('getDisplayVersion', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('prefers the configured product version', () => {
+    vi.stubEnv('REACT_APP_HEADLAMP_PRODUCT_VERSION', '1.2.3');
+    vi.stubEnv('REACT_APP_HEADLAMP_VERSION', '0.35.0');
+
+    expect(getDisplayVersion()).toBe('1.2.3');
+  });
+
+  it('trims the configured product version', () => {
+    vi.stubEnv('REACT_APP_HEADLAMP_PRODUCT_VERSION', ' 1.2.3\t');
+    vi.stubEnv('REACT_APP_HEADLAMP_VERSION', '0.35.0');
+
+    expect(getDisplayVersion()).toBe('1.2.3');
+  });
+
+  it('falls back to the Headlamp version', () => {
+    vi.stubEnv('REACT_APP_HEADLAMP_VERSION', '0.35.0');
+
+    expect(getDisplayVersion()).toBe('0.35.0');
+  });
+
+  it('falls back to the Headlamp version when the product version is empty', () => {
+    vi.stubEnv('REACT_APP_HEADLAMP_PRODUCT_VERSION', '');
+    vi.stubEnv('REACT_APP_HEADLAMP_VERSION', '0.35.0');
+
+    expect(getDisplayVersion()).toBe('0.35.0');
+  });
+
+  it('falls back to the Headlamp version when the product version is whitespace', () => {
+    vi.stubEnv('REACT_APP_HEADLAMP_PRODUCT_VERSION', ' \t\n');
+    vi.stubEnv('REACT_APP_HEADLAMP_VERSION', '0.35.0');
+
+    expect(getDisplayVersion()).toBe('0.35.0');
+  });
+});

--- a/frontend/src/helpers/getProductInfo.ts
+++ b/frontend/src/helpers/getProductInfo.ts
@@ -30,6 +30,20 @@ export function getProductName(): string | undefined {
   return import.meta.env.REACT_APP_HEADLAMP_PRODUCT_NAME;
 }
 
+/**
+ * @returns The version of the product distribution, or undefined when it is not set.
+ */
+export function getProductVersion(): string | undefined {
+  return import.meta.env.REACT_APP_HEADLAMP_PRODUCT_VERSION;
+}
+
+/**
+ * @returns The product distribution version when configured, otherwise the Headlamp version.
+ */
+export function getDisplayVersion(): string | undefined {
+  return getProductVersion()?.trim() || getVersion().VERSION;
+}
+
 /** A page that supports product-configured error content. */
 export type ProductErrorPage = 'error' | 'notFound';
 

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "حساب المستخدم الحالي",
   "Appbar Tools": "أدوات شريط التطبيق",
   "show more": "عرض المزيد",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "معلومات الإصدار",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "বর্তমান ব্যবহারকারীর অ্যাকাউন্ট",
   "Appbar Tools": "অ্যাপবার সরঞ্জাম",
   "show more": "আরও দেখান",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "Version তথ্য",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/cs/translation.json
+++ b/frontend/src/i18n/locales/cs/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "Účet aktuálního uživatele",
   "Appbar Tools": "Nástroje panelu aplikací",
   "show more": "zobrazit více",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "Informace o verzi",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "Konto des aktuellen Benutzers",
   "Appbar Tools": "Appbar-Tools",
   "show more": "mehr anzeigen",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "Account of current user",
   "Appbar Tools": "Appbar Tools",
   "show more": "show more",
+  "Product": "Product",
+  "{{ productName }} Version": "{{ productName }} Version",
   "Version information": "Version information",
   "About dialog tabs": "About dialog tabs",
   "About": "About",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "Cuenta del usuario actual",
   "Appbar Tools": "Herramientas de la barra de aplicación",
   "show more": "mostrar más",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "Compte de l'utilisateur actuel",
   "Appbar Tools": "Outils de la barre d'application",
   "show more": "afficher plus",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "Account of current user",
   "Appbar Tools": "Appbar Tools",
   "show more": "show more",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "Version information",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "",
   "Appbar Tools": "",
   "show more": "",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/hu/translation.json
+++ b/frontend/src/i18n/locales/hu/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "Az aktuális felhasználó fiókja",
   "Appbar Tools": "Alkalmazássáv eszközei",
   "show more": "továbbiak megjelenítése",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "Verzióadatok",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/id/translation.json
+++ b/frontend/src/i18n/locales/id/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "Akun pengguna saat ini",
   "Appbar Tools": "Alat Appbar",
   "show more": "tampilkan selengkapnya",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "Informasi versi",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "Account dell'utente corrente",
   "Appbar Tools": "Strumenti Appbar",
   "show more": "mostra di più",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "現在のユーザーのアカウント",
   "Appbar Tools": "アプリバーツール",
   "show more": "もっと表示",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "현재 사용자 계정",
   "Appbar Tools": "Appbar Tools",
   "show more": "더 보기",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/nl/translation.json
+++ b/frontend/src/i18n/locales/nl/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "Account van huidige gebruiker",
   "Appbar Tools": "Appbar-hulpprogramma's",
   "show more": "meer weergeven",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "Versiegegevens",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/pl/translation.json
+++ b/frontend/src/i18n/locales/pl/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "Konto bieżącego użytkownika",
   "Appbar Tools": "Narzędzia paska aplikacji",
   "show more": "pokaż więcej",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "Informacje o wersji",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/pt-br/translation.json
+++ b/frontend/src/i18n/locales/pt-br/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "Conta do utilizador actual",
   "Appbar Tools": "Ferramentas da barra de aplicação",
   "show more": "mostrar mais",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "Informações da versão",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/pt-pt/translation.json
+++ b/frontend/src/i18n/locales/pt-pt/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "",
   "Appbar Tools": "",
   "show more": "",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "Аккаунт текущего пользователя",
   "Appbar Tools": "Инструменты панели приложений",
   "show more": "показать больше",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "Информация о версии",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/sv/translation.json
+++ b/frontend/src/i18n/locales/sv/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "Konto för aktuell användare",
   "Appbar Tools": "Appfältsverktyg",
   "show more": "visa mer",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "Versionsinformation",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "தற்போதைய பயனரின் கணக்கு",
   "Appbar Tools": "ஆப்பார் கருவிகள்",
   "show more": "மேலும் காட்டு",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/tr/translation.json
+++ b/frontend/src/i18n/locales/tr/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "Geçerli kullanıcının hesabı",
   "Appbar Tools": "Uygulama Çubuğu Araçları",
   "show more": "daha fazla göster",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "Sürüm bilgileri",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "موجودہ صارف کا اکاؤنٹ",
   "Appbar Tools": "ایپ بار ٹولز",
   "show more": "مزید دکھائیں",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "ورژن کی معلومات",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "當前使用者的使用者",
   "Appbar Tools": "應用欄工具",
   "show more": "顯示更多",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -219,6 +219,8 @@
   "Account of current user": "当前用户的账户",
   "Appbar Tools": "应用栏工具",
   "show more": "显示更多",
+  "Product": "",
+  "{{ productName }} Version": "",
   "Version information": "",
   "About dialog tabs": "",
   "About": "",

--- a/frontend/src/make-env.test.js
+++ b/frontend/src/make-env.test.js
@@ -138,6 +138,7 @@ test('writes the default product metadata without requiring Git', async () => {
     REACT_APP_HEADLAMP_GIT_VERSION: 'source-commit',
     REACT_APP_HEADLAMP_PRODUCT_NAME: appInfo.productName,
   });
+  expect(env).not.toHaveProperty('REACT_APP_HEADLAMP_PRODUCT_VERSION');
 });
 
 test('reads product metadata from the default manifest', async () => {
@@ -146,8 +147,9 @@ test('reads product metadata from the default manifest', async () => {
   });
 
   expect(env).toMatchObject({
-    REACT_APP_HEADLAMP_VERSION: '2.3.4',
+    REACT_APP_HEADLAMP_VERSION: '0.0.0',
     REACT_APP_HEADLAMP_PRODUCT_NAME: 'Default Product',
+    REACT_APP_HEADLAMP_PRODUCT_VERSION: '2.3.4',
   });
 });
 
@@ -158,6 +160,7 @@ test('falls back to package metadata when the default manifest is absent', async
     REACT_APP_HEADLAMP_VERSION: '0.0.0',
     REACT_APP_HEADLAMP_PRODUCT_NAME: 'Headlamp',
   });
+  expect(env).not.toHaveProperty('REACT_APP_HEADLAMP_PRODUCT_VERSION');
 });
 
 test('resolves a relative custom manifest from the app directory', async () => {
@@ -167,8 +170,9 @@ test('resolves a relative custom manifest from the app directory', async () => {
   });
 
   expect(env).toMatchObject({
-    REACT_APP_HEADLAMP_VERSION: '3.4.5',
+    REACT_APP_HEADLAMP_VERSION: '0.0.0',
     REACT_APP_HEADLAMP_PRODUCT_NAME: 'Relative Product',
+    REACT_APP_HEADLAMP_PRODUCT_VERSION: '3.4.5',
   });
 });
 
@@ -184,9 +188,10 @@ test('uses custom product metadata and the source commit', async () => {
   });
 
   expect(env).toMatchObject({
-    REACT_APP_HEADLAMP_VERSION: '1.2.3',
+    REACT_APP_HEADLAMP_VERSION: appInfo.version,
     REACT_APP_HEADLAMP_GIT_VERSION: '0123456789abcdef',
     REACT_APP_HEADLAMP_PRODUCT_NAME: 'Example Desktop',
+    REACT_APP_HEADLAMP_PRODUCT_VERSION: '1.2.3',
   });
 });
 
@@ -200,6 +205,7 @@ test('falls back to package metadata for omitted product fields', async () => {
     REACT_APP_HEADLAMP_VERSION: appInfo.version,
     REACT_APP_HEADLAMP_PRODUCT_NAME: 'Example Desktop',
   });
+  expect(env).not.toHaveProperty('REACT_APP_HEADLAMP_PRODUCT_VERSION');
 });
 
 test('falls back to package metadata for empty product fields', async () => {
@@ -212,6 +218,7 @@ test('falls back to package metadata for empty product fields', async () => {
     REACT_APP_HEADLAMP_VERSION: appInfo.version,
     REACT_APP_HEADLAMP_PRODUCT_NAME: appInfo.productName,
   });
+  expect(env).not.toHaveProperty('REACT_APP_HEADLAMP_PRODUCT_VERSION');
 });
 
 test('falls back to package metadata when a manifest has no product', async () => {
@@ -224,6 +231,16 @@ test('falls back to package metadata when a manifest has no product', async () =
     REACT_APP_HEADLAMP_VERSION: appInfo.version,
     REACT_APP_HEADLAMP_PRODUCT_NAME: appInfo.productName,
   });
+  expect(env).not.toHaveProperty('REACT_APP_HEADLAMP_PRODUCT_VERSION');
+});
+
+test('omits a whitespace-only product version', async () => {
+  const env = await createEnv({
+    manifest: { product: { productName: 'Example Desktop', version: ' \t' } },
+    sourceCommit: 'source-commit',
+  });
+
+  expect(env).not.toHaveProperty('REACT_APP_HEADLAMP_PRODUCT_VERSION');
 });
 
 test.each([
@@ -247,9 +264,10 @@ test('preserves dotenv-sensitive characters through Vite', async () => {
   });
 
   expect(env).toMatchObject({
-    REACT_APP_HEADLAMP_VERSION: '1.2.3=build',
+    REACT_APP_HEADLAMP_VERSION: appInfo.version,
     REACT_APP_HEADLAMP_GIT_VERSION: 'source=commit',
     REACT_APP_HEADLAMP_PRODUCT_NAME: 'C# $HOME O\'Reilly "Desktop" \\path',
+    REACT_APP_HEADLAMP_PRODUCT_VERSION: '1.2.3=build',
   });
 });
 


### PR DESCRIPTION
## Summary

Add an optional distribution product version for branded Headlamp builds while
retaining the underlying Headlamp version and Git commit in the version dialog.
The top-bar menu uses the distribution version when configured and keeps the
existing Headlamp version fallback otherwise.

This is independent and does not depend on another Headlamp PR.

## Changes

- read `REACT_APP_HEADLAMP_PRODUCT_VERSION` through documented product-info
  helpers
- show distinct product and Headlamp versions only when they differ
- preserve the existing single-version dialog when the product version is
  absent or empty
- translate complete product-version labels with product-name interpolation
- widen the dialog so product labels and commit identifiers remain readable
- add focused unit and end-to-end coverage before the implementation commit

## Improvements over the existing changes

The downstream patch covered only the configured helper value. This version
adds tests for configured, absent, empty, matching, distinct, and unnamed
products so fallback behavior is explicit and changed decision modules reach
100% branch coverage. It also centralizes the top-bar fallback in
`getDisplayVersion`, translates labels without assuming English word order,
extracts the new keys across all 25 locale catalogs, adds TSDoc for the new
TypeScript API, verifies the user-visible dialog path in the e2e suite, and
widens the dialog because the added labels otherwise broke in the middle of
words.

## Source history

- Azure source PR: https://github.com/Azure/aks-desktop/pull/823
- Original About-dialog commit:
  https://github.com/Azure/aks-desktop/commit/d68693b049faa97b93dd0396103ed4fdd4cf2be4
- Original top-bar commit:
  https://github.com/Azure/aks-desktop/commit/067bf68f3e31574e958a53a3fb3ae98e7206256d
- The existing Headlamp version dialog originated in:
  https://github.com/kubernetes-sigs/headlamp/pull/640

The two original Azure commits are in rebased downstream history without an
originating Azure merge PR association, so unrelated PRs that later inherited
the commits are intentionally not listed.

## Testing

- `npm test -- --run` (218 files, 2,871 tests passed)
- focused Istanbul coverage: 100% branches for `getProductInfo.ts` and
  `VersionDialog.tsx`
- `npm run tsc`
- `npm run build`
- focused ESLint and Prettier checks
- `npx playwright test tests/headlamp.spec.ts --list` (14 tests discovered,
  including the new version-dialog test)
- Storybook before/after verification at 960 x 640

The Playwright test was compiled and discovered locally but not executed because
no Headlamp server was running and the local `test` Kubernetes API endpoint was
unavailable. CI provides the required e2e environment.

## Screenshots

### Before

![Headlamp version dialog before product version configuration](https://raw.githubusercontent.com/illume/headlamp/e9db4a7485ede9099ce3eec11914195551d6666a/7287-version-dialog-before.png)

### After: configured distribution version

![AKS Desktop version dialog with product and Headlamp versions](https://raw.githubusercontent.com/illume/headlamp/e9db4a7485ede9099ce3eec11914195551d6666a/7287-version-dialog-after.png)

Assisted by copilot
