### PR TITLE
helm: Fix large sessionTTL values

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -280,7 +280,7 @@ spec:
             - "-plugins-dir={{ . }}"
             {{- end }}
             {{- if hasKey .Values.config "sessionTTL" }}
-            - "-session-ttl={{ .Values.config.sessionTTL }}"
+            - "-session-ttl={{ int .Values.config.sessionTTL }}"
             {{- end }}
             {{- with .Values.config.podDebugImage }}
             - "-pod-debug-image={{ . }}"

--- a/charts/headlamp/tests/expected_templates/session-ttl.yaml
+++ b/charts/headlamp/tests/expected_templates/session-ttl.yaml
@@ -1,0 +1,142 @@
+---
+# Source: headlamp/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.45.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.45.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: headlamp/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oidc
+  namespace: default
+type: Opaque
+data:
+---
+# Source: headlamp/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+  labels:
+    helm.sh/chart: headlamp-0.45.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.45.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: headlamp
+  namespace: default
+---
+# Source: headlamp/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.45.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.45.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+---
+# Source: headlamp/templates/deployment.yaml
+# This block of code is used to extract the values from the env.
+# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.45.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.45.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+      app.kubernetes.io/instance: headlamp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: headlamp
+        app.kubernetes.io/instance: headlamp
+    spec:
+      serviceAccountName: headlamp
+      automountServiceAccountToken: true
+      hostUsers: true
+      securityContext:
+        {}
+      containers:
+        - name: headlamp
+          securityContext:
+            privileged: false
+            runAsGroup: 101
+            runAsNonRoot: true
+            runAsUser: 100
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.45.0"
+          imagePullPolicy: IfNotPresent
+          
+          env:
+          args:
+            - "-in-cluster"
+            - "-in-cluster-context-name=main"
+            - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=31536000"
+            # Check if externalSecret is disabled
+          ports:
+            - name: http
+              containerPort: 4466
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: "/"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            {}

--- a/charts/headlamp/tests/test_cases/session-ttl.yaml
+++ b/charts/headlamp/tests/test_cases/session-ttl.yaml
@@ -1,0 +1,3 @@
+# This is a test case for large sessionTTL in the Headlamp deployment.
+config:
+  sessionTTL: 31536000


### PR DESCRIPTION
## Summary

Fixes #7325.
Large `sessionTTL` values supplied through a Helm values file can be rendered in scientific notation, causing the Headlamp backend to fail when parsing the `-session-ttl` flag.
This change explicitly converts `sessionTTL` to an integer before rendering the container argument.

## Related Issue

Fixes #7325.

## Changes

- Cast `sessionTTL` to an integer in the Helm deployment template (`charts/headlamp/templates/deployment.yaml`).
- Add a regression test covering the documented maximum value `31536000` (`charts/headlamp/tests/test_cases/session-ttl.yaml`).
- Add expected template fixture for regression test (`charts/headlamp/tests/expected_templates/session-ttl.yaml`).
- Verify that large values are rendered as normal integers rather than scientific notation.

## How to Reproduce the Bug (Before Fix)

1. Create a values file with a large `sessionTTL`:
```yaml
config:
  sessionTTL: 3153600
```
2. Render the chart:
```bash
helm template headlamp ./charts/headlamp --values values.yaml | grep session-ttl
```
3. **Observed (Bug)**: Rendered in scientific notation:
```text
- "-session-ttl=3.1536e+06"
```
When the container starts, the Go flag parser fails with: `invalid value "3.1536e+06" for flag -session-ttl: parse error`.

## Steps to Verify the Fix

1. Provide a Helm values file containing:
```yaml
config:
  sessionTTL: 31536000
```
2. Render the chart:
```bash
helm template headlamp ./charts/headlamp --values <values-file> | grep session-ttl
```
3. **Expected (Fixed)**: Rendered as a standard integer without scientific notation:
```text
- "-session-ttl=31536000"
```

## Tests Ran

- `helm lint ./charts/headlamp`
- `make helm-template-test`
- `git diff --check`

Verified locally:
- `86400` → `-session-ttl=86400`
- `3153600` → `-session-ttl=3153600`
- `31536000` → `-session-ttl=31536000`

## Notes for the Reviewer

- In Helm, numbers from values files are unmarshaled as `float64`. Go template formats `float64` values $\ge 1,000,000$ in scientific notation (`%g`). Using `{{ int .Values.config.sessionTTL }}` casts the value to an integer before string interpolation.
- The default `config.sessionTTL` (`86400`) and all existing chart fixtures remain unchanged.
