### PR TITLE
backend/plugins: compare path components in the containment check

### DIFF
--- a/backend/pkg/plugins/containment_internal_test.go
+++ b/backend/pkg/plugins/containment_internal_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// isSubdirectory guards two paths that take a plugin name from a request, so the
+// escapes below are the cases that matter. The names beginning with a dot are here
+// because the previous implementation rejected them, and they are legal directory
+// names a plugin author may pick.
+func TestIsSubdirectory(t *testing.T) {
+	base := filepath.FromSlash("/plugins")
+
+	tests := []struct {
+		name  string
+		child string
+		want  bool
+	}{
+		{name: "plain child", child: "normal", want: true},
+		{name: "nested child", child: "a/b", want: true},
+		{name: "traversal that resolves back inside", child: "a/../b", want: true},
+
+		{name: "leading dot is a legal name", child: ".hidden", want: true},
+		{name: "leading double dot is a legal name", child: "..foo", want: true},
+		{name: "three dots is a legal name", child: "...", want: true},
+
+		{name: "parent", child: "..", want: false},
+		{name: "escape", child: "../escape", want: false},
+		{name: "escape from a nested path", child: "a/../../escape", want: false},
+		{name: "the directory itself", child: ".", want: false},
+		{name: "empty name resolves to the directory itself", child: "", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isSubdirectory(base, filepath.Join(base, tc.child))
+			if got != tc.want {
+				t.Errorf("isSubdirectory(%q, %q) = %v, want %v", base, tc.child, got, tc.want)
+			}
+		})
+	}
+}
+
+// The previous check compared string prefixes against the whole relative path, so its
+// answer for the same directory name changed with nesting depth: "..foo" was rejected
+// and "sub/..foo" was accepted. Both are children and both must be accepted.
+func TestIsSubdirectoryDoesNotDependOnDepth(t *testing.T) {
+	base := filepath.FromSlash("/plugins")
+
+	shallow := isSubdirectory(base, filepath.Join(base, "..foo"))
+	nested := isSubdirectory(base, filepath.Join(base, "sub", "..foo"))
+
+	if shallow != nested {
+		t.Errorf("same directory name judged differently by depth: %q=%v, %q=%v",
+			"..foo", shallow, "sub/..foo", nested)
+	}
+}
+
+// Paths outside the tree are rejected however they are written, including a sibling
+// whose name starts with the parent's name.
+func TestIsSubdirectoryRejectsOutsidePaths(t *testing.T) {
+	base := filepath.FromSlash("/plugins")
+
+	for _, outside := range []string{"/etc/passwd", "/plugins-evil/x", "/"} {
+		p := filepath.FromSlash(outside)
+		if isSubdirectory(base, p) {
+			t.Errorf("isSubdirectory(%q, %q) = true, want false", base, p)
+		}
+	}
+}

--- a/backend/pkg/plugins/plugins.go
+++ b/backend/pkg/plugins/plugins.go
@@ -676,5 +676,16 @@ func isSubdirectory(parentDir, dirPath string) bool {
 		return false
 	}
 
-	return !strings.HasPrefix(rel, "..") && !strings.HasPrefix(rel, ".")
+	// filepath.Rel reports "." when the two paths are the same directory. A directory
+	// is not a subdirectory of itself, and returning true here would let an empty
+	// plugin name resolve to the plugin root.
+	if rel == "." {
+		return false
+	}
+
+	// filepath.IsLocal answers the question this guard is actually asking: does the
+	// path stay inside the tree it is relative to. It inspects path components, so a
+	// directory named "..foo" is recognised as a child while a real escape, which
+	// always produces a ".." component, is rejected.
+	return filepath.IsLocal(rel)
 }


### PR DESCRIPTION
## What Changed

`isSubdirectory` in `backend/pkg/plugins/plugins.go` guards the two paths that take a plugin name from a request: `isCatalogInstalledPlugin` and `tryDeletePlugin`. It decided containment with string prefixes on the relative path:

```go
return !strings.HasPrefix(rel, "..") && !strings.HasPrefix(rel, ".")
```

That tests how the path is spelled instead of how it is structured, and it gets two things wrong.

**Legal directory names are rejected.** `..foo`, `.hidden` and `...` are all valid names for a directory inside the plugin root. A plugin installed under any of them could not be deleted, since `tryDeletePlugin` refuses the path, and `isCatalogInstalledPlugin` reported it as not catalog-installed without reading its `package.json`.

**The answer changed with depth.** The prefix test only ever sees the front of the whole relative path, so the same directory name was judged differently depending on where it sat:

| name | old | new |
|---|---|---|
| `..foo` | rejected | accepted |
| `sub/..foo` | accepted | accepted |

`filepath.IsLocal` asks the question the guard means to ask, on path components rather than characters. The explicit `rel == "."` case is kept, because `filepath.Rel` returns `"."` when the two paths are the same directory and an empty plugin name must not resolve to the plugin root.

## Escapes are unaffected

Every rejection the old check made for a path leaving the tree is still a rejection. I compared both implementations over the same inputs before changing anything:

| input | old | new |
|---|---|---|
| `..` | false | false |
| `../escape` | false | false |
| `a/../../escape` | false | false |
| `.` and `""` | false | false |
| `/etc/passwd` | false | false |
| `/plugins-evil/x` against a `/plugins` root | false | false |

The sibling case in the last row is the one worth calling out, since a naive containment check written with `strings.HasPrefix` on the absolute path rather than on `filepath.Rel` would accept it.

## Tests

`backend/pkg/plugins/containment_internal_test.go` covers the escapes, the three names that were wrongly rejected, and the depth inconsistency as its own case.

I checked they fail against the previous implementation instead of assuming it. Restoring the old return gives:

```
--- FAIL: TestIsSubdirectory/leading_dot_is_a_legal_name
--- FAIL: TestIsSubdirectory/leading_double_dot_is_a_legal_name
--- FAIL: TestIsSubdirectory/three_dots_is_a_legal_name
--- FAIL: TestIsSubdirectoryDoesNotDependOnDepth
```

With the change in place the package passes, `go build ./...`, `go vet` and `gofmt -l` are clean.

The test file is `package plugins` because `isSubdirectory` is unexported and the existing `plugins_test.go` is an external test package.
