### PR TITLE
0026: Keep project grid visible at high zoom

### DIFF
--- a/e2e-tests/tests/projectResources.spec.ts
+++ b/e2e-tests/tests/projectResources.spec.ts
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, Page, test } from '@playwright/test';
+import { HeadlampPage } from './headlampPage';
+
+const projectName = 'high-zoom-project';
+const namespaceName = 'high-zoom-namespace';
+const namespace = {
+  apiVersion: 'v1',
+  kind: 'Namespace',
+  metadata: {
+    name: namespaceName,
+    uid: namespaceName,
+    resourceVersion: '1',
+    labels: { 'headlamp.dev/project-id': projectName },
+  },
+  status: { phase: 'Active' },
+};
+const deployment = {
+  apiVersion: 'apps/v1',
+  kind: 'Deployment',
+  metadata: {
+    name: 'project-workload',
+    namespace: namespaceName,
+    uid: 'project-workload',
+    resourceVersion: '1',
+  },
+  spec: { replicas: 1, template: { spec: { containers: [] } } },
+  status: { replicas: 1, readyReplicas: 1, availableReplicas: 1 },
+};
+const configMap = {
+  apiVersion: 'v1',
+  kind: 'ConfigMap',
+  metadata: { name: 'project-config', namespace: namespaceName, uid: 'project-config' },
+};
+const persistentVolumeClaim = {
+  apiVersion: 'v1',
+  kind: 'PersistentVolumeClaim',
+  metadata: { name: 'project-storage', namespace: namespaceName, uid: 'project-storage' },
+  spec: {},
+  status: {},
+};
+const service = {
+  apiVersion: 'v1',
+  kind: 'Service',
+  metadata: { name: 'project-service', namespace: namespaceName, uid: 'project-service' },
+  spec: {},
+  status: {},
+};
+const role = {
+  apiVersion: 'rbac.authorization.k8s.io/v1',
+  kind: 'Role',
+  metadata: { name: 'project-role', namespace: namespaceName, uid: 'project-role' },
+  rules: [],
+};
+
+const baseCollectionResponses: Record<
+  string,
+  { apiVersion: string; kind: string; items: object[] }
+> = {
+  namespaces: { apiVersion: 'v1', kind: 'NamespaceList', items: [namespace] },
+  configmaps: { apiVersion: 'v1', kind: 'ConfigMapList', items: [] },
+  endpoints: { apiVersion: 'v1', kind: 'EndpointsList', items: [] },
+  endpointslices: { apiVersion: 'discovery.k8s.io/v1', kind: 'EndpointSliceList', items: [] },
+  persistentvolumeclaims: {
+    apiVersion: 'v1',
+    kind: 'PersistentVolumeClaimList',
+    items: [],
+  },
+  secrets: { apiVersion: 'v1', kind: 'SecretList', items: [] },
+  services: { apiVersion: 'v1', kind: 'ServiceList', items: [] },
+  statefulsets: { apiVersion: 'apps/v1', kind: 'StatefulSetList', items: [] },
+  replicasets: { apiVersion: 'apps/v1', kind: 'ReplicaSetList', items: [] },
+  deployments: { apiVersion: 'apps/v1', kind: 'DeploymentList', items: [deployment] },
+  daemonsets: { apiVersion: 'apps/v1', kind: 'DaemonSetList', items: [] },
+  jobs: { apiVersion: 'batch/v1', kind: 'JobList', items: [] },
+  cronjobs: { apiVersion: 'batch/v1', kind: 'CronJobList', items: [] },
+  ingresses: { apiVersion: 'networking.k8s.io/v1', kind: 'IngressList', items: [] },
+  networkpolicies: {
+    apiVersion: 'networking.k8s.io/v1',
+    kind: 'NetworkPolicyList',
+    items: [],
+  },
+  horizontalpodautoscalers: {
+    apiVersion: 'autoscaling/v2',
+    kind: 'HorizontalPodAutoscalerList',
+    items: [],
+  },
+  roles: { apiVersion: 'rbac.authorization.k8s.io/v1', kind: 'RoleList', items: [] },
+  rolebindings: {
+    apiVersion: 'rbac.authorization.k8s.io/v1',
+    kind: 'RoleBindingList',
+    items: [],
+  },
+  resourcequotas: { apiVersion: 'v1', kind: 'ResourceQuotaList', items: [] },
+  limitranges: { apiVersion: 'v1', kind: 'LimitRangeList', items: [] },
+  applications: { apiVersion: 'argoproj.io/v1alpha1', kind: 'ApplicationList', items: [] },
+};
+const requiredCollections = new Set([
+  'namespaces',
+  'configmaps',
+  'endpoints',
+  'endpointslices',
+  'persistentvolumeclaims',
+  'secrets',
+  'services',
+  'statefulsets',
+  'replicasets',
+  'deployments',
+  'daemonsets',
+  'jobs',
+  'cronjobs',
+  'ingresses',
+  'networkpolicies',
+  'horizontalpodautoscalers',
+  'roles',
+  'rolebindings',
+  'resourcequotas',
+  'limitranges',
+]);
+
+/**
+ * Creates deterministic Kubernetes collection responses for the project page.
+ *
+ * @param includeMultipleCategories Whether to populate resources across all category groups.
+ * @returns Collection responses keyed by Kubernetes plural resource name.
+ */
+function projectCollectionResponses(includeMultipleCategories: boolean) {
+  if (!includeMultipleCategories) {
+    return baseCollectionResponses;
+  }
+
+  return {
+    ...baseCollectionResponses,
+    configmaps: { ...baseCollectionResponses.configmaps, items: [configMap] },
+    persistentvolumeclaims: {
+      ...baseCollectionResponses.persistentvolumeclaims,
+      items: [persistentVolumeClaim],
+    },
+    services: { ...baseCollectionResponses.services, items: [service] },
+    roles: { ...baseCollectionResponses.roles, items: [role] },
+  };
+}
+
+/**
+ * Mocks project collection requests and records unexpected API traffic.
+ *
+ * @param page Playwright page whose Kubernetes requests should be intercepted.
+ * @param cluster Cluster name used in Headlamp API paths.
+ * @param includeMultipleCategories Whether to populate every resource category.
+ * @returns Request tracking used to wait for all project collections.
+ */
+async function mockProjectCollections(
+  page: Page,
+  cluster: string,
+  includeMultipleCategories: boolean
+) {
+  const collectionResponses = projectCollectionResponses(includeMultipleCategories);
+  const requestedCollections = new Set<string>();
+  const unexpectedRequests: string[] = [];
+
+  await page.route(new RegExp(`/clusters/${cluster}/apis?/`), async route => {
+    const request = route.request();
+    const url = new URL(request.url());
+
+    if (request.method() !== 'GET' || url.searchParams.get('watch') === '1') {
+      await route.continue();
+      return;
+    }
+
+    const resource = url.pathname.split('/').at(-1);
+    const isProjectNamespaceList =
+      resource === 'namespaces' &&
+      url.searchParams.get('labelSelector') === `headlamp.dev/project-id=${projectName}`;
+    const isProjectResourceCollection = url.pathname.includes(`/namespaces/${namespaceName}/`);
+    if (!isProjectNamespaceList && !isProjectResourceCollection) {
+      await route.continue();
+      return;
+    }
+
+    const list = resource && collectionResponses[resource];
+    if (!list) {
+      const requestDescription = `${request.method()} ${url.pathname}${url.search}`;
+      unexpectedRequests.push(requestDescription);
+      await route.fulfill({
+        status: 501,
+        json: { message: `Unexpected project resource request: ${requestDescription}` },
+      });
+      return;
+    }
+    requestedCollections.add(resource);
+    await route.fulfill({
+      json: {
+        ...list,
+        metadata: { resourceVersion: '1' },
+      },
+    });
+  });
+
+  return { requestedCollections, unexpectedRequests };
+}
+
+test('keeps the project resources grid visible at 200% text zoom', async ({ page }) => {
+  const cluster = process.env.HEADLAMP_TEST_CLUSTER || 'test';
+  const token = process.env.HEADLAMP_TEST_TOKEN;
+  if (!token) {
+    test.skip(true, 'HEADLAMP_TEST_TOKEN is not set; cannot authenticate to Headlamp.');
+  }
+  const { requestedCollections, unexpectedRequests } = await mockProjectCollections(
+    page,
+    cluster,
+    false
+  );
+
+  const shortViewport = { width: 640, height: 384 };
+  await page.setViewportSize(shortViewport);
+  const headlampPage = new HeadlampPage(page);
+  await headlampPage.navigateToCluster(cluster, token);
+  await headlampPage.navigateTopage(`/project/${projectName}`);
+  await page.addStyleTag({ content: ':root { font-size: 200%; }' });
+  await page.getByRole('tab', { name: 'Resources' }).click();
+
+  await expect
+    .poll(() => [...requiredCollections].filter(item => !requestedCollections.has(item)))
+    .toEqual([]);
+  expect(unexpectedRequests, 'Project Resources made unexpected API requests').toEqual([]);
+
+  const resourceGrid = page.getByTestId('project-resource-grid');
+  const categoryList = resourceGrid.getByTestId('project-resource-categories');
+  const categoryButton = categoryList.getByRole('button', { name: /^Workloads\b/ });
+
+  await expect(resourceGrid).toBeVisible();
+  await expect(categoryButton).toBeVisible();
+  await expect(categoryList.getByRole('button')).toHaveCount(1);
+  await expect
+    .poll(() => resourceGrid.evaluate(element => element.getBoundingClientRect().height))
+    .toBeGreaterThan(shortViewport.height);
+
+  await categoryButton.click();
+  const workload = resourceGrid.getByText('project-workload', { exact: true });
+  await workload.scrollIntoViewIfNeeded();
+  await expect(workload).toBeInViewport();
+});
+
+test('only scrolls project categories in short stacked layouts', async ({ page }) => {
+  const cluster = process.env.HEADLAMP_TEST_CLUSTER || 'test';
+  const token = process.env.HEADLAMP_TEST_TOKEN;
+  if (!token) {
+    test.skip(true, 'HEADLAMP_TEST_TOKEN is not set; cannot authenticate to Headlamp.');
+  }
+  const { requestedCollections, unexpectedRequests } = await mockProjectCollections(
+    page,
+    cluster,
+    true
+  );
+
+  await page.setViewportSize({ width: 640, height: 384 });
+  const headlampPage = new HeadlampPage(page);
+  await headlampPage.navigateToCluster(cluster, token);
+  await headlampPage.navigateTopage(`/project/${projectName}`);
+  await page.addStyleTag({ content: ':root { font-size: 200%; }' });
+  await page.getByRole('tab', { name: 'Resources' }).click();
+
+  await expect
+    .poll(() => [...requiredCollections].filter(item => !requestedCollections.has(item)))
+    .toEqual([]);
+  expect(unexpectedRequests, 'Project Resources made unexpected API requests').toEqual([]);
+
+  const categoryList = page
+    .getByTestId('project-resource-grid')
+    .getByTestId('project-resource-categories');
+  await expect(categoryList.getByRole('button')).toHaveCount(5);
+  await expect
+    .poll(() => categoryList.evaluate(element => element.scrollHeight > element.clientHeight))
+    .toBe(true);
+
+  await page.setViewportSize({ width: 640, height: 900 });
+  await expect
+    .poll(() => categoryList.evaluate(element => element.scrollHeight > element.clientHeight))
+    .toBe(false);
+});

--- a/frontend/src/components/project/ProjectDetails.tsx
+++ b/frontend/src/components/project/ProjectDetails.tsx
@@ -602,7 +602,12 @@ export function ProjectDetailsContent({ project }: { project: ProjectDefinition 
   return (
     <ProjectDetailsContext.Provider value={contextValue}>
       <Box
-        sx={{ display: 'flex', flexDirection: 'column', height: '100%', alignItems: 'flex-start' }}
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: '100%',
+          alignItems: 'flex-start',
+        }}
       >
         <SectionBox
           outterBoxProps={{

--- a/frontend/src/components/project/ProjectResourcesLayout.test.tsx
+++ b/frontend/src/components/project/ProjectResourcesLayout.test.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { KubeObject } from '../../lib/k8s/KubeObject';
+import { ResourceCategory } from '../../lib/k8s/ResourceCategory';
+import { TestContext } from '../../test';
+import { ProjectResourcesTab } from './ProjectResourcesTab';
+import { ResourceCategoriesList } from './ResourceCategoriesList';
+
+const category: ResourceCategory = {
+  label: 'Workloads',
+  icon: 'mdi:circle-slice-2',
+  description: 'Applications and compute resources',
+};
+
+describe('ProjectResourcesTab', () => {
+  it('exposes the resource grid for browser-level layout checks', () => {
+    render(
+      <TestContext>
+        <ProjectResourcesTab projectResources={[]} setSelectedCategoryName={() => {}} />
+      </TestContext>
+    );
+
+    expect(screen.getByTestId('project-resource-grid')).toBeVisible();
+  });
+});
+
+describe('ResourceCategoriesList', () => {
+  it('shows every health state and selects a category', () => {
+    const onCategoryClick = vi.fn();
+    const categories = [
+      {
+        category: { ...category, label: 'Errors' },
+        items: [{} as KubeObject],
+        health: { error: 1, warning: 0, success: 0 },
+      },
+      {
+        category: { ...category, label: 'Warnings' },
+        items: [{} as KubeObject],
+        health: { error: 0, warning: 1, success: 0 },
+      },
+      {
+        category: { ...category, label: 'Healthy' },
+        items: [{} as KubeObject],
+        health: { error: 0, warning: 0, success: 1 },
+      },
+      {
+        category: { ...category, label: 'Empty' },
+        items: [],
+        health: { error: 0, warning: 0, success: 0 },
+      },
+    ];
+
+    render(
+      <TestContext>
+        <ResourceCategoriesList
+          categoryList={categories}
+          selectedCategoryName="Warnings"
+          onCategoryClick={onCategoryClick}
+        />
+      </TestContext>
+    );
+
+    expect(screen.getByRole('button', { name: /Warnings/ })).toHaveClass('Mui-selected');
+    expect(screen.getAllByText('1')).toHaveLength(3);
+    expect(screen.getByText('0')).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button', { name: /Healthy/ }));
+    expect(onCategoryClick).toHaveBeenCalledWith('Healthy');
+  });
+});

--- a/frontend/src/components/project/ProjectResourcesTab.tsx
+++ b/frontend/src/components/project/ProjectResourcesTab.tsx
@@ -403,13 +403,14 @@ export function ProjectResourcesTab({
   return (
     <>
       <Box
+        data-testid="project-resource-grid"
         sx={theme => ({
           display: 'flex',
           border: '1px solid',
           borderColor: theme.palette.divider,
           borderTop: 0,
           flexGrow: 1,
-          minHeight: 0,
+          minHeight: '18.75rem',
           flexBasis: 0,
           [theme.breakpoints.down('md')]: {
             flexDirection: 'column',
@@ -423,7 +424,7 @@ export function ProjectResourcesTab({
         />
         <Box sx={resourcePaneStyles}>
           {selectedCategory && (
-            <Box sx={{ minHeight: '400px' }}>
+            <Box>
               {selectedResources.length === 0 ? (
                 <Typography variant="body2" color="text.secondary">
                   {t('No {{category}} resources found for this project.', {

--- a/frontend/src/components/project/ResourceCategoriesList.tsx
+++ b/frontend/src/components/project/ResourceCategoriesList.tsx
@@ -44,9 +44,16 @@ export function ResourceCategoriesList({
 }) {
   return (
     <Box
-      sx={{
+      data-testid="project-resource-categories"
+      sx={theme => ({
         flexShrink: 0,
-      }}
+        [theme.breakpoints.down('md')]: {
+          '@media (max-height: 48rem)': {
+            maxHeight: '12.5rem',
+            overflowY: 'auto',
+          },
+        },
+      })}
     >
       <List dense>
         {categoryList.map(({ category, items, health }) => {

--- a/frontend/src/components/project/__snapshots__/ProjectResourcesTab.Empty.stories.storyshot
+++ b/frontend/src/components/project/__snapshots__/ProjectResourcesTab.Empty.stories.storyshot
@@ -4,10 +4,12 @@
       style="height: 500px;"
     >
       <div
-        class="MuiBox-root css-gul9zg"
+        class="MuiBox-root css-1nsu8y8"
+        data-testid="project-resource-grid"
       >
         <div
-          class="MuiBox-root css-6su6fj"
+          class="MuiBox-root css-1tzj0y2"
+          data-testid="project-resource-categories"
         >
           <ul
             class="MuiList-root MuiList-padding MuiList-dense css-h4y409-MuiList-root"

--- a/frontend/src/components/project/__snapshots__/ProjectResourcesTab.WithWorkloads.stories.storyshot
+++ b/frontend/src/components/project/__snapshots__/ProjectResourcesTab.WithWorkloads.stories.storyshot
@@ -4,10 +4,12 @@
       style="height: 500px;"
     >
       <div
-        class="MuiBox-root css-gul9zg"
+        class="MuiBox-root css-1nsu8y8"
+        data-testid="project-resource-grid"
       >
         <div
-          class="MuiBox-root css-6su6fj"
+          class="MuiBox-root css-1tzj0y2"
+          data-testid="project-resource-categories"
         >
           <ul
             class="MuiList-root MuiList-padding MuiList-dense css-h4y409-MuiList-root"


### PR DESCRIPTION
## Summary

- Let Project Details grow beyond the viewport so zoomed content remains scrollable.
- Keep the project resources grid at least 300 px tall instead of allowing its flex area to collapse.
- Cap the category list at 200 px on compact layouts and make it vertically scrollable.

## Origin

This independently upstreams the Resources portion of:

- Azure/aks-desktop PR: https://github.com/Azure/aks-desktop/pull/473
- Original commit: https://github.com/Azure/aks-desktop/commit/ece2dd20b51778dbd12a27131938283a0f3ae3cf
- Patch packaging PR: https://github.com/Azure/aks-desktop/pull/823

The behavior commit preserves Tom Gamble's original authorship and author date and adds René Dudfield as co-author.

## Improvements over the existing changes

- Rebased the resource-grid fix directly onto current Headlamp `main` so it remains independent of the adjacent project-tabs work. This avoids importing unrelated responsive tab and map behavior.
- Added focused unit coverage before the behavior commit. The changed resource-grid components reach 85.52% aggregate branch coverage (`ProjectResourcesTab` 84.5%, `ResourceCategoriesList` 100%), making collapse and responsive overflow regressions executable rather than snapshot-only.
- Added a Playwright test for the real Project Details route at a zoom-equivalent compact viewport. Kubernetes collection responses are mocked so the layout assertion is deterministic while still exercising the browser-rendered application.
- Regenerated only the two affected Storybook snapshots against the independent upstream base.
- Uses scalable `rem` layout floors so the available space grows with text size.
- Limits category scrolling to layouts that are both stacked and vertically constrained, leaving narrow-but-tall windows unrestricted.
- Uses stable component hooks and strict collection mocks so unexpected project API requests fail with a clear response.

## Testing

- `npm test -- --run ProjectResourcesTab.test.tsx ProjectResourcesLayout.test.tsx ProjectDetails.test.tsx` (22 passed)
- `npm test -- --run src/storybook.test.tsx -t "project/ProjectResourcesTab"` (2 passed)
- Focused Istanbul branch coverage: 85.52% aggregate
- `npx eslint ... --max-warnings 0` for the six touched frontend TypeScript files
- `npm run tsc`
- `npx playwright test tests/projectResources.spec.ts --list` (2 tests discovered and compiled)

The Playwright scenarios apply 200% text scaling and verify rendered grid growth,
resource reachability, and short-versus-tall category scrolling in CI's
two-cluster fixture.

Assisted by copilot.
