### PR TITLE
app: runCmd: Do not run the command when consent is denied

### DIFF
--- a/app/electron/runCmd.test.ts
+++ b/app/electron/runCmd.test.ts
@@ -18,9 +18,15 @@ import { EventEmitter } from 'events';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 
-const { getShellEnvironmentMock, spawnMock } = vi.hoisted(() => ({
+const { getShellEnvironmentMock, spawnMock, showMessageBoxSyncMock } = vi.hoisted(() => ({
   getShellEnvironmentMock: vi.fn(),
   spawnMock: vi.fn(),
+  showMessageBoxSyncMock: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  BrowserWindow: class {},
+  dialog: { showMessageBoxSync: showMessageBoxSyncMock },
 }));
 
 vi.mock('child_process', () => ({
@@ -460,5 +466,55 @@ describe('addRunCmdConsent', () => {
     for (const cmd of AI_ASSISTANT_COMMANDS) {
       expect(savedSettings?.confirmedCommands?.[cmd]).toBeUndefined();
     }
+  });
+});
+
+describe('command consent', () => {
+  const fakeMainWindow = { id: 1 } as any;
+  const permissionSecrets = { 'runCmd-gh': 99 };
+  const eventData = {
+    id: 'test-id',
+    command: 'gh',
+    args: ['auth', 'token'],
+    options: {},
+    permissionSecrets: { 'runCmd-gh': 99 },
+  };
+  let fakeEvent: any;
+
+  beforeEach(async () => {
+    const { loadSettings } = await import('./settings');
+    // No saved answer for "gh auth", so the consent dialog is shown.
+    vi.mocked(loadSettings).mockReturnValue({ confirmedCommands: {} });
+    getShellEnvironmentMock.mockReset();
+    getShellEnvironmentMock.mockResolvedValue(shellEnvironment);
+    spawnMock.mockReset();
+    spawnMock.mockReturnValue(
+      Object.assign(new EventEmitter(), {
+        stdout: new EventEmitter(),
+        stderr: new EventEmitter(),
+      })
+    );
+    showMessageBoxSyncMock.mockReset();
+    fakeEvent = { sender: { send: vi.fn() } } as any;
+  });
+
+  it('does not run the command when the user denies consent', async () => {
+    // Second button is Deny.
+    showMessageBoxSyncMock.mockReturnValue(1);
+
+    await handleRunCommand(fakeEvent, eventData, fakeMainWindow, permissionSecrets);
+
+    expect(showMessageBoxSyncMock).toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('runs the command when the user allows it', async () => {
+    // First button is Allow.
+    showMessageBoxSyncMock.mockReturnValue(0);
+
+    await handleRunCommand(fakeEvent, eventData, fakeMainWindow, permissionSecrets);
+
+    expect(showMessageBoxSyncMock).toHaveBeenCalled();
+    expect(spawnMock).toHaveBeenCalled();
   });
 });

--- a/app/electron/runCmd.ts
+++ b/app/electron/runCmd.ts
@@ -110,6 +110,10 @@ function checkCommandConsent(command: string, args: string[], mainWindow: Browse
     }
     settings.confirmedCommands[consentKey] = commandChoice;
     saveSettings(SETTINGS_PATH, settings);
+    if (!commandChoice) {
+      console.error(`Invalid command: ${consentKey}, command not allowed by users choice`);
+    }
+    return commandChoice;
   }
   return true;
 }


### PR DESCRIPTION
## Summary

In the desktop app, denying a plugin's `runCommand` request does not stop the command the first time. The consent dialog says "Allow this local command to be executed? Your choice will be saved.", but clicking **Deny** still lets the command run once. The denial only takes effect from the next invocation onwards.

`checkCommandConsent` in `app/electron/runCmd.ts` asks for consent, saves the answer, and then falls through to an unconditional `return true`, so the answer is ignored for that call.

## Related Issue

Fixes #6558

## Changes

- `app/electron/runCmd.ts`: return the answer the user actually gave instead of always returning `true`, and log the refusal the same way the already-denied branch above it does.
- `app/electron/runCmd.test.ts`: add tests for the consent path, which had no coverage. They go through the exported `handleRunCommand`, so they check what a user sees rather than a private function.

## Steps to Test

1. `npm run app:test:unit`
2. The two new tests are under `command consent`: denying the dialog means `spawn` is never called, allowing it means it is.

Without the fix, `does not run the command when the user denies consent` fails because the command is spawned anyway.

## Notes for the Reviewer

The tests need `vi.mock('electron', ...)` because this is the first test in the file that reaches `dialog.showMessageBoxSync`. Outside the Electron runtime `require('electron')` returns the path to the binary rather than the API, so `dialog` is undefined and cannot be called without mocking it.

Nothing outside the consent path changes. Commands that were already allowed or already denied behave exactly as before.

This PR was written in part with the assistance of generative AI. I have reviewed and tested the change myself.
