### PR TITLE
0047: frontend: Include product metadata in document titles

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -729,7 +729,12 @@ async function startServer(flags: string[] = []): Promise<ChildProcessWithoutNul
 
   actualPort = await findAvailablePort(defaultPort);
 
-  let serverArgs: string[] = ['--listen-addr=localhost', `--port=${actualPort}`];
+  let serverArgs: string[] = [
+    '--listen-addr=localhost',
+    `--port=${actualPort}`,
+    '--app-name',
+    app.getName(),
+  ];
   if (!!args.kubeconfig) {
     serverArgs = serverArgs.concat(['--kubeconfig', args.kubeconfig]);
   }

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -277,8 +277,8 @@ func makeBaseURLReplacements(data []byte, baseURL string) []byte {
 	return data
 }
 
-// make sure the base-url is updated in the index.html file.
-func baseURLReplace(staticDir string, baseURL string) {
+// rewriteIndexHTML updates server-owned values in the index.html file.
+func rewriteIndexHTML(staticDir string, baseURL string, productName string) {
 	indexBaseURL := path.Join(staticDir, "index.baseUrl.html")
 	index := path.Join(staticDir, "index.html")
 
@@ -291,6 +291,7 @@ func baseURLReplace(staticDir string, baseURL string) {
 	// replace baseURL starting from the original copy, incase we run this multiple times
 	data := mustReadFile(indexBaseURL)
 	output := makeBaseURLReplacements(data, baseURL)
+	output = spa.ReplaceProductName(output, productName)
 	mustWriteFile(index, output)
 }
 
@@ -722,7 +723,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 	}
 
 	if config.StaticDir != "" {
-		baseURLReplace(config.StaticDir, config.BaseURL)
+		rewriteIndexHTML(config.StaticDir, config.BaseURL, config.AppName)
 	}
 
 	// For when using a base-url, like "/headlamp" with a reverse proxy.
@@ -1231,7 +1232,12 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 
 	// Serve the frontend if needed
 	if spa.UseEmbeddedFiles {
-		r.PathPrefix("/").Handler(spa.NewEmbeddedHandler(spa.StaticFilesEmbed, "index.html", config.BaseURL))
+		r.PathPrefix("/").Handler(spa.NewEmbeddedHandlerWithProductName(
+			spa.StaticFilesEmbed,
+			"index.html",
+			config.BaseURL,
+			config.AppName,
+		))
 	} else if config.StaticDir != "" {
 		staticPath := config.StaticDir
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -2212,7 +2212,7 @@ func TestFileExists(t *testing.T) {
 }
 
 //nolint:funlen
-func TestBaseURLReplace(t *testing.T) {
+func TestRewriteIndexHTML(t *testing.T) {
 	// Create a temporary directory for testing
 	tempDir, err := os.MkdirTemp("", "baseurl_test")
 	require.NoError(t, err)
@@ -2223,6 +2223,7 @@ func TestBaseURLReplace(t *testing.T) {
 	indexContent := []byte(`<!DOCTYPE html>
 <html>
 <head>
+    <title data-headlamp-product-name></title>
     <script>var headlampBaseUrl = __baseUrl__;</script>
     <link rel="stylesheet" href="./styles.css">
 </head>
@@ -2251,6 +2252,7 @@ func TestBaseURLReplace(t *testing.T) {
 			expectedOutput: `<!DOCTYPE html>
 <html>
 <head>
+    <title>Branded &amp; Headlamp</title>
     <script>var headlampBaseUrl = '/';</script>
     <link rel="stylesheet" href="/styles.css">
 </head>
@@ -2265,6 +2267,7 @@ func TestBaseURLReplace(t *testing.T) {
 			expectedOutput: `<!DOCTYPE html>
 <html>
 <head>
+    <title>Branded &amp; Headlamp</title>
     <script>var headlampBaseUrl = '/custom';</script>
     <link rel="stylesheet" href="/custom/styles.css">
 </head>
@@ -2277,7 +2280,7 @@ func TestBaseURLReplace(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			baseURLReplace(tempDir, tc.baseURL)
+			rewriteIndexHTML(tempDir, tc.baseURL, "Branded & Headlamp")
 
 			// Read the modified index.html
 			modifiedContent, err := os.ReadFile(filepath.Join(tempDir, "index.html")) //nolint:gosec

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -82,6 +82,7 @@ func main() {
 // buildHeadlampCFG maps the parsed config into the struct the backend uses.
 func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextStore) *headlampconfig.HeadlampCFG {
 	return &headlampconfig.HeadlampCFG{
+		AppName:                conf.AppName,
 		UseInCluster:           conf.InCluster,
 		InClusterContextName:   conf.InClusterContextName,
 		KubeConfigPath:         conf.KubeConfigPath,

--- a/backend/cmd/server_config_test.go
+++ b/backend/cmd/server_config_test.go
@@ -29,6 +29,7 @@ func TestBuildHeadlampCFG(t *testing.T) {
 
 	t.Run("maps basic fields and splits proxy urls", func(t *testing.T) {
 		conf := &config.Config{
+			AppName:                    "Branded Headlamp",
 			Port:                       4444,
 			InCluster:                  true,
 			InClusterContextName:       "test-incluster",
@@ -45,6 +46,7 @@ func TestBuildHeadlampCFG(t *testing.T) {
 
 		headlampCFG := buildHeadlampCFG(conf, store)
 
+		assert.Equal(t, "Branded Headlamp", headlampCFG.AppName)
 		assert.Equal(t, uint(4444), headlampCFG.Port)
 		assert.True(t, headlampCFG.UseInCluster)
 		assert.Equal(t, "test-incluster", headlampCFG.InClusterContextName)

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -592,7 +592,11 @@ func flagset(appName string) *flag.FlagSet {
 
 func addGeneralFlags(f *flag.FlagSet, appName string) {
 	f.Bool("version", false, "Print version information and exit")
-	f.String("app-name", appName, "Application name used in version output and Kubernetes User-Agent headers")
+	f.String(
+		"app-name",
+		appName,
+		"Application name used in version output, the browser title, and Kubernetes User-Agent headers",
+	)
 	f.Bool("in-cluster", false, "Set when running from a k8s cluster")
 	f.String("in-cluster-context-name", "",
 		"Name to use for the in-cluster Kubernetes context. "+

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -47,6 +47,7 @@ type HeadlampConfig struct {
 }
 
 type HeadlampCFG struct {
+	AppName                string
 	UseInCluster           bool
 	InClusterContextName   string
 	ListenAddr             string

--- a/backend/pkg/spa/embeddedSPAHandler.go
+++ b/backend/pkg/spa/embeddedSPAHandler.go
@@ -2,6 +2,7 @@ package spa
 
 import (
 	"bytes"
+	"html"
 	"io"
 	"io/fs"
 	"net/http"
@@ -18,6 +19,8 @@ type embeddedSpaHandler struct {
 	indexPath string
 	// baseURL is the base URL of the application.
 	baseURL string
+	// productName is inserted into the index document title.
+	productName string
 }
 
 // ServeHTTP serves the static files embedded in the binary.
@@ -113,7 +116,13 @@ func sanitizeEmbeddedPath(rPath string) (string, bool) {
 }
 
 func (h embeddedSpaHandler) rewriteIndexContent(content []byte, isServingIndex bool) []byte {
-	if h.baseURL == "" || !isServingIndex {
+	if !isServingIndex {
+		return content
+	}
+
+	content = ReplaceProductName(content, h.productName)
+
+	if h.baseURL == "" {
 		return content
 	}
 
@@ -127,6 +136,17 @@ func (h embeddedSpaHandler) rewriteIndexContent(content []byte, isServingIndex b
 
 	// Replace url( patterns for CSS.
 	return bytes.ReplaceAll(content, []byte("url("), []byte("url("+h.baseURL+"/"))
+}
+
+const productNamePlaceholder = "<title data-headlamp-product-name></title>"
+
+// ReplaceProductName inserts an HTML-escaped product name into the index title placeholder.
+func ReplaceProductName(content []byte, productName string) []byte {
+	return bytes.ReplaceAll(
+		content,
+		[]byte(productNamePlaceholder),
+		[]byte("<title>"+html.EscapeString(productName)+"</title>"),
+	)
 }
 
 // tryServePrecompressed attempts to serve a precompressed sidecar (e.g.
@@ -181,10 +201,23 @@ func (h embeddedSpaHandler) serveFile(filePath string) ([]byte, error) {
 	return io.ReadAll(f)
 }
 
+// NewEmbeddedHandler creates an embedded SPA handler with an empty product name.
 func NewEmbeddedHandler(staticFS fs.FS, indexPath, baseURL string) *embeddedSpaHandler {
+	return NewEmbeddedHandlerWithProductName(staticFS, indexPath, baseURL, "")
+}
+
+// NewEmbeddedHandlerWithProductName creates an embedded SPA handler that inserts
+// the product name into the index title.
+func NewEmbeddedHandlerWithProductName(
+	staticFS fs.FS,
+	indexPath string,
+	baseURL string,
+	productName string,
+) *embeddedSpaHandler {
 	return &embeddedSpaHandler{
-		staticFS:  staticFS,
-		indexPath: indexPath,
-		baseURL:   baseURL,
+		staticFS:    staticFS,
+		indexPath:   indexPath,
+		baseURL:     baseURL,
+		productName: productName,
 	}
 }

--- a/backend/pkg/spa/embeddedSPAHandler_test.go
+++ b/backend/pkg/spa/embeddedSPAHandler_test.go
@@ -23,7 +23,7 @@ func getTestHTML() string {
 	return `<!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Headlamp</title>
+		<title data-headlamp-product-name></title>
     <script>
         // handles both webpack and rspack build systems
         __baseUrl__ = './<%= BASE_URL %>'.replace('%BASE_' + 'URL%', '').replace('<' + '%= BASE_URL %>', '');
@@ -45,6 +45,10 @@ func TestEmbeddedSpaHandler(t *testing.T) {
 		testHeadlampBaseURLWithBaseURL(t, testHTML)
 	})
 
+	t.Run("check_product_name_is_escaped_in_title", func(t *testing.T) {
+		testProductNameInTitle(t, testHTML)
+	})
+
 	t.Run("check_empty_path_returns_index.html", func(t *testing.T) {
 		testEmptyPathReturnsIndex(t, testHTML)
 	})
@@ -56,6 +60,22 @@ func TestEmbeddedSpaHandler(t *testing.T) {
 	t.Run("file_not_found_uses_index_content_type", func(t *testing.T) {
 		testFileNotFoundUsesIndexContentType(t, testHTML)
 	})
+}
+
+func testProductNameInTitle(t *testing.T, testHTML string) {
+	handler := spa.NewEmbeddedHandlerWithProductName(createTestFS(map[string]*fstest.MapFile{
+		"static/index.html": {Data: []byte(testHTML)},
+	}), "index.html", "/headlamp", "Branded & Headlamp")
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/headlamp/not-found", nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "<title>Branded &amp; Headlamp</title>")
+	assert.NotContains(t, rr.Body.String(), "data-headlamp-product-name")
 }
 
 func testHeadlampBaseURLWithBaseURL(t *testing.T, testHTML string) {

--- a/e2e-tests/tests/multiCluster.spec.ts
+++ b/e2e-tests/tests/multiCluster.spec.ts
@@ -29,6 +29,10 @@ test.describe('multi-cluster setup', () => {
     await expect(page.locator('h1:has-text("Home")')).toBeVisible();
   });
 
+  test('document title should include the route and product names', async ({ page }) => {
+    await expect(page).toHaveTitle('Choose a cluster - Headlamp');
+  });
+
   test("table should contain 'Name' and 'Status' column headers", async ({ page }) => {
     await expect(page.locator('th', { hasText: 'Name' })).toBeVisible();
     await expect(page.locator('th', { hasText: 'Status' })).toBeVisible();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,7 +22,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Headlamp</title>
+    <title data-headlamp-product-name></title>
     <script>
         // handles both webpack and rspack build systems
         __baseUrl__ = '%BASE_URL%<%= BASE_URL %>'.replace('%BASE_' + 'URL%', '').replace('<' + '%= BASE_URL %>', '');

--- a/frontend/src/components/App/RouteSwitcher.test.tsx
+++ b/frontend/src/components/App/RouteSwitcher.test.tsx
@@ -15,26 +15,36 @@
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { TestContext } from '../../test';
 
 vi.mock('../../lib/k8s', () => ({
   useCluster: vi.fn(() => null),
   useClustersConf: vi.fn(() => ({})),
-  useClustersVersion: vi.fn(() => ({})),
+  useClustersVersion: vi.fn(() => [{}, {}]),
   useConnectApi: vi.fn(),
   useSelectedClusters: vi.fn(() => []),
 }));
 
-vi.mock('../../lib/k8s/event', () => ({ default: class Event {} }));
+vi.mock('../../lib/k8s/event', () => ({
+  default: class Event {},
+  useEventWarningList: vi.fn(() => ({})),
+}));
 vi.mock('../common/ObjectEventList', () => ({ default: () => null }));
+vi.mock('./Home', () => ({ default: () => null }));
 
+import { useCluster } from '../../lib/k8s';
 import RouteSwitcher from './RouteSwitcher';
 
 // Verify RouteSwitcher renders stable route keys and handles an unset cluster.
 
 describe('RouteSwitcher', () => {
+  afterEach(() => {
+    vi.mocked(useCluster).mockReturnValue(null);
+    vi.unstubAllEnvs();
+  });
+
   it('assigns unique keys to all rendered AuthRoute components', () => {
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -77,5 +87,36 @@ describe('RouteSwitcher', () => {
         </QueryClientProvider>
       )
     ).not.toThrow();
+  });
+
+  it('includes the configured product name in the document title', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    vi.stubEnv('REACT_APP_HEADLAMP_PRODUCT_NAME', 'AKS Desktop');
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TestContext>
+          <RouteSwitcher requiresToken={() => false} />
+        </TestContext>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => expect(document.title).toBe('Choose a cluster - AKS Desktop'));
+  });
+
+  it('includes the cluster and fallback product names in the document title', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    vi.mocked(useCluster).mockReturnValue('cluster-a');
+    vi.stubEnv('REACT_APP_HEADLAMP_PRODUCT_NAME', '');
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TestContext>
+          <RouteSwitcher requiresToken={() => false} />
+        </TestContext>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => expect(document.title).toBe('cluster-a - Choose a cluster - Headlamp'));
   });
 });

--- a/frontend/src/components/App/RouteSwitcher.tsx
+++ b/frontend/src/components/App/RouteSwitcher.tsx
@@ -19,6 +19,7 @@ import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { Redirect, Route, RouteProps, Switch, useHistory } from 'react-router-dom';
+import { getProductName } from '../../helpers/getProductInfo';
 import { getCluster, getSelectedClusters } from '../../lib/cluster';
 import { useCluster, useClustersConf } from '../../lib/k8s';
 import { testAuth } from '../../lib/k8s/api/v1/clusterApi';
@@ -135,12 +136,8 @@ function PageTitle({
   const cluster = useCluster();
 
   React.useEffect(() => {
-    if (cluster && title) {
-      document.title = `${cluster} - ${title}`;
-      return;
-    }
-
-    document.title = cluster || title || '';
+    const productName = getProductName() || 'Headlamp';
+    document.title = [cluster, title, productName].filter(Boolean).join(' - ');
   }, [cluster, title]);
 
   return <>{children}</>;

--- a/frontend/src/htmlTemplate.test.ts
+++ b/frontend/src/htmlTemplate.test.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('HTML template', () => {
+  it('leaves the title empty until the backend inserts the product name', () => {
+    const template = readFileSync(resolve('index.html'), 'utf8');
+    const document = new DOMParser().parseFromString(template, 'text/html');
+
+    expect(template).toContain('<title data-headlamp-product-name></title>');
+    expect(document.title).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Include the configured product name in browser document titles so branded
Headlamp builds remain identifiable in tabs and browser history.

## Source

- Original Azure title-branding PR:
  https://github.com/Azure/aks-desktop/pull/275
- Original Azure title-branding commit:
  https://github.com/Azure/aks-desktop/commit/49d7f3fdc6f6609251aff63b4f8cc4d290a5fd32
- Original Headlamp page-title PR:
  https://github.com/kubernetes-sigs/headlamp/pull/4362
- Original Headlamp page-title commit:
  https://github.com/kubernetes-sigs/headlamp/commit/b3605df9cc1b1f6b4447c84ca30f6781be00b1bc
- Retained as patch 0047 by Azure/aks-desktop#823:
  https://github.com/Azure/aks-desktop/pull/823
- Patch-series commit:
  https://github.com/Azure/aks-desktop/commit/387eb27e3f586211610dda61949255e7264a9c95
- Embedded downstream patch commit: `172b8349f0dd66c6254f85c826664bf08f59b5f3`
- Original patch author: Oleksandr Dubenko
- Original author date: `2026-07-31T17:58:25Z`

Azure/aks-desktop#275 set the initial HTML title to AKS desktop because Headlamp
would sometimes appear in the app title. Patch 0047 carries that branding intent
into the dynamic cluster and route titles introduced by Headlamp PR #4362. The
downstream product-metadata commit is retained inside patch 0047 but is not a
separately reachable GitHub object.

## Changes

- Pass Electron's product name to the backend through `--app-name`.
- Insert an HTML-escaped product name into the title for filesystem and embedded
  frontend serving.
- Add focused unit coverage for document-title composition and fallback behavior.
- Add an end-to-end document-title assertion for the cluster chooser.
- Keep the HTML template title empty until the backend supplies the product name.
- Compose document titles from the cluster, route, and configured product name.
- Fall back to `Headlamp` when product metadata is unavailable.

## Improvements over the existing changes

- Expands the original two unit cases to cover every cluster and route
  context used by `RouteSwitcher`, configured product metadata, and the fallback
  path. Both branches added by this change are covered.
- Adds browser-level coverage for the exact `Choose a cluster - Headlamp` title
  so the user-visible integration is protected end to end.
- Prevents the default Headlamp title from flashing by inserting the configured
  product name before the backend serves the HTML.
- Keeps the title composition directly in `RouteSwitcher` with its unit and e2e
  coverage in one independently buildable atomic commit.

## Testing

- `go test ./...`
- `go vet ./pkg/spa ./pkg/headlampconfig ./pkg/config`
- `npm run app:tsc`
- `make frontend-i18n-check`
- `npm test -- --run src/htmlTemplate.test.ts src/components/App/RouteSwitcher.test.tsx`
  - 5 tests passed
- Focused Istanbul coverage confirmed both newly added fallback branches execute
- `npm run tsc`
- Focused ESLint and Prettier checks for all changed TypeScript files
- `npm run build`
- `npx playwright test tests/multiCluster.spec.ts --list`
  - 6 tests discovered, including the new document-title test

Assisted by copilot.
