### PR TITLE
frontend: Fix combineClusterListErrors destroying ApiError instances

### DIFF
--- a/frontend/src/lib/util.test.ts
+++ b/frontend/src/lib/util.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { ApiError } from './k8s/api/v2/ApiError';
 import {
   combineClusterListErrors,
   compareUnits,
@@ -93,28 +94,30 @@ describe('combineClusterListErrors', () => {
     expect(result).toBeNull();
   });
 
-  it('should combine errors from multiple clusters', () => {
-    const error1 = { message: 'Error 1', status: 500, name: 'InternalServerError' };
-    const error2 = { message: 'Error 2', status: 404, name: 'NotFoundError' };
+  it('should combine ApiError instances from multiple clusters without corrupting them', () => {
+    const error1 = new ApiError('Error 1', { status: 500 });
+    const error2 = new ApiError('Error 2', { status: 404 });
     const clusterErrors1 = { clusterA: error1 };
     const clusterErrors2 = { clusterB: error2 };
 
     const result = combineClusterListErrors(clusterErrors1, clusterErrors2);
-    expect(result).toEqual({
-      clusterA: error1,
-      clusterB: error2,
-    });
+
+    // Reference identity: the exact same ApiError instance must be returned,
+    // not a plain-object copy that loses the prototype chain.
+    expect(result?.clusterA).toBe(error1);
+    expect(result?.clusterB).toBe(error2);
+    expect(result?.clusterA).toBeInstanceOf(ApiError);
+    expect(result?.clusterB).toBeInstanceOf(ApiError);
   });
 
   it('should ignore null errors', () => {
-    const error1 = { message: 'Error 1', status: 500, name: 'InternalServerError' };
+    const error1 = new ApiError('Error 1', { status: 500 });
     const clusterErrors1 = { clusterA: error1 };
     const clusterErrors2 = { clusterB: null };
 
     const result = combineClusterListErrors(clusterErrors1, clusterErrors2);
-    expect(result).toEqual({
-      clusterA: error1,
-    });
+    expect(result).toEqual({ clusterA: error1 });
+    expect(result?.clusterA).toBe(error1);
   });
 
   it('should return null if all errors are null', () => {

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import merge from 'lodash/merge';
 import React from 'react';
 import { useHistory } from 'react-router';
 import { filterGeneric, filterResource } from '../redux/filterSlice';
@@ -379,7 +378,7 @@ export function combineClusterListErrors(
     return Object.fromEntries(Object.entries(clusterErrors).filter(([, error]) => error !== null));
   });
 
-  const errors = merge({}, ...filteredArgs);
+  const errors = Object.assign({}, ...filteredArgs);
   const hasErrors = Object.values(errors).some(error => error !== null);
 
   return hasErrors ? errors : null;


### PR DESCRIPTION
### Summary
This PR fixes a bug in `combineClusterListErrors` where `lodash/merge` was stripping the class prototypes and methods from `ApiError` instances, converting them into plain objects. By replacing `merge` with `Object.assign`, the instances (and their standard properties like `.message`) are fully preserved.

### Related Issue
Fixes #7309

### Changes
- **`frontend/src/lib/util.ts`**: Replaced `lodash/merge({}, ...filteredArgs)` with `Object.assign({}, ...filteredArgs)` inside `combineClusterListErrors`.

### Steps to Test
1. Check out this branch locally.
2. Induce a multi-cluster API failure (or mock an API response that returns an error status for one or more clusters).
3. Observe the UI where the error should be displayed.
4. Verify that the error messages are rendered correctly and that downstream code relying on `error instanceof ApiError` or `error.message` functions properly, instead of failing silently on a plain object.

### Screenshots
N/A

### Notes for the Reviewer
The original implementation used `lodash/merge`, which performs a deep merge into a plain `{}` object. Because the input dictionaries just map cluster names to `ApiError` class instances, a deep merge was unnecessary and actively harmful (stripping the `Error` prototype). `Object.assign` safely performs the required shallow merge, keeping the class instances intact.