### PR TITLE
frontend: KubeList: Keep resource version on ERROR watch events

### DIFF
--- a/frontend/src/lib/k8s/api/v2/KubeList.test.ts
+++ b/frontend/src/lib/k8s/api/v2/KubeList.test.ts
@@ -156,6 +156,84 @@ describe('KubeList.applyUpdate', () => {
     consoleErrorSpy.mockRestore();
   });
 
+  it('should keep the list resource version when an ERROR event carries none', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const update = {
+      type: 'ERROR',
+      object: { apiVersion: 'v1', kind: 'Status', metadata: {} },
+    } as any;
+
+    const updatedList = KubeList.applyUpdate(initialList, update, itemClass, cluster);
+
+    expect(updatedList.metadata.resourceVersion).toBe('1');
+    consoleSpy.mockRestore();
+  });
+
+  it('should still skip stale updates after an ERROR event', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const afterError = KubeList.applyUpdate(
+      initialList,
+      { type: 'ERROR', object: { apiVersion: 'v1', kind: 'Status', metadata: {} } } as any,
+      itemClass,
+      cluster
+    );
+
+    const stale = KubeList.applyUpdate(
+      afterError,
+      {
+        type: 'DELETED',
+        object: {
+          apiVersion: 'v1',
+          kind: 'MockKubeObject',
+          metadata: { uid: '1', resourceVersion: '1' },
+        },
+      } as any,
+      itemClass,
+      cluster
+    );
+
+    expect(stale.items).toHaveLength(1);
+    consoleSpy.mockRestore();
+  });
+
+  it('should advance the resource version on a BOOKMARK event', () => {
+    const update = {
+      type: 'BOOKMARK',
+      object: { apiVersion: 'v1', kind: 'MockKubeObject', metadata: { resourceVersion: '9' } },
+    } as any;
+
+    const updatedList = KubeList.applyUpdate(initialList, update, itemClass, cluster);
+
+    expect(updatedList.metadata.resourceVersion).toBe('9');
+    expect(updatedList.items).toEqual(initialList.items);
+  });
+
+  it('should ignore a BOOKMARK event with no resource version', () => {
+    const update = {
+      type: 'BOOKMARK',
+      object: { apiVersion: 'v1', kind: 'MockKubeObject', metadata: {} },
+    } as any;
+
+    expect(KubeList.applyUpdate(initialList, update, itemClass, cluster)).toBe(initialList);
+  });
+
+  it('should keep the list resource version when an event carries an empty one', () => {
+    const update = {
+      type: 'ADDED',
+      object: {
+        apiVersion: 'v1',
+        kind: 'MockKubeObject',
+        metadata: { uid: '2', resourceVersion: '' },
+      },
+    } as any;
+
+    const updatedList = KubeList.applyUpdate(initialList, update, itemClass, cluster);
+
+    expect(updatedList.metadata.resourceVersion).toBe('1');
+    expect(updatedList.items).toHaveLength(2);
+  });
+
   it('should log an error on unknown event type', () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const updateEvent: KubeListUpdateEvent<MockKubeObject> = {

--- a/frontend/src/lib/k8s/api/v2/KubeList.ts
+++ b/frontend/src/lib/k8s/api/v2/KubeList.ts
@@ -31,7 +31,7 @@ export interface KubeList<T extends KubeObjectInterface> {
 }
 
 export interface KubeListUpdateEvent<T extends KubeObjectInterface> {
-  type: 'ADDED' | 'MODIFIED' | 'DELETED' | 'ERROR';
+  type: 'ADDED' | 'MODIFIED' | 'DELETED' | 'BOOKMARK' | 'ERROR';
   object: T;
 }
 
@@ -79,18 +79,30 @@ export const KubeList = {
           newItems.splice(index, 1);
         }
         break;
+      case 'BOOKMARK':
+        if (!update.object.metadata.resourceVersion) {
+          return list;
+        }
+        return {
+          ...list,
+          metadata: {
+            ...list.metadata,
+            resourceVersion: update.object.metadata.resourceVersion,
+          },
+        };
       case 'ERROR':
         console.error('Error in update', update);
-        break;
+        return list;
       default:
         console.error('Unknown update type', update);
+        return list;
     }
 
     return {
       ...list,
       metadata: {
         ...list.metadata,
-        resourceVersion: update.object.metadata.resourceVersion!,
+        resourceVersion: update.object.metadata.resourceVersion || list.metadata.resourceVersion,
       },
       items: newItems,
     };

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
@@ -345,6 +345,73 @@ describe('useWatchKubeObjectLists', () => {
     ).toBe(objectB);
   });
 
+  it('should log and invalidate on an Expired ERROR message', () => {
+    const useWebSocketSpy = vi.spyOn(websocket, 'useWebSockets');
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const queryClient = new QueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const endpoint = { version: 'v1', resource: 'pods' };
+    const lists = [{ cluster: 'default', resourceVersion: '5', namespace: 'a' }];
+    const key = kubeObjectListQuery(mockClass, endpoint, 'a', 'default', {}).queryKey;
+
+    queryClient.setQueryData(key, {
+      list: { items: [], metadata: { resourceVersion: '5' } },
+      cluster: 'default',
+    });
+
+    renderHook(() => useWatchKubeObjectLists({ kubeObjectClass: mockClass, lists, endpoint }), {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      ),
+    });
+
+    const update = {
+      type: 'ERROR',
+      object: { kind: 'Status', reason: 'Expired', code: 410, metadata: {} },
+    };
+    useWebSocketSpy.mock.calls[0][0].connections[0].onMessage(update);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error in update', update);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: key });
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('should report a non-expired ERROR message without invalidating', () => {
+    const useWebSocketSpy = vi.spyOn(websocket, 'useWebSockets');
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const queryClient = new QueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const endpoint = { version: 'v1', resource: 'pods' };
+    const lists = [{ cluster: 'default', resourceVersion: '5', namespace: 'a' }];
+    const key = kubeObjectListQuery(mockClass, endpoint, 'a', 'default', {}).queryKey;
+
+    queryClient.setQueryData(key, {
+      list: { items: [], metadata: { resourceVersion: '5' } },
+      cluster: 'default',
+    });
+
+    renderHook(() => useWatchKubeObjectLists({ kubeObjectClass: mockClass, lists, endpoint }), {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      ),
+    });
+
+    const update = {
+      type: 'ERROR',
+      object: { kind: 'Status', reason: 'Forbidden', code: 403, metadata: {} },
+    };
+    useWebSocketSpy.mock.calls[0][0].connections[0].onMessage(update);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error in update', update);
+    expect(invalidateSpy).not.toHaveBeenCalled();
+    expect((queryClient.getQueryData(key) as ListResponse<any>).list.metadata.resourceVersion).toBe(
+      '5'
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
   it('should not call WebSocketManager.subscribe when multiplexer is disabled', () => {
     renderHook(
       () =>
@@ -1232,6 +1299,64 @@ describe('useWatchKubeObjectLists (Multiplexer)', () => {
     );
 
     expect(spy).toHaveBeenCalledWith({ enabled: false, connections: [] });
+  });
+
+  it('should resubscribe from a refreshed cursor after an Expired ERROR message', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const queryClient = new QueryClient();
+    mockClusterFetch
+      .mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve(
+            makeListResponse({ items: [makePod('pod-1', '5')], resourceVersion: '5' })
+          ),
+      } as Response)
+      .mockResolvedValue({
+        json: () =>
+          Promise.resolve(
+            makeListResponse({ items: [makePod('pod-2', '9')], resourceVersion: '9' })
+          ),
+      } as Response);
+
+    renderHook(
+      () =>
+        useKubeObjectList({
+          kubeObjectClass: mockClass,
+          requests: [{ cluster: 'default' }],
+        }),
+      { wrapper: queryClientWrapper(queryClient) }
+    );
+
+    await waitFor(() =>
+      expect(
+        mockSubscribe.mock.calls.some(([, , query]) => query === 'watch=1&resourceVersion=5')
+      ).toBe(true)
+    );
+
+    const onUpdate = mockSubscribe.mock.calls[0][3];
+    const update = {
+      type: 'ERROR',
+      object: { kind: 'Status', reason: 'Expired', code: 410, metadata: {} },
+    };
+
+    await act(async () => {
+      onUpdate(update);
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error in update', update);
+
+    await waitFor(() =>
+      expect(
+        mockSubscribe.mock.calls.some(
+          ([cluster, pathname, query]) =>
+            cluster === 'default' &&
+            pathname === '/api/v1/pods' &&
+            query === 'watch=1&resourceVersion=9'
+        )
+      ).toBe(true)
+    );
+
+    consoleErrorSpy.mockRestore();
   });
 
   it('should omit pagination query params after loading all pages', async () => {

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -333,11 +333,6 @@ function useWatchKubeObjectListsMultiplexed<K extends KubeObject>({
 
       const key = `${cluster}:${namespace || ''}`;
 
-      // Update resource version from incoming message
-      if (update.object?.metadata?.resourceVersion) {
-        latestResourceVersions.current[key] = update.object.metadata.resourceVersion;
-      }
-
       // Create query key for React Query cache
       const queryKey = kubeObjectListQuery<K>(
         kubeObjectClass,
@@ -346,6 +341,27 @@ function useWatchKubeObjectListsMultiplexed<K extends KubeObject>({
         cluster,
         stableQueryParams ?? {}
       ).queryKey;
+
+      if (update.type === 'ERROR') {
+        console.error('Error in update', update);
+        const status = update.object as { reason?: string; code?: number } | undefined;
+        if (status?.reason === 'Expired' || status?.code === 410) {
+          delete latestResourceVersions.current[key];
+          client.invalidateQueries({ queryKey });
+        }
+        return;
+      }
+
+      const incomingResourceVersion = update.object?.metadata?.resourceVersion;
+      if (incomingResourceVersion) {
+        const currentResourceVersion = latestResourceVersions.current[key];
+        if (
+          !currentResourceVersion ||
+          parseInt(incomingResourceVersion) > parseInt(currentResourceVersion)
+        ) {
+          latestResourceVersions.current[key] = incomingResourceVersion;
+        }
+      }
 
       // Update React Query cache with new data
       client.setQueryData(queryKey, (oldResponse: ListResponse<any> | undefined | null) => {
@@ -469,6 +485,18 @@ function useWatchKubeObjectListsLegacy<K extends KubeObject>({
             cluster,
             stableQueryParams ?? {}
           ).queryKey;
+
+          if (update.type === 'ERROR') {
+            console.error('Error in update', update);
+            const status = update.object as unknown as
+              | { reason?: string; code?: number }
+              | undefined;
+            if (status?.reason === 'Expired' || status?.code === 410) {
+              client.invalidateQueries({ queryKey: key });
+            }
+            return;
+          }
+
           client.setQueryData(key, (oldResponse: ListResponse<any> | undefined | null) => {
             if (!oldResponse) return oldResponse;
 


### PR DESCRIPTION
## Summary

`KubeList.applyUpdate` overwrote the list's `resourceVersion` with the incoming event's value for every event type, including `ERROR`. A watch `ERROR` event carries a `Status` object, which has no `metadata.resourceVersion`, so the list's resource version became `undefined`.

That has two consequences. The next reconnect sends `resourceVersion=` with no value, which the API server reads as "start from now", so every event between the error and the reconnect is dropped and the cached list silently drifts from the cluster. And the stale-update guard at the top of the function requires `list.metadata.resourceVersion` to be set, so it stops working from that point on and an out-of-date event is applied — a replayed `DELETED` event then removes an item that still exists.

## Related Issue

Fixes #7340

## Changes

`KubeList.applyUpdate`:

- Return the list unchanged for `ERROR` and unknown event types instead of rebuilding it with an empty resource version.
- Fall back to the current resource version when an applied event does not carry one.
- Handle `BOOKMARK` explicitly: advance the resource version, leave the items alone. This is required by the change above rather than separate from it. `BOOKMARK` previously fell into the `default` branch, where it logged `Unknown update type` and then advanced the cursor by falling through to the shared return. Making `default` return early would have stopped the cursor advancing during idle periods, which is the only thing a bookmark exists to do, so the type is now named in the union and given its own case.

`useKubeObjectList`, both watch paths:

- Log every `ERROR` event, preserving the diagnostic `applyUpdate` used to emit, then handle the event instead of feeding it back into `applyUpdate`.
- On `reason: Expired` or `code: 410`, invalidate the cached list so it is refetched from a fresh resource version. The multiplexed path also drops its tracked cursor, so the resubscription uses the refreshed value rather than the expired one.

Tests — seven added, all of which fail on `main`:

- `KubeList.test.ts` (12 total): the resource version survives an `ERROR` event; a stale `DELETED` event is still skipped afterwards; a `BOOKMARK` with no resource version is ignored; an event with an empty resource version keeps the current one.
- `useKubeObjectList.test.tsx` (41 total): the legacy path logs and invalidates on an expired `ERROR`; it reports a non-expired `ERROR` without invalidating or touching the cursor; and the multiplexed path, driven through the callback passed to `WebSocketManager.subscribe`, resubscribes at the refreshed resource version after an expired `ERROR`.

## Steps to Test

1. `cd frontend && npx vitest run src/lib/k8s/api/v2/KubeList.test.ts src/lib/k8s/api/v2/useKubeObjectList.test.tsx`
2. Confirm 53 tests pass.
3. Check out `main` for `KubeList.ts` and `useKubeObjectList.ts` only, keeping both test files, and re-run: the seven new tests fail.
