### PR TITLE
frontend: k8s: Guard ResourceClasses lookups with an API group match

### DIFF
--- a/frontend/src/components/advancedSearch/ResourceSearch.stories.tsx
+++ b/frontend/src/components/advancedSearch/ResourceSearch.stories.tsx
@@ -132,7 +132,7 @@ Default.args = {
       isNamespaced: true,
     },
     {
-      apiVersion: 'v1',
+      apiVersion: 'apps/v1',
       version: 'v1',
       singularName: 'deployment',
       kind: 'Deployment',

--- a/frontend/src/components/advancedSearch/utils/useKubeLists.test.ts
+++ b/frontend/src/components/advancedSearch/utils/useKubeLists.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { ApiResource } from '../../../lib/k8s/api/v2/ApiResource';
+import { useKubeLists } from './useKubeLists';
+
+const { mockBuiltinUseList, mockFallbackUseList, mockResourceClasses } = vi.hoisted(() => {
+  const builtinItems = [{ marker: 'builtin' }];
+  const fallbackItems = [{ marker: 'fallback' }];
+  const mockBuiltinUseList = vi.fn(() => ({ items: builtinItems, isError: false }));
+  const mockFallbackUseList = vi.fn(() => ({ items: fallbackItems, isError: false }));
+
+  class FakeDeployment {
+    static kind = 'Deployment';
+    static apiVersion = 'apps/v1';
+    static useList = mockBuiltinUseList;
+  }
+
+  return {
+    mockBuiltinUseList,
+    mockFallbackUseList,
+    mockResourceClasses: { Deployment: FakeDeployment },
+  };
+});
+
+vi.mock('../../../redux/filterSlice', () => ({
+  useNamespaces: () => undefined,
+}));
+
+vi.mock('../../../lib/k8s', () => ({
+  ResourceClasses: mockResourceClasses,
+  getResourceClass: (kind: string, apiVersion?: string) => {
+    const cls = (mockResourceClasses as Record<string, any>)[kind];
+    if (!cls) {
+      return null;
+    }
+    if (!apiVersion) {
+      return cls;
+    }
+    const groupOf = (v: string) => (v.includes('/') ? v.split('/')[0] : '');
+    const classVersions = Array.isArray(cls.apiVersion) ? cls.apiVersion : [cls.apiVersion];
+    return classVersions.some((v: string) => groupOf(v) === groupOf(apiVersion)) ? cls : null;
+  },
+}));
+
+vi.mock('../../../lib/k8s/cluster', () => ({
+  KubeObject: class {
+    static useList = mockFallbackUseList;
+  },
+}));
+
+function makeResource(overrides: Partial<ApiResource>): ApiResource {
+  return {
+    apiVersion: 'apps/v1',
+    version: 'v1',
+    pluralName: 'deployments',
+    singularName: 'deployment',
+    kind: 'Deployment',
+    isNamespaced: true,
+    ...overrides,
+  };
+}
+
+describe('useKubeLists', () => {
+  beforeEach(() => {
+    mockBuiltinUseList.mockClear();
+    mockFallbackUseList.mockClear();
+  });
+
+  it('uses the built-in class when kind and apiVersion group match', () => {
+    const { result } = renderHook(() =>
+      useKubeLists([makeResource({ apiVersion: 'apps/v1' })], ['test-cluster'], 100)
+    );
+
+    expect(mockBuiltinUseList).toHaveBeenCalled();
+    expect(mockFallbackUseList).not.toHaveBeenCalled();
+    expect(result.current.items).toEqual([{ marker: 'builtin' }]);
+  });
+
+  it('falls back to the ad-hoc class when the kind matches a built-in but the group differs', () => {
+    // Reproduces issue #7321: a CRD sharing a kind name with a built-in resource
+    // (e.g. Kueue's kueue.x-k8s.io/v1beta1 Workload) must not resolve to the
+    // built-in class from a different group.
+    const { result } = renderHook(() =>
+      useKubeLists([makeResource({ apiVersion: 'kueue.x-k8s.io/v1beta1' })], ['test-cluster'], 100)
+    );
+
+    expect(mockFallbackUseList).toHaveBeenCalled();
+    expect(mockBuiltinUseList).not.toHaveBeenCalled();
+    expect(result.current.items).toEqual([{ marker: 'fallback' }]);
+  });
+});

--- a/frontend/src/components/advancedSearch/utils/useKubeLists.ts
+++ b/frontend/src/components/advancedSearch/utils/useKubeLists.ts
@@ -15,7 +15,7 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
-import { ResourceClasses } from '../../../lib/k8s';
+import { getResourceClass } from '../../../lib/k8s';
 import { ApiError } from '../../../lib/k8s/api/v2/ApiError';
 import { ApiResource } from '../../../lib/k8s/api/v2/ApiResource';
 import { KubeObject, KubeObjectClass } from '../../../lib/k8s/cluster';
@@ -43,7 +43,7 @@ export const useKubeLists = (
       resources
         .map(
           it =>
-            (ResourceClasses as Record<string, KubeObjectClass>)[it.kind] ??
+            getResourceClass(it.kind, it.apiVersion) ??
             class extends KubeObject {
               static kind = it.kind;
               static apiVersion = it.apiVersion;

--- a/frontend/src/components/common/Resource/MetadataDisplay.test.tsx
+++ b/frontend/src/components/common/Resource/MetadataDisplay.test.tsx
@@ -42,6 +42,19 @@ const { mockResourceClasses } = vi.hoisted(() => {
 vi.mock('../../../lib/k8s', () => ({
   ResourceClasses: mockResourceClasses,
   useSelectedClusters: vi.fn(() => ['test-cluster']),
+  getResourceClass: (kind: string, apiVersion?: string) => {
+    const cls = (mockResourceClasses as Record<string, any>)[kind];
+    if (!cls) {
+      return null;
+    }
+    if (!apiVersion) {
+      return cls;
+    }
+    const groupOf = (v: string) => (v.includes('/') ? v.split('/')[0] : '');
+    const apiVersions = Array.isArray(cls.apiVersion) ? cls.apiVersion : [cls.apiVersion];
+    const groupMatches = apiVersions.some((v: string) => groupOf(v) === groupOf(apiVersion));
+    return groupMatches ? cls : null;
+  },
 }));
 
 const theme = createMuiTheme({ base: 'light', name: 'light' });
@@ -155,6 +168,46 @@ describe('MetadataDisplay', () => {
 
     expect(screen.queryByRole('link', { name: 'Job: custom-job' })).not.toBeInTheDocument();
     expect(screen.getByText('Job: custom-job')).toBeInTheDocument();
+  });
+
+  it('renders a link when the group matches but the version differs (loosened from exact apiVersion match)', () => {
+    const ownerReferences = [
+      {
+        apiVersion: 'batch/v1beta1', // Same group as Job (batch/v1), different version.
+        kind: 'Job',
+        name: 'old-version-job',
+        uid: 'uid-5',
+      },
+    ];
+    const resourceWithOwners = {
+      ...mockResource,
+      metadata: { ...mockResource.metadata, ownerReferences },
+    } as unknown as KubeObject;
+
+    renderWithTheme(<MetadataDisplay resource={resourceWithOwners} />);
+
+    const link = screen.getByRole('link', { name: 'Job: old-version-job' });
+    expect(link).toBeInTheDocument();
+  });
+
+  it('renders plain text when the kind matches a built-in but the group differs (issue #7321)', () => {
+    const ownerReferences = [
+      {
+        apiVersion: 'kueue.x-k8s.io/v1beta1',
+        kind: 'Job',
+        name: 'kueue-job',
+        uid: 'uid-6',
+      },
+    ];
+    const resourceWithOwners = {
+      ...mockResource,
+      metadata: { ...mockResource.metadata, ownerReferences },
+    } as unknown as KubeObject;
+
+    renderWithTheme(<MetadataDisplay resource={resourceWithOwners} />);
+
+    expect(screen.queryByRole('link', { name: 'Job: kueue-job' })).not.toBeInTheDocument();
+    expect(screen.getByText('Job: kueue-job')).toBeInTheDocument();
   });
 
   it('correctly interpolates kind in console.error when detailsRoute lookup fails', () => {

--- a/frontend/src/components/common/Resource/MetadataDisplay.tsx
+++ b/frontend/src/components/common/Resource/MetadataDisplay.tsx
@@ -21,7 +21,7 @@ import { Theme } from '@mui/material/styles';
 import Typography, { TypographyProps } from '@mui/material/Typography';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { ResourceClasses, useSelectedClusters } from '../../../lib/k8s';
+import { getResourceClass, useSelectedClusters } from '../../../lib/k8s';
 import { KubeOwnerReference } from '../../../lib/k8s/cluster';
 import { KubeObject } from '../../../lib/k8s/KubeObject';
 import { localeDate } from '../../../lib/util';
@@ -69,19 +69,9 @@ export function MetadataDisplay<T extends KubeObject>(props: MetadataDisplayProp
 
     return ownerReferences
       .map((ownerRef, i) => {
-        // Match both kind AND apiVersion to avoid linking to the wrong resource when
+        // Match both kind AND apiVersion group to avoid linking to the wrong resource when
         // different API groups share the same kind name (e.g. batch/v1 Job vs a CRD Job).
-        const matchingClass =
-          ownerRef.kind in ResourceClasses
-            ? (() => {
-                const cls = ResourceClasses[ownerRef.kind as keyof typeof ResourceClasses];
-                const apiVersions = Array.isArray(cls.apiVersion)
-                  ? cls.apiVersion
-                  : [cls.apiVersion];
-                const apiVersionMatches = apiVersions.includes(ownerRef.apiVersion);
-                return apiVersionMatches ? cls : null;
-              })()
-            : null;
+        const matchingClass = getResourceClass(ownerRef.kind, ownerRef.apiVersion);
 
         if (matchingClass) {
           let routeName;

--- a/frontend/src/components/endpoints/Details.test.tsx
+++ b/frontend/src/components/endpoints/Details.test.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import App from '../../App';
+import { createMuiTheme } from '../../lib/themes';
+import { TestContext } from '../../test';
+import EndpointDetails from './Details';
+
+// cyclic imports fix
+// eslint-disable-next-line no-unused-vars
+const _dont_delete_me = App;
+
+const theme = createMuiTheme({ base: 'light', name: 'light' });
+
+const { mockDetailsGrid } = vi.hoisted(() => ({
+  mockDetailsGrid: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/endpoints', () => ({
+  default: { kind: 'Endpoints', apiVersion: 'v1', detailsRoute: 'endpoint' },
+}));
+
+vi.mock('../common/Resource', () => ({
+  DetailsGrid: (props: any) => {
+    mockDetailsGrid(props);
+    const { extraSections } = props;
+    const sections = typeof extraSections === 'function' ? extraSections(fakeEndpoint) : [];
+    return (
+      <>
+        {sections.map((s: any) => (
+          <React.Fragment key={s.id}>{s.section}</React.Fragment>
+        ))}
+      </>
+    );
+  },
+}));
+
+const fakeEndpoint: any = {
+  subsets: [
+    {
+      addresses: [{ ip: '10.0.0.1', hostname: 'host-1', targetRef: undefined }],
+      ports: [],
+    },
+  ],
+};
+
+function renderWithAddresses(addresses: any[]) {
+  fakeEndpoint.subsets = [{ addresses, ports: [] }];
+
+  return render(
+    <TestContext routerMap={{ namespace: 'default', name: 'my-endpoint' }}>
+      <ThemeProvider theme={theme}>
+        <EndpointDetails name="my-endpoint" namespace="default" />
+      </ThemeProvider>
+    </TestContext>
+  );
+}
+
+describe('EndpointDetails target rendering', () => {
+  beforeEach(() => {
+    mockDetailsGrid.mockReset();
+  });
+
+  it('renders a link when the target kind and apiVersion group match', () => {
+    renderWithAddresses([
+      {
+        ip: '10.0.0.1',
+        targetRef: { kind: 'Endpoints', apiVersion: 'v1', name: 'target-1', namespace: 'default' },
+      },
+    ]);
+
+    expect(screen.getByRole('link', { name: 'target-1' })).toBeInTheDocument();
+  });
+
+  it('falls back to plain text when the target kind matches a built-in but the group differs', () => {
+    // Reproduces issue #7321: a CRD sharing a kind name with a built-in resource
+    // must not resolve to the built-in class.
+    renderWithAddresses([
+      {
+        ip: '10.0.0.2',
+        targetRef: {
+          kind: 'Endpoints',
+          apiVersion: 'kueue.x-k8s.io/v1beta1',
+          name: 'target-2',
+          namespace: 'default',
+        },
+      },
+    ]);
+
+    expect(screen.queryByRole('link', { name: 'target-2' })).not.toBeInTheDocument();
+    expect(screen.getByText('target-2')).toBeInTheDocument();
+  });
+
+  it('falls back to plain text when there is no targetRef kind', () => {
+    renderWithAddresses([{ ip: '10.0.0.3', targetRef: undefined }]);
+
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
+  });
+});

--- a/frontend/src/components/endpoints/Details.tsx
+++ b/frontend/src/components/endpoints/Details.tsx
@@ -16,7 +16,7 @@
 
 import { useTranslation } from 'react-i18next';
 import { useLocation, useParams } from 'react-router-dom';
-import { ResourceClasses } from '../../lib/k8s';
+import { getResourceClass } from '../../lib/k8s';
 import Endpoints, { KubeEndpoint } from '../../lib/k8s/endpoints';
 import Empty from '../common/EmptyContent';
 import Link from '../common/Link';
@@ -77,10 +77,11 @@ export default function EndpointDetails(props: {
                             {
                               label: t('Target'),
                               getter: address => {
-                                const targetRefClass = !!address.targetRef?.kind
-                                  ? ResourceClasses[
-                                      address.targetRef?.kind as keyof typeof ResourceClasses
-                                    ]
+                                const targetRefClass = address.targetRef?.kind
+                                  ? getResourceClass(
+                                      address.targetRef.kind,
+                                      address.targetRef.apiVersion
+                                    )
                                   : null;
                                 if (!!targetRefClass) {
                                   return (

--- a/frontend/src/lib/k8s/event.test.ts
+++ b/frontend/src/lib/k8s/event.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import App from '../../App';
+import Event from './event';
+
+// cyclic imports fix
+// eslint-disable-next-line no-unused-vars
+const _dont_delete_me = App;
+
+function makeEvent(involvedObject: any) {
+  return new Event({
+    involvedObject,
+    metadata: {
+      name: 'test-event',
+      namespace: 'default',
+      uid: 'event-uid',
+      creationTimestamp: '2020-01-01T00:00:00Z',
+    },
+  } as any);
+}
+
+describe('Event involvedObjectInstance', () => {
+  it('resolves a built-in class when kind and apiVersion group match', () => {
+    const event = makeEvent({
+      kind: 'PriorityClass',
+      apiVersion: 'scheduling.k8s.io/v1',
+      name: 'high-priority',
+    });
+
+    expect(event.involvedObjectInstance).not.toBeNull();
+    expect(event.involvedObjectInstance?.kind).toBe('PriorityClass');
+  });
+
+  it('returns null when the involvedObject kind matches a built-in but the group differs', () => {
+    // Reproduces issue #7321: a CRD sharing a kind name with a built-in resource
+    // (e.g. Kueue's kueue.x-k8s.io/v1beta1 Workload vs. scheduling.k8s.io's
+    // PriorityClass-style registration) must not resolve to the wrong class.
+    const event = makeEvent({
+      kind: 'PriorityClass',
+      apiVersion: 'kueue.x-k8s.io/v1beta1',
+      name: 'not-a-priority-class',
+    });
+
+    expect(event.involvedObjectInstance).toBeNull();
+  });
+
+  it('returns null when there is no involvedObject', () => {
+    const event = makeEvent(undefined);
+    expect(event.involvedObjectInstance).toBeNull();
+  });
+});

--- a/frontend/src/lib/k8s/event.ts
+++ b/frontend/src/lib/k8s/event.ts
@@ -15,12 +15,11 @@
  */
 
 import { useMemo } from 'react';
-import { ResourceClasses } from '.';
+import { getResourceClass } from '.';
 import { request } from './api/v1/clusterRequests';
 import type { QueryParameters } from './api/v1/queryParameters';
 import type { ApiError } from './api/v2/ApiError';
 import type { KubeMetadata } from './KubeMetadata';
-import type { KubeObjectClass } from './KubeObject';
 import { KubeObject } from './KubeObject';
 
 export interface KubeEvent {
@@ -176,9 +175,10 @@ class Event extends KubeObject<KubeEvent> {
       return null;
     }
 
-    const InvolvedObjectClass = (ResourceClasses as Record<string, KubeObjectClass>)[
-      this.involvedObject.kind
-    ];
+    const InvolvedObjectClass = getResourceClass(
+      this.involvedObject.kind,
+      this.involvedObject.apiVersion
+    );
     let objInstance: KubeObject | null = null;
     if (!!InvolvedObjectClass) {
       objInstance = new InvolvedObjectClass(

--- a/frontend/src/lib/k8s/hpa.test.ts
+++ b/frontend/src/lib/k8s/hpa.test.ts
@@ -86,4 +86,28 @@ describe('HPA class', () => {
     expect(metrics[0].value).toBe('0% (0m)/0%');
     expect(metrics[0].shortValue).toBe('0% /0%');
   });
+
+  describe('referenceObject', () => {
+    it('resolves the target class when kind and apiVersion group match', () => {
+      const data = JSON.parse(JSON.stringify(mockHpaData));
+      const hpa = new HPA(data);
+
+      expect(hpa.referenceObject).not.toBeNull();
+      expect(hpa.referenceObject?.kind).toBe('Deployment');
+    });
+
+    it('returns null when the target kind matches a built-in but the group differs', () => {
+      // Reproduces issue #7321: a CRD sharing a kind name with a built-in resource
+      // must not resolve to the built-in class.
+      const data = JSON.parse(JSON.stringify(mockHpaData));
+      data.spec.scaleTargetRef = {
+        apiVersion: 'kueue.x-k8s.io/v1beta1',
+        kind: 'Deployment',
+        name: 'test-deployment',
+      };
+      const hpa = new HPA(data);
+
+      expect(hpa.referenceObject).toBeNull();
+    });
+  });
 });

--- a/frontend/src/lib/k8s/hpa.ts
+++ b/frontend/src/lib/k8s/hpa.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { ResourceClasses } from '.';
+import { getResourceClass } from '.';
 import type { KubeMetadata } from './KubeMetadata';
-import { KubeObject, type KubeObjectClass, type KubeObjectInterface } from './KubeObject';
+import { KubeObject, type KubeObjectInterface } from './KubeObject';
 export interface CrossVersionObjectReference {
   apiVersion: string;
   kind: string;
@@ -370,7 +370,7 @@ class HPA extends KubeObject<KubeHPA> {
       return null;
     }
 
-    const TargetObjectClass = (ResourceClasses as Record<string, KubeObjectClass>)[target.kind];
+    const TargetObjectClass = getResourceClass(target.kind, target.apiVersion);
     let objInstance: KubeObject | null = null;
     if (!!TargetObjectClass) {
       objInstance = new TargetObjectClass({

--- a/frontend/src/lib/k8s/index.test.ts
+++ b/frontend/src/lib/k8s/index.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { createRouteURL } from '../router/createRouteURL';
-import { labelSelectorToQuery, ResourceClasses } from '.';
+import { getResourceClass, labelSelectorToQuery, ResourceClasses } from '.';
 import { LabelSelector } from './cluster';
 import { KubeObjectClass } from './KubeObject';
 import Namespace from './namespace';
@@ -350,5 +350,48 @@ describe('Namespace testing', () => {
       expect(makeNamespace('renamed', 'kube-system').isProtected()).toBe(true);
       expect(makeNamespace('kube-system', 'my-app').isProtected()).toBe(false);
     });
+  });
+});
+
+describe('getResourceClass', () => {
+  it('returns null for a kind that has no registered class', () => {
+    expect(getResourceClass('TotallyUnknownKind')).toBeNull();
+  });
+
+  it('returns the class unchanged when no apiVersion is given, even for a known kind', () => {
+    expect(getResourceClass('Pod')).toBe(ResourceClasses.Pod);
+  });
+
+  it('matches a core-group (bare version) apiVersion against a class declaring "v1"', () => {
+    expect(getResourceClass('Pod', 'v1')).toBe(ResourceClasses.Pod);
+  });
+
+  it('matches a grouped apiVersion against a class declaring the same group/version', () => {
+    expect(getResourceClass('Deployment', 'apps/v1')).toBe(ResourceClasses.Deployment);
+  });
+
+  it('matches when the version differs but the group matches', () => {
+    // PodDisruptionBudget is registered as policy/v1, but a CRD/older cluster
+    // reporting policy/v1beta1 is still the same group and should match.
+    expect(getResourceClass('PodDisruptionBudget', 'policy/v1beta1')).toBe(
+      ResourceClasses.PodDisruptionBudget
+    );
+  });
+
+  it('matches against any entry when the static apiVersion is an array', () => {
+    expect(getResourceClass('Gateway', 'gateway.networking.k8s.io/v1beta1')).toBe(
+      ResourceClasses.Gateway
+    );
+  });
+
+  it('returns null when the kind matches but the group does not (issue #7321)', () => {
+    // Reproduces the reported ambiguity: a CRD (e.g. Kueue's kueue.x-k8s.io/v1beta1
+    // Workload) can share a kind name with a built-in resource registered under a
+    // different group (here: PriorityClass under scheduling.k8s.io/v1). Only the
+    // group match should resolve to the built-in class.
+    expect(getResourceClass('PriorityClass', 'kueue.x-k8s.io/v1beta1')).toBeNull();
+    expect(getResourceClass('PriorityClass', 'scheduling.k8s.io/v1')).toBe(
+      ResourceClasses.PriorityClass
+    );
   });
 });

--- a/frontend/src/lib/k8s/index.ts
+++ b/frontend/src/lib/k8s/index.ts
@@ -41,6 +41,7 @@ import Ingress from './ingress';
 import IngressClass from './ingressClass';
 import Job from './job';
 import JobSet from './jobSet';
+import type { KubeObjectClass } from './KubeObject';
 import LeaderWorkerSet from './leaderWorkerSet';
 import { Lease } from './lease';
 import { LimitRange } from './limitRange';
@@ -112,6 +113,43 @@ export const ResourceClasses = {
   TCPRoute,
   UDPRoute,
 };
+
+/**
+ * Extracts the API group from a "GROUP/VERSION" (or bare "VERSION") string.
+ *
+ * A bare version (no "/") belongs to the core group, represented as ''.
+ */
+function apiGroupOf(apiVersion: string): string {
+  return apiVersion.includes('/') ? apiVersion.split('/')[0] : '';
+}
+
+/**
+ * Looks up the {@link KubeObjectClass} registered for a given `kind`, guarding against
+ * a CRD sharing a `kind` name with a built-in resource from a different API group
+ * (e.g. Kueue's `kueue.x-k8s.io/v1beta1` `Workload` vs. `scheduling.k8s.io` `Workload`).
+ *
+ * @param kind - the kind of the resource, e.g. "Pod".
+ * @param apiVersion - the apiVersion of the specific object being resolved, e.g. "apps/v1".
+ *   If omitted or empty, the class registered for `kind` is returned unchecked.
+ * @returns the matching class, or null if there is no class registered for `kind`, or if
+ *   `apiVersion` is given and its group doesn't match any of the class's registered groups.
+ */
+export function getResourceClass(kind: string, apiVersion?: string): KubeObjectClass | null {
+  const cls = (ResourceClasses as Record<string, KubeObjectClass>)[kind];
+  if (!cls) {
+    return null;
+  }
+
+  if (!apiVersion) {
+    return cls;
+  }
+
+  const classApiVersions = Array.isArray(cls.apiVersion) ? cls.apiVersion : [cls.apiVersion];
+  const requestedGroup = apiGroupOf(apiVersion);
+  const groupMatches = classApiVersions.some(version => apiGroupOf(version) === requestedGroup);
+
+  return groupMatches ? cls : null;
+}
 
 /** Hook for getting or fetching the clusters configuration.
  * This gets the clusters from the redux store. The redux store is updated

--- a/frontend/src/lib/k8s/vpa.test.ts
+++ b/frontend/src/lib/k8s/vpa.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import App from '../../App';
+import VPA from './vpa';
+
+// cyclic imports fix
+// eslint-disable-next-line no-unused-vars
+const _dont_delete_me = App;
+
+function makeVpa(targetRef: any) {
+  return new VPA({
+    apiVersion: 'autoscaling.k8s.io/v1',
+    kind: 'VerticalPodAutoscaler',
+    metadata: {
+      name: 'test-vpa',
+      namespace: 'default',
+      uid: 'vpa-uid',
+      creationTimestamp: '2020-01-01T00:00:00Z',
+    },
+    spec: {
+      targetRef,
+    },
+  } as any);
+}
+
+describe('VPA referenceObject', () => {
+  it('resolves the target class when kind and apiVersion group match', () => {
+    const vpa = makeVpa({
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      name: 'test-deployment',
+    });
+
+    expect(vpa.referenceObject).not.toBeNull();
+    expect(vpa.referenceObject?.kind).toBe('Deployment');
+  });
+
+  it('returns null when the target kind matches a built-in but the group differs', () => {
+    // Reproduces issue #7321: a CRD sharing a kind name with a built-in resource
+    // must not resolve to the built-in class.
+    const vpa = makeVpa({
+      apiVersion: 'kueue.x-k8s.io/v1beta1',
+      kind: 'Deployment',
+      name: 'not-a-deployment',
+    });
+
+    expect(vpa.referenceObject).toBeNull();
+  });
+
+  it('returns null when there is no targetRef', () => {
+    const vpa = makeVpa(undefined);
+    expect(vpa.referenceObject).toBeNull();
+  });
+});

--- a/frontend/src/lib/k8s/vpa.ts
+++ b/frontend/src/lib/k8s/vpa.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { ResourceClasses } from '.';
+import { getResourceClass } from '.';
 import { request } from './api/v1/clusterRequests';
-import type { KubeObjectClass, KubeObjectInterface } from './KubeObject';
+import type { KubeObjectInterface } from './KubeObject';
 import { KubeObject } from './KubeObject';
 
 type ResourceName = 'cpu' | 'memory' | 'storage' | 'ephemeral-storage';
@@ -142,7 +142,7 @@ class VPA extends KubeObject<KubeVPA> {
       return null;
     }
 
-    const TargetObjectClass = (ResourceClasses as Record<string, KubeObjectClass>)[target.kind];
+    const TargetObjectClass = getResourceClass(target.kind, target.apiVersion);
     let objInstance: KubeObject | null = null;
     if (!!TargetObjectClass) {
       objInstance = new TargetObjectClass({

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -535,6 +535,7 @@
       "useEventListForClusters": [Function],
       "useEventWarningList": [Function],
     },
+    "getResourceClass": [Function],
     "getVersion": [Function],
     "ingress": {
       "default": [Function],


### PR DESCRIPTION
## What this does

`ResourceClasses` is keyed by kind alone, so several call sites resolved a reference by kind and used the result without checking the referenced object's `apiVersion`. A CRD sharing a kind with a built-in silently resolved to the built-in class — producing links to details pages for objects that don't exist, and, in advanced search, listing from the wrong API group.

This adds `getResourceClass(kind, apiVersion)` to `frontend/src/lib/k8s/index.ts` and routes the kind-only lookups through it.

The helper returns the registered class only when the reference's API group matches one of the groups the class declares. Matching is on the **group**, not the full `group/version`, so a reference carrying a version the class doesn't enumerate (e.g. a `batch/v1beta1` owner reference against a class declaring `batch/v1`) still resolves. It handles both the string and array forms of `static apiVersion`, and treats a bare version like `v1` as the core group.

## Call sites

Each keeps its existing fallback when there's no match:

| Site | Fallback on group mismatch |
|---|---|
| `lib/k8s/event.ts` — `Event.involvedObjectInstance` | `null`, so `cluster/Overview.tsx` renders no link |
| `lib/k8s/hpa.ts` — `HPA.referenceObject` | `null` |
| `lib/k8s/vpa.ts` — `VPA.referenceObject` | `null` |
| `components/endpoints/Details.tsx` — target column | plain text |
| `advancedSearch/utils/useKubeLists.ts` | the existing ad-hoc `KubeObject` subclass built from the discovered resource |
| `common/Resource/MetadataDisplay.tsx` — owner references | plain text |

The issue named the first, fifth and sixth; `hpa.ts`, `vpa.ts` and `endpoints/Details.tsx` have the identical defect and a reference that carries an `apiVersion`, so they're fixed here too.

Out of scope, deliberately: `serviceaccount/Details.tsx` (RBAC `roleRef` — `apiGroup`-only and realistically never collides), `Resource.tsx` env-var refs (no `apiVersion` to match on), and the `UNDER_TEST || STORYBOOK` guard in `crd.ts`.

## Behavior change worth reviewer attention

`MetadataDisplay.tsx` already had an inline guard from 12cb69dae that required an **exact** `apiVersion` match. It now uses the shared helper, so it matches on group instead. That's an intentional loosening: an owner reference carrying a version the class doesn't enumerate links again, where the exact match silently dropped it. There's a test covering exactly that case.

## Why this matters now

#6562 registers `scheduling.k8s.io` `PodGroup` and `Workload`. Kueue ships `kueue.x-k8s.io/v1beta1` kind `Workload`, and Volcano and sig-scheduling coscheduling ship kind `PodGroup` — clusters likely to run both.

Note that #6562 isn't in this branch, so `ResourceClasses` has no `Workload`/`PodGroup` yet and the literal collision can't be written as a fixture. The regression tests use the same shape with classes that do exist: `PriorityClass` (`scheduling.k8s.io/v1`) and `Job` (`batch/v1`) against a `kueue.x-k8s.io/v1beta1` reference.

## Testing

- Unit tests for `getResourceClass`: unknown kind, known kind with no `apiVersion`, core-group match, grouped match, version-differs-group-matches, array-valued `apiVersion`, and group mismatch.
- A same-kind/different-group regression test at each of the six call sites. New test files for `event.ts`, `vpa.ts`, `endpoints/Details.tsx` and `useKubeLists.ts`, which had none.

`npx vitest run` over the affected trees goes from 35 files / 605 tests to 39 / 627, with no regressions. `npm run tsc`, ESLint and Prettier are clean.

Fixes #7321
