### PR TITLE
frontend: router: Add regression test for BackendTrafficPolicy route key

### DIFF
--- a/frontend/src/lib/router/backendtrafficpolicyRoute.test.ts
+++ b/frontend/src/lib/router/backendtrafficpolicyRoute.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Integration-style regression test for the xbackendtrafficpolicy route key.
+ *
+ * The unit tests in createRouteURL.test.ts mock getRoute, so they cannot
+ * catch a misspelled key in the real default-route registry. This test
+ * imports the actual registered routes and verifies that the key exists
+ * and resolves to the expected URL pattern.
+ *
+ * The route key uses the 'x' prefix because the Kubernetes resource kind
+ * is XBackendTrafficPolicy (Gateway API experimental), and getRoute()
+ * resolves detailsRoute (which returns the kind) via case-insensitive
+ * key matching.
+ */
+
+// Side-effect import: executing index.tsx calls setDefaultRoutes(defaultRoutes),
+// which populates the real route registry used by getDefaultRoutes().
+import './index';
+import { describe, expect, it } from 'vitest';
+import { getDefaultRoutes } from './getDefaultRoutes';
+
+describe('xbackendtrafficpolicy route registration (regression for route key)', () => {
+  it('has an xbackendtrafficpolicy key in the default routes', () => {
+    const routes = getDefaultRoutes();
+    expect(routes).toHaveProperty('xbackendtrafficpolicy');
+  });
+
+  it('resolves to the expected path pattern', () => {
+    const routes = getDefaultRoutes();
+    expect(routes['xbackendtrafficpolicy'].path).toBe('/backendtrafficpolicy/:namespace/:name');
+  });
+});


### PR DESCRIPTION
## Summary

The route key `xbackendtrafficpolicy` in the default-route registry is intentionally prefixed with `x` — it matches the Kubernetes resource kind `XBackendTrafficPolicy` (a Gateway API experimental resource). `getRoute()` resolves `detailsRoute` (which returns the kind) via case-insensitive key matching, so `xbackendtrafficpolicy` correctly maps to `XBackendTrafficPolicy`.

fixes #7307

This PR adds a regression test against the real default-route registry to prevent accidental renames of this key in the future.

## Changes

- **frontend/src/lib/router/backendtrafficpolicyRoute.test.ts** *(new)*: Integration-style regression test that verifies the `xbackendtrafficpolicy` key exists in the route registry and resolves to the expected URL pattern (`/backendtrafficpolicy/:namespace/:name`).

## Steps to Test

1. Run the new regression test:
   ```
   npx vitest run src/lib/router/backendtrafficpolicyRoute.test.ts
   ```
2. Run the full frontend test suite to verify no regressions:
   ```
   npm run frontend:test
   ```
