### PR TITLE
frontend: TooltipLight: Fix styling application by using slotProps

### DIFF
--- a/frontend/src/components/common/Tooltip/TooltipLight.tsx
+++ b/frontend/src/components/common/Tooltip/TooltipLight.tsx
@@ -29,38 +29,47 @@ export interface TooltipLightProps extends Omit<TooltipProps, 'children'> {
 }
 
 export default function TooltipLight(props: TooltipLightProps) {
-  const { children, interactive = true, ...rest } = props;
+  const { children, interactive = true, slotProps, ...rest } = props;
   const disableInteractive = !interactive;
-
-  if (typeof children === 'string') {
-    return (
-      <Tooltip
-        disableInteractive={disableInteractive}
-        TransitionComponent={Fade}
-        TransitionProps={{ timeout: 0 }}
-        sx={theme => ({
-          backgroundColor: theme.palette.background.default,
-          color: theme.palette.resourceToolTip.color,
-          boxShadow: theme.shadows[1],
-          fontSize: '1rem',
-          whiteSpace: 'pre-line',
-        })}
-        {...rest}
-      >
-        <span>{children}</span>
-      </Tooltip>
-    );
-  }
 
   return (
     <Tooltip
       {...rest}
+      disableInteractive={disableInteractive}
       TransitionComponent={Fade}
       TransitionProps={{ timeout: 0 }}
+      slotProps={{
+        ...slotProps,
+        tooltip: {
+          ...props.componentsProps?.tooltip,
+          ...slotProps?.tooltip,
+          sx: [
+            theme => ({
+              backgroundColor: theme.palette.background.default,
+              color: theme.palette.resourceToolTip.color,
+              boxShadow: theme.shadows[1],
+              fontSize: '1rem',
+              whiteSpace: 'pre-line',
+            }),
+            ...(Array.isArray(props.componentsProps?.tooltip?.sx)
+              ? props.componentsProps.tooltip.sx
+              : [props.componentsProps?.tooltip?.sx ?? false]),
+            ...(Array.isArray(slotProps?.tooltip?.sx)
+              ? slotProps.tooltip.sx
+              : [slotProps?.tooltip?.sx ?? false]),
+          ],
+        },
+      }}
       // children prop in the mui Tooltip is defined as ReactElement which is not totally correct
       // string should be a valid child and is used a lot in this project
       // but it's not included in the ReactElement type
-      children={props.children as unknown as ReactElement}
+      children={
+        typeof children === 'string' ? (
+          <span>{children}</span>
+        ) : (
+          (props.children as unknown as ReactElement)
+        )
+      }
     />
   );
 }


### PR DESCRIPTION
## Summary

This PR fixes #7080 by ensuring that custom styling applied to `TooltipLight` properly targets the tooltip content wrapper. It replaces the top-level `sx` property (which incorrectly styles the tooltip wrapper in MUI v5) with the appropriate `slotProps.tooltip.sx` property. 

Additionally, this PR unifies the rendering path for `string` and `ReactElement` children, reducing duplicated code.

## Related Issue

Fixes #7080

## Changes

- **`frontend/src/components/common/Tooltip/TooltipLight.tsx`**
  - Removed the duplicated `if (typeof children === 'string')` return path.
  - Replaced the `sx={...}` property with `slotProps={{ tooltip: { sx: ... } }}` to correctly target the tooltip content.
  - Unified the `children` prop logic to dynamically wrap strings in a `<span>` while preserving the intended ReactElement structure for other inputs.

## Steps to Test

1. Start the frontend: `npm start`
2. Navigate to a resource view that utilizes `TooltipLight` (e.g., hovering over status icons or elements with multi-line tooltips).
3. Verify that the tooltip now correctly applies its styling (e.g., light-themed background).
4. Verify that multi-line tooltips no longer collapse into a single line, as the `white-space: pre-line` CSS rule is now successfully applied.

## Notes for the Reviewer

- Tested locally and confirmed that the standard tooltip styling is fully restored.
- The change was verified against existing `TooltipLight.stories.tsx` components and does not break any snapshots.