### PR TITLE
frontend: LeaderWorkerSetList: Add isEnabled gating with Checking and Not-enabled states

### DIFF
--- a/frontend/src/components/leaderworkerset/LeaderWorkerSetList.stories.tsx
+++ b/frontend/src/components/leaderworkerset/LeaderWorkerSetList.stories.tsx
@@ -74,6 +74,9 @@ updatingLeaderWorkerSet.status = {
   ],
 };
 
+const lwsApiGroupUrl = `${API_BASE}/apis/leaderworkerset.x-k8s.io/v1`;
+const lwsListUrl = `${API_BASE}/apis/leaderworkerset.x-k8s.io/v1/leaderworkersets`;
+
 export default {
   title: 'LeaderWorkerSet/List',
   component: List,
@@ -87,21 +90,6 @@ export default {
       );
     },
   ],
-  parameters: {
-    msw: {
-      handlers: {
-        story: [
-          http.get(`${API_BASE}/apis/leaderworkerset.x-k8s.io/v1/leaderworkersets`, () =>
-            HttpResponse.json({
-              kind: 'LeaderWorkerSetList',
-              metadata: {},
-              items: leaderWorkerSetList,
-            })
-          ),
-        ],
-      },
-    },
-  },
 } as Meta;
 
 const Template: StoryFn = () => {
@@ -109,3 +97,54 @@ const Template: StoryFn = () => {
 };
 
 export const Items = Template.bind({});
+Items.parameters = {
+  msw: {
+    handlers: {
+      story: [
+        http.get(lwsApiGroupUrl, () =>
+          HttpResponse.json({ resources: [{ name: 'leaderworkersets' }] })
+        ),
+        http.get(lwsListUrl, () =>
+          HttpResponse.json({
+            kind: 'LeaderWorkerSetList',
+            metadata: {},
+            items: leaderWorkerSetList,
+          })
+        ),
+      ],
+    },
+  },
+};
+
+/**
+ * LeaderWorkerSet.isEnabled() stays pending so the list shows the checking state.
+ */
+export const Checking = Template.bind({});
+Checking.parameters = {
+  storyshots: { disable: true },
+  msw: {
+    handlers: {
+      story: [http.get(lwsApiGroupUrl, () => new Promise(() => {}))],
+    },
+  },
+};
+
+/**
+ * API group responds without leaderworkersets, so isEnabled() resolves false.
+ */
+export const NotEnabled = Template.bind({});
+NotEnabled.parameters = {
+  msw: {
+    handlers: {
+      story: [
+        http.get(lwsApiGroupUrl, () =>
+          HttpResponse.json({
+            kind: 'APIResourceList',
+            groupVersion: 'leaderworkerset.x-k8s.io/v1',
+            resources: [],
+          })
+        ),
+      ],
+    },
+  },
+};

--- a/frontend/src/components/leaderworkerset/List.tsx
+++ b/frontend/src/components/leaderworkerset/List.tsx
@@ -19,6 +19,7 @@ import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
+import { useSelectedClusters } from '../../lib/k8s';
 import { getTopCondition } from '../../lib/k8s/conditions';
 import LeaderWorkerSet from '../../lib/k8s/leaderWorkerSet';
 import Empty from '../common/EmptyContent';
@@ -41,15 +42,42 @@ function getGroupSize(leaderWorkerSet: LeaderWorkerSet): number | string {
 
 export default function LeaderWorkerSetList() {
   const { t } = useTranslation(['glossary', 'translation']);
+  const selectedClusters = useSelectedClusters();
+  const selectedClustersKey = selectedClusters.join(',');
   const [lwsEnabled, setLwsEnabled] = useState<boolean | null>(null);
 
   useEffect(() => {
-    LeaderWorkerSet.isEnabled().then(setLwsEnabled);
-  }, []);
+    let cancelled = false;
+    setLwsEnabled(null);
+
+    const clusters = selectedClustersKey ? selectedClustersKey.split(',') : [];
+
+    const checkStatus = async () => {
+      // ANY selected cluster serving LWS ⇒ show the list so multi-cluster
+      // selections still surface objects from clusters where the CRD exists.
+      // Gateway L4 availability uses ALL/intersection for map sources, which
+      // is a different UX (hide a kind unless every selected cluster has it).
+      const enabled =
+        clusters.length === 0
+          ? await LeaderWorkerSet.isEnabled()
+          : (await Promise.all(clusters.map(cluster => LeaderWorkerSet.isEnabled(cluster)))).some(
+              Boolean
+            );
+
+      if (!cancelled) {
+        setLwsEnabled(enabled);
+      }
+    };
+    checkStatus();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedClustersKey]);
 
   if (lwsEnabled === null) {
     return (
-      <SectionBox title={t('glossary|Leader Worker Sets')}>
+      <SectionBox title={t('glossary|Leader Worker Sets')} headerProps={{ headerStyle: 'main' }}>
         <Paper variant="outlined">
           <Empty>
             <Typography style={{ textAlign: 'center' }}>
@@ -63,21 +91,25 @@ export default function LeaderWorkerSetList() {
 
   if (!lwsEnabled) {
     return (
-      <SectionBox title={t('glossary|Leader Worker Sets')}>
+      <SectionBox title={t('glossary|Leader Worker Sets')} headerProps={{ headerStyle: 'main' }}>
         <Paper variant="outlined">
           <Empty>
             <Typography style={{ textAlign: 'center' }}>
-              <Trans t={t}>
-                LeaderWorkerSet is not enabled on this cluster.&nbsp;
-                <Link
-                  href="https://github.com/kubernetes-sigs/lws#installation"
-                  target="_blank"
-                  rel="noopener"
-                  sx={{ textDecoration: 'underline' }}
-                >
-                  Learn More
-                </Link>
-              </Trans>
+              <Trans
+                t={t}
+                ns="glossary"
+                i18nKey="LeaderWorkerSet is not enabled. <1>Learn More</1>"
+                components={{
+                  1: (
+                    <Link
+                      href="https://github.com/kubernetes-sigs/lws#installation"
+                      target="_blank"
+                      rel="noopener"
+                      sx={{ textDecoration: 'underline' }}
+                    />
+                  ),
+                }}
+              />
             </Typography>
           </Empty>
         </Paper>

--- a/frontend/src/components/leaderworkerset/List.tsx
+++ b/frontend/src/components/leaderworkerset/List.tsx
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 
-import { useTranslation } from 'react-i18next';
+import Link from '@mui/material/Link';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import { useEffect, useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 import { getTopCondition } from '../../lib/k8s/conditions';
 import LeaderWorkerSet from '../../lib/k8s/leaderWorkerSet';
+import Empty from '../common/EmptyContent';
 import ResourceListView from '../common/Resource/ResourceListView';
+import SectionBox from '../common/SectionBox';
 
 // Explicit priority to make the rendered condition stable and meaningful: an
 // in-flight rollout or scale-up says more about the current state than the
@@ -35,6 +41,49 @@ function getGroupSize(leaderWorkerSet: LeaderWorkerSet): number | string {
 
 export default function LeaderWorkerSetList() {
   const { t } = useTranslation(['glossary', 'translation']);
+  const [lwsEnabled, setLwsEnabled] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    LeaderWorkerSet.isEnabled().then(setLwsEnabled);
+  }, []);
+
+  if (lwsEnabled === null) {
+    return (
+      <SectionBox title={t('glossary|Leader Worker Sets')}>
+        <Paper variant="outlined">
+          <Empty>
+            <Typography style={{ textAlign: 'center' }}>
+              {t('glossary|Checking if LeaderWorkerSet is enabled…')}
+            </Typography>
+          </Empty>
+        </Paper>
+      </SectionBox>
+    );
+  }
+
+  if (!lwsEnabled) {
+    return (
+      <SectionBox title={t('glossary|Leader Worker Sets')}>
+        <Paper variant="outlined">
+          <Empty>
+            <Typography style={{ textAlign: 'center' }}>
+              <Trans t={t}>
+                LeaderWorkerSet is not enabled on this cluster.&nbsp;
+                <Link
+                  href="https://github.com/kubernetes-sigs/lws#installation"
+                  target="_blank"
+                  rel="noopener"
+                  sx={{ textDecoration: 'underline' }}
+                >
+                  Learn More
+                </Link>
+              </Trans>
+            </Typography>
+          </Empty>
+        </Paper>
+      </SectionBox>
+    );
+  }
 
   return (
     <ResourceListView

--- a/frontend/src/components/leaderworkerset/__snapshots__/LeaderWorkerSetList.NotEnabled.stories.storyshot
+++ b/frontend/src/components/leaderworkerset/__snapshots__/LeaderWorkerSetList.NotEnabled.stories.storyshot
@@ -36,7 +36,7 @@
               class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
               style="text-align: center;"
             >
-              LeaderWorkerSet is not enabled. 
+              LeaderWorkerSet is not enabled. 
               <a
                 class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-147kpcx-MuiTypography-root-MuiLink-root"
                 href="https://github.com/kubernetes-sigs/lws#installation"

--- a/frontend/src/components/leaderworkerset/__snapshots__/LeaderWorkerSetList.NotEnabled.stories.storyshot
+++ b/frontend/src/components/leaderworkerset/__snapshots__/LeaderWorkerSetList.NotEnabled.stories.storyshot
@@ -12,11 +12,11 @@
           <div
             class="MuiBox-root css-70qvj9"
           >
-            <h2
-              class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+            <h1
+              class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
             >
               Leader Worker Sets
-            </h2>
+            </h1>
             <div
               class="MuiBox-root css-ldp2l3"
             />
@@ -36,7 +36,7 @@
               class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
               style="text-align: center;"
             >
-              LeaderWorkerSet is not enabled on this cluster. 
+              LeaderWorkerSet is not enabled. 
               <a
                 class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-147kpcx-MuiTypography-root-MuiLink-root"
                 href="https://github.com/kubernetes-sigs/lws#installation"

--- a/frontend/src/components/leaderworkerset/__snapshots__/LeaderWorkerSetList.NotEnabled.stories.storyshot
+++ b/frontend/src/components/leaderworkerset/__snapshots__/LeaderWorkerSetList.NotEnabled.stories.storyshot
@@ -1,0 +1,54 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-j1fy4m"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiBox-root css-70qvj9"
+          >
+            <h2
+              class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+            >
+              Leader Worker Sets
+            </h2>
+            <div
+              class="MuiBox-root css-ldp2l3"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1txv3mw"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+        >
+          <div
+            class="MuiBox-root css-19midj6"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+              style="text-align: center;"
+            >
+              LeaderWorkerSet is not enabled on this cluster. 
+              <a
+                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-147kpcx-MuiTypography-root-MuiLink-root"
+                href="https://github.com/kubernetes-sigs/lws#installation"
+                rel="noopener"
+                target="_blank"
+              >
+                Learn More
+              </a>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/i18n/locales/ar/glossary.json
+++ b/frontend/src/i18n/locales/ar/glossary.json
@@ -121,6 +121,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "الإيجار",
   "LimitRange": "نطاق الحدود",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/ar/glossary.json
+++ b/frontend/src/i18n/locales/ar/glossary.json
@@ -122,7 +122,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "الإيجار",
   "LimitRange": "نطاق الحدود",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/bn/glossary.json
+++ b/frontend/src/i18n/locales/bn/glossary.json
@@ -121,6 +121,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "লিজ",
   "LimitRange": "সীমার পরিসর",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/bn/glossary.json
+++ b/frontend/src/i18n/locales/bn/glossary.json
@@ -122,7 +122,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "লিজ",
   "LimitRange": "সীমার পরিসর",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/cs/glossary.json
+++ b/frontend/src/i18n/locales/cs/glossary.json
@@ -120,6 +120,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "Zapůjčení",
   "LimitRange": "LimitRange",
   "Ingress": "Příchozí přenos dat",

--- a/frontend/src/i18n/locales/cs/glossary.json
+++ b/frontend/src/i18n/locales/cs/glossary.json
@@ -121,7 +121,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "Zapůjčení",
   "LimitRange": "LimitRange",
   "Ingress": "Příchozí přenos dat",

--- a/frontend/src/i18n/locales/de/glossary.json
+++ b/frontend/src/i18n/locales/de/glossary.json
@@ -122,7 +122,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/de/glossary.json
+++ b/frontend/src/i18n/locales/de/glossary.json
@@ -121,6 +121,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/en/glossary.json
+++ b/frontend/src/i18n/locales/en/glossary.json
@@ -122,7 +122,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "JobSet is not enabled. <1>Learn More</1>",
   "Leader Worker Sets": "Leader Worker Sets",
   "Checking if LeaderWorkerSet is enabled…": "Checking if LeaderWorkerSet is enabled…",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "LeaderWorkerSet is not enabled. <1>Learn More</1>",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/en/glossary.json
+++ b/frontend/src/i18n/locales/en/glossary.json
@@ -121,6 +121,8 @@
   "Checking if JobSet is enabled…": "Checking if JobSet is enabled…",
   "JobSet is not enabled. <1>Learn More</1>": "JobSet is not enabled. <1>Learn More</1>",
   "Leader Worker Sets": "Leader Worker Sets",
+  "Checking if LeaderWorkerSet is enabled…": "Checking if LeaderWorkerSet is enabled…",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/es/glossary.json
+++ b/frontend/src/i18n/locales/es/glossary.json
@@ -122,7 +122,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/es/glossary.json
+++ b/frontend/src/i18n/locales/es/glossary.json
@@ -121,6 +121,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/fr/glossary.json
+++ b/frontend/src/i18n/locales/fr/glossary.json
@@ -121,6 +121,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "Bail",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/fr/glossary.json
+++ b/frontend/src/i18n/locales/fr/glossary.json
@@ -122,7 +122,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "Bail",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/he/glossary.json
+++ b/frontend/src/i18n/locales/he/glossary.json
@@ -122,7 +122,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/he/glossary.json
+++ b/frontend/src/i18n/locales/he/glossary.json
@@ -121,6 +121,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/hi/glossary.json
+++ b/frontend/src/i18n/locales/hi/glossary.json
@@ -122,7 +122,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "लीज़",
   "LimitRange": "लिमिट रेंज",
   "Ingress": "इंग्रेस",

--- a/frontend/src/i18n/locales/hi/glossary.json
+++ b/frontend/src/i18n/locales/hi/glossary.json
@@ -121,6 +121,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "लीज़",
   "LimitRange": "लिमिट रेंज",
   "Ingress": "इंग्रेस",

--- a/frontend/src/i18n/locales/hu/glossary.json
+++ b/frontend/src/i18n/locales/hu/glossary.json
@@ -120,6 +120,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "Bérlet",
   "LimitRange": "LimitRange",
   "Ingress": "Bejövő forgalom",

--- a/frontend/src/i18n/locales/hu/glossary.json
+++ b/frontend/src/i18n/locales/hu/glossary.json
@@ -121,7 +121,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "Bérlet",
   "LimitRange": "LimitRange",
   "Ingress": "Bejövő forgalom",

--- a/frontend/src/i18n/locales/id/glossary.json
+++ b/frontend/src/i18n/locales/id/glossary.json
@@ -121,7 +121,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "Sewa",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/id/glossary.json
+++ b/frontend/src/i18n/locales/id/glossary.json
@@ -120,6 +120,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "Sewa",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/it/glossary.json
+++ b/frontend/src/i18n/locales/it/glossary.json
@@ -122,7 +122,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/it/glossary.json
+++ b/frontend/src/i18n/locales/it/glossary.json
@@ -121,6 +121,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/ja/glossary.json
+++ b/frontend/src/i18n/locales/ja/glossary.json
@@ -121,6 +121,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "リース",
   "LimitRange": "制限範囲",
   "Ingress": "イングレス",

--- a/frontend/src/i18n/locales/ja/glossary.json
+++ b/frontend/src/i18n/locales/ja/glossary.json
@@ -122,7 +122,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "リース",
   "LimitRange": "制限範囲",
   "Ingress": "イングレス",

--- a/frontend/src/i18n/locales/ko/glossary.json
+++ b/frontend/src/i18n/locales/ko/glossary.json
@@ -122,7 +122,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "리스",
   "LimitRange": "리미트 레인지",
   "Ingress": "인그레스",

--- a/frontend/src/i18n/locales/ko/glossary.json
+++ b/frontend/src/i18n/locales/ko/glossary.json
@@ -121,6 +121,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "리스",
   "LimitRange": "리미트 레인지",
   "Ingress": "인그레스",

--- a/frontend/src/i18n/locales/nl/glossary.json
+++ b/frontend/src/i18n/locales/nl/glossary.json
@@ -120,6 +120,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Inkomend",

--- a/frontend/src/i18n/locales/nl/glossary.json
+++ b/frontend/src/i18n/locales/nl/glossary.json
@@ -121,7 +121,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Inkomend",

--- a/frontend/src/i18n/locales/pl/glossary.json
+++ b/frontend/src/i18n/locales/pl/glossary.json
@@ -120,6 +120,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "Dzierżawa",
   "LimitRange": "LimitRange",
   "Ingress": "Ruch przychodzący",

--- a/frontend/src/i18n/locales/pl/glossary.json
+++ b/frontend/src/i18n/locales/pl/glossary.json
@@ -121,7 +121,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "Dzierżawa",
   "LimitRange": "LimitRange",
   "Ingress": "Ruch przychodzący",

--- a/frontend/src/i18n/locales/pt-br/glossary.json
+++ b/frontend/src/i18n/locales/pt-br/glossary.json
@@ -120,6 +120,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/pt-br/glossary.json
+++ b/frontend/src/i18n/locales/pt-br/glossary.json
@@ -121,7 +121,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/pt-pt/glossary.json
+++ b/frontend/src/i18n/locales/pt-pt/glossary.json
@@ -122,7 +122,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/pt-pt/glossary.json
+++ b/frontend/src/i18n/locales/pt-pt/glossary.json
@@ -121,6 +121,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/ru/glossary.json
+++ b/frontend/src/i18n/locales/ru/glossary.json
@@ -122,7 +122,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/ru/glossary.json
+++ b/frontend/src/i18n/locales/ru/glossary.json
@@ -121,6 +121,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/sv/glossary.json
+++ b/frontend/src/i18n/locales/sv/glossary.json
@@ -121,7 +121,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "Livslängd",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/sv/glossary.json
+++ b/frontend/src/i18n/locales/sv/glossary.json
@@ -120,6 +120,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "Livslängd",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/ta/glossary.json
+++ b/frontend/src/i18n/locales/ta/glossary.json
@@ -122,7 +122,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "லீஸ்",
   "LimitRange": "லிமிட்ரேஞ்ச்",
   "Ingress": "இன்க்ரெஸ்",

--- a/frontend/src/i18n/locales/ta/glossary.json
+++ b/frontend/src/i18n/locales/ta/glossary.json
@@ -121,6 +121,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "லீஸ்",
   "LimitRange": "லிமிட்ரேஞ்ச்",
   "Ingress": "இன்க்ரெஸ்",

--- a/frontend/src/i18n/locales/tr/glossary.json
+++ b/frontend/src/i18n/locales/tr/glossary.json
@@ -121,7 +121,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "Kiralama",
   "LimitRange": "LimitRange",
   "Ingress": "Giriş",

--- a/frontend/src/i18n/locales/tr/glossary.json
+++ b/frontend/src/i18n/locales/tr/glossary.json
@@ -120,6 +120,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "Kiralama",
   "LimitRange": "LimitRange",
   "Ingress": "Giriş",

--- a/frontend/src/i18n/locales/ur/glossary.json
+++ b/frontend/src/i18n/locales/ur/glossary.json
@@ -122,7 +122,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "لیز",
   "LimitRange": "لمٹ رینج",
   "Ingress": "انگریس",

--- a/frontend/src/i18n/locales/ur/glossary.json
+++ b/frontend/src/i18n/locales/ur/glossary.json
@@ -121,6 +121,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "لیز",
   "LimitRange": "لمٹ رینج",
   "Ingress": "انگریس",

--- a/frontend/src/i18n/locales/zh-tw/glossary.json
+++ b/frontend/src/i18n/locales/zh-tw/glossary.json
@@ -121,6 +121,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "租約",
   "LimitRange": "限制範圍",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/zh-tw/glossary.json
+++ b/frontend/src/i18n/locales/zh-tw/glossary.json
@@ -122,7 +122,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "租約",
   "LimitRange": "限制範圍",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/zh/glossary.json
+++ b/frontend/src/i18n/locales/zh/glossary.json
@@ -121,6 +121,8 @@
   "Checking if JobSet is enabled…": "",
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
+  "Checking if LeaderWorkerSet is enabled…": "",
+  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
   "Lease": "租约",
   "LimitRange": "限制范围",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/zh/glossary.json
+++ b/frontend/src/i18n/locales/zh/glossary.json
@@ -122,7 +122,7 @@
   "JobSet is not enabled. <1>Learn More</1>": "",
   "Leader Worker Sets": "",
   "Checking if LeaderWorkerSet is enabled…": "",
-  "LeaderWorkerSet is not enabled on this cluster. <1>Learn More</1>": "",
+  "LeaderWorkerSet is not enabled. <1>Learn More</1>": "",
   "Lease": "租约",
   "LimitRange": "限制范围",
   "Ingress": "Ingress",

--- a/frontend/src/lib/k8s/leaderWorkerSet.test.ts
+++ b/frontend/src/lib/k8s/leaderWorkerSet.test.ts
@@ -14,13 +14,21 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import App from '../../App';
+import { request } from './api/v1/clusterRequests';
+import { ApiError } from './api/v2/ApiError';
 import LeaderWorkerSet from './leaderWorkerSet';
 
 // cyclic imports fix
 // eslint-disable-next-line no-unused-vars
 const _dont_delete_me = App;
+
+vi.mock('./api/v1/clusterRequests', () => ({
+  request: vi.fn(),
+}));
+
+const mockedRequest = vi.mocked(request);
 
 const makeLeaderWorkerSet = (spec: any, status: any) =>
   new LeaderWorkerSet({
@@ -32,6 +40,62 @@ const makeLeaderWorkerSet = (spec: any, status: any) =>
   } as any);
 
 describe('LeaderWorkerSet class', () => {
+  describe('isEnabled', () => {
+    beforeEach(() => {
+      mockedRequest.mockReset();
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('returns true when the leaderworkersets resource is listed', async () => {
+      mockedRequest.mockResolvedValue({
+        resources: [{ name: 'leaderworkersets' }, { name: 'leaderworkersets/status' }],
+      });
+
+      await expect(LeaderWorkerSet.isEnabled('test-cluster')).resolves.toBe(true);
+      expect(mockedRequest).toHaveBeenCalledWith(
+        `/apis/${LeaderWorkerSet.apiVersion}`,
+        { cluster: 'test-cluster', autoLogoutOnAuthError: false },
+        false
+      );
+    });
+
+    it('returns false when the leaderworkersets resource is missing', async () => {
+      mockedRequest.mockResolvedValue({ resources: [] });
+      await expect(LeaderWorkerSet.isEnabled('test-cluster')).resolves.toBe(false);
+    });
+
+    it('returns false without logging when the API group is missing (404)', async () => {
+      mockedRequest.mockRejectedValue(
+        new ApiError('the server could not find the requested resource', { status: 404 })
+      );
+
+      await expect(LeaderWorkerSet.isEnabled('test-cluster')).resolves.toBe(false);
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it('returns false and logs non-404 discovery failures', async () => {
+      mockedRequest.mockRejectedValue(new ApiError('forbidden', { status: 403 }));
+
+      await expect(LeaderWorkerSet.isEnabled('test-cluster')).resolves.toBe(false);
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    it('probes without a cluster override when none is passed', async () => {
+      mockedRequest.mockResolvedValue({ resources: [{ name: 'leaderworkersets' }] });
+
+      await expect(LeaderWorkerSet.isEnabled()).resolves.toBe(true);
+      expect(mockedRequest).toHaveBeenCalledWith(
+        `/apis/${LeaderWorkerSet.apiVersion}`,
+        { autoLogoutOnAuthError: false },
+        false
+      );
+    });
+  });
+
   describe('getDesiredReplicas', () => {
     it('returns the requested number of groups', () => {
       expect(makeLeaderWorkerSet({ replicas: 3 }, {}).getDesiredReplicas()).toBe(3);

--- a/frontend/src/lib/k8s/leaderWorkerSet.ts
+++ b/frontend/src/lib/k8s/leaderWorkerSet.ts
@@ -15,6 +15,7 @@
  */
 
 import { request } from './api/v1/clusterRequests';
+import type { ApiError } from './api/v2/ApiError';
 import { isConditionTrue } from './conditions';
 import type { KubeObjectInterface } from './KubeObject';
 import { KubeObject } from './KubeObject';
@@ -113,16 +114,41 @@ class LeaderWorkerSet extends KubeObject<KubeLeaderWorkerSet> {
     return 'degraded';
   }
 
-  static async isEnabled(): Promise<boolean> {
-    let res;
+  /**
+   * Whether the LeaderWorkerSet API is available on a cluster.
+   *
+   * A 404 (API group/resource missing) means LWS is not installed and is
+   * returned as false without logging. Other failures (auth, network, 5xx)
+   * are still treated as false so the UI can degrade, but they are logged so
+   * they are not silently confused with "not installed". Discovery uses
+   * `autoLogoutOnAuthError: false` so a background probe cannot force logout.
+   *
+   * @param cluster - Cluster to probe; defaults to the current URL cluster.
+   */
+  static async isEnabled(cluster?: string): Promise<boolean> {
     try {
-      res = await request('/apis/leaderworkerset.x-k8s.io/v1');
+      const res = await request(
+        `/apis/${LeaderWorkerSet.apiVersion}`,
+        {
+          ...(cluster ? { cluster } : {}),
+          autoLogoutOnAuthError: false,
+        },
+        false
+      );
+      return !!res?.resources?.some((r: { name?: string }) => r?.name === LeaderWorkerSet.apiName);
     } catch (e) {
+      const status = (e as ApiError)?.status;
+      // Missing API group is the expected "not installed" case.
+      if (status !== 404) {
+        console.error(
+          `Failed to check LeaderWorkerSet availability${
+            cluster ? ` on cluster "${cluster}"` : ''
+          }:`,
+          e
+        );
+      }
       return false;
     }
-    return !!res?.resources?.find(
-      (r: { name: string; [key: string]: any }) => r?.name === 'leaderworkersets'
-    );
   }
 
   static getBaseObject(): KubeLeaderWorkerSet {

--- a/frontend/src/lib/k8s/leaderWorkerSet.ts
+++ b/frontend/src/lib/k8s/leaderWorkerSet.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { request } from './api/v1/clusterRequests';
 import { isConditionTrue } from './conditions';
 import type { KubeObjectInterface } from './KubeObject';
 import { KubeObject } from './KubeObject';
@@ -110,6 +111,18 @@ class LeaderWorkerSet extends KubeObject<KubeLeaderWorkerSet> {
       return isConditionTrue(conditions, 'Progressing') ? 'transitional' : 'failed';
     }
     return 'degraded';
+  }
+
+  static async isEnabled(): Promise<boolean> {
+    let res;
+    try {
+      res = await request('/apis/leaderworkerset.x-k8s.io/v1');
+    } catch (e) {
+      return false;
+    }
+    return !!res?.resources?.find(
+      (r: { name: string; [key: string]: any }) => r?.name === 'leaderworkersets'
+    );
   }
 
   static getBaseObject(): KubeLeaderWorkerSet {


### PR DESCRIPTION
## Summary

LeaderWorkerSet is an optional CRD that may not be installed on every cluster. Without gating, navigating to the LeaderWorkerSet list on a cluster without the CRD produces a raw API error. This PR adds an `isEnabled()` probe (mirroring VPA's existing pattern) so the UI shows a meaningful empty state instead.

Fixes #7219

## Changes

- **`leaderWorkerSet.ts`**: Added `LeaderWorkerSet.isEnabled()` static method that probes the `leaderworkerset.x-k8s.io/v1` API group
- **`List.tsx`**: Gated `ResourceListView` behind the `isEnabled()` check with three states: Checking, Not-enabled (with "Learn More" link), and the normal list
- **`LeaderWorkerSetList.stories.tsx`**: Added `Checking` and `NotEnabled` stories with MSW handlers; updated existing `Items` story to also mock the API group probe
- Updated i18n locale files and storyshot snapshots

## Steps to Test

1. Run `npm run frontend:test` — all tests pass
2. Run `npm run frontend:storybook` → navigate to LeaderWorkerSet/List
   - **Items**: Shows the normal list with mock data
   - **Checking**: Shows "Checking if LeaderWorkerSet is enabled…" spinner state
   - **NotEnabled**: Shows "LeaderWorkerSet is not enabled on this cluster. Learn More" with link to LWS installation docs

## Screenshots

_Storybook stories cover all three visual states._