### PR TITLE
Fix clusters randomly requiring an ID token after a kubeconfig reload

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1936,7 +1936,13 @@ func clusterRequestHandler(c *HeadlampConfig) http.Handler { //nolint:funlen
 
 		contextKey, kContext, err := c.getContextWithWebSocketFallback(r, contextKey)
 		if err != nil {
-			c.handleError(w, ctx, span, err, "failed to get context", http.StatusNotFound)
+			// The store returns a bare "key not found" here, which reaches the client as
+			// the body of this 404 and reads like a problem on the cluster's side. Name
+			// the cluster the backend could not find instead.
+			c.handleError(w, ctx, span,
+				fmt.Errorf("cluster %q not found: %w", mux.Vars(r)["clusterName"], err),
+				"failed to get context", http.StatusNotFound)
+
 			return
 		}
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -4581,3 +4581,37 @@ func TestExternalProxyOversizeResponseGzip(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, int(maxProxyResponseSize), rr.Body.Len())
 }
+
+// The store answers a miss with a bare "key not found", which used to reach the
+// browser as the body of this 404 and read like the cluster had rejected the
+// request. The response has to name the cluster the backend could not find.
+func TestClusterRequestUnknownClusterNamesTheCluster(t *testing.T) {
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("APPDATA", t.TempDir())
+
+	cfg := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:    false,
+				KubeConfigPath:  filepath.Join(t.TempDir(), "missing-kubeconfig"),
+				KubeConfigStore: kubeconfig.NewContextStore(),
+			},
+			Cache:            cache.New[interface{}](),
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	}
+
+	handler := createHeadlampHandler(context.Background(), cfg)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/clusters/no-such-cluster/api/v1/pods", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+	assert.Contains(t, rr.Body.String(), `cluster "no-such-cluster" not found`)
+}

--- a/backend/pkg/kubeconfig/export_test.go
+++ b/backend/pkg/kubeconfig/export_test.go
@@ -32,3 +32,6 @@ func (rt *UserAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 
 	return urt.RoundTrip(req)
 }
+
+// SyncContexts is exported for testing.
+var SyncContexts = syncContexts

--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -498,6 +498,11 @@ func (c *Context) AuthType() string {
 type ContextLoadError struct {
 	ContextName string
 	Error       error
+	// KubeConfigPath is the file the context was read from, when it came from one.
+	// With ContextName it identifies the context the same way Context.ClusterID
+	// does, which is what lets callers match a failure against a stored context
+	// whose name has since been replaced by a custom one.
+	KubeConfigPath string
 }
 
 // LoadContextsFromFile loads contexts from a kubeconfig file.
@@ -521,7 +526,13 @@ func LoadContextsFromFile(kubeConfigPath string, source int) ([]Context, []Conte
 	for i := range contexts {
 		contexts[i].KubeConfigPath = kubeConfigPath
 		// create the clusterID from the path and context name
-		contexts[i].ClusterID = fmt.Sprintf("%s+%s", kubeConfigPath, contexts[i].Name)
+		contexts[i].ClusterID = ContextClusterID(kubeConfigPath, contexts[i].Name)
+	}
+
+	// The failures need the same origin, so callers can identify which stored
+	// context each one refers to.
+	for i := range contextErrors {
+		contextErrors[i].KubeConfigPath = kubeConfigPath
 	}
 
 	return contexts, contextErrors, nil
@@ -1345,12 +1356,22 @@ func SkipKubeContextInCommaSeparatedString(blackKubeContextNameStr string) shoul
 func LoadAndStoreKubeConfigs(kubeConfigStore ContextStore, kubeConfigs string, source int,
 	ignoreFunc shouldBeSkippedFunc,
 ) error {
-	var errs []error
-
 	kubeConfigContexts, contextErrors, err := LoadContextsFromMultipleFiles(kubeConfigs, source)
 	if err != nil {
 		return fmt.Errorf("error loading kubeconfig files: %w", err)
 	}
+
+	return storeContexts(kubeConfigStore, kubeConfigContexts, contextErrors, ignoreFunc)
+}
+
+// storeContexts stores the given contexts in the store, skipping the ones the
+// ignoreFunc rejects. contextErrors are the load errors from the parse that
+// produced the contexts; they are returned joined with any error hit while
+// storing, so callers report them the same way regardless of which one failed.
+func storeContexts(kubeConfigStore ContextStore, contexts []Context,
+	contextErrors []ContextLoadError, ignoreFunc shouldBeSkippedFunc,
+) error {
+	var errs []error
 
 	// if pass the shouldBeSkippedFunc=nil, it works like before
 	_ignoreFunc := ignoreFunc
@@ -1358,7 +1379,7 @@ func LoadAndStoreKubeConfigs(kubeConfigStore ContextStore, kubeConfigs string, s
 		_ignoreFunc = AllowAllKubeContext
 	}
 
-	for _, kubeConfigContext := range kubeConfigContexts {
+	for _, kubeConfigContext := range contexts {
 		if _ignoreFunc(kubeConfigContext) {
 			continue
 		}
@@ -1376,6 +1397,13 @@ func LoadAndStoreKubeConfigs(kubeConfigStore ContextStore, kubeConfigs string, s
 	}
 
 	return errors.Join(errs...)
+}
+
+// ContextClusterID builds the identifier that ties a context to the file it was
+// read from. It stays stable when a context is stored under a custom name, so it
+// is the way to recognise a stored context from a fresh read of the kubeconfig.
+func ContextClusterID(kubeConfigPath, contextName string) string {
+	return fmt.Sprintf("%s+%s", kubeConfigPath, MakeDNSFriendly(contextName))
 }
 
 // MakeDNSFriendly converts a string to a DNS-friendly format.

--- a/backend/pkg/kubeconfig/watcher.go
+++ b/backend/pkg/kubeconfig/watcher.go
@@ -124,7 +124,7 @@ func addFilesToWatcher(watcher *fsnotify.Watcher, paths []string) {
 // syncContexts synchronizes the contexts in the store with the ones in the kubeconfig files.
 func syncContexts(kubeConfigStore ContextStore, paths string, source int, ignoreFunc shouldBeSkippedFunc) error {
 	// First read all kubeconfig files to get new contexts
-	newContexts, _, err := LoadContextsFromMultipleFiles(paths, source)
+	newContexts, contextLoadErrors, err := LoadContextsFromMultipleFiles(paths, source)
 	if err != nil {
 		return fmt.Errorf("error reading kubeconfig files: %w", err)
 	}
@@ -135,11 +135,68 @@ func syncContexts(kubeConfigStore ContextStore, paths string, source int, ignore
 		return fmt.Errorf("error getting existing contexts: %w", err)
 	}
 
-	// Find and remove contexts that no longer exist in the kubeconfig
-	// but only for contexts that came from KubeConfig source
+	removeStaleContexts(kubeConfigStore, existingContexts, newContexts, contextLoadErrors)
+
+	// Now store the contexts read above. Reusing that read instead of loading the
+	// files again keeps the removals and the additions based on the same view of
+	// the kubeconfig.
+	if err := storeContexts(kubeConfigStore, newContexts, contextLoadErrors, ignoreFunc); err != nil {
+		return fmt.Errorf("error storing contexts: %w", err)
+	}
+
+	return nil
+}
+
+// failedContextIDs indexes the contexts that failed to load, by both the ClusterID
+// they would have been given and their plain name.
+//
+// A stored context is keyed by its custom name once it has been renamed in
+// Headlamp, so its name no longer matches the one the kubeconfig reports for the
+// failure. ClusterID keeps the original file-and-context identity through a
+// rename, so it is what recognises those. The plain name is only there for
+// contexts read from somewhere other than a file, which have no ClusterID.
+func failedContextIDs(contextLoadErrors []ContextLoadError) map[string]bool {
+	failed := make(map[string]bool, len(contextLoadErrors)*2)
+
+	for _, contextLoadError := range contextLoadErrors {
+		if contextLoadError.ContextName == "" {
+			continue
+		}
+
+		failed[MakeDNSFriendly(contextLoadError.ContextName)] = true
+
+		if contextLoadError.KubeConfigPath != "" {
+			failed[ContextClusterID(contextLoadError.KubeConfigPath, contextLoadError.ContextName)] = true
+		}
+	}
+
+	return failed
+}
+
+// removeStaleContexts removes the contexts that no longer exist in the kubeconfig
+// files, but only the ones that came from the KubeConfig source.
+//
+// Contexts that failed to load are kept. Such a context is still in the kubeconfig,
+// it just could not be parsed this time around: kubectl and friends rewrite
+// kubeconfig files in place rather than atomically, so a reload landing mid-write
+// can see a context whose cluster or user entry has not been written back yet.
+// Removing it would leave it missing from the store until the next change event or
+// a restart, and every request for it would fail meanwhile as if the cluster needed
+// a token. Keep it and let the next reload correct it instead.
+func removeStaleContexts(kubeConfigStore ContextStore, existingContexts []*Context,
+	newContexts []Context, contextLoadErrors []ContextLoadError,
+) {
+	failedToLoad := failedContextIDs(contextLoadErrors)
+
 	for _, existingCtx := range existingContexts {
-		// Skip contexts from other sources
-		if existingCtx.Source != KubeConfig {
+		// Skip contexts from other sources, and the ones that just failed to load.
+		// A context read from a file is matched by its ClusterID, which is
+		// qualified by that file: two kubeconfigs may hold a context of the same
+		// name, and matching on the name alone would let a failure in one of them
+		// keep a context the other one really did remove. The name is only used
+		// for entries that have no ClusterID to match on.
+		if existingCtx.Source != KubeConfig || failedToLoad[existingCtx.ClusterID] ||
+			(existingCtx.ClusterID == "" && failedToLoad[MakeDNSFriendly(existingCtx.Name)]) {
 			continue
 		}
 
@@ -160,12 +217,4 @@ func syncContexts(kubeConfigStore ContextStore, paths string, source int, ignore
 			}
 		}
 	}
-
-	// Now load and store the new configurations
-	err = LoadAndStoreKubeConfigs(kubeConfigStore, paths, source, ignoreFunc)
-	if err != nil {
-		return fmt.Errorf("error loading kubeconfig files: %w", err)
-	}
-
-	return nil
 }

--- a/backend/pkg/kubeconfig/watcher_test.go
+++ b/backend/pkg/kubeconfig/watcher_test.go
@@ -3,6 +3,7 @@ package kubeconfig_test
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -115,4 +116,315 @@ func TestWatchAndLoadFiles(t *testing.T) {
 			require.NoError(t, err)
 		}
 	}()
+}
+
+// twoContextKubeconfig is a kubeconfig with two independent contexts.
+const twoContextKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://cluster-a.example.com
+  name: cluster-a
+- cluster:
+    server: https://cluster-b.example.com
+  name: cluster-b
+contexts:
+- context:
+    cluster: cluster-a
+    user: user-a
+  name: context-a
+- context:
+    cluster: cluster-b
+    user: user-b
+  name: context-b
+current-context: context-a
+users:
+- name: user-a
+  user:
+    token: token-a
+- name: user-b
+  user:
+    token: token-b
+`
+
+// partiallyWrittenKubeconfig is what twoContextKubeconfig looks like when it is
+// read while being rewritten in place: context-b is there but the user entry it
+// points at has not been written back yet.
+const partiallyWrittenKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://cluster-a.example.com
+  name: cluster-a
+- cluster:
+    server: https://cluster-b.example.com
+  name: cluster-b
+contexts:
+- context:
+    cluster: cluster-a
+    user: user-a
+  name: context-a
+- context:
+    cluster: cluster-b
+    user: user-b
+  name: context-b
+current-context: context-a
+users:
+- name: user-a
+  user:
+    token: token-a
+`
+
+// singleContextKubeconfig is twoContextKubeconfig with context-b genuinely removed.
+const singleContextKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://cluster-a.example.com
+  name: cluster-a
+contexts:
+- context:
+    cluster: cluster-a
+    user: user-a
+  name: context-a
+current-context: context-a
+users:
+- name: user-a
+  user:
+    token: token-a
+`
+
+// writeKubeconfig writes contents to path, failing the test if it cannot.
+func writeKubeconfig(t *testing.T, path, contents string) {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+}
+
+// storeWithBothContexts returns a store loaded from a kubeconfig holding both
+// contexts, along with the path of that kubeconfig.
+func storeWithBothContexts(t *testing.T) (kubeconfig.ContextStore, string) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "config")
+	writeKubeconfig(t, path, twoContextKubeconfig)
+
+	store := kubeconfig.NewContextStore()
+	require.NoError(t, kubeconfig.LoadAndStoreKubeConfigs(store, path, kubeconfig.KubeConfig, nil))
+
+	for _, name := range []string{"context-a", "context-b"} {
+		_, err := store.GetContext(name)
+		require.NoError(t, err, "%s should be loaded before syncing", name)
+	}
+
+	return store, path
+}
+
+// A context that fails to load is still in the kubeconfig, it just could not be
+// parsed on this pass. Dropping it would leave it missing from the store until
+// the next change event or a restart, so it has to survive the sync. See #7154.
+func TestSyncContextsKeepsContextsThatFailedToLoad(t *testing.T) {
+	store, path := storeWithBothContexts(t)
+
+	writeKubeconfig(t, path, partiallyWrittenKubeconfig)
+
+	err := kubeconfig.SyncContexts(store, path, kubeconfig.KubeConfig, nil)
+	require.Error(t, err, "the partial kubeconfig should be reported as a load error")
+	require.Contains(t, err.Error(), "context-b")
+
+	_, err = store.GetContext("context-b")
+	require.NoError(t, err, "context-b should be kept after failing to load")
+
+	_, err = store.GetContext("context-a")
+	require.NoError(t, err, "context-a should be untouched")
+}
+
+// Contexts that are really gone from the kubeconfig still have to be removed.
+func TestSyncContextsRemovesDeletedContexts(t *testing.T) {
+	store, path := storeWithBothContexts(t)
+
+	writeKubeconfig(t, path, singleContextKubeconfig)
+
+	require.NoError(t, kubeconfig.SyncContexts(store, path, kubeconfig.KubeConfig, nil))
+
+	_, err := store.GetContext("context-b")
+	require.Error(t, err, "context-b should be removed once it is gone from the kubeconfig")
+
+	_, err = store.GetContext("context-a")
+	require.NoError(t, err, "context-a should be untouched")
+}
+
+// renamedKubeconfig is twoContextKubeconfig with context-b renamed in Headlamp,
+// so the store keys it by its custom name rather than the kubeconfig one.
+const renamedKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://cluster-a.example.com
+  name: cluster-a
+- cluster:
+    server: https://cluster-b.example.com
+  name: cluster-b
+contexts:
+- context:
+    cluster: cluster-a
+    user: user-a
+  name: context-a
+- context:
+    cluster: cluster-b
+    user: user-b
+    extensions:
+    - extension:
+        customName: renamed-b
+      name: headlamp_info
+  name: context-b
+current-context: context-a
+users:
+- name: user-a
+  user:
+    token: token-a
+- name: user-b
+  user:
+    token: token-b
+`
+
+// partiallyWrittenRenamedKubeconfig is renamedKubeconfig caught mid-rewrite, with
+// the user entry that context-b points at not written back yet.
+const partiallyWrittenRenamedKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://cluster-a.example.com
+  name: cluster-a
+- cluster:
+    server: https://cluster-b.example.com
+  name: cluster-b
+contexts:
+- context:
+    cluster: cluster-a
+    user: user-a
+  name: context-a
+- context:
+    cluster: cluster-b
+    user: user-b
+    extensions:
+    - extension:
+        customName: renamed-b
+      name: headlamp_info
+  name: context-b
+current-context: context-a
+users:
+- name: user-a
+  user:
+    token: token-a
+`
+
+// A renamed context is stored under its custom name, so a load failure reported
+// against the kubeconfig name has to be matched by ClusterID instead. Otherwise
+// the failure looks like a context that is gone and the rename gets dropped.
+func TestSyncContextsKeepsRenamedContextThatFailedToLoad(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	writeKubeconfig(t, path, renamedKubeconfig)
+
+	store := kubeconfig.NewContextStore()
+	require.NoError(t, kubeconfig.LoadAndStoreKubeConfigs(store, path, kubeconfig.KubeConfig, nil))
+
+	_, err := store.GetContext("renamed-b")
+	require.NoError(t, err, "the renamed context should be stored under its custom name")
+
+	writeKubeconfig(t, path, partiallyWrittenRenamedKubeconfig)
+
+	err = kubeconfig.SyncContexts(store, path, kubeconfig.KubeConfig, nil)
+	require.Error(t, err, "the partial kubeconfig should be reported as a load error")
+
+	_, err = store.GetContext("renamed-b")
+	require.NoError(t, err, "the renamed context should be kept after failing to load")
+
+	_, err = store.GetContext("context-a")
+	require.NoError(t, err, "context-a should be untouched")
+}
+
+// sharedNameKubeconfig holds a context named like the one in twoContextKubeconfig,
+// which kubeconfig supports across files.
+const sharedNameKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://cluster-c.example.com
+  name: cluster-c
+contexts:
+- context:
+    cluster: cluster-c
+    user: user-c
+  name: context-b
+current-context: context-b
+users:
+- name: user-c
+  user:
+    token: token-c
+`
+
+// partiallyWrittenSharedNameKubeconfig is sharedNameKubeconfig caught mid-rewrite,
+// with the user entry context-b points at not written back yet.
+const partiallyWrittenSharedNameKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://cluster-c.example.com
+  name: cluster-c
+contexts:
+- context:
+    cluster: cluster-c
+    user: user-c
+  name: context-b
+current-context: context-b
+users: []
+`
+
+// joinKubeConfigPaths joins paths the way the KUBECONFIG env var does.
+func joinKubeConfigPaths(paths ...string) string {
+	delimiter := ":"
+	if runtime.GOOS == "windows" {
+		delimiter = ";"
+	}
+
+	return strings.Join(paths, delimiter)
+}
+
+// A failure has to be matched against the file it came from. Two kubeconfigs can
+// hold a context of the same name, and the stored one belongs to whichever file
+// was read last; a failure in the other file says nothing about it, so it must
+// not keep it alive once its own file has dropped it.
+func TestSyncContextsRemovesDeletedContextDespiteSameNameFailingElsewhere(t *testing.T) {
+	dir := t.TempDir()
+
+	otherPath := filepath.Join(dir, "other-config")
+	writeKubeconfig(t, otherPath, sharedNameKubeconfig)
+
+	path := filepath.Join(dir, "config")
+	writeKubeconfig(t, path, twoContextKubeconfig)
+
+	paths := joinKubeConfigPaths(otherPath, path)
+
+	store := kubeconfig.NewContextStore()
+	require.NoError(t, kubeconfig.LoadAndStoreKubeConfigs(store, paths, kubeconfig.KubeConfig, nil))
+
+	storedB, err := store.GetContext("context-b")
+	require.NoError(t, err)
+	require.Equal(t, kubeconfig.ContextClusterID(path, "context-b"), storedB.ClusterID,
+		"the stored context-b should be the one from the file read last")
+
+	// The other file's context-b fails to load, while the file the stored one
+	// came from drops it for real.
+	writeKubeconfig(t, otherPath, partiallyWrittenSharedNameKubeconfig)
+	writeKubeconfig(t, path, singleContextKubeconfig)
+
+	err = kubeconfig.SyncContexts(store, paths, kubeconfig.KubeConfig, nil)
+	require.Error(t, err, "the partial kubeconfig should be reported as a load error")
+
+	_, err = store.GetContext("context-b")
+	require.Error(t, err, "context-b should be removed once the file holding it dropped it")
+
+	_, err = store.GetContext("context-a")
+	require.NoError(t, err, "context-a should be untouched")
 }

--- a/frontend/src/components/authchooser/AuthChooser.test.tsx
+++ b/frontend/src/components/authchooser/AuthChooser.test.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { TestContext } from '../../test';
+import AuthChooser from '.';
+
+const { clustersConf, mockTestAuth } = vi.hoisted(() => ({
+  clustersConf: {} as Record<string, any>,
+  mockTestAuth: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s', () => ({
+  useClustersConf: () => clustersConf,
+}));
+
+vi.mock('../../lib/k8s/api/v1/clusterApi', () => ({
+  testAuth: (...args: any[]) => mockTestAuth(...args),
+}));
+
+// AppLogo, rendered by the dialog, reads theme.palette.navbar, which is not set up here.
+vi.mock('../../lib/themes', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../lib/themes')>()),
+  useNavBarMode: () => 'light',
+}));
+
+vi.mock('../../lib/cluster', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../lib/cluster')>()),
+  getCluster: () => 'test-cluster',
+  getClusterPrefixedPath: () => '/c/:cluster',
+}));
+
+/** Rejects the auth test with an ApiError carrying the given status. */
+function failAuthWith(status: number, statusText: string) {
+  const error = new Error(statusText) as Error & { status: number };
+  error.status = status;
+  mockTestAuth.mockRejectedValue(error);
+}
+
+function renderAuthChooser() {
+  return render(
+    <TestContext>
+      <AuthChooser />
+    </TestContext>
+  );
+}
+
+describe('AuthChooser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const key of Object.keys(clustersConf)) {
+      delete clustersConf[key];
+    }
+    clustersConf['test-cluster'] = { name: 'test-cluster', auth_type: '' };
+  });
+
+  it('asks for a token when the cluster rejects the request as unauthorized', async () => {
+    failAuthWith(401, 'Unauthorized');
+
+    renderAuthChooser();
+
+    await waitFor(() => expect(clustersConf['test-cluster'].useToken).toBe(true));
+    expect(screen.queryByText(/Failed to get authentication information/)).not.toBeInTheDocument();
+  });
+
+  it('asks for a token when the cluster rejects the request as forbidden', async () => {
+    failAuthWith(403, 'Forbidden');
+
+    renderAuthChooser();
+
+    await waitFor(() => expect(clustersConf['test-cluster'].useToken).toBe(true));
+  });
+
+  // A failure that is not the cluster asking for credentials -- here the backend not
+  // finding the cluster -- has to surface as an error instead of quietly sending the
+  // user to the token page. See https://github.com/kubernetes-sigs/headlamp/issues/7154
+  it('shows the error instead of asking for a token when the request fails otherwise', async () => {
+    failAuthWith(404, 'Not Found');
+
+    renderAuthChooser();
+
+    expect(await screen.findByText(/Failed to get authentication information/)).toBeInTheDocument();
+    expect(clustersConf['test-cluster'].useToken).toBeUndefined();
+  });
+
+  it('does not cache a token requirement when the cluster is unreachable', async () => {
+    failAuthWith(502, 'Bad Gateway');
+
+    renderAuthChooser();
+
+    await waitFor(() => expect(screen.getByText(/Failed to connect/)).toBeInTheDocument());
+    expect(clustersConf['test-cluster'].useToken).toBeUndefined();
+  });
+
+  it('goes straight through when the auth test succeeds', async () => {
+    mockTestAuth.mockResolvedValue({});
+
+    renderAuthChooser();
+
+    await waitFor(() => expect(clustersConf['test-cluster'].useToken).toBe(false));
+  });
+});

--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -132,12 +132,14 @@ function AuthChooser({ children }: AuthChooserProps) {
           })
           .catch(err => {
             if (!cancelledRef.current) {
-              console.debug(`Requiring token for ${clusterName} as testing auth failed:`, err);
+              console.debug(`Testing auth failed for ${clusterName}:`, err);
 
-              // Ideally we'd only not assign the error if it was 401 or 403 (so we let the logic
-              // proceed to request a token), but let's first check whether this is all we get
-              // from clusters that require a token.
-              if ([408, 504, 502].includes(err.status)) {
+              // Only a 401 or a 403 means the cluster is actually asking us for credentials.
+              // Anything else -- the backend not finding the cluster, a broken exec credential
+              // plugin, an unreachable API server -- is a real error, and falling through to the
+              // token page hides it behind a login prompt that cannot fix it.
+              // See https://github.com/kubernetes-sigs/headlamp/issues/7154
+              if (![401, 403].includes(err.status)) {
                 errorObj = err;
               }
 


### PR DESCRIPTION
## Summary

Clusters that work for weeks suddenly start showing the "please paste your authentication token" dialog, while `kubectl` keeps working against the same cluster, and only restarting Headlamp clears it.

The console output in #7154 shows the failing auth probe came back with the body `key not found`, which is the context store's `cache.ErrNotFound` returned as a 404 by the cluster proxy. It is not an auth failure at all: the backend had no context under that cluster name at that moment. AuthChooser treated the 404 as "this cluster wants a token", and since `useToken` is preserved across config refreshes, the cluster stayed on the token page for the rest of the session.

## Related Issue

Fixes #7154

## Changes

**backend: don't drop a context because one reload failed to parse it**

`syncContexts` removes every stored context missing from the parse it just did, and `loadContextsFromData` leaves out any context that hit a per-context error. So a context that fails to parse once is removed and not added back — the watcher's ticker only reloads when the watched file count changes, so it stays missing until the next kubeconfig write or a restart, and every request for that cluster 404s meanwhile.

Contexts that reported a load error are now kept, and the removals and additions are driven by the same read of the files instead of reading them twice. A context renamed in Headlamp is stored under its custom name, so a failure reported against the kubeconfig name would not match it; `ContextLoadError` now carries the source file and the match is done on `ClusterID`, which keeps the original identity through a rename.

This is reachable in normal use: kubectl, kubectx and `aws eks update-kubeconfig` rewrite kubeconfig files in place rather than atomically, so a reload triggered mid-write can read a file where a context is present but the user or cluster entry it references has not been written back yet. That is a hypothesis for the trigger; the bug being fixed here is that a transient parse failure is made permanent.

**frontend: only ask for a token on 401/403**

`AuthChooser` counted 408/504/502 as real errors and let everything else fall through to `useToken`, so any other failure — the backend not finding the cluster, a broken exec credential plugin, an unreachable API server — surfaced as a token prompt the user cannot satisfy. It now treats only 401 and 403 as the cluster asking for credentials and shows anything else as the error it is, with the existing Try Again button. This matches how `RouteSwitcher` already classifies auth errors (`isExplicitAuthError`).

**backend: name the cluster in the 404**

`key not found` reaching the browser as the body of the proxy 404 is what made this look cluster-side in the first place. It now reads `cluster "x" not found: key not found`.

## Steps to Test

Each fix has a test that fails without it:

- `cd backend && go test ./pkg/kubeconfig/ -run TestSyncContexts`
  `TestSyncContextsKeepsContextsThatFailedToLoad` loads two contexts, rewrites the kubeconfig as it would look caught mid-write (one context's user entry missing), syncs, and expects the context to still be in the store. `TestSyncContextsKeepsRenamedContextThatFailedToLoad` does the same for a context renamed in Headlamp, which the store keys by its custom name. `TestSyncContextsRemovesDeletedContexts` checks contexts genuinely removed from the kubeconfig are still dropped.
- `cd backend && go test ./cmd/ -run TestClusterRequestUnknownClusterNamesTheCluster`
  Drives the handler with an empty store and asserts both the 404 and that the body names the cluster instead of returning a bare `key not found`.
- `cd frontend && npx vitest run src/components/authchooser`
  401/403 still lead to the token flow; a 404 and a 502 surface as errors and do not cache `useToken`.

Manually, against any cluster: while Headlamp is running, rewrite `~/.kube/config` in place so that one context temporarily references a user entry that is not there yet (or just save a partially written copy over it). Before this change that cluster starts asking for an ID token until Headlamp is restarted; after it, the cluster keeps working.

## Notes for the Reviewer

- The three commits are independent; the frontend one is worth having on its own, since it stops any backend-side failure from being reported to users as a token prompt.
- Kept the scope to not-removing on failure, renamed contexts included. Debouncing the watcher, and the fact that a renamed context is still removed and re-added on every *successful* sync — a window I measured at ~2.5ms on a 15-cluster kubeconfig, during which requests for it 404 — are separate issues.
