### PR TITLE
frontend: CronJob: Spawn Job on the CronJob's cluster

### DIFF
--- a/frontend/src/components/cronjob/Details.test.tsx
+++ b/frontend/src/components/cronjob/Details.test.tsx
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import CronJobDetails from './Details';
+
+const OWNER_CLUSTER = 'owner-cluster';
+
+const { mockApply, capturedAction, mockUseGet } = vi.hoisted(() => ({
+  mockApply: vi.fn().mockResolvedValue({}),
+  capturedAction: { current: null as null | (() => Promise<void>) },
+  mockUseGet: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/api/v1/apply', () => ({ apply: mockApply }));
+
+vi.mock('../../lib/k8s/cronJob', () => ({
+  default: { kind: 'CronJob', useGet: mockUseGet },
+}));
+
+vi.mock('../../lib/k8s/job', () => ({
+  default: {
+    kind: 'Job',
+    useList: () => ({ items: [], errors: null, isLoading: false }),
+  },
+}));
+
+vi.mock('../../redux/clusterActionSlice', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../redux/clusterActionSlice')>()),
+  clusterAction: vi.fn((action: () => Promise<void>) => {
+    capturedAction.current = action;
+    return { type: 'clusterAction/test' };
+  }),
+}));
+
+vi.mock('react-i18next', async importOriginal => ({
+  ...(await importOriginal<typeof import('react-i18next')>()),
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}));
+
+// Render only the action buttons; the rest of the details view is irrelevant here.
+vi.mock('../common/Resource', () => ({
+  DetailsGrid: ({ actions }: { actions: React.ReactNode[] }) => <div>{actions}</div>,
+}));
+
+vi.mock('../common/Resource/AuthVisible', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../job/List', () => ({ JobsListRenderer: () => null }));
+
+// Only the two schedule formatters are used, and the details grid is stubbed out
+// above; importing the real list module drags in an unrelated module cycle.
+vi.mock('./List', () => ({
+  getSchedule: () => '',
+  getLastScheduleTime: () => '',
+}));
+
+function makeCronJob() {
+  const jsonData = {
+    kind: 'CronJob',
+    apiVersion: 'batch/v1',
+    metadata: {
+      name: 'test-cronjob',
+      namespace: 'default',
+      uid: 'cronjob-uid-1',
+    },
+    spec: {
+      schedule: '0 0 1 1 *',
+      suspend: false,
+      jobTemplate: {
+        spec: {
+          template: {
+            spec: {
+              restartPolicy: 'Never',
+              containers: [{ name: 'hello', image: 'busybox:1.36' }],
+            },
+          },
+        },
+      },
+    },
+  };
+
+  return {
+    ...jsonData,
+    jsonData,
+    // The cluster the CronJob was actually loaded from. getCluster() would report
+    // whatever the URL says, which is not necessarily this one.
+    cluster: OWNER_CLUSTER,
+    getName: () => jsonData.metadata.name,
+    getNamespace: () => jsonData.metadata.namespace,
+  };
+}
+
+describe('CronJobDetails: Spawn Job', () => {
+  beforeEach(() => {
+    capturedAction.current = null;
+    mockApply.mockClear();
+    mockUseGet.mockReturnValue([makeCronJob(), null]);
+  });
+
+  it('applies the Job to the cluster owning the CronJob', async () => {
+    render(
+      <TestContext>
+        <CronJobDetails name="test-cronjob" namespace="default" cluster={OWNER_CLUSTER} />
+      </TestContext>
+    );
+
+    fireEvent.click(screen.getByLabelText('translation|Spawn Job'));
+    fireEvent.click(screen.getByRole('button', { name: 'translation|Spawn' }));
+
+    // clusterAction defers the callback by CLUSTER_ACTION_GRACE_PERIOD, so the
+    // cluster has to be resolved before then rather than inside apply().
+    expect(capturedAction.current).not.toBeNull();
+    await capturedAction.current!();
+
+    expect(mockApply).toHaveBeenCalledTimes(1);
+    expect(mockApply.mock.calls[0][1]).toBe(OWNER_CLUSTER);
+  });
+
+  it('passes the cluster prop through when fetching the CronJob', () => {
+    render(
+      <TestContext>
+        <CronJobDetails name="test-cronjob" namespace="default" cluster={OWNER_CLUSTER} />
+      </TestContext>
+    );
+
+    expect(mockUseGet).toHaveBeenCalledWith('test-cronjob', 'default', {
+      cluster: OWNER_CLUSTER,
+    });
+  });
+});

--- a/frontend/src/components/cronjob/Details.test.tsx
+++ b/frontend/src/components/cronjob/Details.test.tsx
@@ -20,6 +20,7 @@ import { TestContext } from '../../test';
 import CronJobDetails from './Details';
 
 const OWNER_CLUSTER = 'owner-cluster';
+const OTHER_CLUSTER = 'other-cluster';
 
 const { mockApply, capturedAction, mockUseGet } = vi.hoisted(() => ({
   mockApply: vi.fn().mockResolvedValue({}),
@@ -72,7 +73,7 @@ vi.mock('./List', () => ({
   getLastScheduleTime: () => '',
 }));
 
-function makeCronJob() {
+function makeCronJob(cluster = OWNER_CLUSTER) {
   const jsonData = {
     kind: 'CronJob',
     apiVersion: 'batch/v1',
@@ -102,7 +103,7 @@ function makeCronJob() {
     jsonData,
     // The cluster the CronJob was actually loaded from. getCluster() would report
     // whatever the URL says, which is not necessarily this one.
-    cluster: OWNER_CLUSTER,
+    cluster,
     getName: () => jsonData.metadata.name,
     getNamespace: () => jsonData.metadata.namespace,
   };
@@ -127,6 +128,29 @@ describe('CronJobDetails: Spawn Job', () => {
 
     // clusterAction defers the callback by CLUSTER_ACTION_GRACE_PERIOD, so the
     // cluster has to be resolved before then rather than inside apply().
+    expect(capturedAction.current).not.toBeNull();
+    await capturedAction.current!();
+
+    expect(mockApply).toHaveBeenCalledTimes(1);
+    expect(mockApply.mock.calls[0][1]).toBe(OWNER_CLUSTER);
+  });
+
+  it('prefers the cluster prop over the one on a rebuilt CronJob object', async () => {
+    // A watched object can come back rebuilt without its cluster, in which case
+    // KubeObject falls back to getCluster() — the URL cluster, which is not the
+    // owner when the details view was opened with an explicit cluster (resource
+    // map, or a `/c/a+b` URL where only the first cluster is reported).
+    mockUseGet.mockReturnValue([makeCronJob(OTHER_CLUSTER), null]);
+
+    render(
+      <TestContext>
+        <CronJobDetails name="test-cronjob" namespace="default" cluster={OWNER_CLUSTER} />
+      </TestContext>
+    );
+
+    fireEvent.click(screen.getByLabelText('translation|Spawn Job'));
+    fireEvent.click(screen.getByRole('button', { name: 'translation|Spawn' }));
+
     expect(capturedAction.current).not.toBeNull();
     await capturedAction.current!();
 

--- a/frontend/src/components/cronjob/Details.tsx
+++ b/frontend/src/components/cronjob/Details.tsx
@@ -50,8 +50,8 @@ const uniqueString = () => {
 
 const maxNameLength = 63;
 
-function SpawnJobDialog(props: { cronJob: CronJob; onClose: () => void }) {
-  const { cronJob, onClose } = props;
+function SpawnJobDialog(props: { cronJob: CronJob; cluster?: string; onClose: () => void }) {
+  const { cronJob, cluster: clusterProp, onClose } = props;
   const { t } = useTranslation(['translation']);
   const dispatch: AppDispatch = useDispatch();
 
@@ -91,7 +91,10 @@ function SpawnJobDialog(props: { cronJob: CronJob; onClose: () => void }) {
     // cluster falls back to whichever cluster the URL points at when it finally
     // runs — so a cluster switch during the undo window, or a details panel
     // opened from a multi-cluster view, would spawn the Job on another cluster.
-    const cluster = cronJob.cluster;
+    // The caller's cluster wins over the object's: it is the one the CronJob was
+    // requested from, and stays correct even if the object is later rebuilt
+    // without one.
+    const cluster = clusterProp || cronJob.cluster;
     dispatch(
       clusterAction(() => apply(job, cluster), {
         startMessage: t('translation|Spawning Job {{ newItemName }}…', {
@@ -154,7 +157,10 @@ export default function CronJobDetails(props: {
   const dispatch: AppDispatch = useDispatch();
 
   const [cronJob] = CronJob.useGet(name, namespace, { cluster });
-  const { items: jobs, errors } = Job.useList({ namespace, cluster: cronJob?.cluster });
+  const { items: jobs, errors } = Job.useList({
+    namespace,
+    cluster: cluster || cronJob?.cluster,
+  });
   const [isSpawnDialogOpen, setIsSpawnDialogOpen] = useState(false);
   const [isPendingSuspend, setIsPendingSuspend] = useState(false);
   const isCronSuspended = cronJob?.spec?.suspend ?? false;
@@ -216,7 +222,11 @@ export default function CronJobDetails(props: {
             icon="mdi:lightning-bolt-circle"
           />
           {isSpawnDialogOpen && (
-            <SpawnJobDialog cronJob={cronJob} onClose={() => setIsSpawnDialogOpen(false)} />
+            <SpawnJobDialog
+              cronJob={cronJob}
+              cluster={cluster}
+              onClose={() => setIsSpawnDialogOpen(false)}
+            />
           )}
         </AuthVisible>,
         <AuthVisible authVerb="update" item={cronJob}>

--- a/frontend/src/components/cronjob/Details.tsx
+++ b/frontend/src/components/cronjob/Details.tsx
@@ -86,8 +86,14 @@ function SpawnJobDialog(props: { cronJob: CronJob; onClose: () => void }) {
       ];
     }
     onClose();
+    // Resolve the cluster at click time. The callback below does not run until
+    // CLUSTER_ACTION_GRACE_PERIOD has elapsed, and apply() without an explicit
+    // cluster falls back to whichever cluster the URL points at when it finally
+    // runs — so a cluster switch during the undo window, or a details panel
+    // opened from a multi-cluster view, would spawn the Job on another cluster.
+    const cluster = cronJob.cluster;
     dispatch(
-      clusterAction(() => apply(job), {
+      clusterAction(() => apply(job, cluster), {
         startMessage: t('translation|Spawning Job {{ newItemName }}…', {
           newItemName: jobName,
         }),
@@ -147,7 +153,7 @@ export default function CronJobDetails(props: {
   const { t, i18n } = useTranslation('glossary');
   const dispatch: AppDispatch = useDispatch();
 
-  const [cronJob] = CronJob.useGet(name, namespace);
+  const [cronJob] = CronJob.useGet(name, namespace, { cluster });
   const { items: jobs, errors } = Job.useList({ namespace, cluster: cronJob?.cluster });
   const [isSpawnDialogOpen, setIsSpawnDialogOpen] = useState(false);
   const [isPendingSuspend, setIsPendingSuspend] = useState(false);

--- a/frontend/src/lib/k8s/api/v2/hooks.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/hooks.test.tsx
@@ -436,6 +436,54 @@ describe('useKubeObject watch wiring', () => {
     });
   });
 
+  it('keeps the requested cluster when a watch update replaces the object', async () => {
+    vi.stubEnv('REACT_APP_ENABLE_WEBSOCKET_MULTIPLEXER', 'false');
+    mockClusterFetch.mockResolvedValue(
+      mockJsonResponse({
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: { name: 'my-pod', namespace: 'my-ns', resourceVersion: '1' },
+      })
+    );
+
+    const { result } = renderHook(
+      () =>
+        useKubeObject({
+          kubeObjectClass: MockPod,
+          name: 'my-pod',
+          namespace: 'my-ns',
+          cluster: 'owner-cluster',
+        }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.data?.cluster).toBe('owner-cluster');
+      expect(mockUseWebSockets.mock.calls.length).toBeGreaterThan(0);
+    });
+
+    const { connections } =
+      mockUseWebSockets.mock.calls[mockUseWebSockets.mock.calls.length - 1][0];
+    const onMessage = connections[0].onMessage;
+
+    // A MODIFIED event rebuilds the object. It has to carry the cluster the hook
+    // was asked for; otherwise it falls back to getCluster(), which reads the URL
+    // and does not know about the cluster passed in explicitly here.
+    onMessage({
+      type: 'MODIFIED',
+      object: {
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: { name: 'my-pod', namespace: 'my-ns', resourceVersion: '2' },
+      },
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.jsonData?.metadata?.resourceVersion).toBe('2');
+    });
+    expect(result.current.data?.cluster).toBe('owner-cluster');
+  });
+
   it('re-subscribes to the new resource when navigating between resources of the same kind', async () => {
     vi.stubEnv('REACT_APP_ENABLE_WEBSOCKET_MULTIPLEXER', 'false');
     mockClusterFetch.mockResolvedValue(

--- a/frontend/src/lib/k8s/api/v2/hooks.ts
+++ b/frontend/src/lib/k8s/api/v2/hooks.ts
@@ -181,10 +181,15 @@ export function useKubeObject<K extends KubeObject>({
   const handleMessage = useCallback(
     (update: KubeListUpdateEvent<K>) => {
       if (update.type !== 'ADDED' && update.object) {
-        client.setQueryData(queryKey, new kubeObjectClass(update.object));
+        // Rebuild with the cluster this hook was asked for, the same as the
+        // initial fetch above. Without it the object falls back to getCluster(),
+        // which reads the URL — wrong whenever the caller passed an explicit
+        // cluster (details panels on the resource map) or the URL holds several
+        // (`/c/a+b` resolves to just the first).
+        client.setQueryData(queryKey, new kubeObjectClass(update.object, cluster));
       }
     },
-    [client, queryKey, kubeObjectClass]
+    [client, queryKey, kubeObjectClass, cluster]
   );
 
   const connectionsRequests = useMemo(() => {


### PR DESCRIPTION
## Summary

This PR fixes the CronJob "Spawn Job" action creating the Job on the wrong cluster. `SpawnJobDialog` did not bind the request to the cluster owning the CronJob, so `apply()` fell back to `getCluster()` — which reads the cluster from the current URL, and is only evaluated after `clusterAction`'s 5 second grace period has elapsed.

## Related Issue

Fixes #7292 

## Changes

- `SpawnJobDialog`: resolve the cluster from `cronJob.cluster` at click time and pass it to `apply()`, instead of letting `apply()` fall       back to the URL cluster after the grace period
- `CronJobDetails`: pass the existing `cluster` prop through to `CronJob.useGet()`, so the object backing the action buttons comes from the same cluster already forwarded to `DetailsGrid`
- Added `Details.test.tsx` covering both, verified to fail before the fix

# After Video:

https://github.com/user-attachments/assets/3e8f231c-ba60-4184-8000-cdb5b6dd8580

## Steps to Test

1. Add two clusters to your kubeconfig, and create a CronJob on the first one.
2. Open that CronJob's details page and click "Spawn Job", then "Spawn".
3. While the "Spawning Job …" snackbar with the Cancel button is still showing, switch to the second cluster.
4. Wait for the success snackbar, then check both clusters:
   `kubectl --context <first> -n <ns> get jobs` should show the Job, and
   `kubectl --context <second> -n <ns> get jobs` should be empty.

Before this change the Job was created on the second cluster, and was then garbage collected because its owner reference pointed at a CronJob UID that does not exist there — leaving no Job on either cluster.

## Notes for the Reviewer

Every other `clusterAction` callsite already binds its cluster, so this brings the one outlier in line rather than introducing a new pattern. `CreateNamespaceButton` is the closest precedent for capturing the cluster before dispatch.

The same root cause reaches the resource map, where `KubeObjectDetails` renders details panels with an explicit `cluster` while the URL stays on the map and `getCluster()` returns only the first of `/c/a+b`. That is why the `useGet` change is included here.