### PR TITLE
frontend: remove redundant clusterRoleBindings and clusterRoles routes

### DIFF
--- a/docs/development/api/classes/lib_k8s_clusterRole.ClusterRole.md
+++ b/docs/development/api/classes/lib_k8s_clusterRole.ClusterRole.md
@@ -59,6 +59,24 @@
 
 ## Accessors
 
+### listRoute
+
+• `Static` `get` **listRoute**(): `string`
+
+#### Returns
+
+`string`
+
+#### Overrides
+
+Role.listRoute
+
+#### Defined in
+
+[lib/k8s/clusterRole.ts:27](https://github.com/kubernetes-sigs/headlamp/blob/072d2509b/frontend/src/lib/k8s/clusterRole.ts#L27)
+
+___
+
 ### detailsRoute
 
 • `get` **detailsRoute**(): `string`

--- a/docs/development/api/classes/lib_k8s_clusterRoleBinding.ClusterRoleBinding.md
+++ b/docs/development/api/classes/lib_k8s_clusterRoleBinding.ClusterRoleBinding.md
@@ -59,6 +59,24 @@
 
 ## Accessors
 
+### listRoute
+
+• `Static` `get` **listRoute**(): `string`
+
+#### Returns
+
+`string`
+
+#### Overrides
+
+RoleBinding.listRoute
+
+#### Defined in
+
+[lib/k8s/clusterRoleBinding.ts:27](https://github.com/kubernetes-sigs/headlamp/blob/072d2509b/frontend/src/lib/k8s/clusterRoleBinding.ts#L27)
+
+___
+
 ### detailsRoute
 
 • `get` **detailsRoute**(): `string`

--- a/frontend/src/lib/k8s/clusterRole.ts
+++ b/frontend/src/lib/k8s/clusterRole.ts
@@ -23,6 +23,10 @@ class ClusterRole extends KubeObject<KubeRole> {
   static apiVersion = 'rbac.authorization.k8s.io/v1';
   static isNamespaced = false;
 
+  static get listRoute() {
+    return 'roles';
+  }
+
   get rules() {
     return this.jsonData!.rules;
   }

--- a/frontend/src/lib/k8s/clusterRoleBinding.ts
+++ b/frontend/src/lib/k8s/clusterRoleBinding.ts
@@ -23,6 +23,10 @@ class ClusterRoleBinding extends KubeObject<KubeRoleBinding> {
   static apiVersion = 'rbac.authorization.k8s.io/v1';
   static isNamespaced = false;
 
+  static get listRoute() {
+    return 'roleBindings';
+  }
+
   get roleRef() {
     return this.jsonData!.roleRef;
   }

--- a/frontend/src/lib/router/createRouteURL.test.ts
+++ b/frontend/src/lib/router/createRouteURL.test.ts
@@ -25,6 +25,12 @@ vi.mock('./getRoute', () => ({
     if (name === 'pluginSimpleRoute') {
       return { path: '/plugin', useClusterURL: false };
     }
+    if (name === 'roles') {
+      return { path: '/c/:cluster/roles', useClusterURL: true };
+    }
+    if (name === 'roleBindings') {
+      return { path: '/c/:cluster/rolebindings', useClusterURL: true };
+    }
     return undefined;
   }),
 }));
@@ -70,5 +76,23 @@ describe('createRouteURL', () => {
     const message = warnSpy.mock.calls[0][0] as string;
     expect(message).toContain('pluginParameterizedRoute');
     expect(message).toContain('/plugin/:namespace/:name');
+  });
+
+  it('handles deprecated alias clusterRoles', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(createRouteURL('clusterRoles', { cluster: 'minikube' })).toBe('/c/minikube/roles');
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[Deprecation] Route name "clusterRoles" is deprecated. Please use "roles" instead.'
+    );
+  });
+
+  it('handles deprecated alias clusterRoleBindings', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(createRouteURL('clusterRoleBindings', { cluster: 'minikube' })).toBe(
+      '/c/minikube/rolebindings'
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[Deprecation] Route name "clusterRoleBindings" is deprecated. Please use "roleBindings" instead.'
+    );
   });
 });

--- a/frontend/src/lib/router/createRouteURL.tsx
+++ b/frontend/src/lib/router/createRouteURL.tsx
@@ -48,6 +48,20 @@ export function setStore(newStore: AppStore) {
 export function createRouteURL(routeName?: string, params: RouteURLProps = {}) {
   if (!routeName) return '';
 
+  // Handle deprecated route aliases to prevent breaking plugins
+  let resolvedRouteName = routeName;
+  if (routeName === 'clusterRoles') {
+    console.warn(
+      '[Deprecation] Route name "clusterRoles" is deprecated. Please use "roles" instead.'
+    );
+    resolvedRouteName = 'roles';
+  } else if (routeName === 'clusterRoleBindings') {
+    console.warn(
+      '[Deprecation] Route name "clusterRoleBindings" is deprecated. Please use "roleBindings" instead.'
+    );
+    resolvedRouteName = 'roleBindings';
+  }
+
   const store = getStore();
   const storeRoutes = !store ? {} : store.getState().routes.routes;
 
@@ -55,22 +69,25 @@ export function createRouteURL(routeName?: string, params: RouteURLProps = {}) {
   const matchingStoredRouteByName =
     storeRoutes &&
     Object.entries(storeRoutes).find(
-      ([, route]) => route.name?.toLowerCase() === routeName.toLowerCase()
+      ([, route]) => route.name?.toLowerCase() === resolvedRouteName.toLowerCase()
     )?.[1];
 
   // Then try to find by path
   const matchingStoredRouteByPath =
     storeRoutes &&
-    Object.entries(storeRoutes).find(([key]) => key.toLowerCase() === routeName.toLowerCase())?.[1];
+    Object.entries(storeRoutes).find(
+      ([key]) => key.toLowerCase() === resolvedRouteName.toLowerCase()
+    )?.[1];
 
   if (matchingStoredRouteByPath && !matchingStoredRouteByName) {
     console.warn(
-      `[Deprecation] Route "${routeName}" was found by path instead of name. ` +
+      `[Deprecation] Route "${resolvedRouteName}" was found by path instead of name. ` +
         'Please use route names instead of paths when calling createRouteURL.'
     );
   }
 
-  const route = matchingStoredRouteByName || matchingStoredRouteByPath || getRoute(routeName);
+  const route =
+    matchingStoredRouteByName || matchingStoredRouteByPath || getRoute(resolvedRouteName);
 
   if (!route) {
     return '';

--- a/frontend/src/lib/router/index.tsx
+++ b/frontend/src/lib/router/index.tsx
@@ -673,12 +673,7 @@ const defaultRoutes: { [routeName: string]: Route } = {
     sidebar: 'roles',
     component: () => <RoleDetails />,
   },
-  clusterRoles: {
-    path: '/roles',
-    exact: true,
-    sidebar: 'roles',
-    component: () => <RoleList />,
-  },
+
   roleBindings: {
     path: '/rolebindings',
     exact: true,
@@ -700,12 +695,7 @@ const defaultRoutes: { [routeName: string]: Route } = {
     sidebar: 'roleBindings',
     component: () => <RoleBindingDetails />,
   },
-  clusterRoleBindings: {
-    path: '/rolebindings',
-    exact: true,
-    sidebar: 'roleBindings',
-    component: () => <RoleBindingDetails />,
-  },
+
   secrets: {
     path: '/secrets',
     exact: true,


### PR DESCRIPTION
### Summary
This PR removes redundant and conflicting route definitions for `clusterRoleBindings` and `clusterRoles` in the main router configuration (`frontend/src/lib/router/index.tsx`). 

### Related Issue
Fixes #7311

### Changes
- Removed the `clusterRoleBindings` route object block.
- Removed the `clusterRoles` route object block.

### Steps to Test
1. Check out this branch locally.
2. Ensure you have a working Kubernetes cluster connection in Headlamp.
3. Navigate to **Access Control > Roles** in the sidebar. Verify that both Roles and ClusterRoles are listed and the page loads without routing errors.
4. Navigate to **Access Control > Role Bindings** in the sidebar. Verify that both RoleBindings and ClusterRoleBindings are listed and the page loads without routing errors.
5. Click on individual ClusterRoles and ClusterRoleBindings from the list to verify that their respective details views still load correctly.

### Screenshots
N/A

### Notes for the Reviewer
Because Headlamp consolidates namespace-scoped and cluster-scoped access control resources into unified list views at `/roles` and `/rolebindings`, the secondary `clusterRoleBindings` and `clusterRoles` route objects were entirely redundant. Worse, they shared the exact same paths (`/rolebindings` and `/roles`) which created a route key collision. The `clusterRoleBindings` route also erroneously pointed to a Details view for a URL path that lacked dynamic parameters. Removing these blocks eliminates dead code and prevents routing conflicts while preserving the intended unified list views.