### PR TITLE
frontend: ResourceMap: Preserve namespace filter when query param absent

### DIFF
--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -34,10 +34,8 @@ import {
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDispatch } from 'react-redux';
 import Namespace from '../../lib/k8s/namespace';
 import K8sNode from '../../lib/k8s/node';
-import { setNamespaceFilter } from '../../redux/filterSlice';
 import { useTypedSelector } from '../../redux/hooks';
 import { NamespacesAutocomplete } from '../common/NamespacesAutocomplete';
 import { MAP_PERFORMANCE_FEATURES_ENABLED } from './config';
@@ -71,6 +69,7 @@ import { GraphSourceManager, useSources } from './sources/GraphSources';
 import { GraphSourcesView } from './sources/GraphSourcesView';
 import { useGraphViewport } from './useGraphViewport';
 import { useQueryParamsState } from './useQueryParamsState';
+import { useSyncNamespaceParam } from './useSyncNamespaceParam';
 
 // Re-exported here for backwards compatibility with existing consumers that
 // imported these from GraphView.tsx. The actual definitions live in
@@ -132,17 +131,12 @@ function GraphViewContent({
   defaultFilters = defaultFiltersValue,
 }: GraphViewInternalProps) {
   const { t } = useTranslation();
-  const dispatch = useDispatch();
 
   // List of selected namespaces
   const namespaces = useTypedSelector(state => state.filter).namespaces;
 
   // Sync namespace and URL
-  const [namespacesParam] = useQueryParamsState<string>('namespace', '');
-  useEffect(() => {
-    const list = namespacesParam?.split(' ') ?? [];
-    dispatch(setNamespaceFilter(list));
-  }, [namespacesParam, dispatch]);
+  useSyncNamespaceParam();
 
   // Filters
   const [hasErrorsFilter, setHasErrorsFilter] = useState(false);

--- a/frontend/src/components/resourceMap/useSyncNamespaceParam.test.tsx
+++ b/frontend/src/components/resourceMap/useSyncNamespaceParam.test.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import { renderHook } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { Router } from 'react-router-dom';
+import filterReducer, { initialState as FILTER_INITIAL_STATE } from '../../redux/filterSlice';
+import { useSyncNamespaceParam } from './useSyncNamespaceParam';
+
+describe('useSyncNamespaceParam', () => {
+  const STORAGE_KEY = 'headlamp-selected-namespace_test-cluster';
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  function createTestStore(initialNamespaces: string[] = []) {
+    return configureStore({
+      reducer: {
+        filter: filterReducer,
+      },
+      preloadedState: {
+        filter: {
+          ...FILTER_INITIAL_STATE,
+          namespaces: new Set(initialNamespaces),
+        },
+      },
+      middleware: getDefaultMiddleware =>
+        getDefaultMiddleware({
+          serializableCheck: false,
+        }),
+    });
+  }
+
+  function createWrapper(store: ReturnType<typeof createTestStore>, initialPath: string) {
+    const history = createMemoryHistory({ initialEntries: [initialPath] });
+    window.history.pushState({}, '', initialPath);
+
+    return function Wrapper({ children }: { children: React.ReactNode }) {
+      return (
+        <Provider store={store}>
+          <Router history={history}>{children}</Router>
+        </Provider>
+      );
+    };
+  }
+
+  it('should preserve existing namespace filter in store and localStorage when query param is absent', () => {
+    const store = createTestStore(['kube-system']);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['kube-system']));
+
+    const wrapper = createWrapper(store, '/c/test-cluster/map');
+    renderHook(() => useSyncNamespaceParam(), { wrapper });
+
+    expect(store.getState().filter.namespaces).toEqual(new Set(['kube-system']));
+    expect(localStorage.getItem(STORAGE_KEY)).toBe(JSON.stringify(['kube-system']));
+  });
+
+  it('should update namespace filter in store and localStorage when query param is present', () => {
+    const store = createTestStore(['default']);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['default']));
+
+    const wrapper = createWrapper(store, '/c/test-cluster/map?namespace=kube-system');
+    renderHook(() => useSyncNamespaceParam(), { wrapper });
+
+    expect(store.getState().filter.namespaces).toEqual(new Set(['kube-system']));
+    expect(localStorage.getItem(STORAGE_KEY)).toBe(JSON.stringify(['kube-system']));
+  });
+
+  it('should handle multiple space-separated namespaces in query param', () => {
+    const store = createTestStore([]);
+
+    const wrapper = createWrapper(store, '/c/test-cluster/map?namespace=default+kube-system');
+    renderHook(() => useSyncNamespaceParam(), { wrapper });
+
+    expect(store.getState().filter.namespaces).toEqual(new Set(['default', 'kube-system']));
+    expect(localStorage.getItem(STORAGE_KEY)).toBe(JSON.stringify(['default', 'kube-system']));
+  });
+
+  it('should reset filter when namespace query param is explicitly empty', () => {
+    const store = createTestStore(['kube-system']);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['kube-system']));
+
+    const wrapper = createWrapper(store, '/c/test-cluster/map?namespace=');
+    renderHook(() => useSyncNamespaceParam(), { wrapper });
+
+    expect(store.getState().filter.namespaces).toEqual(new Set());
+    expect(localStorage.getItem(STORAGE_KEY)).toBe(JSON.stringify([]));
+  });
+});

--- a/frontend/src/components/resourceMap/useSyncNamespaceParam.ts
+++ b/frontend/src/components/resourceMap/useSyncNamespaceParam.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { setNamespaceFilter } from '../../redux/filterSlice';
+import { useQueryParamsState } from './useQueryParamsState';
+
+/**
+ * Synchronizes the 'namespace' query parameter from the URL to the global Redux namespace filter.
+ *
+ * When the 'namespace' parameter is present in the URL, it splits the value on spaces and
+ * updates the namespace filter. When the parameter is absent (undefined), existing filter
+ * selections are preserved untouched.
+ */
+export function useSyncNamespaceParam() {
+  const dispatch = useDispatch();
+  const [namespacesParam] = useQueryParamsState<string>('namespace', '');
+
+  useEffect(() => {
+    if (namespacesParam !== undefined) {
+      const list = namespacesParam.split(' ');
+      dispatch(setNamespaceFilter(list));
+    }
+  }, [namespacesParam, dispatch]);
+}


### PR DESCRIPTION
## Summary

Preserves the global namespace filter selection when navigating to the Resource Map with no `namespace` query parameter in the URL.

## Related Issue

Addresses item 2 of #7242 (Map resetting the namespace filter on mount).

## Changes

- Extracted the URL-to-filter sync into `useSyncNamespaceParam` in `frontend/src/components/resourceMap/useSyncNamespaceParam.ts`.
- Guarded `setNamespaceFilter` dispatch so it only fires when the `namespace` query parameter is present in the URL (`namespacesParam !== undefined`).
- Added unit tests covering absent, present, multiple, and empty query parameters.

## Steps to Test

1. Select a namespace filter (for example `kube-system`).
2. Navigate to the Resource Map (`/map` or `/c/<cluster>/map`) without a `?namespace=` parameter.
3. Verify that the selected namespace in the header autocomplete and in Redux remains `kube-system`, and `localStorage` is not wiped.
4. Navigate to `/c/<cluster>/map?namespace=default` and confirm the filter updates to `default`.
5. Run unit tests: `npm run test src/components/resourceMap/useSyncNamespaceParam.test.tsx`.

## Screenshots (if applicable)

N/A (logic fix)

## Notes for the Reviewer

The effect originally added in ae7d94164 intended to let query parameters survive a refresh, but reading an absent parameter returned `undefined`, causing `setNamespaceFilter([])` to run on every visit to `/map` and overwrite the cluster's persisted selection.

For users with an active namespace selection, this changes the Map's initial view from unfiltered to opening filtered to that saved selection, matching how the rest of the application behaves. The previous unfiltered-on-open behavior was a side effect of the selection being cleared on mount rather than an intended default.
