### PR TITLE
frontend: ClusterChooserPopup: Fix recent cluster ordering

### DIFF
--- a/frontend/src/components/cluster/ClusterChooserPopup.test.tsx
+++ b/frontend/src/components/cluster/ClusterChooserPopup.test.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import ClusterChooserPopup from './ClusterChooserPopup';
+
+const selectedClusters: string[] = [];
+vi.mock('../../lib/k8s', () => ({
+  useClustersConf: () => ({
+    'cluster-a': { name: 'cluster-a' },
+    'cluster-b': { name: 'cluster-b' },
+    'cluster-c': { name: 'cluster-c' },
+  }),
+  useSelectedClusters: () => selectedClusters,
+}));
+
+function Wrapper() {
+  const ref = React.useRef<HTMLSpanElement>(null);
+  const [anchor, setAnchor] = React.useState<HTMLElement | null>(null);
+  React.useEffect(() => setAnchor(ref.current), []);
+  return (
+    <>
+      <span ref={ref} />
+      <ClusterChooserPopup anchor={anchor} />
+    </>
+  );
+}
+
+describe('ClusterChooserPopup', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    selectedClusters.length = 0;
+  });
+
+  it('lists recent clusters most-recent-first', async () => {
+    localStorage.setItem('recent_clusters', JSON.stringify(['cluster-c', 'cluster-a']));
+
+    render(
+      <TestContext urlPrefix="/c">
+        <Wrapper />
+      </TestContext>
+    );
+
+    const names = (await screen.findAllByRole('option')).map(option => option.id);
+
+    expect(names).toEqual(['cluster-c', 'cluster-a', 'cluster-b']);
+  });
+
+  it('does not repeat a cluster listed twice in storage', async () => {
+    localStorage.setItem('recent_clusters', JSON.stringify(['cluster-c', 'cluster-c']));
+
+    render(
+      <TestContext urlPrefix="/c">
+        <Wrapper />
+      </TestContext>
+    );
+
+    const names = (await screen.findAllByRole('option')).map(option => option.id);
+
+    expect(names).toEqual(['cluster-c', 'cluster-a', 'cluster-b']);
+  });
+
+  it('still pins the current cluster above the other recent ones', async () => {
+    selectedClusters.push('cluster-a');
+    localStorage.setItem('recent_clusters', JSON.stringify(['cluster-c', 'cluster-a']));
+
+    render(
+      <TestContext urlPrefix="/c">
+        <Wrapper />
+      </TestContext>
+    );
+
+    const names = (await screen.findAllByRole('option')).map(option => option.id);
+
+    expect(names).toEqual(['cluster-a', 'cluster-c', 'cluster-b']);
+  });
+});

--- a/frontend/src/components/cluster/ClusterChooserPopup.tsx
+++ b/frontend/src/components/cluster/ClusterChooserPopup.tsx
@@ -117,7 +117,7 @@ function ClusterChooserPopup(props: ChooserPopupPros) {
     const recentClustersNames = !!filter ? [] : getRecentClusters();
 
     const clustersToShow: Cluster[] = [];
-    const recentClusters: Cluster[] = [];
+    const recentByName = new Map<string, Cluster>();
 
     allClusters.forEach(c => {
       const cluster = { ...c };
@@ -126,21 +126,20 @@ function ClusterChooserPopup(props: ChooserPopupPros) {
       }
 
       if (recentClustersNames.includes(c.name)) {
-        recentClusters.push(cluster);
+        recentByName.set(cluster.name, cluster);
       } else {
         clustersToShow.push(cluster);
       }
     });
 
-    recentClusters.sort((a, b) => {
-      if (a.isCurrent) {
-        return -1;
-      } else if (b.isCurrent) {
-        return 1;
-      }
+    const recentlyUsed = Array.from(new Set(recentClustersNames))
+      .map(name => recentByName.get(name))
+      .filter((cluster): cluster is Cluster => !!cluster);
 
-      return 0;
-    });
+    const recentClusters = [
+      ...recentlyUsed.filter(cluster => cluster.isCurrent),
+      ...recentlyUsed.filter(cluster => !cluster.isCurrent),
+    ];
 
     clustersToShow.sort((a, b) => {
       if (a.isCurrent) {


### PR DESCRIPTION
## Summary

`getRecentClusters()` returns cluster names most-recent-first, but `ClusterChooserPopup` builds its "Recent clusters" list by iterating `Object.values(clusters)` and pushing the matching entries, so the recency order is lost and the list follows the cluster config order instead.

`Chooser.tsx` and `Home/RecentClusters.tsx` read the same helper by mapping over the stored names, which preserves the order.

## Related Issue

Fixes #7338

## Changes

- Build the recent list by walking the stored names instead of the cluster config.
- De-duplicate the stored names, since a repeated entry in `localStorage` rendered the same cluster twice.
- Keep the current cluster pinned to the top using a stable partition rather than a non-transitive comparator.
- Added `ClusterChooserPopup.test.tsx` covering recency order, duplicate entries and current-cluster pinning.

## Steps to Test

1. `cd frontend && npx vitest run src/components/cluster/ClusterChooserPopup.test.tsx`
2. Confirm 3 tests pass. They fail on `main`.
