### PR TITLE
backend: cluster: Fix WebSocket auth fallback

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1232,6 +1232,30 @@ func (c *HeadlampConfig) shouldUseUnsafeServiceAccountTokenForContext(kContext *
 	return c.shouldUseUnsafeServiceAccountToken() && kContext.UsesInClusterServiceAccountToken()
 }
 
+// getContextWithWebSocketFallback returns the requested context, falling back to the cluster
+// context when a WebSocket request references a missing user-specific context.
+func (c *HeadlampConfig) getContextWithWebSocketFallback(
+	r *http.Request,
+	contextKey string,
+) (string, *kubeconfig.Context, error) {
+	kContext, err := c.KubeConfigStore.GetContext(contextKey)
+	if err == nil {
+		return contextKey, kContext, nil
+	}
+
+	clusterName := mux.Vars(r)["clusterName"]
+	if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") &&
+		contextKey != clusterName &&
+		errors.Is(err, cache.ErrNotFound) {
+		kContext, fallbackErr := c.KubeConfigStore.GetContext(clusterName)
+		if fallbackErr == nil {
+			return clusterName, kContext, nil
+		}
+	}
+
+	return contextKey, nil, err
+}
+
 func tokenFromCookie(r *http.Request, clusterName string) string {
 	if cookieToken, err := auth.GetTokenFromCookie(r, clusterName); err == nil && cookieToken != "" {
 		return cookieToken
@@ -1858,7 +1882,7 @@ func clusterRequestHandler(c *HeadlampConfig) http.Handler { //nolint:funlen
 			return
 		}
 
-		kContext, err := c.KubeConfigStore.GetContext(contextKey)
+		contextKey, kContext, err := c.getContextWithWebSocketFallback(r, contextKey)
 		if err != nil {
 			c.handleError(w, ctx, span, err, "failed to get context", http.StatusNotFound)
 			return

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -4030,6 +4030,66 @@ func TestClusterRequestHandlerUsesServiceAccountToken(t *testing.T) { //nolint:f
 	assert.Empty(t, receivedProxyAuthToken)
 }
 
+func TestClusterRequestHandlerFallsBackToClusterContextForWebSocketCookie(t *testing.T) {
+	const cluster = "main"
+
+	var receivedAuth, receivedProtocol string
+
+	kubeAPI := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		receivedProtocol = r.Header.Get("Sec-Websocket-Protocol")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"kind":"PodList","items":[]}`))
+	}))
+	t.Cleanup(kubeAPI.Close)
+
+	kubeConfigStore := kubeconfig.NewContextStore()
+	require.NoError(t, kubeConfigStore.AddContext(&kubeconfig.Context{
+		Name: cluster,
+		Cluster: &api.Cluster{
+			Server:                kubeAPI.URL,
+			InsecureSkipTLSVerify: true,
+		},
+		AuthInfo: &api.AuthInfo{},
+	}))
+
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				KubeConfigStore: kubeConfigStore,
+			},
+			Cache:            cache.New[interface{}](),
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	}
+
+	router := mux.NewRouter()
+	handleClusterAPI(c, router)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/clusters/main/api/v1/pods", nil)
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set(
+		"Sec-Websocket-Protocol",
+		"base64url.headlamp.authorization.k8s.io.stale-user, v4.channel.k8s.io",
+	)
+	req.AddCookie(&http.Cookie{
+		Name:     "headlamp-auth-main.0",
+		Value:    "cookie-token",
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
+	})
+
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "Bearer cookie-token", receivedAuth)
+	assert.Equal(t, "v4.channel.k8s.io", receivedProtocol)
+}
+
 func TestClusterRequestHandlerStripsProxyAuthTokenHeader(t *testing.T) {
 	const cluster, proxyAuthTokenHeader = "main", "Impersonate-User"
 

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -260,7 +260,7 @@ func GetContextKeyAndKContext(w http.ResponseWriter,
 		return nil, nil, "", nil, err
 	}
 
-	kContext, err := c.KubeConfigStore.GetContext(contextKey)
+	contextKey, kContext, err := c.getContextWithWebSocketFallback(r, contextKey)
 	if err != nil {
 		c.handleError(w, ctx, span, err, "failed to get context", http.StatusNotFound)
 		return nil, nil, "", nil, err


### PR DESCRIPTION
Fixes #6539

Supersedes #6540 by @rishh09, which has been awaiting a rebase since 2026-08-13. The original commit is carried over unchanged — same author, same `Signed-off-by` — so authorship and credit remain with @rishh09. No code was modified; this PR only rebases and tidies the history that reviewers asked for on #6540.

## What this changes

WebSocket cluster API requests derive a user-specific context key from the `base64url.headlamp.authorization.k8s.io.<userId>` subprotocol. In in-cluster OIDC/cookie deployments that `userId` is never registered in the token store, so the lookup misses with `cache.ErrNotFound` and the request fails with `404 key not found` — even when the same request carries a valid `headlamp-auth-<cluster>.<n>` cookie that would authenticate it. This breaks any plugin using a raw WebSocket that includes the userId subprotocol (KubeVirt VNC/serial console, terminals, port-forward).

`getContextWithWebSocketFallback()` falls back to the route's `{clusterName}` context when a WebSocket request references a missing user-specific context, so the existing cookie and `Authorization` handling can still promote credentials onto the proxied request.

The fallback is deliberately fenced to three conditions, so no other lookup failure is masked:

- the request is a WebSocket upgrade,
- the derived context key differs from the cluster name,
- the error is `cache.ErrNotFound` specifically.

A stateless/dynamic-kubeconfig context that exists but fails for any other reason is therefore never silently downgraded to the shared cluster context.

## What changed relative to #6540

- Rebased onto current `main` (the branch was 457 commits behind; the rebase was conflict-free).
- Squashed the docs-only follow-up commit into the implementation commit, as requested in review, and wrote the stale-context/404 rationale into the commit body.

The resulting diff is byte-identical to the diff on #6540.

## Testing

- `go build ./...` — clean
- `go test ./...` — exit 0, 15 packages ok, no failures
- `go test ./cmd/ -run TestClusterRequestHandlerFallsBackToClusterContextForWebSocketCookie -v` — PASS
- `go fmt ./cmd/ ./pkg/**` — no changes
- `./tools/golangci-lint run` — 0 issues

Regression coverage is the test added by @rishh09: a stale `base64url.headlamp.authorization.k8s.io...` WebSocket subprotocol combined with a valid auth cookie now proxies successfully and promotes the cookie to `Authorization`.
