### PR TITLE
frontend: ReleaseNotesModal: Make scrollable region focusable

### DIFF
--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.tsx
@@ -51,7 +51,7 @@ export default function ReleaseNotesModal(props: ReleaseNotesModalProps) {
           appVersion: appVersion,
         })}
       </DialogTitle>
-      <DialogContent dividers>
+      <DialogContent dividers tabIndex={0}>
         <Box
           sx={{
             '& img': { display: 'block', maxWidth: '100%', height: 'auto' },

--- a/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotes.Default.stories.storyshot
+++ b/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotes.Default.stories.storyshot
@@ -138,6 +138,7 @@
         </h2>
         <div
           class="MuiDialogContent-root MuiDialogContent-dividers css-1t4vnk2-MuiDialogContent-root"
+          tabindex="0"
         >
           <div
             class="MuiBox-root css-wicc6q"

--- a/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.HtmlImage.stories.storyshot
+++ b/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.HtmlImage.stories.storyshot
@@ -66,6 +66,7 @@
         </h2>
         <div
           class="MuiDialogContent-root MuiDialogContent-dividers css-1t4vnk2-MuiDialogContent-root"
+          tabindex="0"
         >
           <div
             class="MuiBox-root css-wicc6q"

--- a/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.Show.stories.storyshot
+++ b/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.Show.stories.storyshot
@@ -66,6 +66,7 @@
         </h2>
         <div
           class="MuiDialogContent-root MuiDialogContent-dividers css-1t4vnk2-MuiDialogContent-root"
+          tabindex="0"
         >
           <div
             class="MuiBox-root css-wicc6q"

--- a/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.Table.stories.storyshot
+++ b/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.Table.stories.storyshot
@@ -66,6 +66,7 @@
         </h2>
         <div
           class="MuiDialogContent-root MuiDialogContent-dividers css-1t4vnk2-MuiDialogContent-root"
+          tabindex="0"
         >
           <div
             class="MuiBox-root css-wicc6q"


### PR DESCRIPTION
## Summary

This PR fixes #7185 by ensuring the scrollable region inside the `ReleaseNotesModal` is accessible via keyboard navigation. By adding `tabIndex={0}` to the `<DialogContent>` component, screen readers and keyboard-only users can now properly focus and scroll through the release notes.

## Related Issue

Fixes #7185

## Changes

- **`frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.tsx`**
  - Appended `tabIndex={0}` to `DialogContent`.

## Steps to Test

1. Start Storybook: `npm run frontend:storybook`
2. Navigate to `common/ReleaseNotes/ReleaseNotesModal` -> `Show`.
3. Open the **Accessibility** addon tab and observe that the `scrollable-region-focusable` violation no longer appears.
4. Using your keyboard, press `Tab` to navigate to the scrollable content area and use the arrow keys to scroll.

## Notes for the Reviewer

- Clean branch off `main`, no conflicts.
- Adheres to standard React accessibility guidelines (JSX-a11y) for scrollable regions without interactive children.
