### PR TITLE
backend: auth: Fix auth cookie clearing and cluster name collision

### DIFF
--- a/backend/pkg/auth/cookies.go
+++ b/backend/pkg/auth/cookies.go
@@ -27,6 +27,8 @@ import (
 const (
 	// chunkSize is the size of each token chunk, less than 4KB because of the size limit.
 	chunkSize = 3800
+	// maxCookieChunks is the maximum number of token chunk cookies to clear.
+	maxCookieChunks = 10
 )
 
 // GetCookiePath returns the full cookie path including baseURL.
@@ -39,15 +41,34 @@ func GetCookiePath(baseURL, cluster string) string {
 	return "/clusters/" + cluster
 }
 
+// fnvHash computes a 32-bit FNV-1a hash formatted as an 8-character hex string.
+func fnvHash(s string) string {
+	var h uint32 = 2166136261
+	for i := 0; i < len(s); i++ {
+		h ^= uint32(s[i])
+		h *= 16777619
+	}
+
+	return fmt.Sprintf("%08x", h)
+}
+
 // SanitizeClusterName ensures cluster names are safe for use in cookie names.
 func SanitizeClusterName(cluster string) string {
 	// Only allow alphanumeric characters, hyphens, and underscores
 	reg := regexp.MustCompile(`[^a-zA-Z0-9\-_]`)
 	sanitized := reg.ReplaceAllString(cluster, "")
 
-	// Limit length to prevent issues
-	if len(sanitized) > 50 {
-		sanitized = sanitized[:50]
+	// Limit length to prevent issues and use a deterministic hash suffix if original
+	// or sanitized name exceeds 50 characters to avoid collisions.
+	if len(cluster) > 50 || len(sanitized) > 50 {
+		hashSuffix := fnvHash(cluster)
+		prefix := sanitized
+
+		if len(prefix) > 41 {
+			prefix = prefix[:41]
+		}
+
+		return prefix + "-" + hashSuffix
 	}
 
 	return sanitized
@@ -86,13 +107,14 @@ func SetTokenCookie(w http.ResponseWriter, r *http.Request, cluster, token, base
 		return
 	}
 
-	// Clear any existing cookies
-	ClearTokenCookie(w, r, cluster, baseURL)
-
 	secure := IsSecureContext(r)
 
-	// if token is larger than maxCookieSize, split it into multiple cookies
+	// if token requires more chunks than maxCookieChunks, reject to prevent storing partial credentials
 	chunks := splitToken(token, chunkSize)
+	if len(chunks) > maxCookieChunks {
+		return
+	}
+
 	for i, chunk := range chunks {
 		// G124: Secure is set from IsSecureContext so localhost development still works;
 		// HttpOnly and SameSite are set unconditionally.
@@ -108,6 +130,9 @@ func SetTokenCookie(w http.ResponseWriter, r *http.Request, cluster, token, base
 
 		http.SetCookie(w, cookie)
 	}
+
+	// Clear any leftover higher-index cookies from previous longer tokens
+	ClearTokenCookieFrom(w, r, cluster, baseURL, len(chunks))
 }
 
 // GetTokenFromCookie retrieves an authentication cookie for a specific cluster.
@@ -138,6 +163,11 @@ func GetTokenFromCookie(r *http.Request, cluster string) (string, error) {
 
 // ClearTokenCookie clears an authentication cookie for a specific cluster.
 func ClearTokenCookie(w http.ResponseWriter, r *http.Request, cluster, baseURL string) {
+	ClearTokenCookieFrom(w, r, cluster, baseURL, 0)
+}
+
+// ClearTokenCookieFrom clears authentication cookies starting from startChunk up to maxCookieChunks.
+func ClearTokenCookieFrom(w http.ResponseWriter, r *http.Request, cluster, baseURL string, startChunk int) {
 	sanitizedCluster := SanitizeClusterName(cluster)
 	if sanitizedCluster == "" {
 		return
@@ -145,15 +175,10 @@ func ClearTokenCookie(w http.ResponseWriter, r *http.Request, cluster, baseURL s
 
 	secure := IsSecureContext(r)
 
-	// clear chunked cookies
-	for i := 0; ; i++ {
+	// Clear chunked cookies starting from startChunk up to maxCookieChunks to ensure potential
+	// stale chunks are invalidated even when request URL path does not match cookie path.
+	for i := startChunk; i < maxCookieChunks; i++ {
 		cookieName := fmt.Sprintf("headlamp-auth-%s.%d", sanitizedCluster, i)
-
-		_, err := r.Cookie(cookieName)
-		if err != nil {
-			// No more cookies for this cluster
-			break
-		}
 
 		// G124: Secure is set from IsSecureContext so localhost development still works;
 		// HttpOnly and SameSite are set unconditionally.
@@ -166,7 +191,36 @@ func ClearTokenCookie(w http.ResponseWriter, r *http.Request, cluster, baseURL s
 			Path:     GetCookiePath(baseURL, cluster),
 			MaxAge:   -1,
 		}
+
 		http.SetCookie(w, cookie)
+	}
+
+	// For long cluster names, also clear legacy unhashed 50-character prefix cookies
+	// to ensure smooth transition from older releases.
+	reg := regexp.MustCompile(`[^a-zA-Z0-9\-_]`)
+	rawSanitized := reg.ReplaceAllString(cluster, "")
+
+	if rawSanitized != "" && (len(cluster) > 50 || len(rawSanitized) > 50) {
+		legacyCluster := rawSanitized
+		if len(legacyCluster) > 50 {
+			legacyCluster = legacyCluster[:50]
+		}
+
+		for i := 0; i < maxCookieChunks; i++ {
+			cookieName := fmt.Sprintf("headlamp-auth-%s.%d", legacyCluster, i)
+
+			cookie := &http.Cookie{ //nolint:gosec
+				Name:     cookieName,
+				Value:    "",
+				HttpOnly: true,
+				Secure:   secure,
+				SameSite: http.SameSiteStrictMode,
+				Path:     GetCookiePath(baseURL, cluster),
+				MaxAge:   -1,
+			}
+
+			http.SetCookie(w, cookie)
+		}
 	}
 }
 

--- a/backend/pkg/auth/cookies_test.go
+++ b/backend/pkg/auth/cookies_test.go
@@ -19,6 +19,7 @@ package auth_test
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -33,6 +34,9 @@ const (
 )
 
 func TestSanitizeClusterName(t *testing.T) {
+	longInput := "very-long-cluster-name-that-exceeds-fifty-characters-limit"
+	longExpected := "very-long-cluster-name-that-exceeds-fifty-1daebb19"
+
 	tests := []struct {
 		input    string
 		expected string
@@ -42,7 +46,7 @@ func TestSanitizeClusterName(t *testing.T) {
 		{"cluster123", "cluster123"},
 		{"my-cluster@#$%", "my-cluster"},
 		{"", ""},
-		{"very-long-cluster-name-that-exceeds-fifty-characters-limit", "very-long-cluster-name-that-exceeds-fifty-characte"},
+		{longInput, longExpected},
 	}
 
 	for _, test := range tests {
@@ -50,6 +54,37 @@ func TestSanitizeClusterName(t *testing.T) {
 		if result != test.expected {
 			t.Errorf("SanitizeClusterName(%q) = %q, expected %q", test.input, result, test.expected)
 		}
+	}
+}
+
+func TestSanitizeClusterName_NoCollisionsOnLongPrefixes(t *testing.T) {
+	clusterA := "production-us-east-1-kubernetes-cluster-primary-alpha"
+	clusterB := "production-us-east-1-kubernetes-cluster-primary-bravo"
+
+	sanitizedA := auth.SanitizeClusterName(clusterA)
+	sanitizedB := auth.SanitizeClusterName(clusterB)
+
+	if len(sanitizedA) > 50 {
+		t.Errorf("Expected len(sanitizedA) <= 50, got %d", len(sanitizedA))
+	}
+
+	if len(sanitizedB) > 50 {
+		t.Errorf("Expected len(sanitizedB) <= 50, got %d", len(sanitizedB))
+	}
+
+	if sanitizedA == sanitizedB {
+		t.Errorf("Expected distinct sanitized names for distinct clusters, but both got %q", sanitizedA)
+	}
+
+	// Test distinct cluster names >50 chars that sanitize to the same 50-char base prefix
+	lossyA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@"
+	lossyB := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#"
+
+	sanitizedLossyA := auth.SanitizeClusterName(lossyA)
+	sanitizedLossyB := auth.SanitizeClusterName(lossyB)
+
+	if sanitizedLossyA == sanitizedLossyB {
+		t.Errorf("Expected distinct sanitized names for lossy sanitized clusters, but got %q", sanitizedLossyA)
 	}
 }
 
@@ -175,10 +210,10 @@ func TestSetAndGetAuthCookie(t *testing.T) {
 	testTTL := 100
 	auth.SetTokenCookie(w, req, "test-cluster", "test-token", "", testTTL)
 
-	// Check if cookie was set
+	// Check if cookie was set (1 token chunk + 9 cleared chunk headers)
 	cookies := w.Result().Cookies()
-	if len(cookies) != 1 {
-		t.Fatalf("Expected 1 cookie, got %d", len(cookies))
+	if len(cookies) != 10 {
+		t.Fatalf("Expected 10 cookies, got %d", len(cookies))
 	}
 
 	cookie := cookies[0]
@@ -203,7 +238,11 @@ func TestSetAndGetAuthCookie(t *testing.T) {
 	}
 
 	// Test getting the cookie
-	req.AddCookie(cookie)
+	for _, c := range cookies {
+		if c.MaxAge > 0 {
+			req.AddCookie(c)
+		}
+	}
 
 	token, err := auth.GetTokenFromCookie(req, "test-cluster")
 	if err != nil {
@@ -211,7 +250,7 @@ func TestSetAndGetAuthCookie(t *testing.T) {
 	}
 
 	if token != "test-token" {
-		t.Errorf("Expected token 'test-token', got %q", token)
+		t.Errorf("Expected token to be 'test-token', got %q", token)
 	}
 }
 
@@ -228,13 +267,15 @@ func TestGetAuthCookieChunked(t *testing.T) {
 
 	// Check if cookie was set
 	cookies := w.Result().Cookies()
-	if len(cookies) < 2 {
-		t.Fatalf("Expected at least 2 cookies for a chunked token, got %d", len(cookies))
+	if len(cookies) != 10 {
+		t.Fatalf("Expected 10 cookies (2 token chunks + 8 cleared chunks), got %d", len(cookies))
 	}
 
 	// Test getting the cookie
 	for _, cookie := range cookies {
-		req.AddCookie(cookie)
+		if cookie.MaxAge > 0 {
+			req.AddCookie(cookie)
+		}
 	}
 
 	token, err := auth.GetTokenFromCookie(req, "test-cluster")
@@ -247,50 +288,136 @@ func TestGetAuthCookieChunked(t *testing.T) {
 	}
 }
 
+func applyResponseCookies(cookieMap map[string]*http.Cookie, cookies []*http.Cookie) {
+	for _, c := range cookies {
+		if c.MaxAge < 0 {
+			delete(cookieMap, c.Name)
+		} else {
+			cookieMap[c.Name] = c
+		}
+	}
+}
+
+func TestSetTokenCookie_OverwritesLongerTokenWithShorterToken(t *testing.T) {
+	cluster := "test-cluster"
+	longToken := strings.Repeat("A", 3800*3+500)
+	shortToken := strings.Repeat("B", 3800+500)
+
+	req1 := httptest.NewRequestWithContext(context.Background(), "GET", localhostOrigin, nil)
+	req1.Host = localhost
+	w1 := httptest.NewRecorder()
+
+	auth.SetTokenCookie(w1, req1, cluster, longToken, "", 86400)
+
+	cookieMap := make(map[string]*http.Cookie)
+	applyResponseCookies(cookieMap, w1.Result().Cookies())
+
+	reqVerify1 := httptest.NewRequestWithContext(context.Background(), "GET", localhostOrigin, nil)
+	for _, c := range cookieMap {
+		reqVerify1.AddCookie(c)
+	}
+
+	retrievedLong, err := auth.GetTokenFromCookie(reqVerify1, cluster)
+	if err != nil || retrievedLong != longToken {
+		t.Fatalf("Expected retrieved long token to match longToken, err: %v", err)
+	}
+
+	req2 := httptest.NewRequestWithContext(context.Background(), "GET", localhostOrigin, nil)
+	req2.Host = localhost
+
+	for _, c := range cookieMap {
+		req2.AddCookie(c)
+	}
+
+	w2 := httptest.NewRecorder()
+	auth.SetTokenCookie(w2, req2, cluster, shortToken, "", 86400)
+
+	applyResponseCookies(cookieMap, w2.Result().Cookies())
+
+	reqVerify2 := httptest.NewRequestWithContext(context.Background(), "GET", localhostOrigin, nil)
+	for _, c := range cookieMap {
+		reqVerify2.AddCookie(c)
+	}
+
+	retrievedShort, err := auth.GetTokenFromCookie(reqVerify2, cluster)
+	if err != nil || retrievedShort != shortToken {
+		t.Fatalf("Expected retrieved short token to match shortToken, err: %v", err)
+	}
+}
+
+func TestSetTokenCookie_RejectsOversizedToken(t *testing.T) {
+	cluster := "test-cluster"
+	// Token requiring 11 chunks (> 10 maxCookieChunks)
+	oversizedToken := strings.Repeat("X", 3800*10+500)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", localhostOrigin, nil)
+	req.Host = localhost
+	w := httptest.NewRecorder()
+
+	auth.SetTokenCookie(w, req, cluster, oversizedToken, "", 86400)
+
+	cookies := w.Result().Cookies()
+	if len(cookies) != 0 {
+		t.Fatalf("Expected 0 cookies set for oversized token exceeding maxCookieChunks, got %d", len(cookies))
+	}
+}
+
 func TestClearAuthCookie(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), "GET", localhostOrigin, nil)
 	req.Host = localhost
 	w := httptest.NewRecorder()
 
-	// Set cookie
-	req.AddCookie(&http.Cookie{
-		Name:     "headlamp-auth-test-cluster.0",
-		Value:    "test-token",
-		HttpOnly: true,
-		Secure:   true,
-		SameSite: http.SameSiteStrictMode,
-		Path:     "/",
-		MaxAge:   86400, // 24 hours
-	})
+	// Set a 2-chunk cookie first
+	auth.SetTokenCookie(w, req, "test-cluster", strings.Repeat("a", 5000), "", 86400)
 
-	// Clear a cookie
-	auth.ClearTokenCookie(w, req, "test-cluster", "")
+	// Clear the cookie
+	req2 := httptest.NewRequestWithContext(context.Background(), "GET", localhostOrigin, nil)
+	for _, cookie := range w.Result().Cookies() {
+		req2.AddCookie(cookie)
+	}
 
-	// Check if cookie was set
+	w2 := httptest.NewRecorder()
+	auth.ClearTokenCookie(w2, req2, "test-cluster", "")
+
+	cookies := w2.Result().Cookies()
+	if len(cookies) != 10 {
+		t.Fatalf("Expected 10 cleared cookies, got %d", len(cookies))
+	}
+
+	for i, cookie := range cookies {
+		expectedName := fmt.Sprintf("headlamp-auth-test-cluster.%d", i)
+		if cookie.Name != expectedName {
+			t.Errorf("Expected cookie name %q, got %q", expectedName, cookie.Name)
+		}
+
+		if cookie.Value != "" {
+			t.Errorf("Expected cookie value to be empty for %s, got %q", cookie.Name, cookie.Value)
+		}
+
+		if cookie.MaxAge != -1 {
+			t.Errorf("Expected MaxAge to be -1 for %s, got %d", cookie.Name, cookie.MaxAge)
+		}
+	}
+}
+
+func TestClearAuthCookie_WithoutIncomingCookies(t *testing.T) {
+	// Verify that ClearTokenCookie helper unconditionally emits cookie deletion headers up to maxCookieChunks
+	// even when the incoming request carries no cookies.
+	req := httptest.NewRequestWithContext(context.Background(), "POST", "http://localhost:4466/", nil)
+	w := httptest.NewRecorder()
+
+	auth.ClearTokenCookie(w, req, "my-cluster", "")
+
 	cookies := w.Result().Cookies()
-	if len(cookies) != 1 {
-		t.Fatalf("Expected 1 cookie, got %d", len(cookies))
+	if len(cookies) != 10 {
+		t.Fatalf("Expected 10 expiration cookies when request carries no incoming cookies, got %d", len(cookies))
 	}
 
-	// Test clearing the cookie
-	auth.ClearTokenCookie(w, req, "test-cluster", "")
-
-	// Check if cookie was cleared
-	clearedCookies := w.Result().Cookies()
-	if len(clearedCookies) != 1 {
-		t.Fatalf("Expected 1 cookie, got %d", len(clearedCookies))
+	if cookies[0].Name != "headlamp-auth-my-cluster.0" {
+		t.Errorf("Expected first cookie name 'headlamp-auth-my-cluster.0', got %q", cookies[0].Name)
 	}
 
-	cookie := clearedCookies[0]
-	if cookie.Name != "headlamp-auth-test-cluster.0" {
-		t.Errorf("Expected cookie name 'headlamp-auth-test-cluster.0', got %q", cookie.Name)
-	}
-
-	if cookie.Value != "" {
-		t.Errorf("Expected cookie value to be empty, got %q", cookie.Value)
-	}
-
-	if cookie.MaxAge != -1 {
-		t.Errorf("Expected MaxAge to be -1, got %d", cookie.MaxAge)
+	if cookies[0].MaxAge != -1 {
+		t.Errorf("Expected MaxAge to be -1, got %d", cookies[0].MaxAge)
 	}
 }


### PR DESCRIPTION
Fixes #7351

## Problem

1. **Failure to Clear Path-Scoped Cookies on Global/Logout Endpoints:**
   `ClearTokenCookie` in `backend/pkg/auth/cookies.go` relied on `r.Cookie(cookieName)` being present in the incoming HTTP request. However, `SetTokenCookie` sets cookies with `Path: /clusters/<cluster>`. When a user logs out or clears a token via global endpoints (e.g. `/auth/set-token`), the request URL path does not match the cookie path. The browser omits the cookie from the request header, causing `r.Cookie(...)` to return `http.ErrNoCookie` and `ClearTokenCookie` to `break` on index `0` without sending any `MaxAge: -1` expiration headers.
2. **Stale Chunk Leftover & JWT Token Corruption:**
   When updating a multi-chunk token to a shorter token, breaking early on missing incoming cookies left higher-index chunk cookies active in the browser. Subsequent calls to `GetTokenFromCookie` concatenated the new chunk with stale old chunks, corrupting the token.
3. **Cluster Name Collision:**
   `SanitizeClusterName` truncated cluster names at 50 characters without hashing, leading to cookie name collisions for clusters sharing a long prefix.

## Fix

- Refactored `ClearTokenCookie` to unconditionally issue `Set-Cookie` deletion headers (`MaxAge: -1`) up to `maxCookieChunks` (10 chunks), ensuring complete cookie clearing regardless of incoming request headers or request URL path.
- Updated `SanitizeClusterName` to append an 8-character FNV-1a hash suffix (`sanitized[:41] + "-" + hashSuffix`) when cluster names exceed 50 characters, preventing cookie name collisions while maintaining 100% backward compatibility for names under 50 characters.

## Testing

Added regression tests in `backend/pkg/auth/cookies_test.go`:
- `TestClearAuthCookie_WithoutIncomingCookies`: Verifies `ClearTokenCookie` issues `Set-Cookie` deletion headers even when the request carries no incoming cookies (e.g. requests to `/auth/set-token`).
- `TestClearAuthCookie`: Verifies `ClearTokenCookie` issues deletion headers for all chunks up to `maxCookieChunks`.
- `TestSanitizeClusterName_NoCollisionsOnLongPrefixes`: Verifies distinct 50-character sanitized names are produced for long cluster names sharing a prefix.
- `go test ./pkg/auth/...` — all unit tests passing.
