### PR TITLE
frontend: Don't send API requests when no cluster is selected

### DIFF
--- a/frontend/src/lib/k8s/KubeObject.test.ts
+++ b/frontend/src/lib/k8s/KubeObject.test.ts
@@ -43,11 +43,43 @@ vi.mock('./patchUtils', () => ({
   computeRawPatchCount: vi.fn(),
 }));
 
+import { renderHook } from '@testing-library/react';
+import { useSelectedClusters } from './api/v1/hooks';
+import { makeListRequests, useKubeObjectList } from './api/v2/useKubeObjectList';
 import { KubeObject } from './KubeObject';
 
 describe('KubeObject', () => {
   it('returns no API group when the class does not define an API version', () => {
     expect(KubeObject.apiGroupName).toBeUndefined();
+  });
+
+  describe('useList', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('requests no clusters when no cluster is selected', () => {
+      vi.mocked(useSelectedClusters).mockReturnValue([]);
+      vi.mocked(useKubeObjectList).mockReturnValue([null, null] as any);
+
+      renderHook(() => KubeObject.useList());
+
+      expect(makeListRequests).toHaveBeenCalledWith([], expect.any(Function), undefined, undefined);
+    });
+
+    it('requests the selected clusters when no explicit cluster is given', () => {
+      vi.mocked(useSelectedClusters).mockReturnValue(['cluster-a']);
+      vi.mocked(useKubeObjectList).mockReturnValue([null, null] as any);
+
+      renderHook(() => KubeObject.useList());
+
+      expect(makeListRequests).toHaveBeenCalledWith(
+        ['cluster-a'],
+        expect.any(Function),
+        undefined,
+        undefined
+      );
+    });
   });
 
   it('matches subclasses that define a custom API group and kind', () => {

--- a/frontend/src/lib/k8s/KubeObject.ts
+++ b/frontend/src/lib/k8s/KubeObject.ts
@@ -395,9 +395,10 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
     // Create requests for each cluster and namespace
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const requests = useMemo(() => {
-      const clusterList = cluster
-        ? [cluster]
-        : clusters || (fallbackClusters.length === 0 ? [''] : fallbackClusters);
+      // When no cluster is explicitly requested and none is selected, make no
+      // requests: a request without a cluster would go to the backend's own
+      // root, which serves the SPA index.html instead of any Kubernetes API.
+      const clusterList = cluster ? [cluster] : clusters || fallbackClusters;
 
       const namespacesFromParams =
         typeof namespace === 'string'

--- a/frontend/src/lib/k8s/api/v2/hooks.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/hooks.test.tsx
@@ -87,6 +87,20 @@ describe('useEndpoints', () => {
     expect(mockClusterFetch).not.toHaveBeenCalled();
   });
 
+  it('does not probe when no cluster is given', () => {
+    const endpoints: KubeObjectEndpoint[] = [
+      { group: 'apiextensions.k8s.io', version: 'v1', resource: 'customresourcedefinitions' },
+      { group: 'apiextensions.k8s.io', version: 'v1beta1', resource: 'customresourcedefinitions' },
+    ];
+
+    const { result } = renderHook(() => useEndpoints(endpoints, ''), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.endpoint).toBeUndefined();
+    expect(mockClusterFetch).not.toHaveBeenCalled();
+  });
+
   it('uses name-based GET probing in endpoint priority order', async () => {
     const endpoints: KubeObjectEndpoint[] = [
       { group: 'extensions', version: 'v1beta1', resource: 'ingresses' },

--- a/frontend/src/lib/k8s/api/v2/hooks.ts
+++ b/frontend/src/lib/k8s/api/v2/hooks.ts
@@ -299,7 +299,9 @@ export const useEndpoints = (
   );
 
   const { data: endpoint, error } = useQuery<KubeObjectEndpoint, ApiError>({
-    enabled: endpoints.length > 1,
+    // Probing without a cluster would hit the backend's own root, which
+    // serves the SPA index.html with a 200 and makes the probe "succeed".
+    enabled: endpoints.length > 1 && !!cluster,
     retry: false,
     queryKey: ['endpoints', cluster, namespace, name ?? '', endpointsKey],
     queryFn: () => getWorkingEndpoint(endpoints, cluster!, namespace, name),


### PR DESCRIPTION
Fixes #7317

## What this does

On routes without a cluster in the URL (the home / cluster chooser screen, or
the initial render at `/` before the single-cluster redirect),
`KubeObject.useList()` fell back to a cluster list of `['']`. `clusterFetch()`
then built URLs without the `/clusters/<name>` prefix, so requests such as
`GET /apis/apiextensions.k8s.io/v1/customresourcedefinitions` went to the
backend's own root and got the SPA `index.html` back with a 200. The endpoint
probe in `useEndpoints()` treated that as a working endpoint, the list fetch
failed to parse HTML as JSON, and react-query retried forever — a permanent
request/`Failed to fetch CRDs: SyntaxError: Unexpected token '<'` loop on the
home screen of multi-cluster setups (via the unconditional `CRD.useList()` in
`useSidebarItems`), and a burst of it on every page load in single-cluster
setups.

Two changes:

- `KubeObject.useList()`: when no cluster is explicitly requested and none is
  selected, make **no requests** instead of falling back to `['']`. The backend
  only proxies Kubernetes APIs under `/clusters/{clusterName}/`, so a
  cluster-less request can never be valid.
- `useEndpoints()`: gate the multi-version endpoint probe on a non-empty
  cluster, so probing (e.g. CRD v1/v1beta1) doesn't fire cluster-less either —
  this also covers callers that pass `clusters: []` explicitly, whose probe
  previously still ran with an `undefined` cluster.

No change for any request that has a cluster: explicit `cluster`/`clusters`
options and the selected-clusters fallback behave as before.

## Why we need it

Console error/retry noise on every Headlamp deployment: permanent on the
multi-cluster home screen, per-page-load in single-cluster setups. The probe
also "discovers" endpoints from HTML 200s, which is wrong data for the cache.

## Testing done

- New unit tests — two that fail on `main` and pass with this change:
  - `KubeObject.useList` requests no clusters when none is selected
    (asserts `makeListRequests` receives `[]`, previously `['']`).
  - `useEndpoints` does not probe when no cluster is given
    (previously called `clusterFetch` with `cluster: ''`).

  Plus a guard test that the selected-clusters fallback still works
  (passes before and after).
- `vitest run src/lib/k8s/ src/components/Sidebar/ src/components/globalSearch/`
  → 35 files, 623 tests pass.
- Manual before/after with `ghcr.io/headlamp-k8s/headlamp:v0.44.0` and a
  credential-less kubeconfig (no live cluster needed — see the repro in the
  linked issue), overlaying the patched build via
  `-v $PWD/frontend/build:/headlamp/frontend:ro`:
  - Two-cluster home screen — before: cluster-less CRD requests with retry
    backoff (0.3s/1.3s/3.3s/7.3s...) + console error loop; after: **zero**
    Kubernetes API requests while no cluster is selected.
  - Single-cluster pre-login flow — before: 3 cluster-less requests at ~330ms
    on every load; after: none; all remaining requests carry
    `/clusters/<name>/` and the login flow is unchanged.