### PR TITLE
docs: clarify e2e kubeconfig certificate setup

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -83,22 +83,44 @@ rather than as an obvious configuration problem.
 `dynamicCluster.spec.ts` reads your kubeconfig with `kubectl config view`, which
 redacts embedded `certificate-authority-data` and the client certificate fields,
 and then reads the referenced files from disk. If those fields are embedded
-rather than file paths, six tests in that file fail with `ENOENT`.
+rather than file paths, seven tests in that file fail with `ENOENT`.
 
 CI works around this by rewriting the kubeconfig so the certificates live in
 files. If you hit those failures, do the same, and note that the paths must be
 absolute, because the test resolves them relative to its own working directory:
 
 ```bash
+umask 077
 mkdir -p ~/headlamp-e2e-certs
-kubectl config view --raw --minify --context=test -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' | base64 --decode > ~/headlamp-e2e-certs/ca.crt
-kubectl config set-cluster kind-test --certificate-authority="$HOME/headlamp-e2e-certs/ca.crt" --embed-certs=false
-kubectl config unset clusters.kind-test.certificate-authority-data
-```
 
-Do the same for the `client-certificate-data` and `client-key-data` fields on
-the user entry. To update the second cluster, use `--context=test2` and the
-`kind-test2` cluster entry.
+# test cluster
+kubectl config view --raw --minify --context=test -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' | base64 --decode > ~/headlamp-e2e-certs/test-ca.crt
+kubectl config view --raw --minify --context=test -o jsonpath='{.users[0].user.client-certificate-data}' | base64 --decode > ~/headlamp-e2e-certs/test-client.crt
+kubectl config view --raw --minify --context=test -o jsonpath='{.users[0].user.client-key-data}' | base64 --decode > ~/headlamp-e2e-certs/test-client.key
+
+kubectl config set-cluster kind-test \
+  --certificate-authority="$HOME/headlamp-e2e-certs/test-ca.crt" \
+  --embed-certs=false
+
+kubectl config set-credentials admin@kind-test \
+  --client-certificate="$HOME/headlamp-e2e-certs/test-client.crt" \
+  --client-key="$HOME/headlamp-e2e-certs/test-client.key" \
+  --embed-certs=false
+
+# test2 cluster
+kubectl config view --raw --minify --context=test2 -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' | base64 --decode > ~/headlamp-e2e-certs/test2-ca.crt
+kubectl config view --raw --minify --context=test2 -o jsonpath='{.users[0].user.client-certificate-data}' | base64 --decode > ~/headlamp-e2e-certs/test2-client.crt
+kubectl config view --raw --minify --context=test2 -o jsonpath='{.users[0].user.client-key-data}' | base64 --decode > ~/headlamp-e2e-certs/test2-client.key
+
+kubectl config set-cluster kind-test2 \
+  --certificate-authority="$HOME/headlamp-e2e-certs/test2-ca.crt" \
+  --embed-certs=false
+
+kubectl config set-credentials admin@kind-test2 \
+  --client-certificate="$HOME/headlamp-e2e-certs/test2-client.crt" \
+  --client-key="$HOME/headlamp-e2e-certs/test2-client.key" \
+  --embed-certs=false
+```
 
 ### Additional suites
 


### PR DESCRIPTION
## Summary

Clarifies the kubeconfig certificate setup in `e2e-tests/README.md` by replacing the abbreviated "do the same" instructions with complete commands for both `test` and `test2`.

## Related Issue

Fixes #7348

## Changes

- Added separate CA, client certificate, and client key files for `test` and `test2`
- Added explicit `kubectl config set-cluster` commands for both clusters
- Added explicit `kubectl config set-credentials` commands for both users
- Removed the need for contributors to derive the missing certificate setup steps themselves

## Steps to Test

1. Follow the kubeconfig certificate section in `e2e-tests/README.md`.
2. Verify that certificate files are created for both `test` and `test2`.
3. Verify that both kubeconfig cluster and user entries reference the certificate files on disk.

## Screenshots (if applicable)

Not applicable.

## Notes for the Reviewer

Issue #7348 originally covered three e2e documentation gaps. Since the issue was filed, the updated multi-cluster setup on `main` has already addressed the working-directory flow and loading the Headlamp image into `test2`.

This PR therefore keeps the current upstream setup and addresses the remaining kubeconfig certificate documentation gap.