### PR TITLE
0048: Configure product-specific error content

### DIFF
--- a/docs/development/frontend.md
+++ b/docs/development/frontend.md
@@ -36,6 +36,23 @@ This command starts the Vite development server for the frontend
 We use [react-query](https://tanstack.com/query/latest/docs/framework/react/overview)
 for network requests. If you need the devtools for react-query, you can simply set `REACT_APP_ENABLE_REACT_QUERY_DEVTOOLS=true` in the `.env` file.
 
+## Product error content
+
+Products that build Headlamp can customize the generic error and not-found
+pages with these build-time environment variables:
+
+| Environment variable                        | Default                           | Description                                           |
+| ------------------------------------------- | --------------------------------- | ----------------------------------------------------- |
+| `REACT_APP_HEADLAMP_ERROR_PAGE_TITLE`       | `Uh-oh! Something went wrong.`    | Title for the generic error page.                     |
+| `REACT_APP_HEADLAMP_ERROR_PAGE_GRAPHIC`     | Headlamp broken illustration      | URL or public path of the generic error page graphic. |
+| `REACT_APP_HEADLAMP_NOT_FOUND_PAGE_TITLE`   | `Whoops! This page doesn't exist` | Title for the not-found page.                         |
+| `REACT_APP_HEADLAMP_NOT_FOUND_PAGE_GRAPHIC` | Headlamp 404 illustration         | URL or public path of the not-found page graphic.     |
+
+Set the variables in `frontend/.env` or in the environment used to start or
+build the frontend. Restart the development server or rebuild the frontend
+after changing them. Product-provided titles are not translated by Headlamp;
+products are responsible for localizing their text and graphics.
+
 ## Linting
 
 For local development, run:

--- a/frontend/src/components/404/index.test.tsx
+++ b/frontend/src/components/404/index.test.tsx
@@ -22,6 +22,10 @@ vi.mock('notistack', () => ({
 }));
 
 describe('NotFoundComponent', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('shows the default not-found content', () => {
     const { container } = render(<NotFoundComponent />);
 
@@ -30,5 +34,15 @@ describe('NotFoundComponent', () => {
       'src',
       expect.stringContaining('headlamp-404.svg')
     );
+  });
+
+  it('shows product-specific not-found content', () => {
+    vi.stubEnv('REACT_APP_HEADLAMP_NOT_FOUND_PAGE_TITLE', 'Product page missing');
+    vi.stubEnv('REACT_APP_HEADLAMP_NOT_FOUND_PAGE_GRAPHIC', '/product/not-found.svg');
+
+    const { container } = render(<NotFoundComponent />);
+
+    expect(screen.getByRole('heading', { name: 'Product page missing' })).toBeVisible();
+    expect(container.querySelector('img')).toHaveAttribute('src', '/product/not-found.svg');
   });
 });

--- a/frontend/src/components/404/index.test.tsx
+++ b/frontend/src/components/404/index.test.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import NotFoundComponent from '.';
+
+vi.mock('notistack', () => ({
+  useSnackbar: () => ({ enqueueSnackbar: vi.fn() }),
+}));
+
+describe('NotFoundComponent', () => {
+  it('shows the default not-found content', () => {
+    const { container } = render(<NotFoundComponent />);
+
+    expect(screen.getByRole('heading', { name: `Whoops! This page doesn't exist` })).toBeVisible();
+    expect(container.querySelector('img')).toHaveAttribute(
+      'src',
+      expect.stringContaining('headlamp-404.svg')
+    );
+  });
+});

--- a/frontend/src/components/404/index.tsx
+++ b/frontend/src/components/404/index.tsx
@@ -16,14 +16,15 @@
 
 import { useTranslation } from 'react-i18next';
 import headlampBrokenImage from '../../assets/headlamp-404.svg';
+import { getErrorPageGraphic, getErrorPageTitle } from '../../helpers/getProductInfo';
 import ErrorComponent from '../common/ErrorPage';
 
 export default function NotFoundComponent() {
   const { t } = useTranslation();
   return (
     <ErrorComponent
-      graphic={headlampBrokenImage as any}
-      title={t(`Whoops! This page doesn't exist`)}
+      graphic={(getErrorPageGraphic('notFound') || headlampBrokenImage) as any}
+      title={getErrorPageTitle('notFound') || t(`Whoops! This page doesn't exist`)}
     />
   );
 }

--- a/frontend/src/components/common/ErrorPage/ErrorPage.test.tsx
+++ b/frontend/src/components/common/ErrorPage/ErrorPage.test.tsx
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ErrorComponent from './ErrorPage';
+
+const { mockEnqueueSnackbar } = vi.hoisted(() => ({
+  mockEnqueueSnackbar: vi.fn(),
+}));
+
+vi.mock('notistack', () => ({
+  useSnackbar: () => ({ enqueueSnackbar: mockEnqueueSnackbar }),
+}));
+
+describe('ErrorComponent', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    mockEnqueueSnackbar.mockReset();
+  });
+
+  it('shows the default error content', () => {
+    const { container } = render(<ErrorComponent />);
+
+    expect(screen.getByRole('heading', { name: 'Uh-oh! Something went wrong.' })).toBeVisible();
+    expect(container.querySelector('img')).toHaveAttribute(
+      'src',
+      expect.stringContaining('headlamp-broken.svg')
+    );
+  });
+
+  it('renders explicit content without typography or an image', () => {
+    render(
+      <ErrorComponent
+        title={<span>Plain title</span>}
+        message={<span>Plain message</span>}
+        graphic={<span>Plain graphic</span>}
+        withTypography={false}
+      />
+    );
+
+    expect(screen.getByText('Plain title')).toBeVisible();
+    expect(screen.getByText('Plain message')).toBeVisible();
+    expect(screen.getByText('Plain graphic')).toBeVisible();
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+  });
+
+  it('renders an explicit message with typography', () => {
+    render(<ErrorComponent message="Try again later" />);
+
+    expect(screen.getByRole('heading', { name: 'Try again later' })).toBeVisible();
+  });
+
+  it('copies error details', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    const error = new Error('Request failed');
+    error.stack = 'Request stack';
+
+    render(<ErrorComponent error={error} />);
+    await user.click(screen.getByRole('button', { name: /Error Details$/ }));
+    await user.click(screen.getByRole('button', { name: /Copy$/ }));
+
+    expect(writeText).toHaveBeenCalledWith('Request stack');
+    await waitFor(() =>
+      expect(mockEnqueueSnackbar).toHaveBeenCalledWith('translation|Copied to clipboard', {
+        variant: 'success',
+      })
+    );
+  });
+
+  it('reports clipboard failures', async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new Error('Clipboard unavailable')) },
+    });
+    const error = new Error('Request failed');
+    error.stack = 'Request stack';
+
+    render(<ErrorComponent error={error} />);
+    await user.click(screen.getByRole('button', { name: /Error Details$/ }));
+    await user.click(screen.getByRole('button', { name: /Copy$/ }));
+
+    await waitFor(() =>
+      expect(mockEnqueueSnackbar).toHaveBeenCalledWith('translation|Failed to copy to clipboard', {
+        variant: 'error',
+      })
+    );
+  });
+
+  it('reports a truncated error when the issue popup is blocked', async () => {
+    const user = userEvent.setup();
+    const open = vi.spyOn(window, 'open').mockReturnValue(null);
+    const error = new Error(`Request\n${'failed'.repeat(20)}`);
+    error.stack = 'x'.repeat(1001);
+
+    render(<ErrorComponent error={error} />);
+    await user.click(screen.getByRole('button', { name: /Error Details$/ }));
+    await user.click(screen.getByRole('button', { name: /Open Issue on GitHub$/ }));
+
+    const issueUrl = decodeURIComponent(open.mock.calls[0][0] as string);
+    expect(issueUrl).toContain('Crash Report: Request failed');
+    expect(issueUrl).toContain('... (truncated)');
+    expect(issueUrl).toContain('Headlamp Version\n');
+    expect(issueUrl).toContain('Git Commit\n');
+    expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
+      'translation|Unable to open GitHub. Please check your popup blocker settings or copy the error details manually.',
+      { variant: 'warning' }
+    );
+  });
+
+  it('opens an issue with fallback error text and configured versions', async () => {
+    const user = userEvent.setup();
+    const open = vi.spyOn(window, 'open').mockReturnValue(window);
+    vi.stubEnv('REACT_APP_HEADLAMP_VERSION', '1.2.3');
+    vi.stubEnv('REACT_APP_HEADLAMP_GIT_VERSION', 'abc123');
+    const error = new Error('');
+    error.stack = 'Short stack';
+
+    render(<ErrorComponent error={error} />);
+    await user.click(screen.getByRole('button', { name: /Error Details$/ }));
+    await user.click(screen.getByRole('button', { name: /Open Issue on GitHub$/ }));
+
+    const issueUrl = decodeURIComponent(open.mock.calls[0][0] as string);
+    expect(issueUrl).toContain('Crash Report: Application Error');
+    expect(issueUrl).toContain('An error occurred in the application');
+    expect(issueUrl).toContain('Headlamp Version\n1.2.3');
+    expect(issueUrl).toContain('Git Commit\nabc123');
+    expect(mockEnqueueSnackbar).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/common/ErrorPage/ErrorPage.test.tsx
+++ b/frontend/src/components/common/ErrorPage/ErrorPage.test.tsx
@@ -43,6 +43,28 @@ describe('ErrorComponent', () => {
     );
   });
 
+  it('shows product-specific error content', () => {
+    vi.stubEnv('REACT_APP_HEADLAMP_ERROR_PAGE_TITLE', 'Product error');
+    vi.stubEnv('REACT_APP_HEADLAMP_ERROR_PAGE_GRAPHIC', '/product/error.svg');
+
+    const { container } = render(<ErrorComponent />);
+
+    expect(screen.getByRole('heading', { name: 'Product error' })).toBeVisible();
+    expect(container.querySelector('img')).toHaveAttribute('src', '/product/error.svg');
+  });
+
+  it('prefers explicit content over product defaults', () => {
+    vi.stubEnv('REACT_APP_HEADLAMP_ERROR_PAGE_TITLE', 'Product error');
+    vi.stubEnv('REACT_APP_HEADLAMP_ERROR_PAGE_GRAPHIC', '/product/error.svg');
+
+    const { container } = render(
+      <ErrorComponent title="Request error" graphic="/request/error.svg" />
+    );
+
+    expect(screen.getByRole('heading', { name: 'Request error' })).toBeVisible();
+    expect(container.querySelector('img')).toHaveAttribute('src', '/request/error.svg');
+  });
+
   it('renders explicit content without typography or an image', () => {
     render(
       <ErrorComponent

--- a/frontend/src/components/common/ErrorPage/ErrorPage.tsx
+++ b/frontend/src/components/common/ErrorPage/ErrorPage.tsx
@@ -28,19 +28,25 @@ import { useSnackbar } from 'notistack';
 import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import headlampBrokenImage from '../../../assets/headlamp-broken.svg';
-import { getVersion } from '../../../helpers/getProductInfo';
+import {
+  getErrorPageGraphic,
+  getErrorPageTitle,
+  getVersion,
+} from '../../../helpers/getProductInfo';
 
 const WidthImg = styled('img')({
   width: '100%',
 });
 
 export interface ErrorComponentProps {
-  /** The main title to display. By default it is: "Uh-oh! Something went wrong." */
+  /** The main title to display. Defaults to the product-configured title, then Headlamp's
+   * "Uh-oh! Something went wrong." fallback. */
   title?: React.ReactNode;
   /** The message to display. By default it is: "Head back <a href="..."> home</a>." */
   message?: React.ReactNode;
   /** The graphic or element to display as a main graphic. If used as a string, it will be
-   * used as the source for displaying an image. By default it is "headlamp-broken.svg". */
+   * used as the source for displaying an image. Defaults to the product-configured graphic,
+   * then Headlamp's "headlamp-broken.svg" fallback. */
   graphic?: React.ReactNode;
   /** Whether to use Typography or not. By default it is true. */
   withTypography?: boolean;
@@ -103,10 +109,10 @@ export default function ErrorComponent(props: ErrorComponentProps) {
   const { t } = useTranslation();
   const { enqueueSnackbar } = useSnackbar();
   const {
-    title = t('Uh-oh! Something went wrong.'),
+    title = getErrorPageTitle('error') || t('Uh-oh! Something went wrong.'),
     message = '',
     withTypography = true,
-    graphic = headlampBrokenImage,
+    graphic = getErrorPageGraphic('error') || headlampBrokenImage,
     error,
   } = props;
   return (

--- a/frontend/src/helpers/getProductInfo.ts
+++ b/frontend/src/helpers/getProductInfo.ts
@@ -29,3 +29,30 @@ export function getVersion() {
 export function getProductName(): string | undefined {
   return import.meta.env.REACT_APP_HEADLAMP_PRODUCT_NAME;
 }
+
+/** A page that supports product-configured error content. */
+export type ProductErrorPage = 'error' | 'notFound';
+
+/**
+ * Returns the product-configured title for an error page.
+ *
+ * @param page - The error page whose title should be returned.
+ * @returns The configured title, or undefined if it is not set.
+ */
+export function getErrorPageTitle(page: ProductErrorPage): string | undefined {
+  return page === 'error'
+    ? import.meta.env.REACT_APP_HEADLAMP_ERROR_PAGE_TITLE
+    : import.meta.env.REACT_APP_HEADLAMP_NOT_FOUND_PAGE_TITLE;
+}
+
+/**
+ * Returns the product-configured graphic URL for an error page.
+ *
+ * @param page - The error page whose graphic should be returned.
+ * @returns The configured graphic URL, or undefined if it is not set.
+ */
+export function getErrorPageGraphic(page: ProductErrorPage): string | undefined {
+  return page === 'error'
+    ? import.meta.env.REACT_APP_HEADLAMP_ERROR_PAGE_GRAPHIC
+    : import.meta.env.REACT_APP_HEADLAMP_NOT_FOUND_PAGE_GRAPHIC;
+}


### PR DESCRIPTION
## Summary

- Allow products to configure titles and graphics for the generic error and
  not-found pages at build time.
- Preserve Headlamp's existing content when product values are absent.
- Keep explicit `ErrorPage` props higher priority than product defaults.
- Document the four build-time variables, defaults, and localization behavior
  in the frontend development guide.

## Source

This upstreams retained patch 0048 from:

- https://github.com/Azure/aks-desktop/pull/823
- https://github.com/Azure/aks-desktop/commit/387eb27e3f586211610dda61949255e7264a9c95

The retained patch records original source commit
`54f6941bcd764cbe8230d802f2f0946e83222b4e`, authored by Joaquim Rocha on
2026-08-01. That source object is no longer available from Azure/aks-desktop,
so PR 823 is the only related Azure pull request that could be verified.

## Improvements over the existing changes

- Add tests for Headlamp's existing error-page defaults in a separate commit
  before the product customization, making fallback regressions explicit.
- Add component-level tests for configured content and explicit prop priority,
  so build-time env defaults are covered at their actual render call sites.
- Centralize product values in the existing `getProductInfo.ts` module while
  retaining direct env member access for Vite and Rsbuild compatibility.
- Update the public `ErrorComponentProps` TSDoc to describe product defaults
  and Headlamp fallbacks accurately.
- Document all four environment variables, their defaults, and localization
  ownership in `docs/development/frontend.md`.
- Raise focused branch coverage to 89.13%; each changed source file is above
  80% branch coverage.

These changes make the upstream version safer to review and maintain while
preserving the behavior of the retained downstream patch.

## Testing

- `npm test -- --run src/components/404/index.test.tsx src/components/common/ErrorPage/ErrorPage.test.tsx --coverage --coverage.include=src/components/404/index.tsx --coverage.include=src/components/common/ErrorPage/ErrorPage.tsx --coverage.include=src/helpers/getProductInfo.ts --coverage.reporter=text --coverage.thresholds.branches=80`
  - 11 tests passed
  - 89.13% branch coverage overall
  - 100% branches for the 404 component
  - 86.84% branches for `ErrorPage.tsx`
  - 100% branches for `getProductInfo.ts`
- `npm run tsc`
- `npm run build`
- `npm run build:rsbuild`

The existing Playwright test `404 page is present` in
`e2e-tests/tests/headlamp.spec.ts` covers this UI area. It was not run locally
because it requires the deployed Kubernetes e2e environment and token.

## Screenshots

### Before: default Headlamp content

![Default Headlamp not-found title and illustration](https://raw.githubusercontent.com/illume/headlamp/727de45edb2bcb10123e44c054f56884e2a81faf/pr-screenshots/0048-product-error-before.png)

### After: configured product content

![Product-specific not-found title and illustration](https://raw.githubusercontent.com/illume/headlamp/727de45edb2bcb10123e44c054f56884e2a81faf/pr-screenshots/0048-product-error-after.png)

The after capture uses representative product values for both the title and
graphic to show the two build-time configuration options together.

Assisted by copilot
