### PR TITLE
frontend: filter out undefined query parameters in URL helpers

### DIFF
--- a/frontend/src/lib/k8s/api/v1/formatUrl.test.ts
+++ b/frontend/src/lib/k8s/api/v1/formatUrl.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { asQuery } from './formatUrl';
+
+describe('asQuery', () => {
+  it('should omit undefined and null entries but keep valid ones', () => {
+    const query = {
+      valid: '1',
+      empty: '',
+      isNull: null,
+      isUndefined: undefined,
+      numeric: 0,
+    };
+    // @ts-ignore - testing nullish values passing through
+    const result = asQuery(query);
+    expect(result).toBe('?valid=1&empty=&numeric=0');
+  });
+
+  it('should return empty string if no valid parameters', () => {
+    // @ts-ignore
+    const result = asQuery({ isNull: null, isUndefined: undefined });
+    expect(result).toBe('');
+  });
+
+  it('should return empty string if undefined passed', () => {
+    expect(asQuery()).toBe('');
+  });
+});

--- a/frontend/src/lib/k8s/api/v1/formatUrl.ts
+++ b/frontend/src/lib/k8s/api/v1/formatUrl.ts
@@ -64,7 +64,11 @@ export function asQuery(queryParams?: QueryParameters): string {
     newQueryParams = { ...omit(queryParams, 'limit') };
   }
 
-  return !!newQueryParams && !!Object.keys(newQueryParams).length
-    ? '?' + new URLSearchParams(newQueryParams).toString()
+  const cleanQueryParams = Object.fromEntries(
+    Object.entries(newQueryParams).filter(([, v]) => v !== undefined && v !== null)
+  ) as Record<string, string>;
+
+  return !!cleanQueryParams && !!Object.keys(cleanQueryParams).length
+    ? '?' + new URLSearchParams(cleanQueryParams).toString()
     : '';
 }

--- a/frontend/src/lib/k8s/api/v2/makeUrl.test.ts
+++ b/frontend/src/lib/k8s/api/v2/makeUrl.test.ts
@@ -73,4 +73,12 @@ describe('makeUrl', () => {
       'http://example.com/some/path?watch=1'
     );
   });
+
+  it('should omit undefined and null query parameters but keep valid ones', () => {
+    const urlParts = ['http://example.com', 'path'];
+    const query = { valid: '1', empty: '', isNull: null, isUndefined: undefined, numeric: 0 };
+    // @ts-ignore - testing nullish values passing through
+    const result = makeUrl(urlParts, query);
+    expect(result).toBe('http://example.com/path?valid=1&empty=&numeric=0');
+  });
 });

--- a/frontend/src/lib/k8s/api/v2/makeUrl.ts
+++ b/frontend/src/lib/k8s/api/v2/makeUrl.ts
@@ -36,7 +36,10 @@ export function makeUrl(urlParts: any[] | string, query: Record<string, any> = {
           .map(it => (typeof it === 'string' ? it : String(it)))
           .filter(Boolean)
           .join('/');
-  const queryString = new URLSearchParams(query).toString();
+  const cleanQuery = Object.fromEntries(
+    Object.entries(query).filter(([, v]) => v !== undefined && v !== null)
+  );
+  const queryString = new URLSearchParams(cleanQuery).toString();
   const fullUrl = queryString ? `${url}?${queryString}` : url;
 
   // replace multiple slashes with a single one


### PR DESCRIPTION
### Summary
This PR fixes a bug in `makeUrl` and `formatUrl` where explicitly passing an `undefined` parameter (e.g., `{ fieldSelector: undefined }`) would cause `URLSearchParams` to convert it to the literal string `"undefined"`. By filtering out `undefined` and `null` values beforehand, we ensure the generated query strings are clean and valid for the Kubernetes API.

### Related Issue
Fixes #7313

### Changes
- **`frontend/src/lib/k8s/api/v2/makeUrl.ts`**: Strip undefined/null keys from the `query` object before passing to `URLSearchParams`.
- **`frontend/src/lib/k8s/api/v1/formatUrl.ts`**: Strip undefined/null keys from `newQueryParams` before passing to `URLSearchParams`.

### Steps to Test
1. Check out this branch locally.
2. In the browser console (or unit tests), test `makeUrl` or `formatUrl` with an `undefined` parameter value (e.g., `makeUrl(['api', 'v1', 'pods'], { watch: '1', fieldSelector: undefined })`).
3. Verify that the returned URL string ends in `?watch=1` without `&fieldSelector=undefined`.

### Screenshots
N/A

### Notes for the Reviewer
When interacting with the Kubernetes API, client components occasionally pass `undefined` as a query parameter value if a specific filter isn't active. Because `new URLSearchParams()` does not automatically ignore `undefined` values (it stringifies them to `"undefined"`), the resulting URL queries were becoming malformed and rejected by the API. Filtering the object via `Object.entries` securely prevents this without affecting valid truthy or falsy strings/numbers.