### PR TITLE
frontend: Settings: Strip all whitespace from pasted input

### DIFF
--- a/frontend/src/components/App/Settings/ClusterNameEditor.tsx
+++ b/frontend/src/components/App/Settings/ClusterNameEditor.tsx
@@ -200,7 +200,7 @@ export function ClusterNameEditor({
             <TextField
               onChange={event => {
                 let value = event.target.value;
-                value = value.replace(' ', '');
+                value = value.replace(/\s/g, '');
                 setNewClusterName(value);
                 checkNameInUse(value);
               }}

--- a/frontend/src/components/App/Settings/NodeShellSettings.tsx
+++ b/frontend/src/components/App/Settings/NodeShellSettings.tsx
@@ -87,7 +87,7 @@ export default function NodeShellSettings(props: SettingsProps) {
             value: (
               <TextField
                 onChange={event => {
-                  const value = event.target.value.replace(' ', '');
+                  const value = event.target.value.replace(/\s/g, '');
                   updateNodeShell({ linuxImage: value });
                 }}
                 value={image}
@@ -111,7 +111,7 @@ export default function NodeShellSettings(props: SettingsProps) {
             value: (
               <TextField
                 onChange={event => {
-                  const value = event.target.value.replace(' ', '');
+                  const value = event.target.value.replace(/\s/g, '');
                   setNamespaceInput(value);
                   if (isValidNamespaceFormat(value) || value === '') {
                     updateNodeShell({ namespace: value });

--- a/frontend/src/components/App/Settings/SettingsCluster.test.tsx
+++ b/frontend/src/components/App/Settings/SettingsCluster.test.tsx
@@ -230,6 +230,27 @@ describe('SettingsCluster states and namespaces', () => {
     ).toMatchObject({ defaultNamespace: 'team-a' });
   });
 
+  it('strips every space from a pasted default namespace', async () => {
+    renderSettings();
+    const input = screen.getByRole('textbox', { name: 'Default namespace' });
+
+    await userEvent.click(input);
+    await userEvent.paste('kube  system');
+
+    expect(input).toHaveValue('kubesystem');
+    expect(input).toHaveAttribute('aria-invalid', 'false');
+  });
+
+  it('strips every space from a pasted allowed namespace', async () => {
+    renderSettings();
+    const input = screen.getByRole('textbox', { name: 'Allowed namespaces' });
+
+    await userEvent.click(input);
+    await userEvent.paste('team  a');
+
+    expect(input).toHaveValue('teama');
+  });
+
   it('adds, deduplicates, and removes allowed namespaces', async () => {
     renderSettings({ allowedNamespaces: ['zeta'] });
     const input = screen.getByRole('textbox', { name: 'Allowed namespaces' });

--- a/frontend/src/components/App/Settings/SettingsCluster.tsx
+++ b/frontend/src/components/App/Settings/SettingsCluster.tsx
@@ -332,7 +332,7 @@ export default function SettingsCluster() {
               value: (
                 <TextField
                   onChange={event => {
-                    const value = event.target.value.replace(' ', '');
+                    const value = event.target.value.replace(/\s/g, '');
                     setDefaultNamespaceInput(value);
                     if (isValidNamespaceFormat(value) || value === '') {
                       setClusterSettings(s => ({ ...s, defaultNamespace: value }));
@@ -370,7 +370,7 @@ export default function SettingsCluster() {
                   <TextField
                     onChange={event => {
                       let value = event.target.value;
-                      value = value.replace(' ', '');
+                      value = value.replace(/\s/g, '');
                       setNewAllowedNamespace(value);
                     }}
                     placeholder={t('glossary|Namespace')}


### PR DESCRIPTION
## Summary

Five settings inputs sanitise their value with `.replace(' ', '')`, which removes only the first space. Typing hides this because the handler runs per keystroke, but pasting a value containing more than one space leaves the remaining spaces in place and the field then fails its own validation.

`PodDebugSettings.tsx` in the same directory already uses `.replace(/\s/g, '')`.

## Related Issue

Fixes #7339

## Changes

- Use `.replace(/\s/g, '')` in the five affected inputs: `SettingsCluster` (default namespace, allowed namespaces), `ClusterNameEditor` (custom cluster name) and `NodeShellSettings` (namespace, image).
- Added two tests covering a pasted value containing two spaces.

## Steps to Test

1. `cd frontend && npx vitest run src/components/App/Settings/SettingsCluster.test.tsx`
2. Confirm 13 tests pass. The two new ones fail on `main`.
3. Optionally: paste `kube  system` into a cluster's Default namespace field and confirm it becomes `kubesystem`.
