### PR TITLE
0036: app: electron: Expose platform in desktop API

### DIFF
--- a/app/e2e-tests/tests/desktopPlatform.spec.ts
+++ b/app/e2e-tests/tests/desktopPlatform.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import path from 'path';
+import { _electron } from 'playwright';
+
+/** Window fields made available by the Electron preload bridge. */
+type DesktopWindow = Window & {
+  /** APIs exposed to Headlamp's renderer process. */
+  desktopApi: {
+    /** Operating system platform hosting the desktop app. */
+    platform: NodeJS.Platform;
+  };
+};
+
+const electronExecutable = process.platform === 'win32' ? 'electron.cmd' : 'electron';
+const electronPath = path.resolve(__dirname, `../../node_modules/.bin/${electronExecutable}`);
+const appPath = path.resolve(__dirname, '../../');
+
+test.describe('desktop platform API', () => {
+  test('exposes the host platform to the renderer', async () => {
+    test.skip(process.env.PLAYWRIGHT_TEST_MODE !== 'app', 'The preload bridge is desktop-only');
+
+    const electronApp = await _electron.launch({
+      cwd: appPath,
+      executablePath: electronPath,
+      args: ['.'],
+      env: {
+        ...process.env,
+        NODE_ENV: 'development',
+        ELECTRON_DEV: 'true',
+      },
+    });
+
+    try {
+      const page = await electronApp.firstWindow();
+      const platform = await page.evaluate(
+        () => (window as unknown as DesktopWindow).desktopApi.platform
+      );
+
+      expect(platform).toBe(process.platform);
+    } finally {
+      await electronApp.close();
+    }
+  });
+});

--- a/app/electron/preload.test.ts
+++ b/app/electron/preload.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const electronMocks = vi.hoisted(() => ({
+  exposeInMainWorld: vi.fn(),
+  invoke: vi.fn(),
+  on: vi.fn(),
+  removeListener: vi.fn(),
+  send: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  contextBridge: {
+    exposeInMainWorld: electronMocks.exposeInMainWorld,
+  },
+  ipcRenderer: {
+    invoke: electronMocks.invoke,
+    on: electronMocks.on,
+    removeListener: electronMocks.removeListener,
+    send: electronMocks.send,
+  },
+}));
+
+await import('./preload');
+
+const desktopApi = electronMocks.exposeInMainWorld.mock.calls[0][1];
+
+describe('desktop preload API', () => {
+  beforeEach(() => {
+    electronMocks.invoke.mockReset();
+    electronMocks.on.mockReset();
+    electronMocks.removeListener.mockReset();
+    electronMocks.send.mockReset();
+  });
+
+  it('exposes the host platform', () => {
+    expect(desktopApi.platform).toBe(process.platform);
+  });
+
+  it('sends messages only on allowed channels', () => {
+    desktopApi.send('locale', 'en');
+    desktopApi.send('not-allowed', 'ignored');
+
+    expect(electronMocks.send).toHaveBeenCalledOnce();
+    expect(electronMocks.send).toHaveBeenCalledWith('locale', 'en');
+  });
+
+  it('receives messages only on allowed channels and strips the event', () => {
+    const listener = vi.fn();
+    const unsubscribe = desktopApi.receive('locale', listener);
+    const wrappedListener = electronMocks.on.mock.calls[0][1];
+
+    wrappedListener({ sender: 'private' }, 'fr');
+    expect(listener).toHaveBeenCalledWith('fr');
+    expect(desktopApi.receive('not-allowed', listener)).toBeUndefined();
+
+    unsubscribe();
+    expect(electronMocks.removeListener).toHaveBeenCalledWith('locale', wrappedListener);
+  });
+
+  it('removes the wrapped listener registered for a channel', () => {
+    const listener = vi.fn();
+    desktopApi.receive('locale', listener);
+    const wrappedListener = electronMocks.on.mock.calls[0][1];
+
+    desktopApi.removeListener('locale', listener);
+
+    expect(electronMocks.removeListener).toHaveBeenCalledWith('locale', wrappedListener);
+  });
+
+  it('falls back to removing the provided listener', () => {
+    const listener = vi.fn();
+    desktopApi.receive('locale', listener);
+
+    desktopApi.removeListener('currentMenu', listener);
+    desktopApi.removeListener('locale', vi.fn());
+
+    expect(electronMocks.removeListener).toHaveBeenNthCalledWith(1, 'currentMenu', listener);
+    expect(electronMocks.removeListener).toHaveBeenNthCalledWith(2, 'locale', expect.any(Function));
+  });
+});

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -117,4 +117,5 @@ contextBridge.exposeInMainWorld('desktopApi', {
   notifyClusterChange: (cluster: string | null) => {
     ipcRenderer.send('cluster-changed', cluster);
   },
+  platform: process.platform,
 });

--- a/frontend/src/i18n/electronI18n.tsx
+++ b/frontend/src/i18n/electronI18n.tsx
@@ -18,12 +18,6 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { isElectron } from '../helpers/isElectron';
 
-declare global {
-  interface Window {
-    desktopApi: any;
-  }
-}
-
 // If we're running under electron, we need to communicate any language changes.
 const ipcRenderer = isElectron() ? window.desktopApi : null;
 

--- a/frontend/src/plugin/lib.ts
+++ b/frontend/src/plugin/lib.ts
@@ -67,6 +67,14 @@ export abstract class Plugin {
   abstract initialize(register: Registry): boolean | void;
 }
 
+/** APIs exposed to Headlamp's renderer process by the desktop preload bridge. */
+export interface DesktopApi {
+  /** Operating system platform hosting the desktop app. */
+  platform: NodeJS.Platform;
+  /** Additional APIs exposed by the desktop preload bridge. */
+  [key: string]: any;
+}
+
 declare global {
   interface Window {
     pluginLib: {
@@ -76,7 +84,7 @@ declare global {
       [pluginId: string]: Plugin;
     };
     registerPlugin: (pluginId: string, pluginObj: Plugin) => void;
-    desktopApi: any;
+    desktopApi: DesktopApi;
   }
 }
 


### PR DESCRIPTION
## Summary

- expose the host operating-system platform through the context-isolated
  desktop preload API
- define and document the shared `DesktopApi` TypeScript contract
- verify the contract with focused preload unit coverage and an Electron e2e
  test

## Provenance

This rebases the downstream Headlamp change carried by:

- Original commit `c5ee2d24071b9fc188debc0b68e2d92f2cf51fc8`
  (`app: expose platform in desktop API`), authored by Oleksandr Dubenko on
  2026-07-31
- https://github.com/Azure/aks-desktop/pull/823

The feature commit preserves the original author and author date and adds
René Dudfield as a co-author.

## Improvements over the existing changes

- Add focused unit coverage for the preload bridge, including every branch in
  its send, receive, unsubscribe, and listener-removal paths. This guards the
  context-isolation boundary where the platform value is actually exposed.
- Add an Electron e2e test that reads `window.desktopApi.platform` from the
  renderer. This proves the value survives compilation and the real preload
  bridge rather than only satisfying TypeScript.
- Document the exported `DesktopApi` interface and its fields with TSDoc so
  plugin authors can understand the desktop-only contract.
- Rebase onto current `main` and omit two obsolete downstream test-fixture
  hunks whose test files no longer exist upstream.

## Testing

- `cd app && npm test` (151 tests passed)
- focused `app/electron/preload.ts` coverage: 92.5% statements, 100% branches,
  26.66% functions, and 92.5% lines
- `cd frontend && npm run tsc`
- `cd frontend && npm test -- --run src/i18n/config.test.ts` (3 tests passed)
- `cd app/e2e-tests && npm run test-app -- tests/desktopPlatform.spec.ts`
  (1 test passed)

The plugin compatibility file-snapshot test was also attempted, but the
existing Vitest harness failed before comparison with `SnapshotClient.setup()`
not initialized. Its non-snapshot assertion passed, and frontend typechecking
completed successfully.

## Screenshots

Not applicable. This exposes an API value and has no visual change.

Assisted by copilot.
