### PR TITLE
frontend: LogViewer, Terminal: Dispose FitAddon on unmount

### DIFF
--- a/frontend/src/components/common/LogViewer.tsx
+++ b/frontend/src/components/common/LogViewer.tsx
@@ -132,6 +132,7 @@ export function LogViewer(props: LogViewerProps) {
       window.removeEventListener('resize', pageResizeHandler);
       xtermRef.current?.dispose();
       searchAddonRef.current?.dispose();
+      fitAddonRef.current?.dispose();
       xtermRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/components/common/LogViewer.tsx
+++ b/frontend/src/components/common/LogViewer.tsx
@@ -132,7 +132,7 @@ export function LogViewer(props: LogViewerProps) {
       window.removeEventListener('resize', pageResizeHandler);
       xtermRef.current?.dispose();
       searchAddonRef.current?.dispose();
-      fitAddonRef.current?.dispose();
+      fitAddonRef.current?.dispose?.();
       xtermRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -357,7 +357,7 @@ export default function Terminal(props: TerminalProps) {
 
       return function cleanup() {
         xtermRef.current?.xterm.dispose();
-        fitAddonRef.current?.dispose();
+        fitAddonRef.current?.dispose?.();
         execOrAttachRef.current?.cancel();
         execOrAttachRef.current = null;
         window.removeEventListener('resize', handler);

--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -357,6 +357,7 @@ export default function Terminal(props: TerminalProps) {
 
       return function cleanup() {
         xtermRef.current?.xterm.dispose();
+        fitAddonRef.current?.dispose();
         execOrAttachRef.current?.cancel();
         execOrAttachRef.current = null;
         window.removeEventListener('resize', handler);


### PR DESCRIPTION
## Summary

The `FitAddon` attaches resize observers and DOM listeners to the terminal container. Without disposing it on component unmount, navigating in and out of log/terminal views continuously leaks memory via orphaned observers and detached DOM nodes.

Fixes #7314

## Changes

- `LogViewer.tsx`: Added `fitAddonRef.current?.dispose()` in the cleanup function
- `Terminal.tsx`: Added `fitAddonRef.current?.dispose()` in the cleanup function

## Steps to Test

1. Open a Pod's log viewer or terminal view
2. Navigate away to a different page
3. Repeat several times
4. Inspect DevTools → Memory: FitAddon observers should no longer accumulate