### PR TITLE
frontend: Overview: Do not crash on corrupt event-filter storage value

### DIFF
--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -44,6 +44,7 @@ import {
   PodsStatusCircleChart,
 } from './Charts';
 import { ClusterGroupErrorMessage } from './ClusterGroupErrorMessage';
+import { loadEventWarningSwitch, storeEventWarningSwitch } from './eventWarningSwitch';
 
 const OVERVIEW_REFETCH_INTERVAL_MS = 60_000;
 
@@ -111,21 +112,13 @@ export default function Overview() {
 }
 
 function EventsSection() {
-  const EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY = 'EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY';
-  const EVENT_WARNING_SWITCH_DEFAULT = true;
   const { t } = useTranslation(['translation', 'glossary']);
   const location = useLocation();
   const queryParams = new URLSearchParams(location.search);
   const eventsFilter = queryParams.get('eventsFilter');
   const filterFunc = useFilterFunc<Event>(['.jsonData.involvedObject.kind']);
-  const [isWarningEventSwitchChecked, setIsWarningEventSwitchChecked] = React.useState(
-    Boolean(
-      JSON.parse(
-        localStorage.getItem(EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY) ||
-          EVENT_WARNING_SWITCH_DEFAULT.toString()
-      )
-    )
-  );
+  const [isWarningEventSwitchChecked, setIsWarningEventSwitchChecked] =
+    React.useState(loadEventWarningSwitch);
   const namespace = useNamespaces();
   const { items: events, errors: eventsErrors } = Event.useList({
     limit: Event.maxLimit,
@@ -188,7 +181,7 @@ function EventsSection() {
             label={t('Only warnings ({{ numWarnings }})', { numWarnings })}
             control={<Switch color="primary" />}
             onChange={(event, checked) => {
-              localStorage.setItem(EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY, checked.toString());
+              storeEventWarningSwitch(checked);
               setIsWarningEventSwitchChecked(checked);
             }}
             key="warning-toggle"

--- a/frontend/src/components/cluster/eventWarningSwitch.test.ts
+++ b/frontend/src/components/cluster/eventWarningSwitch.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY,
+  loadEventWarningSwitch,
+  parseStoredEventWarningSwitch,
+  storeEventWarningSwitch,
+} from './eventWarningSwitch';
+
+describe('parseStoredEventWarningSwitch', () => {
+  it('defaults to true when nothing is stored', () => {
+    expect(parseStoredEventWarningSwitch(null)).toBe(true);
+  });
+
+  it('parses stored true/false', () => {
+    expect(parseStoredEventWarningSwitch('true')).toBe(true);
+    expect(parseStoredEventWarningSwitch('false')).toBe(false);
+  });
+
+  it('falls back to the default on corrupt values instead of throwing', () => {
+    expect(parseStoredEventWarningSwitch('not-json')).toBe(true);
+    expect(parseStoredEventWarningSwitch('{truncated')).toBe(true);
+    expect(parseStoredEventWarningSwitch('123')).toBe(true);
+    expect(parseStoredEventWarningSwitch('')).toBe(true);
+  });
+});
+
+describe('loadEventWarningSwitch/storeEventWarningSwitch', () => {
+  afterEach(() => {
+    localStorage.removeItem(EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY);
+  });
+
+  it('defaults to true when nothing is stored', () => {
+    expect(loadEventWarningSwitch()).toBe(true);
+  });
+
+  it('does not throw and returns the default on corrupt stored values', () => {
+    localStorage.setItem(EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY, 'not-json');
+    expect(() => loadEventWarningSwitch()).not.toThrow();
+    expect(loadEventWarningSwitch()).toBe(true);
+  });
+
+  it('round-trips the preference through localStorage', () => {
+    storeEventWarningSwitch(false);
+    expect(loadEventWarningSwitch()).toBe(false);
+
+    storeEventWarningSwitch(true);
+    expect(loadEventWarningSwitch()).toBe(true);
+  });
+
+  it('falls back to the default and warns when localStorage.getItem throws', () => {
+    const spyWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const spyGetItem = vi.spyOn(localStorage, 'getItem').mockImplementation(() => {
+      throw new Error('Storage disabled');
+    });
+
+    try {
+      expect(loadEventWarningSwitch()).toBe(true);
+      expect(spyWarn).toHaveBeenCalledWith(
+        `Failed to read ${EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY} from localStorage, falling back to the default:`,
+        expect.any(Error)
+      );
+    } finally {
+      spyGetItem.mockRestore();
+      spyWarn.mockRestore();
+    }
+  });
+
+  it('does not throw and warns when localStorage.setItem throws', () => {
+    const spyWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const spySetItem = vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+      throw new Error('Storage disabled');
+    });
+
+    try {
+      expect(() => storeEventWarningSwitch(false)).not.toThrow();
+      expect(spyWarn).toHaveBeenCalledWith(
+        `Failed to set ${EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY} in localStorage:`,
+        expect.any(Error)
+      );
+    } finally {
+      spySetItem.mockRestore();
+      spyWarn.mockRestore();
+    }
+  });
+});

--- a/frontend/src/components/cluster/eventWarningSwitch.ts
+++ b/frontend/src/components/cluster/eventWarningSwitch.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY = 'EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY';
+export const EVENT_WARNING_SWITCH_DEFAULT = true;
+
+/**
+ * Parses the stored "only warnings" event filter preference. The value is only
+ * ever written as 'true'/'false', so anything else (missing, corrupt, written
+ * by something else) falls back to the default instead of crashing the render.
+ */
+export function parseStoredEventWarningSwitch(storedValue: string | null): boolean {
+  if (storedValue === 'true' || storedValue === 'false') {
+    return storedValue === 'true';
+  }
+
+  return EVENT_WARNING_SWITCH_DEFAULT;
+}
+
+/**
+ * Reads the "only warnings" event filter preference from localStorage. Storage
+ * access can itself throw when disabled/restricted, so guard it and fall back
+ * to the default rather than crashing the render.
+ */
+export function loadEventWarningSwitch(): boolean {
+  let stored: string | null = null;
+  try {
+    stored = localStorage.getItem(EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY);
+  } catch (e) {
+    console.warn(
+      `Failed to read ${EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY} from localStorage, falling back to the default:`,
+      e
+    );
+  }
+
+  return parseStoredEventWarningSwitch(stored);
+}
+
+/** Stores the "only warnings" event filter preference, ignoring storage failures. */
+export function storeEventWarningSwitch(checked: boolean): void {
+  try {
+    localStorage.setItem(EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY, checked.toString());
+  } catch (e) {
+    console.warn(`Failed to set ${EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY} in localStorage:`, e);
+  }
+}


### PR DESCRIPTION
Fixes #7322

## Summary
The "Only warnings" events toggle in the Cluster Overview read its initial
state with an unguarded `JSON.parse(localStorage.getItem(...))` inside a
`useState` initializer. If `EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY` holds a
value that is not valid JSON, `JSON.parse` throws a `SyntaxError` during
render and the Cluster Overview page crashes until the key is cleared.

This is the same class of localStorage-hardening fix as the recent
SecretList, notifications, tableSettings, and recentClusters changes.

## Reachability
The app only ever writes `'true'`/`'false'` (valid JSON), so this is not
reachable through normal UI use. It is triggered by a pre-existing corrupt or
foreign value under that key (stale data, a manual edit, or a future format
change).

## Changes
- Add `eventWarningSwitch.ts` with `parseStoredEventWarningSwitch` (strict
  `'true'`/`'false'` parser that cannot throw) and guarded
  `loadEventWarningSwitch` / `storeEventWarningSwitch` helpers.
- `Overview.tsx` uses a lazy `useState` initializer and the store helper on
  toggle; the inline unguarded parse is removed.
- Add `eventWarningSwitch.test.ts` covering default, valid, corrupt
  (`"not-json"`), and throwing-storage cases.

Default behavior (`true`) and the persisted value format are unchanged.

## How to test
```javascript
// devtools console, then open Cluster Overview
localStorage.setItem('EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY', 'not-json')
```
Before: page crashes with `SyntaxError: ... is not valid JSON`.
After: page renders with the toggle at its default.

```bash
cd frontend
npx vitest run src/components/cluster/eventWarningSwitch.test.ts src/components/cluster/Overview.test.tsx
```

## Verification
- Unit tests: 9 passing (8 new + existing `Overview.test.tsx`)
- `tsgo --noEmit`, `eslint`, `prettier --check`: clean

