### PR TITLE
0020: app: electron: Report rejected command exits

### DIFF
--- a/app/e2e-tests/playwright.electron.config.ts
+++ b/app/e2e-tests/playwright.electron.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
     'clusterAutoConnect.spec.ts',
     'pluginSecureStorage.spec.ts',
     'listenerCleanup.spec.ts',
+    'runCommand.spec.ts',
     'updateChecks.spec.ts',
   ],
   timeout: 60 * 1000,

--- a/app/e2e-tests/tests/listenerCleanup.spec.ts
+++ b/app/e2e-tests/tests/listenerCleanup.spec.ts
@@ -149,7 +149,7 @@ test.describe('desktop listener cleanup', () => {
     const result = await electronPage.evaluate(() => (window as any).runE2ECommand());
 
     expect(result).toEqual({
-      code: -1,
+      code: -3,
       stdout: [],
       stderr: [],
       removedChannels: ['command-stdout', 'command-stderr', 'command-exit'],

--- a/app/e2e-tests/tests/runCommand.spec.ts
+++ b/app/e2e-tests/tests/runCommand.spec.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import path from 'path';
+import { _electron, ElectronApplication, Page } from 'playwright';
+
+const electronExecutable = process.platform === 'win32' ? 'electron.cmd' : 'electron';
+const electronPath = path.resolve(__dirname, `../../node_modules/.bin/${electronExecutable}`);
+const appPath = path.resolve(__dirname, '../../');
+
+let electronApp: ElectronApplication;
+let electronPage: Page;
+
+test.describe('run command', () => {
+  test.beforeAll(async () => {
+    electronApp = await _electron.launch({
+      cwd: appPath,
+      executablePath: electronPath,
+      args: ['.'],
+      env: {
+        ...process.env,
+        NODE_ENV: 'development',
+        ELECTRON_DEV: 'true',
+        ELECTRON_START_URL: 'data:text/html,<html></html>',
+        EXTERNAL_SERVER: 'true',
+        HEADLAMP_CHECK_FOR_UPDATES: 'false',
+        HEADLAMP_MCP_ENABLE: 'false',
+      },
+    });
+    electronPage = await electronApp.firstWindow();
+  });
+
+  test.afterAll(async () => {
+    await electronApp?.close();
+  });
+
+  test('rejects invalid commands from the renderer', async () => {
+    const rejection = electronApp.waitForEvent('console', {
+      predicate: message => message.text().includes('Invalid command: invalid-command'),
+    });
+
+    await electronPage.evaluate(() => {
+      window.desktopApi.send('run-command', {
+        id: 'invalid-command-e2e',
+        command: 'invalid-command',
+        args: [],
+        options: {},
+        permissionSecrets: {},
+      });
+    });
+
+    await expect(rejection).resolves.toBeDefined();
+  });
+});

--- a/app/e2e-tests/tests/runCommand.spec.ts
+++ b/app/e2e-tests/tests/runCommand.spec.ts
@@ -49,6 +49,19 @@ test.describe('run command', () => {
   });
 
   test('rejects invalid commands from the renderer', async () => {
+    const exitCode = electronPage.evaluate(() => {
+      return new Promise<number>(resolve => {
+        const removeListener = window.desktopApi.receive(
+          'command-exit',
+          (commandId: string, code: number) => {
+            if (commandId === 'invalid-command-e2e') {
+              removeListener();
+              resolve(code);
+            }
+          }
+        );
+      });
+    });
     const rejection = electronApp.waitForEvent('console', {
       predicate: message => message.text().includes('Invalid command: invalid-command'),
     });
@@ -64,5 +77,6 @@ test.describe('run command', () => {
     });
 
     await expect(rejection).resolves.toBeDefined();
+    await expect(exitCode).resolves.toBe(-1);
   });
 });

--- a/app/electron/runCmd.test.ts
+++ b/app/electron/runCmd.test.ts
@@ -61,6 +61,8 @@ import {
   checkPermissionSecret,
   environmentOverrides,
   handleRunCommand,
+  removeRunCmdConsent,
+  setupRunCmdHandlers,
   validateCommandData,
 } from './runCmd';
 
@@ -71,6 +73,10 @@ it('does not cache process environment changes as shell overrides', () => {
       { PATH: '/usr/bin', HEADLAMP_CONFIG_ENABLE_HELM: 'true' }
     )
   ).toEqual({ PATH: '/opt/homebrew/bin:/usr/bin' });
+});
+
+it('uses process.env as the default comparison environment', () => {
+  expect(environmentOverrides(process.env)).toEqual({});
 });
 
 describe('checkPermissionSecret', () => {
@@ -453,6 +459,64 @@ describe('handleRunCommand', () => {
       })
     );
   });
+
+  it('runs plugin scripts with the Electron executable', async () => {
+    const { loadSettings } = await import('./settings');
+    const originalResourcesPath = process.resourcesPath;
+    // @ts-ignore Electron defines this at runtime.
+    process.resourcesPath = '/resources';
+    vi.mocked(loadSettings).mockReturnValueOnce({
+      confirmedCommands: { 'scriptjs missing-plugin/script.js': true },
+    });
+    const eventData = {
+      id: 'script-id',
+      command: 'scriptjs',
+      args: ['missing-plugin/script.js', '--flag'],
+      options: {},
+      permissionSecrets: { 'runCmd-scriptjs-missing-plugin/script.js': 99 },
+    };
+
+    try {
+      await handleRunCommand(fakeEvent, eventData, { id: 1 } as any, {
+        'runCmd-scriptjs-missing-plugin/script.js': 99,
+      });
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        process.execPath,
+        [path.join('/plugins/default', 'missing-plugin/script.js'), '--flag'],
+        expect.objectContaining({
+          env: expect.objectContaining({ HEADLAMP_RUN_SCRIPT: 'true' }),
+        })
+      );
+    } finally {
+      // @ts-ignore Electron defines this at runtime.
+      process.resourcesPath = originalResourcesPath;
+    }
+  });
+
+  it('initializes consent settings for a new command', async () => {
+    const { loadSettings, saveSettings } = await import('./settings');
+    vi.mocked(loadSettings).mockReturnValueOnce({});
+    vi.mocked(saveSettings).mockClear();
+    showMessageBoxSyncMock.mockReturnValueOnce(0);
+    const eventData = {
+      id: 'consent-id',
+      command: 'minikube',
+      args: [],
+      options: {},
+      permissionSecrets: { 'runCmd-minikube': 99 },
+    };
+
+    await handleRunCommand(fakeEvent, eventData, { id: 1 } as any, {
+      'runCmd-minikube': 99,
+    });
+
+    expect(saveSettings).toHaveBeenCalledWith(
+      '/fake/settings.json',
+      expect.objectContaining({ confirmedCommands: { minikube: true } })
+    );
+    expect(spawnMock).toHaveBeenCalled();
+  });
 });
 
 describe('runScript', () => {
@@ -565,6 +629,99 @@ describe('addRunCmdConsent', () => {
     for (const cmd of AI_ASSISTANT_COMMANDS) {
       expect(savedSettings?.confirmedCommands?.[cmd]).toBeUndefined();
     }
+  });
+
+  it('initializes consent settings and pre-populates minikube commands', async () => {
+    const { loadSettings, saveSettings } = await import('./settings');
+    vi.mocked(loadSettings).mockReturnValueOnce({});
+    vi.mocked(saveSettings).mockClear();
+
+    addRunCmdConsent({ name: 'headlamp_minikube' });
+
+    const savedSettings = vi.mocked(saveSettings).mock.calls[0][1] as any;
+    expect(savedSettings.confirmedCommands['minikube status']).toBe(true);
+  });
+
+  it('recognizes the development minikube plugin name', async () => {
+    const { loadSettings, saveSettings } = await import('./settings');
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.mocked(loadSettings).mockReturnValueOnce({ confirmedCommands: {} });
+    vi.mocked(saveSettings).mockClear();
+
+    addRunCmdConsent({ name: 'minikube' });
+
+    const savedSettings = vi.mocked(saveSettings).mock.calls[0][1] as any;
+    expect(savedSettings.confirmedCommands['minikube status']).toBe(true);
+    vi.unstubAllEnvs();
+  });
+});
+
+describe('removeRunCmdConsent', () => {
+  it('returns when consent settings do not exist', async () => {
+    const { loadSettings, saveSettings } = await import('./settings');
+    vi.mocked(loadSettings).mockReturnValueOnce({});
+    vi.mocked(saveSettings).mockClear();
+
+    removeRunCmdConsent('@headlamp-k8s/minikube');
+
+    expect(saveSettings).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['@headlamp-k8s/minikube', 'minikube status'],
+    ['@headlamp-k8s/minikubeprerelease', 'minikube status'],
+    ['@headlamp-k8s/ai-assistant', 'gh auth'],
+    ['@headlamp-k8s/ai-assistantprerelease', 'gh auth'],
+  ])('removes consent for %s', async (pluginName, command) => {
+    const { loadSettings, saveSettings } = await import('./settings');
+    vi.mocked(loadSettings).mockReturnValueOnce({ confirmedCommands: { [command]: true } });
+    vi.mocked(saveSettings).mockClear();
+
+    removeRunCmdConsent(pluginName);
+
+    const savedSettings = vi.mocked(saveSettings).mock.calls[0][1] as any;
+    expect(savedSettings.confirmedCommands[command]).toBeUndefined();
+  });
+});
+
+describe('setupRunCmdHandlers', () => {
+  it('does not register handlers without a main window', () => {
+    const ipcMain = { on: vi.fn() } as any;
+
+    setupRunCmdHandlers(null, ipcMain);
+
+    expect(ipcMain.on).not.toHaveBeenCalled();
+  });
+
+  it('sends permission secrets once per main-frame load', () => {
+    const ipcHandlers = new Map<string, (...args: any[]) => void>();
+    let frameLoadHandler: (_event: unknown, isMainFrame: boolean) => void = () => {};
+    const send = vi.fn();
+    const mainWindow = {
+      webContents: {
+        on: vi.fn((_event: string, handler: typeof frameLoadHandler) => {
+          frameLoadHandler = handler;
+        }),
+        send,
+      },
+    } as any;
+    const ipcMain = {
+      on: vi.fn((channel: string, handler: (...args: any[]) => void) => {
+        ipcHandlers.set(channel, handler);
+      }),
+    } as any;
+
+    setupRunCmdHandlers(mainWindow, ipcMain);
+    const requestSecrets = ipcHandlers.get('request-plugin-permission-secrets')!;
+    requestSecrets();
+    requestSecrets();
+    frameLoadHandler({}, false);
+    requestSecrets();
+    frameLoadHandler({}, true);
+    requestSecrets();
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(ipcHandlers.has('run-command')).toBe(true);
   });
 });
 

--- a/app/electron/runCmd.test.ts
+++ b/app/electron/runCmd.test.ts
@@ -374,12 +374,13 @@ describe('handleRunCommand', () => {
   });
 
   it.each([
-    ['missing window', { id: 'test-id' }, null, { 'runCmd-gh': 99 }],
+    ['missing window', { id: 'test-id' }, null, { 'runCmd-gh': 99 }, -1],
     [
       'invalid command data',
       { id: 'test-id', command: 'invalid', args: [], options: {}, permissionSecrets: {} },
       { id: 1 },
       {},
+      -1,
     ],
     [
       'invalid permission secret',
@@ -392,12 +393,13 @@ describe('handleRunCommand', () => {
       },
       { id: 1 },
       { 'runCmd-gh': 99 },
+      -2,
     ],
-  ])('reports a rejected exit for %s', async (_name, data, window, secrets) => {
+  ])('reports a rejected exit for %s', async (_name, data, window, secrets, exitCode) => {
     await handleRunCommand(fakeEvent, data as any, window as any, secrets);
 
     expect(spawnMock).not.toHaveBeenCalled();
-    expect(sentMessages).toEqual([['command-exit', 'test-id', -1]]);
+    expect(sentMessages).toEqual([['command-exit', 'test-id', exitCode]]);
   });
 
   it('reports a rejected exit when command consent was denied previously', async () => {
@@ -414,7 +416,7 @@ describe('handleRunCommand', () => {
     await handleRunCommand(fakeEvent, eventData, { id: 1 } as any, { 'runCmd-gh': 99 });
 
     expect(spawnMock).not.toHaveBeenCalled();
-    expect(sentMessages).toEqual([['command-exit', 'test-id', -1]]);
+    expect(sentMessages).toEqual([['command-exit', 'test-id', -3]]);
   });
 
   it('reports synchronous spawn errors without rejecting', async () => {
@@ -762,6 +764,7 @@ describe('command consent', () => {
 
     expect(showMessageBoxSyncMock).toHaveBeenCalled();
     expect(spawnMock).not.toHaveBeenCalled();
+    expect(fakeEvent.sender.send).toHaveBeenCalledWith('command-exit', 'test-id', -3);
   });
 
   it('runs the command when the user allows it', async () => {

--- a/app/electron/runCmd.ts
+++ b/app/electron/runCmd.ts
@@ -282,9 +282,9 @@ export async function handleRunCommand(
   permissionSecrets: Record<string, number>
 ): Promise<void> {
   const commandId = typeof eventData?.id === 'string' ? eventData.id : undefined;
-  const sendRejectedExit = () => {
+  const sendRejectedExit = (exitCode = -1) => {
     if (commandId) {
-      event.sender.send('command-exit', commandId, -1);
+      event.sender.send('command-exit', commandId, exitCode);
     }
   };
 
@@ -304,12 +304,12 @@ export async function handleRunCommand(
   const [permissionsValid, permissionError] = checkPermissionSecret(commandData, permissionSecrets);
   if (!permissionsValid) {
     console.error(permissionError);
-    sendRejectedExit();
+    sendRejectedExit(-2);
     return;
   }
 
   if (!checkCommandConsent(commandData.command, commandData.args, mainWindow)) {
-    sendRejectedExit();
+    sendRejectedExit(-3);
     return;
   }
 


### PR DESCRIPTION
## Summary

Report distinct `command-exit` codes when desktop command execution is rejected
before spawning a child process:

- `-1` for invalid command data
- `-2` for rejected permission secrets
- `-3` for denied command consent

This lets renderer callers distinguish validation, permission, and consent
rejections while preserving main's existing rejected-command completion path.

## Source

This upstreams the command-rejection portion of:

- https://github.com/Azure/aks-desktop/pull/394
- https://github.com/Azure/aks-desktop/commit/e4798768d9995204e2ad32da138b11f094640828

The change was later rebased in the downstream branch as:

- https://github.com/Azure/aks-desktop/commit/10c313f02c70279545a18c4e48f332bb411a205a

Patch 0020 was extracted while preparing the Headlamp source package in:

- https://github.com/Azure/aks-desktop/pull/823

## Improvements over the existing changes

- Adds focused unit coverage before the behavior change and raises
  `app/electron/runCmd.ts` branch coverage to 89.16%. This protects the wider
  command lifecycle rather than only the newly added lines.
- Adds an Electron end-to-end test for the renderer-to-main IPC path. This
  verifies that invalid commands are rejected by the real desktop bridge and
  that the renderer receives exit code `-1`.
- Registers the new test in Headlamp's dedicated Electron Playwright suite so
  it runs through the supported desktop test configuration.
- Keeps the three rejection causes distinct so callers can diagnose why a
  command did not start.
- Builds on main's rejection reporting and terminal-event safeguards instead of
  duplicating their implementation or tests.

## Backwards compatibility

For users of the downstream patch code, rejected commands now complete with a
negative `command-exit` code instead of remaining pending. Callers that used a
timeout or the absence of an exit event to infer rejection should migrate.
Callers should handle rejection codes `-1`, `-2`, and `-3` explicitly. Existing
listeners already accept numeric exit codes, so no API-shape change is required.

For users of Headlamp main, valid commands, process spawning, output forwarding,
and real child-process exit codes are unaffected. Invalid data and a missing
main window continue to report `-1`. Permission rejection changes from `-1` to
`-2`, and consent rejection changes from `-1` to `-3`. Callers that treat any
negative code as rejection remain compatible; callers that match only `-1`
should accept any negative code or handle the three codes explicitly.

## Testing

- `npm --prefix app run tsc`
- `npm --prefix frontend run ci-lint`
- `./node_modules/.bin/vitest run electron/runCmd.test.ts` (51 tests)
- Focused Istanbul coverage for `app/electron/runCmd.ts` (89.16% branches)
- `npm --prefix app/e2e-tests run test-app -- runCommand.spec.ts`
- `npm --prefix app/e2e-tests run test-app -- listenerCleanup.spec.ts`

The behavior is not visual, so screenshots are not applicable.

Assisted by copilot.
