### PR TITLE
frontend: Pod: Split log stream chunks into lines

### DIFF
--- a/frontend/src/components/common/Resource/LogsButton.test.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.test.tsx
@@ -566,10 +566,15 @@ describe('LogsButton', () => {
     await waitFor(() => expect(onLogsCallback).toBeDefined());
 
     act(() => {
-      onLogsCallback({ logs: Array.from({ length: 1001 }, (_, index) => `line ${index}\n`) });
+      onLogsCallback({ logs: Array.from({ length: 2500 }, (_, index) => `line ${index}\n`) });
     });
     expect(mockXTermWrite).toHaveBeenCalledWith(expect.stringContaining('line 999'));
     expect(requestAnimationFrameSpy).toHaveBeenCalled();
+
+    // A batch larger than the chunk size has to be drained completely, even if the
+    // stream goes quiet right after it.
+    expect(mockXTermWrite).toHaveBeenCalledWith(expect.stringContaining('line 1000'));
+    expect(mockXTermWrite).toHaveBeenCalledWith(expect.stringContaining('line 2499'));
 
     mockXTermWrite.mockClear();
     unmount();
@@ -901,6 +906,77 @@ describe('LogsButton', () => {
     // Verify stream was not restarted
     expect(getLogsCallCount).toBe(1);
   });
+  // A severity change repaints the terminal from the logs kept in state. Only the entries
+  // already drained are on screen, so repainting the whole batch would let the frames that
+  // are still queued append their entries a second time.
+  it('does not duplicate the queued tail when the severity changes mid-drain', async () => {
+    const frames: FrameRequestCallback[] = [];
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(callback => {
+        frames.push(callback);
+        return frames.length;
+      });
+    mockClusterFetch.mockResolvedValue({
+      json: async () => ({ items: [mockPodData] }),
+    });
+
+    let onLogsCallback: any;
+    Pod.prototype.getLogs = vi.fn((...args: any[]) => {
+      onLogsCallback = args.find(arg => typeof arg === 'function');
+      return () => {};
+    }) as any;
+
+    render(
+      <TestContext>
+        <LogsButton item={new Deployment(deploymentData as any)} />
+      </TestContext>
+    );
+    fireEvent.click(screen.getByLabelText('translation|Show logs'));
+    const activityContent = mockActivityLaunch.mock.calls[0][0].content;
+    render(<TestContext>{activityContent}</TestContext>);
+
+    // The drain only runs for a single selected pod; "All pods" repaints wholesale.
+    await waitFor(() => expect(document.querySelectorAll('.MuiSelect-select')[0]).toBeTruthy());
+    fireEvent.mouseDown(document.querySelectorAll('.MuiSelect-select')[0]);
+    fireEvent.click(await screen.findByText('test-pod-1'));
+    await waitFor(() => expect(onLogsCallback).toBeDefined());
+
+    // Two chunks worth of entries, so the second one is left queued on a frame.
+    const newLogs = Array.from({ length: 1500 }, (_, index) => `[ERROR] line ${index}\n`);
+    act(() => onLogsCallback({ logs: newLogs }));
+    expect(frames).toHaveLength(1);
+
+    // Repaint under a narrowed severity while that frame is still pending. Clicking INFO
+    // deselects it, so the ERROR entries above stay on screen.
+    mockXTermWrite.mockClear();
+    const severitySelect = document.querySelectorAll('.MuiSelect-select')[3];
+    fireEvent.mouseDown(severitySelect);
+    await waitFor(() => expect(document.querySelector('.MuiList-root')).toBeInTheDocument());
+    const infoOption = Array.from(document.querySelectorAll('.MuiMenuItem-root')).find(
+      el => el.textContent === 'INFO'
+    );
+    fireEvent.click(infoOption!);
+    fireEvent.keyDown(document.activeElement!, { key: 'Escape' });
+    await waitFor(() => expect(mockXTermClear).toHaveBeenCalled());
+
+    // The repaint owes the terminal only what had been drained, so the frame that is still
+    // queued can append the rest without any entry reaching the terminal twice.
+    const repainted = mockXTermWrite.mock.calls.map(call => call[0]).join('');
+    expect(repainted).toContain('line 999');
+    expect(repainted).not.toContain('line 1000');
+
+    act(() => frames[0](0));
+
+    const written = mockXTermWrite.mock.calls.map(call => call[0]).join('');
+    const timesWritten = (index: number) => written.split(`line ${index}\r\n`).length - 1;
+    expect(timesWritten(999)).toBe(1);
+    expect(timesWritten(1000)).toBe(1);
+    expect(timesWritten(1499)).toBe(1);
+
+    requestAnimationFrameSpy.mockRestore();
+  });
+
   it('broadcasts severity updates to other hook instances', async () => {
     const getLogsMock = vi.fn(() => {
       return () => {};

--- a/frontend/src/components/common/Resource/LogsButton.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.tsx
@@ -143,9 +143,14 @@ export function WorkloadLogs({ item }: WorkloadLogsProps) {
 
   // Re-render xterm when selectedSeverities changes without restarting the stream
   useEffect(() => {
-    if (xtermRef.current && logs.logs.length > 0) {
+    // Only the entries up to lastLineShown have reached the terminal: a drain can still
+    // have frames queued for the rest. Rewriting the whole batch here would leave those
+    // frames appending their entries a second time, duplicating the tail.
+    const shown = logs.logs.slice(0, logs.lastLineShown + 1);
+
+    if (xtermRef.current && shown.length > 0) {
       xtermRef.current.clear();
-      const filtered = filterLogsBySeverity(logs.logs, selectedSeverities);
+      const filtered = filterLogsBySeverity(shown, selectedSeverities);
       xtermRef.current.write(filtered.join('').replaceAll('\n', '\r\n'));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -360,6 +365,7 @@ export function WorkloadLogs({ item }: WorkloadLogsProps) {
     }
 
     let cleanup: (() => void) | null = null;
+    let cancelDrain: (() => void) | null = null;
     let isSubscribed = true;
 
     // Handle paused logs state - avoid fetching new logs
@@ -375,47 +381,58 @@ export function WorkloadLogs({ item }: WorkloadLogsProps) {
       const pod = pods[selectedPodIndex as number];
       if (pod) {
         let lastLogLength = 0;
+        let latestLogs: string[] = [];
+        let drainHandle: number | null = null;
+
+        // Write the entries that have not been displayed yet in bounded chunks, yielding
+        // to the browser between them. A single callback can carry more entries than one
+        // chunk holds, so keep scheduling frames until everything has been drained,
+        // otherwise the tail of a large batch would stay undisplayed once the stream ends.
+        const drain = () => {
+          drainHandle = null;
+
+          const terminalRef = xtermRef.current;
+          if (!isSubscribed || !terminalRef || lastLogLength >= latestLogs.length) return;
+
+          const CHUNK_SIZE = 1000; // Process 1000 lines at a time
+          const startIdx = lastLogLength;
+          const endIdx = Math.min(startIdx + CHUNK_SIZE, latestLogs.length);
+
+          // Apply severity filter to the new chunk using the ref to avoid effect restart
+          const chunk = latestLogs.slice(startIdx, endIdx);
+          const filteredChunk = filterLogsBySeverity(chunk, selectedSeveritiesRef.current);
+          terminalRef.write(filteredChunk.join('').replaceAll('\n', '\r\n'));
+          lastLogLength = endIdx;
+
+          setLogs({
+            logs: latestLogs, // Keep raw logs for downloads
+            lastLineShown: endIdx - 1,
+          });
+
+          // If there are more logs to process, schedule them for the next frame
+          if (lastLogLength < latestLogs.length) {
+            drainHandle = requestAnimationFrame(drain);
+          }
+        };
+
+        cancelDrain = () => {
+          if (drainHandle !== null) {
+            cancelAnimationFrame(drainHandle);
+            drainHandle = null;
+          }
+        };
+
         cleanup = pod.getLogs(
           selectedContainer,
           ({ logs: newLogs }: { logs: string[]; hasJsonLogs?: boolean }) => {
             if (!isSubscribed) return;
 
-            setLogs(current => {
-              const terminalRef = xtermRef.current;
-              if (!terminalRef) return current;
+            latestLogs = newLogs;
 
-              // Only process new logs in chunks for better performance
-              if (newLogs.length > lastLogLength) {
-                const CHUNK_SIZE = 1000; // Process 1000 lines at a time
-                const startIdx = lastLogLength;
-                const endIdx = Math.min(startIdx + CHUNK_SIZE, newLogs.length);
-
-                // Apply severity filter to the new chunk using the ref to avoid effect restart
-                const chunk = newLogs.slice(startIdx, endIdx);
-                const filteredChunk = filterLogsBySeverity(chunk, selectedSeveritiesRef.current);
-                const filteredContent = filteredChunk.join('').replaceAll('\n', '\r\n');
-
-                terminalRef.write(filteredContent);
-                lastLogLength = endIdx;
-
-                // If there are more logs to process, schedule them for the next frame
-                if (endIdx < newLogs.length) {
-                  requestAnimationFrame(() => {
-                    setLogs(current => ({
-                      ...current,
-                      logs: newLogs, // Keep raw logs for downloads
-                      lastLineShown: endIdx - 1,
-                    }));
-                  });
-                  return current;
-                }
-              }
-
-              return {
-                logs: newLogs, // Keep raw logs
-                lastLineShown: newLogs.length - 1,
-              };
-            });
+            // A drain is already in flight; it picks the new entries up on its next frame.
+            if (drainHandle === null) {
+              drain();
+            }
           },
           {
             tailLines: lines,
@@ -434,6 +451,9 @@ export function WorkloadLogs({ item }: WorkloadLogsProps) {
 
     return () => {
       isSubscribed = false;
+      if (cancelDrain) {
+        cancelDrain();
+      }
       if (cleanup) {
         cleanup();
       }

--- a/frontend/src/components/common/Resource/logSeverityFilter.test.ts
+++ b/frontend/src/components/common/Resource/logSeverityFilter.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { detectSeverity, filterLogsBySeverity } from './logSeverityFilter';
+import { ALL_SEVERITIES, detectSeverity, filterLogsBySeverity } from './logSeverityFilter';
 
 describe('logSeverityFilter', () => {
   describe('detectSeverity', () => {
@@ -97,6 +97,64 @@ describe('logSeverityFilter', () => {
     it('returns only structureless logs if no severities are selected', () => {
       const result = filterLogsBySeverity(logs, []);
       expect(result).toEqual(['Plain text log without severity']);
+    });
+  });
+
+  describe('filterLogsBySeverity with one line per entry', () => {
+    const lines = [
+      '{"level":"info","message":"test0"}\n',
+      '{"level":"warn","message":"test1"}\n',
+      '{"level":"error","message":"test2"}\n',
+    ];
+
+    it('keeps only the error line', () => {
+      expect(filterLogsBySeverity(lines, ['error'])).toEqual([
+        '{"level":"error","message":"test2"}\n',
+      ]);
+    });
+
+    it('keeps only the info line', () => {
+      expect(filterLogsBySeverity(lines, ['info'])).toEqual([
+        '{"level":"info","message":"test0"}\n',
+      ]);
+    });
+
+    it('keeps every line when all severities are selected', () => {
+      expect(filterLogsBySeverity(lines, ALL_SEVERITIES).join('')).toBe(lines.join(''));
+    });
+
+    it('keeps lines with no detectable severity', () => {
+      const mixed = ['plain line\n', '{"level":"error","message":"boom"}\n'];
+      expect(filterLogsBySeverity(mixed, ['warn'])).toEqual(['plain line\n']);
+    });
+
+    it('rejoins to the original text when nothing is filtered out', () => {
+      expect(filterLogsBySeverity(lines, ['error', 'warn', 'info']).join('')).toBe(lines.join(''));
+    });
+  });
+
+  describe('filterLogsBySeverity with prettified entries', () => {
+    const prettify = (level: string, message: string) =>
+      JSON.stringify({ level, message }, null, 2) + '\n';
+
+    const entries = [prettify('info', 'test0'), prettify('error', 'test2')];
+
+    it('drops a whole prettified object rather than part of it', () => {
+      expect(filterLogsBySeverity(entries, ['error'])).toEqual([prettify('error', 'test2')]);
+    });
+
+    it('never leaks a fragment of a filtered-out object', () => {
+      expect(filterLogsBySeverity(entries, ['error']).join('')).not.toContain('test0');
+    });
+
+    it('keeps a whole prettified object that matches', () => {
+      expect(filterLogsBySeverity(entries, ['info'])).toEqual([prettify('info', 'test0')]);
+    });
+
+    it('keeps a prettified object with a timestamp in front of it', () => {
+      const timestamped = '2025-01-01T00:00:00Z\n' + prettify('error', 'boom');
+      expect(filterLogsBySeverity([timestamped], ['error'])).toEqual([timestamped]);
+      expect(filterLogsBySeverity([timestamped], ['info'])).toEqual([]);
     });
   });
 });

--- a/frontend/src/components/common/Resource/logSeverityFilter.ts
+++ b/frontend/src/components/common/Resource/logSeverityFilter.ts
@@ -90,14 +90,17 @@ function normalizeSeverity(token: string): LogSeverity {
 }
 
 /**
- * Filter an array of log lines by the selected severity levels.
+ * Filter log entries by the selected severity levels.
  *
- * Lines with no detectable severity are always included to avoid
+ * An entry is matched as a whole, so a prettified JSON object spanning
+ * several lines is never broken up.
+ *
+ * Entries with no detectable severity are always included to avoid
  * hiding plain-text or structureless output.
  *
- * @param logs - The full array of log lines.
+ * @param logs - The log entries.
  * @param selectedSeverities - The severity levels to keep.
- * @returns The filtered array of log lines.
+ * @returns The matching entries, preserving any existing trailing newline.
  */
 export function filterLogsBySeverity(logs: string[], selectedSeverities: LogSeverity[]): string[] {
   // If all severities are selected, skip filtering for performance
@@ -107,9 +110,9 @@ export function filterLogsBySeverity(logs: string[], selectedSeverities: LogSeve
 
   const severitySet = new Set(selectedSeverities);
 
-  return logs.filter(line => {
-    const severity = detectSeverity(line);
-    // Always show lines with no detectable severity
+  return logs.filter(entry => {
+    const severity = detectSeverity(entry);
+    // Always show entries with no detectable severity
     if (severity === null) {
       return true;
     }

--- a/frontend/src/lib/k8s/pod.test.ts
+++ b/frontend/src/lib/k8s/pod.test.ts
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+import { Base64 } from 'js-base64';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import App from '../../App';
 import { post } from './api/v1/clusterRequests';
+import { stream } from './api/v1/streamingApi';
 import Pod from './pod';
 
 // cyclic imports fix
@@ -35,6 +37,13 @@ vi.mock('./api/v1/clusterRequests', async importOriginal => {
       capturedPatchBodies.push(body);
     }),
   };
+});
+
+vi.mock('./api/v1/streamingApi', async () => {
+  const actual = await vi.importActual<typeof import('./api/v1/streamingApi')>(
+    './api/v1/streamingApi'
+  );
+  return { ...actual, stream: vi.fn() };
 });
 
 describe('Pod class', () => {
@@ -216,6 +225,103 @@ describe('Pod class', () => {
     it('classifies a Succeeded pod as healthy', () => {
       const pod = makePod({ phase: 'Succeeded' });
       expect(pod.getHealth()).toBe('healthy');
+    });
+  });
+  describe('getLogs', () => {
+    const chunk =
+      '{"level":"info","message":"test0"}\n' +
+      '{"level":"warn","message":"test1"}\n' +
+      '{"level":"error","message":"test2"}\n';
+
+    function startLogStream(logsOptions: object = {}) {
+      let onResults: (item: string) => void = () => {};
+      let onFail: () => void = () => {};
+      const cancelStream = vi.fn();
+
+      vi.mocked(stream).mockImplementation(((
+        _url: string,
+        cb: (item: string) => void,
+        args: { failCb?: () => void }
+      ) => {
+        onResults = cb;
+        onFail = args.failCb ?? (() => {});
+        return { cancel: cancelStream, getSocket: () => null };
+      }) as any);
+
+      const pod = new Pod(JSON.parse(JSON.stringify(mockPodData)));
+      const updates: string[][] = [];
+      const cancel = pod.getLogs('container-1', ({ logs }) => updates.push([...logs]), {
+        follow: true,
+        ...logsOptions,
+      });
+
+      return {
+        send: (text: string) => onResults(Base64.encode(text)),
+        endStream: () => onFail(),
+        cancel,
+        cancelStream,
+        last: () => updates[updates.length - 1],
+        updateCount: () => updates.length,
+      };
+    }
+
+    it('gives each line of a chunk its own entry', () => {
+      const logStream = startLogStream();
+      logStream.send(chunk);
+
+      expect(logStream.last()).toEqual([
+        '{"level":"info","message":"test0"}\n',
+        '{"level":"warn","message":"test1"}\n',
+        '{"level":"error","message":"test2"}\n',
+      ]);
+    });
+
+    it('rejoins the lines to the original text', () => {
+      const logStream = startLogStream();
+      logStream.send(chunk);
+
+      expect(logStream.last().join('')).toBe(chunk);
+    });
+
+    it('waits for the rest of a line split across two chunks', () => {
+      const logStream = startLogStream();
+
+      logStream.send('{"level":"error","mess');
+      expect(logStream.last()).toEqual([]);
+
+      logStream.send('age":"split"}\n');
+      expect(logStream.last()).toEqual(['{"level":"error","message":"split"}\n']);
+    });
+
+    it('emits a trailing line without a newline once the stream ends', () => {
+      const logStream = startLogStream();
+
+      logStream.send('{"level":"error","message":"last"}');
+      expect(logStream.last()).toEqual([]);
+
+      logStream.endStream();
+      expect(logStream.last()).toEqual(['{"level":"error","message":"last"}']);
+    });
+
+    it('does not report logs while being cancelled', () => {
+      const logStream = startLogStream();
+
+      logStream.send('{"level":"error","message":"last"}');
+      const updatesBeforeCancel = logStream.updateCount();
+
+      logStream.cancel();
+      expect(logStream.updateCount()).toBe(updatesBeforeCancel);
+      expect(logStream.cancelStream).toHaveBeenCalled();
+    });
+
+    it('prettifies every line of a chunk, not only the first', () => {
+      const logStream = startLogStream({ prettifyLogs: true });
+      logStream.send(chunk);
+
+      const output = logStream.last().join('');
+      expect(output).toContain('test0');
+      expect(output).toContain('test1');
+      expect(output).toContain('test2');
     });
   });
 });

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -201,6 +201,8 @@ class Pod extends KubeObject<KubePod> {
 
     let logs: string[] = [];
     let hasJsonLogs = false;
+    let pending = '';
+    let decoder = new TextDecoder();
     let url = `/api/v1/namespaces/${this.getNamespace()}/pods/${this.getName()}/log?container=${container}&previous=${showPrevious}&timestamps=${showTimestamps}&follow=${follow}`;
 
     // Negative tailLines parameter fetches all logs. If it's non negative it fetches
@@ -248,16 +250,39 @@ class Pod extends KubeObject<KubePod> {
       }
     }
 
+    function splitLines(text: string): string[] {
+      return text.match(/[^\n]*\n|[^\n]+/g) ?? [];
+    }
+
+    function pushLine(line: string) {
+      const jsonMatch = line.trim().match(/(\{.*\})/);
+      if (jsonMatch) hasJsonLogs = true;
+      logs.push(hasJsonLogs && prettifyLogs ? prettifyLogLine(line) : line);
+    }
+
+    function flushPending() {
+      pending += decoder.decode();
+
+      if (pending === '') return;
+
+      pushLine(pending);
+      pending = '';
+      onLogs({ logs, hasJsonLogs });
+    }
+
     function onResults(item: string) {
       if (!item) return;
 
-      const decodedLog = Base64.decode(item);
-      if (!decodedLog || decodedLog.trim() === '') return;
-      const trimmedLog = decodedLog.trim();
-      const jsonMatch = trimmedLog.match(/(\{.*\})/);
-      if (jsonMatch) hasJsonLogs = true;
-      const processedLog = hasJsonLogs && prettifyLogs ? prettifyLogLine(decodedLog) : decodedLog;
-      logs.push(processedLog);
+      // Decode as a stream: the backend base64-encodes each message on its own, so a
+      // multibyte character can be split across two of them.
+      const decodedLog = decoder.decode(Base64.toUint8Array(item), { stream: true });
+      if (!decodedLog) return;
+
+      const lines = splitLines(pending + decodedLog);
+      const lastLine = lines[lines.length - 1];
+      pending = lastLine !== undefined && !lastLine.endsWith('\n') ? (lines.pop() as string) : '';
+
+      lines.forEach(pushLine);
       onLogs({ logs, hasJsonLogs });
     }
 
@@ -267,6 +292,8 @@ class Pod extends KubeObject<KubePod> {
       connectCb: () => {
         logs = [];
         hasJsonLogs = false;
+        pending = '';
+        decoder = new TextDecoder();
       },
       /**
        * This callback is called when the connection is closed. It then check
@@ -274,6 +301,8 @@ class Pod extends KubeObject<KubePod> {
        * due to an error, it stops further reconnection attempts.
        */
       failCb: () => {
+        flushPending();
+
         // If it's a reconnection attempt, stop further reconnection attempts
         if (follow && isReconnecting) {
           isReconnecting = false;

--- a/frontend/src/lib/k8s/podLogSeverity.test.ts
+++ b/frontend/src/lib/k8s/podLogSeverity.test.ts
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Base64 } from 'js-base64';
+import { describe, expect, it, vi } from 'vitest';
+import App from '../../App';
+import {
+  ALL_SEVERITIES,
+  filterLogsBySeverity,
+  LogSeverity,
+} from '../../components/common/Resource/logSeverityFilter';
+import { stream } from './api/v1/streamingApi';
+import Pod from './pod';
+
+// cyclic imports fix
+// eslint-disable-next-line no-unused-vars
+const _dont_delete_me = App;
+
+vi.mock('./api/v1/streamingApi', async () => {
+  const actual = await vi.importActual<typeof import('./api/v1/streamingApi')>(
+    './api/v1/streamingApi'
+  );
+  return { ...actual, stream: vi.fn() };
+});
+
+describe('pod log severity filtering', () => {
+  const REPRO =
+    '{"level":"info","message":"test0"}\n' +
+    '{"level":"warn","message":"test1"}\n' +
+    '{"level":"error","message":"test2"}\n' +
+    '{"level":"warn","message":"test3"}\n' +
+    '{"level":"debug","message":"test4"}\n';
+
+  function streamLogs(
+    chunks: Array<string | Uint8Array>,
+    logsOptions: object = {},
+    complete = false
+  ): string[] {
+    let onResults: (item: string) => void = () => {};
+    let failCb: () => void = () => {};
+    vi.mocked(stream).mockImplementation(((
+      _url: string,
+      cb: (item: string) => void,
+      options: { failCb?: () => void }
+    ) => {
+      onResults = cb;
+      failCb = options?.failCb ?? (() => {});
+      return { cancel: vi.fn(), getSocket: () => null };
+    }) as any);
+
+    const pod = new Pod({
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: { name: 'test-pod', namespace: 'default', resourceVersion: '123' },
+      spec: { containers: [{ name: 'container-1' }] },
+      status: {},
+    } as any);
+
+    let received: string[] = [];
+    pod.getLogs('container-1', ({ logs }) => (received = [...logs]), {
+      follow: true,
+      ...logsOptions,
+    });
+    chunks.forEach(chunk =>
+      onResults(typeof chunk === 'string' ? Base64.encode(chunk) : Base64.fromUint8Array(chunk))
+    );
+    if (complete) {
+      failCb();
+    }
+
+    return received;
+  }
+
+  const messagesFor = (logs: string[], severities: LogSeverity[]) =>
+    filterLogsBySeverity(logs, severities)
+      .join('')
+      .match(/test\d/g) ?? [];
+
+  const arrivals: Record<string, string[]> = {
+    'a single chunk': [REPRO],
+    'two chunks split mid-line': [REPRO.slice(0, 80), REPRO.slice(80)],
+    'one message per line': REPRO.split(/(?<=\n)/).filter(Boolean),
+  };
+
+  Object.entries(arrivals).forEach(([name, chunks]) => {
+    describe(`arriving as ${name}`, () => {
+      const logs = streamLogs(chunks);
+
+      it('shows every line when all severities are selected', () => {
+        expect(messagesFor(logs, ALL_SEVERITIES)).toEqual([
+          'test0',
+          'test1',
+          'test2',
+          'test3',
+          'test4',
+        ]);
+      });
+
+      it('shows only the error line', () => {
+        expect(messagesFor(logs, ['error'])).toEqual(['test2']);
+      });
+
+      it('shows only the warn lines', () => {
+        expect(messagesFor(logs, ['warn'])).toEqual(['test1', 'test3']);
+      });
+
+      it('shows only the info line', () => {
+        expect(messagesFor(logs, ['info'])).toEqual(['test0']);
+      });
+
+      it('shows only the debug line', () => {
+        expect(messagesFor(logs, ['debug'])).toEqual(['test4']);
+      });
+
+      it('rejoins the lines to the original text', () => {
+        expect(logs.join('')).toBe(REPRO);
+      });
+    });
+  });
+
+  describe('with prettified logs', () => {
+    const logs = streamLogs([REPRO], { prettifyLogs: true });
+
+    it('gives each message its own prettified entry', () => {
+      expect(logs).toHaveLength(5);
+    });
+
+    it('shows only the error message', () => {
+      expect(messagesFor(logs, ['error'])).toEqual(['test2']);
+    });
+
+    it('shows only the warn messages', () => {
+      expect(messagesFor(logs, ['warn'])).toEqual(['test1', 'test3']);
+    });
+
+    it('keeps each shown object intact', () => {
+      const shown = filterLogsBySeverity(logs, ['error']).join('');
+      expect(JSON.parse(shown)).toEqual({ level: 'error', message: 'test2' });
+    });
+
+    it('leaks no fragment of a filtered-out object', () => {
+      const shown = filterLogsBySeverity(logs, ['error']).join('');
+      ['test0', 'test1', 'test3', 'test4'].forEach(message => expect(shown).not.toContain(message));
+    });
+  });
+
+  describe('with a multibyte character split across two messages', () => {
+    const text = 'héllo wörld — ünïcode\n';
+    const bytes = new TextEncoder().encode(text);
+    const splitAt = new TextEncoder().encode(text.slice(0, text.indexOf('—'))).length + 1;
+    const logs = streamLogs([bytes.slice(0, splitAt), bytes.slice(splitAt)]);
+
+    it('rejoins the messages to the original text', () => {
+      expect(logs.join('')).toBe(text);
+    });
+
+    it('does not corrupt the split character', () => {
+      expect(logs.join('')).not.toContain('�');
+    });
+  });
+
+  describe('with blank lines', () => {
+    const text = '{"level":"info","message":"test0"}\n\n   \n{"level":"error","message":"test2"}\n';
+
+    it('keeps them in the rejoined text', () => {
+      expect(streamLogs([text]).join('')).toBe(text);
+    });
+
+    it('keeps them when each line arrives on its own', () => {
+      expect(streamLogs(text.split(/(?<=\n)/).filter(Boolean)).join('')).toBe(text);
+    });
+  });
+
+  describe('when the stream ends', () => {
+    it('flushes a last line that never got a newline', () => {
+      const logs = streamLogs(['test0\n', 'no newline'], {}, true);
+      expect(logs.join('')).toBe('test0\nno newline');
+    });
+
+    it('flushes a last line of only whitespace', () => {
+      expect(streamLogs(['test0\n', '  '], {}, true).join('')).toBe('test0\n  ');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes the log severity filter selecting the wrong lines, by making each log line its own entry instead of letting one stream chunk hold several lines that were all judged by the severity of the first one. The log stream arrives chunked on arbitrary byte boundaries rather than on line ends, so one chunk could carry several lines and one line could span two chunks. That is why the misclassification got worse the more log lines there were.

## Related Issue

Fixes #7137

## Changes

- Updated `frontend/src/lib/k8s/pod.ts` — `getLogs()` splits each chunk on newlines and holds back a trailing partial line until the rest arrives, so one stored entry is always one log line
- Fixed the last line of a stream being dropped when it has no trailing newline, by flushing the held-back line from `failCb` instead of from the cancel path
- Updated `frontend/src/components/common/Resource/logSeverityFilter.ts` — documented that an entry is matched as a whole (logic unchanged)
- Added tests for chunk splitting, lines spanning two chunks, prettified entries, and the reported reproduction end to end

## Steps to Test

1. Create a pod that emits JSON logs with explicit severity levels:

   ```sh
   kubectl run log-severity-demo --image=busybox --restart=Never -- sh -c '
     echo "{\"level\":\"info\",\"message\":\"test0\"}"
     echo "{\"level\":\"warn\",\"message\":\"test1\"}"
     echo "{\"level\":\"error\",\"message\":\"test2\"}"
     echo "{\"level\":\"warn\",\"message\":\"test3\"}"
     echo "{\"level\":\"debug\",\"message\":\"test4\"}"
     sleep 3600'
   ```

2. Open the pod in Headlamp, click **Logs**, leave **Prettify** off.
3. Filter by **Error** → only `test2`. **Warning** → `test1` and `test3`.  **Info** → `test0`. **Debug** → `test4`. All severities → all five.
4. Turn **Prettify** on and repeat. Each view should show whole JSON objects, never a stray `{`, `}`, or lone field from a filtered-out log.

## Notes for the Reviewer

- The `logSeverityFilter.ts` diff is docs and a rename only; its logic is identical to `main`. The real fix is entirely in `pod.ts`.
- `failCb` is used rather than the cancel path because `connectStream` skips `onFail` when we close the socket ourselves, so it fires exactly when the stream ends on its own. Flushing from cancel pushed a debounced `setState` while the log viewer was tearing down.
- Entries are classified whole rather than re-split inside the filter, because with **Prettify** on an entry is a multi-line JSON object — splitting it would drop its `"level"` line and leave the braces and remaining fields on screen. There is a test for this.

