### PR TITLE
 ci: Add timeout-minutes to storybook mocks and a11y jobs

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -237,6 +237,9 @@ jobs:
   test-storybook-mocks:
     name: test storybook mocks
     runs-on: ${{ matrix.os }}
+    # Normal runs finish well under 12 minutes; a stalled apt mirror or
+    # download should fail fast instead of hanging for the 6 hour default.
+    timeout-minutes: 25
     strategy:
       matrix:
         node-version: [22.x]
@@ -274,6 +277,9 @@ jobs:
   test-a11y:
     name: test accessibility
     runs-on: ${{ matrix.os }}
+    # Normal runs finish well under 12 minutes; a stalled apt mirror or
+    # download should fail fast instead of hanging for the 6 hour default.
+    timeout-minutes: 25
     strategy:
       matrix:
         node-version: [22.x]


### PR DESCRIPTION
## Problem

Neither the `test storybook mocks` nor the `test accessibility` job in `frontend.yml` sets `timeout-minutes`, so a wedged step keeps the job "in progress" until GitHub's default **6-hour** cap, blocking the PR's checks the whole time.

This is not hypothetical — on 2026-08-18 both jobs hung for over an hour on the same step at the same timestamp, stuck in **Install Playwright browsers**:

- Example stuck job: https://github.com/kubernetes-sigs/headlamp/actions/runs/32273924454/job/96136678852?pr=7344

The `--with-deps` flag makes Playwright run `apt-get`, and the runner's `azure.archive.ubuntu.com` mirror was broken, so apt retried indefinitely (repeated `Ign:` lines in the log). A separate run the next day hit the same stall but recovered after ~36 minutes — so this mirror flake is actively recurring. (#7255 / commit af11a7f1c already dropped `--with-deps` from the storybook-mocks job, which removes the apt dependency there; this PR adds the general safety net.)

## Why 25 minutes

Derived from the last 20 completed runs of this workflow rather than picked as a round number:

| Job | Typical duration | Slowest healthy run |
|---|---|---|
| test storybook mocks | 1.5–7 min | 6m 48s |
| test accessibility | 5.5–11.5 min | 11m 24s |

25 minutes is roughly **2× the slowest healthy run observed** (11m 24s), which is the standard margin: comfortably above normal variance (npm cache misses, slow runners, browser download hiccups, suite growth), while turning a wedged runner into a fast, one-click-retryable failure instead of a 6-hour zombie. The cost asymmetry favors a tight-ish cap: a false positive costs one re-run (~10 min), a missing timeout costs hours of blocked CI.

## Changes

- Add `timeout-minutes: 25` to the `test-storybook-mocks` and `test-a11y` jobs, with a comment explaining the rationale.
