### PR TITLE
backend: frontend: Protect desktop APIs with app token

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -49,6 +49,21 @@ jobs:
         make app-linux
     - name: Verify Linux build
       run: npm run app:verify-build-linux
+    - name: Start Minikube
+      uses: medyagh/setup-minikube@d8c0eb871f6f455542491d86a574477bd3894533 # latest
+    - name: Verify Minikube
+      run: |
+        minikube status
+        kubectl config use-context minikube
+        kubectl get nodes
+    - name: Run app e2e tests
+      env:
+        HEADLAMP_APP_E2E_CONTEXT: minikube
+      run: |
+        make backend
+        npm --prefix app/e2e-tests ci
+        npm --prefix app/e2e-tests exec -- playwright install --with-deps chromium
+          xvfb-run npm run app:test:e2e -- backendToken.spec.ts
   build-windows:
     strategy:
       matrix:

--- a/app/e2e-tests/playwright.electron.config.ts
+++ b/app/e2e-tests/playwright.electron.config.ts
@@ -25,7 +25,12 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
-  testMatch: ['clusterRename.spec.ts', 'namespaces.spec.ts', 'clusterAutoConnect.spec.ts'],
+  testMatch: [
+    'backendToken.spec.ts',
+    'clusterRename.spec.ts',
+    'namespaces.spec.ts',
+    'clusterAutoConnect.spec.ts',
+  ],
   timeout: 60 * 1000,
   expect: {
     timeout: 120000,

--- a/app/e2e-tests/tests/backendToken.spec.ts
+++ b/app/e2e-tests/tests/backendToken.spec.ts
@@ -1,0 +1,436 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { _electron, Page } from 'playwright';
+
+const clusterName = `headlamp-token-${process.pid}`;
+const watchNamespace = `headlamp-token-watch-${process.pid}`;
+const testDir = path.join(os.tmpdir(), `headlamp-e2e-backend-token-${process.pid}`);
+const minikubeKubeconfig = path.join(testDir, 'minikube.kubeconfig');
+const appKubeconfig = path.join(testDir, 'app.kubeconfig');
+const isolatedConfigDir = path.join(testDir, 'config');
+const electronExecutable = process.platform === 'win32' ? 'electron.cmd' : 'electron';
+const electronPath = path.resolve(__dirname, `../../node_modules/.bin/${electronExecutable}`);
+const appPath = path.resolve(__dirname, '../../');
+const backendPath = path.resolve(appPath, '../backend/headlamp-server');
+const backendProtocolPrefix = 'base64url.headlamp.backend.authorization.k8s.io.';
+const multiplexerProtocol = 'headlamp.multiplexer.k8s.io';
+const reusableClusterContext = process.env.HEADLAMP_APP_E2E_CONTEXT;
+
+let electronApp: Awaited<ReturnType<typeof _electron.launch>>;
+let electronPage: Page;
+
+function run(
+  command: string,
+  args: string[],
+  ignoreFailure = false,
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  try {
+    return execFileSync(command, args, {
+      encoding: 'utf8',
+      env,
+      stdio: ['ignore', 'pipe', 'inherit'],
+    }).trim();
+  } catch (error) {
+    if (ignoreFailure) {
+      return '';
+    }
+    throw error;
+  }
+}
+
+/**
+ * Writes an isolated certificate-backed kubeconfig for the desktop app.
+ * Reuses a CI cluster context when configured, otherwise creates a local Minikube profile.
+ */
+function setupCertificateBackedCluster(): void {
+  fs.mkdirSync(isolatedConfigDir, { recursive: true, mode: 0o700 });
+
+  if (reusableClusterContext) {
+    fs.writeFileSync(
+      appKubeconfig,
+      run('kubectl', [
+        '--context',
+        reusableClusterContext,
+        'config',
+        'view',
+        '--minify',
+        '--raw',
+        '--flatten',
+      ]),
+      { mode: 0o600 }
+    );
+    const isolatedContext = run('kubectl', [
+      '--kubeconfig',
+      appKubeconfig,
+      'config',
+      'current-context',
+    ]);
+    run('kubectl', [
+      '--kubeconfig',
+      appKubeconfig,
+      'config',
+      'rename-context',
+      isolatedContext,
+      clusterName,
+    ]);
+  } else {
+    run('minikube', ['start', '--profile', clusterName], false, {
+      ...process.env,
+      KUBECONFIG: minikubeKubeconfig,
+    });
+  }
+
+  const kubeconfig = run('kubectl', [
+    '--kubeconfig',
+    reusableClusterContext ? appKubeconfig : minikubeKubeconfig,
+    '--context',
+    clusterName,
+    'config',
+    'view',
+    '--minify',
+    '--raw',
+    '--flatten',
+  ]);
+  if (
+    !kubeconfig.includes('certificate-authority-data:') ||
+    !kubeconfig.includes('client-certificate-data:')
+  ) {
+    throw new Error('Expected the test cluster to produce a certificate-backed kubeconfig');
+  }
+  fs.writeFileSync(appKubeconfig, kubeconfig, { mode: 0o600 });
+}
+
+/**
+ * Requests the selected backend port from the Electron main process.
+ *
+ * @returns The selected port, or undefined until one has been assigned.
+ */
+function getBackendPort(): Promise<number | undefined> {
+  return electronPage.evaluate(
+    () =>
+      new Promise<number | undefined>((resolve, reject) => {
+        const desktopApi = (
+          window as Window & {
+            desktopApi?: {
+              send: (channel: string, data?: unknown) => void;
+              receive: (
+                channel: string,
+                callback: (port: number | undefined) => void
+              ) => (() => void) | undefined;
+            };
+          }
+        ).desktopApi;
+        if (!desktopApi) {
+          reject(new Error('Desktop API is unavailable'));
+          return;
+        }
+
+        let unsubscribe: (() => void) | undefined;
+        const timeout = window.setTimeout(() => {
+          unsubscribe?.();
+          resolve(undefined);
+        }, 250);
+        unsubscribe = desktopApi.receive('backend-port', port => {
+          window.clearTimeout(timeout);
+          unsubscribe?.();
+          resolve(port);
+        });
+        desktopApi.send('request-backend-port');
+      })
+  );
+}
+
+/**
+ * Waits until the backend listener enforces authentication on its config route.
+ *
+ * @returns The port of the ready backend server.
+ */
+async function waitForBackend(): Promise<number> {
+  let backendPort: number | undefined;
+
+  await expect
+    .poll(
+      async () => {
+        backendPort = await getBackendPort();
+        if (!backendPort) {
+          return undefined;
+        }
+
+        try {
+          return (await fetch(`http://localhost:${backendPort}/config`)).status;
+        } catch {
+          return undefined;
+        }
+      },
+      { timeout: 30_000 }
+    )
+    .toBe(403);
+
+  return backendPort!;
+}
+
+function getBackendToken(): Promise<string> {
+  return electronPage.evaluate(
+    () =>
+      new Promise<string>((resolve, reject) => {
+        const desktopApi = (
+          window as Window & {
+            desktopApi?: {
+              send: (channel: string, data?: unknown) => void;
+              receive: (
+                channel: string,
+                callback: (token: string) => void
+              ) => (() => void) | undefined;
+            };
+          }
+        ).desktopApi;
+        if (!desktopApi) {
+          reject(new Error('Desktop API is unavailable'));
+          return;
+        }
+
+        let unsubscribe: (() => void) | undefined;
+        unsubscribe = desktopApi.receive('backend-token', token => {
+          unsubscribe?.();
+          resolve(token);
+        });
+        desktopApi.send('request-backend-token');
+      })
+  );
+}
+
+test.beforeAll(async () => {
+  test.setTimeout(4 * 60 * 1000);
+
+  fs.accessSync(backendPath, fs.constants.X_OK);
+  setupCertificateBackedCluster();
+  electronApp = await _electron.launch({
+    cwd: appPath,
+    executablePath: electronPath,
+    args: ['.'],
+    env: {
+      ...process.env,
+      NODE_ENV: 'development',
+      ELECTRON_DEV: 'true',
+      KUBECONFIG: appKubeconfig,
+      XDG_CONFIG_HOME: isolatedConfigDir,
+    },
+  });
+  electronPage = await electronApp.firstWindow();
+  await electronPage.waitForLoadState('load');
+});
+
+test.afterAll(async () => {
+  test.setTimeout(2 * 60 * 1000);
+
+  await electronApp?.close();
+  if (fs.existsSync(appKubeconfig)) {
+    run(
+      'kubectl',
+      ['--kubeconfig', appKubeconfig, 'delete', 'namespace', watchNamespace, '--ignore-not-found'],
+      true
+    );
+  }
+  if (!reusableClusterContext) {
+    run('minikube', ['delete', '--profile', clusterName], true, {
+      ...process.env,
+      KUBECONFIG: minikubeKubeconfig,
+    });
+  }
+  fs.rmSync(testDir, { force: true, recursive: true });
+});
+
+test.describe('desktop backend token', () => {
+  test('rejects missing and wrong tokens for REST and multiplexer requests', async () => {
+    const backendPort = await waitForBackend();
+
+    const protectedURLs = [
+      `http://localhost:${backendPort}/config`,
+      `http://localhost:${backendPort}/clusters/${clusterName}/version`,
+    ];
+    for (const url of protectedURLs) {
+      const response = await fetch(url);
+      expect(response.status).toBe(403);
+
+      const wrongTokenResponse = await fetch(url, {
+        headers: { 'X-HEADLAMP_BACKEND-TOKEN': 'wrong-token' },
+      });
+      expect(wrongTokenResponse.status).toBe(403);
+    }
+
+    const websocketOpened = (protocols?: string[]) =>
+      electronPage.evaluate(
+        ({ port, protocols }) =>
+          new Promise<boolean>(resolve => {
+            const socket = new WebSocket(`ws://localhost:${port}/wsMultiplexer`, protocols);
+            const timeout = window.setTimeout(() => {
+              socket.close();
+              resolve(false);
+            }, 5000);
+
+            socket.addEventListener('open', () => {
+              window.clearTimeout(timeout);
+              socket.close();
+              resolve(true);
+            });
+            socket.addEventListener('error', () => {
+              window.clearTimeout(timeout);
+              resolve(false);
+            });
+          }),
+        { port: backendPort, protocols }
+      );
+    await expect(websocketOpened()).resolves.toBe(false);
+
+    const wrongTokenProtocol =
+      backendProtocolPrefix + Buffer.from('wrong-token').toString('base64url');
+    await expect(websocketOpened([multiplexerProtocol, wrongTokenProtocol])).resolves.toBe(false);
+  });
+
+  test('authorizes certificate-backed REST and multiplexer watch updates', async () => {
+    test.setTimeout(2 * 60 * 1000);
+    const backendPort = await waitForBackend();
+    const backendToken = await getBackendToken();
+
+    const helperResponse = await fetch(
+      `http://localhost:${backendPort}/clusters/${clusterName}/portforward/list`,
+      {
+        headers: { 'X-HEADLAMP_BACKEND-TOKEN': backendToken },
+      }
+    );
+    expect(helperResponse.status).toBe(200);
+
+    const namespacesPath = `/clusters/${clusterName}/api/v1/namespaces`;
+    const responsePromise = electronPage.waitForResponse(response => {
+      const url = new URL(response.url());
+      return url.pathname === namespacesPath && url.searchParams.get('watch') !== '1';
+    });
+    await electronPage.evaluate(name => {
+      window.location.hash = `#/c/${name}`;
+    }, clusterName);
+    await electronPage.waitForURL(new RegExp(`/c/${clusterName}`));
+    await electronPage.getByText('Namespaces', { exact: true }).click();
+
+    const response = await responsePromise;
+    expect(response.status()).toBe(200);
+    expect(response.request().headers()['x-headlamp_backend-token']).toBeTruthy();
+
+    const backendProtocol = backendProtocolPrefix + Buffer.from(backendToken).toString('base64url');
+
+    await electronPage.evaluate(
+      ({ port, protocol, publicProtocol, cluster, namespace }) =>
+        new Promise<void>((resolve, reject) => {
+          type WatchWindow = Window & {
+            backendTokenWatch?: Promise<string>;
+            backendTokenWatchSocket?: WebSocket;
+          };
+          const watchWindow = window as WatchWindow;
+          const socket = new WebSocket(`ws://localhost:${port}/wsMultiplexer`, [
+            publicProtocol,
+            protocol,
+          ]);
+          watchWindow.backendTokenWatchSocket = socket;
+
+          let resolveWatch: (data: string) => void = () => {};
+          let rejectWatch: (error: Error) => void = () => {};
+          watchWindow.backendTokenWatch = new Promise<string>((watchResolve, watchReject) => {
+            resolveWatch = watchResolve;
+            rejectWatch = watchReject;
+          });
+
+          const timeout = window.setTimeout(() => {
+            const error = new Error('Timed out waiting for a multiplexer watch update');
+            rejectWatch(error);
+            reject(error);
+            socket.close();
+          }, 30000);
+
+          socket.addEventListener('open', () => {
+            socket.send(
+              JSON.stringify({
+                clusterId: cluster,
+                path: '/api/v1/namespaces',
+                query: 'watch=1',
+                userId: 'desktop-e2e',
+                type: 'REQUEST',
+              })
+            );
+          });
+          socket.addEventListener('message', event => {
+            const message = JSON.parse(String(event.data));
+            if (message.type === 'ERROR') {
+              const error = new Error(message.data || 'Multiplexer returned an error');
+              window.clearTimeout(timeout);
+              rejectWatch(error);
+              reject(error);
+              socket.close();
+              return;
+            }
+            if (message.type === 'STATUS' && JSON.parse(message.data).state === 'connected') {
+              resolve();
+              return;
+            }
+            if (message.type === 'DATA') {
+              const data = message.binary ? atob(message.data) : message.data;
+              if (data.includes(namespace)) {
+                window.clearTimeout(timeout);
+                resolveWatch(data);
+              }
+            }
+          });
+          socket.addEventListener('error', () => {
+            const error = new Error('Multiplexer WebSocket failed');
+            window.clearTimeout(timeout);
+            rejectWatch(error);
+            reject(error);
+          });
+        }),
+      {
+        port: backendPort,
+        protocol: backendProtocol,
+        publicProtocol: multiplexerProtocol,
+        cluster: clusterName,
+        namespace: watchNamespace,
+      }
+    );
+
+    run('kubectl', ['--kubeconfig', appKubeconfig, 'create', 'namespace', watchNamespace]);
+    const watchData = await electronPage.evaluate(
+      () =>
+        (
+          window as Window & {
+            backendTokenWatch?: Promise<string>;
+          }
+        ).backendTokenWatch
+    );
+
+    expect(watchData).toContain(watchNamespace);
+    await electronPage.evaluate(() => {
+      (
+        window as Window & {
+          backendTokenWatchSocket?: WebSocket;
+        }
+      ).backendTokenWatchSocket?.close();
+    });
+  });
+});

--- a/app/electron/tray.test.ts
+++ b/app/electron/tray.test.ts
@@ -17,8 +17,8 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { isTrayIconEnabled, setTrayIconEnabled } from './tray';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getClusterStatuses, isTrayIconEnabled, setTrayIconEnabled } from './tray';
 
 function tmpPath(): string {
   return path.join(os.tmpdir(), `tray-test-${Date.now()}-${Math.random()}.json`);
@@ -89,5 +89,41 @@ describe('tray icon setting', () => {
     const unwritable = path.join(os.tmpdir(), `tray-test-${Date.now()}`, 'nope', 'settings.json');
     expect(() => setTrayIconEnabled(false, unwritable)).not.toThrow();
     expect(fs.existsSync(unwritable)).toBe(false);
+  });
+});
+
+describe('tray cluster status requests', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the backend token header for config and cluster health requests', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ clusters: [{ name: 'test-cluster' }] }),
+      })
+      .mockResolvedValueOnce({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await getClusterStatuses({
+      backendToken: 'desktop-token',
+      createWindow: vi.fn(),
+      getBackendPort: () => 4466,
+      getMainWindow: () => null,
+      isDev: true,
+      quit: vi.fn(),
+    });
+
+    const expectedHeaders = { 'X-HEADLAMP_BACKEND-TOKEN': 'desktop-token' };
+    expect(fetchMock).toHaveBeenNthCalledWith(1, 'http://localhost:4466/config', {
+      headers: expectedHeaders,
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'http://localhost:4466/clusters/test-cluster/healthz',
+      { headers: expectedHeaders }
+    );
   });
 });

--- a/app/electron/tray.ts
+++ b/app/electron/tray.ts
@@ -147,10 +147,11 @@ export function createHeadlampTray(options: HeadlampTrayOptions): boolean {
   return true;
 }
 
-async function getClusterStatuses(options: HeadlampTrayOptions): Promise<ClusterStatus[]> {
+export async function getClusterStatuses(options: HeadlampTrayOptions): Promise<ClusterStatus[]> {
   try {
+    // Keep the app token separate from Authorization, which cluster routes reserve for Kubernetes credentials.
     const configResponse = await fetch(`http://localhost:${options.getBackendPort()}/config`, {
-      headers: { Authorization: `Bearer ${options.backendToken}` },
+      headers: { 'X-HEADLAMP_BACKEND-TOKEN': options.backendToken },
     });
 
     if (!configResponse.ok) {
@@ -175,7 +176,7 @@ async function getClusterStatuses(options: HeadlampTrayOptions): Promise<Cluster
         const healthResponse = await fetch(
           `http://localhost:${options.getBackendPort()}/clusters/${cluster.name}/healthz`,
           {
-            headers: { Authorization: `Bearer ${options.backendToken}` },
+            headers: { 'X-HEADLAMP_BACKEND-TOKEN': options.backendToken },
           }
         );
 

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -414,7 +414,7 @@ func addPluginDeleteRoute(config *HeadlampConfig, r *mux.Router) {
 
 		logger.Log(logger.LevelInfo, nil, nil, "Received DELETE request for plugin: "+mux.Vars(r)["name"])
 
-		if err := config.checkHeadlampBackendToken(w, r); err != nil {
+		if err := auth.CheckBackendToken(config.UseInCluster, w, r); err != nil {
 			if config.TelemetryHandler != nil {
 				config.TelemetryHandler.RecordError(span, err, "Invalid backend token")
 			}
@@ -759,54 +759,66 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 	addPluginRoutes(config, r)
 
 	// Setup port forwarding handlers.
-	r.HandleFunc("/clusters/{clusterName}/portforward", func(w http.ResponseWriter, r *http.Request) {
-		contextKey, err := config.getContextKeyForRequest(r)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
+	r.Handle(
+		"/clusters/{clusterName}/portforward",
+		auth.NewBackendTokenMiddleware(config.UseInCluster)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			contextKey, err := config.getContextKeyForRequest(r)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
 
-		portforward.StartPortForward(
-			config.KubeConfigStore,
-			config.Cache,
-			config.shouldUseUnsafeServiceAccountToken(),
-			contextKey,
-			w,
-			r,
-		)
-	}).Methods("POST")
+			portforward.StartPortForward(
+				config.KubeConfigStore,
+				config.Cache,
+				config.shouldUseUnsafeServiceAccountToken(),
+				contextKey,
+				w,
+				r,
+			)
+		})),
+	).Methods("POST")
 
-	r.HandleFunc("/clusters/{clusterName}/portforward", func(w http.ResponseWriter, r *http.Request) {
-		contextKey, err := config.getContextKeyForRequest(r)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
+	r.Handle(
+		"/clusters/{clusterName}/portforward",
+		auth.NewBackendTokenMiddleware(config.UseInCluster)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			contextKey, err := config.getContextKeyForRequest(r)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
 
-		portforward.StopOrDeletePortForward(config.Cache, contextKey, w, r)
-	}).Methods("DELETE")
+			portforward.StopOrDeletePortForward(config.Cache, contextKey, w, r)
+		})),
+	).Methods("DELETE")
 
-	r.HandleFunc("/clusters/{clusterName}/portforward/list", func(w http.ResponseWriter, r *http.Request) {
-		contextKey, err := config.getContextKeyForRequest(r)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
+	r.Handle(
+		"/clusters/{clusterName}/portforward/list",
+		auth.NewBackendTokenMiddleware(config.UseInCluster)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			contextKey, err := config.getContextKeyForRequest(r)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
 
-		portforward.GetPortForwards(config.Cache, contextKey, w, r)
-	})
-	r.HandleFunc("/clusters/{clusterName}/portforward", func(w http.ResponseWriter, r *http.Request) {
-		contextKey, err := config.getContextKeyForRequest(r)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
+			portforward.GetPortForwards(config.Cache, contextKey, w, r)
+		})),
+	)
+	r.Handle(
+		"/clusters/{clusterName}/portforward",
+		auth.NewBackendTokenMiddleware(config.UseInCluster)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			contextKey, err := config.getContextKeyForRequest(r)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
 
-		portforward.GetPortForwardByID(config.Cache, contextKey, w, r)
-	}).Methods("GET")
+			portforward.GetPortForwardByID(config.Cache, contextKey, w, r)
+		})),
+	).Methods("GET")
 
 	// Expose user info so the frontend can show the current user in the top bar using the per-cluster auth cookie.
-	r.HandleFunc("/clusters/{clusterName}/me",
+	r.Handle("/clusters/{clusterName}/me", auth.NewBackendTokenMiddleware(config.UseInCluster)(
 		auth.HandleMe(auth.MeHandlerOptions{
 			UsernamePaths:           config.MeUsernamePaths,
 			EmailPaths:              config.MeEmailPaths,
@@ -817,11 +829,11 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			ProxyAuthGroupHeader:    config.ProxyAuthGroupHeader,
 			ProxyAuthEmailHeader:    config.ProxyAuthEmailHeader,
 		}),
-	).Methods("GET")
+	)).Methods("GET")
 
 	config.handleClusterRequests(r)
 
-	r.HandleFunc("/externalproxy", func(w http.ResponseWriter, r *http.Request) {
+	externalProxyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		proxyURL := r.Header.Get("proxy-to")
 		if proxyURL == "" && r.Header.Get("Forward-to") != "" {
 			proxyURL = r.Header.Get("Forward-to")
@@ -949,16 +961,21 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			return
 		}
 	})
+	r.Handle("/externalproxy", auth.NewBackendTokenMiddleware(config.UseInCluster)(externalProxyHandler))
 
 	// Configuration
-	r.HandleFunc("/config", config.getConfig).Methods("GET")
+	r.Handle("/config", auth.NewBackendTokenMiddleware(config.UseInCluster)(
+		http.HandlerFunc(config.getConfig))).Methods("GET")
 
 	// Auth token management
-	r.HandleFunc("/auth/set-token", config.handleSetToken).Methods("POST")
+	r.Handle("/auth/set-token", auth.NewBackendTokenMiddleware(config.UseInCluster)(
+		http.HandlerFunc(config.handleSetToken))).Methods("POST")
 
 	// Websocket connections
 	if config.Multiplexer != nil {
-		r.HandleFunc("/wsMultiplexer", config.Multiplexer.HandleClientWebSocket)
+		r.Handle("/wsMultiplexer", auth.NewBackendTokenMiddleware(config.UseInCluster)(
+			http.HandlerFunc(config.Multiplexer.HandleClientWebSocket),
+		))
 	}
 
 	config.addClusterSetupRoute(r)
@@ -1109,9 +1126,11 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		http.Redirect(w, r, authURL, http.StatusFound)
 	}).Queries("cluster", "{cluster}")
 
-	r.HandleFunc("/drain-node", config.handleNodeDrain).Methods("POST")
-	r.HandleFunc("/drain-node-status",
-		config.handleNodeDrainStatus).Methods("GET").Queries("cluster", "{cluster}", "nodeName", "{node}")
+	r.Handle("/drain-node",
+		auth.NewBackendTokenMiddleware(config.UseInCluster)(http.HandlerFunc(config.handleNodeDrain))).Methods("POST")
+	r.Handle("/drain-node-status",
+		auth.NewBackendTokenMiddleware(config.UseInCluster)(http.HandlerFunc(
+			config.handleNodeDrainStatus))).Methods("GET").Queries("cluster", "{cluster}", "nodeName", "{node}")
 
 	r.HandleFunc("/oidc-callback", func(w http.ResponseWriter, r *http.Request) {
 		// Shadow createHeadlampHandler's outer-scope err so any log call in
@@ -1701,63 +1720,40 @@ func getHelmHandler(c *HeadlampConfig, w http.ResponseWriter, r *http.Request) (
 	return helmHandler, nil
 }
 
-// Check request for header "X-HEADLAMP_BACKEND-TOKEN" matches HEADLAMP_BACKEND_TOKEN env
-// This check is to prevent access except for from the app.
-// The app sets HEADLAMP_BACKEND_TOKEN, and gives the token to the frontend.
-func (c *HeadlampConfig) checkHeadlampBackendToken(w http.ResponseWriter, r *http.Request) error {
-	if c.UseInCluster {
-		return nil
-	}
-
-	backendToken := r.Header.Get("X-HEADLAMP_BACKEND-TOKEN")
-	backendTokenEnv := os.Getenv("HEADLAMP_BACKEND_TOKEN")
-
-	if backendToken != backendTokenEnv || backendTokenEnv == "" {
-		http.Error(w, "access denied", http.StatusForbidden)
-		return errors.New("X-HEADLAMP_BACKEND-TOKEN does not match HEADLAMP_BACKEND_TOKEN")
-	}
-
-	return nil
-}
-
 // handleClusterServiceProxy registers a new route for the path serviceproxy/{namespace}/{name}
 // to proxy requests to in-cluster services.
 func handleClusterServiceProxy(c *HeadlampConfig, router *mux.Router) {
-	router.HandleFunc("/clusters/{clusterName}/serviceproxy/{namespace}/{name}",
-		func(w http.ResponseWriter, r *http.Request) {
+	router.Handle("/clusters/{clusterName}/serviceproxy/{namespace}/{name}",
+		auth.NewBackendTokenMiddleware(c.UseInCluster)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			serviceproxy.RequestHandler(c.KubeConfigStore, c.shouldUseUnsafeServiceAccountToken(), w, r)
-		}).Queries("request", "{request}").
+		}))).Queries("request", "{request}").
 		Methods("GET")
 }
 
 func handleClusterHelm(c *HeadlampConfig, router *mux.Router) {
-	router.PathPrefix("/clusters/{clusterName}/helm/{.*}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-		path := r.URL.Path
-		clusterName := mux.Vars(r)["clusterName"]
+	router.PathPrefix("/clusters/{clusterName}/helm/{.*}").Handler(
+		auth.NewBackendTokenMiddleware(c.UseInCluster)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			path := r.URL.Path
+			clusterName := mux.Vars(r)["clusterName"]
 
-		_, span := telemetry.CreateSpan(ctx, r, "helm", "handleClusterHelm",
-			attribute.String("cluster", clusterName),
-		)
+			_, span := telemetry.CreateSpan(ctx, r, "helm", "handleClusterHelm",
+				attribute.String("cluster", clusterName),
+			)
 
-		c.TelemetryHandler.RecordEvent(span, "Starting Helm operation request")
-		defer span.End()
+			c.TelemetryHandler.RecordEvent(span, "Starting Helm operation request")
+			defer span.End()
 
-		c.TelemetryHandler.RecordRequestCount(ctx, r, attribute.String("cluster", clusterName))
+			c.TelemetryHandler.RecordRequestCount(ctx, r, attribute.String("cluster", clusterName))
 
-		if err := c.checkHeadlampBackendToken(w, r); err != nil {
-			c.handleError(w, ctx, span, err, "failed to check headlamp backend token", http.StatusForbidden)
-			return
-		}
+			helmHandler, err := getHelmHandler(c, w, r)
+			if err != nil {
+				c.handleError(w, ctx, span, err, "failed to get helm handler", http.StatusForbidden)
+				return
+			}
 
-		helmHandler, err := getHelmHandler(c, w, r)
-		if err != nil {
-			c.handleError(w, ctx, span, err, "failed to get helm handler", http.StatusForbidden)
-			return
-		}
-
-		c.dispatchHelmRoute(ctx, span, w, r, path, clusterName, helmHandler)
-	})
+			c.dispatchHelmRoute(ctx, span, w, r, path, clusterName, helmHandler)
+		})))
 }
 
 func (c *HeadlampConfig) helmRouteReleaseHandler(
@@ -2021,14 +2017,15 @@ func clusterRequestHandler(c *HeadlampConfig) http.Handler { //nolint:funlen
 // It parses the request and creates a proxy request to the cluster.
 // That proxy is saved in the cache with the context key.
 func handleClusterAPI(c *HeadlampConfig, router *mux.Router) {
-	router.HandleFunc("/clusters/{clusterName}/set-token", c.handleSetToken).Methods("POST")
+	router.Handle("/clusters/{clusterName}/set-token",
+		auth.NewBackendTokenMiddleware(c.UseInCluster)(http.HandlerFunc(c.handleSetToken))).Methods("POST")
 
 	handler := clusterRequestHandler(c)
 	if c.CacheEnabled {
 		handler = CacheMiddleWare(c)(handler)
 	}
 
-	router.PathPrefix("/clusters/{clusterName}/{api:.*}").Handler(handler)
+	router.PathPrefix("/clusters/{clusterName}/{api:.*}").Handler(auth.NewBackendTokenMiddleware(c.UseInCluster)(handler))
 }
 
 func recordRequestCompletion(c *HeadlampConfig, ctx context.Context,
@@ -2307,7 +2304,7 @@ func (c *HeadlampConfig) addCluster(w http.ResponseWriter, r *http.Request) { //
 
 	c.TelemetryHandler.RecordRequestCount(ctx, r)
 
-	if err := c.checkHeadlampBackendToken(w, r); err != nil {
+	if err := auth.CheckBackendToken(c.UseInCluster, w, r); err != nil {
 		c.TelemetryHandler.RecordError(span, err, "invalid backend token")
 		c.TelemetryHandler.RecordErrorCount(ctx, attribute.String("error.type", "invalid token"))
 		logger.Log(logger.LevelError, nil, err, "invalid token")
@@ -2516,7 +2513,7 @@ func (c *HeadlampConfig) deleteCluster(w http.ResponseWriter, r *http.Request) {
 
 	name := mux.Vars(r)["name"]
 
-	if err := c.checkHeadlampBackendToken(w, r); err != nil {
+	if err := auth.CheckBackendToken(c.UseInCluster, w, r); err != nil {
 		c.TelemetryHandler.RecordError(span, err, "invalid backend token")
 		c.TelemetryHandler.RecordErrorCount(ctx, attribute.String("error.type", "invalid_token"))
 		logger.Log(logger.LevelError, nil, err, "invalid token")
@@ -2909,7 +2906,8 @@ func (c *HeadlampConfig) addClusterSetupRoute(r *mux.Router) {
 		return
 	}
 	// Get stateless cluster
-	r.HandleFunc("/parseKubeConfig", c.parseKubeConfig).Methods("POST")
+	r.Handle("/parseKubeConfig", auth.NewBackendTokenMiddleware(c.UseInCluster)(
+		http.HandlerFunc(c.parseKubeConfig))).Methods("POST")
 
 	// POST a cluster
 	r.HandleFunc("/cluster", c.addCluster).Methods("POST")
@@ -2918,7 +2916,8 @@ func (c *HeadlampConfig) addClusterSetupRoute(r *mux.Router) {
 	r.HandleFunc("/cluster/{name}", c.deleteCluster).Methods("DELETE")
 
 	// Rename a cluster
-	r.HandleFunc("/cluster/{name}", c.renameCluster).Methods("PUT")
+	r.Handle("/cluster/{name}",
+		auth.NewBackendTokenMiddleware(c.UseInCluster)(http.HandlerFunc(c.renameCluster))).Methods("PUT")
 }
 
 /*

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -950,7 +950,14 @@ func newExternalProxyHandler(t *testing.T, upstream string) http.Handler {
 }
 
 func TestExternalProxyForwarding(t *testing.T) {
+	const backendToken = "desktop-token"
+
+	t.Setenv("HEADLAMP_BACKEND_TOKEN", backendToken)
+
+	var forwardedBackendToken string
+
 	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		forwardedBackendToken = r.Header.Get("X-HEADLAMP_BACKEND-TOKEN")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
 
@@ -966,6 +973,7 @@ func TestExternalProxyForwarding(t *testing.T) {
 	}
 
 	req.Header.Set("proxy-to", proxyServer.URL)
+	req.Header.Set("X-HEADLAMP_BACKEND-TOKEN", backendToken)
 
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -973,6 +981,7 @@ func TestExternalProxyForwarding(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rr.Code)
 	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
 	assert.Equal(t, `{"error": "not found"}`, rr.Body.String())
+	assert.Empty(t, forwardedBackendToken)
 }
 
 func TestExternalProxyStreamsLargeBody(t *testing.T) {
@@ -1094,7 +1103,7 @@ func TestDrainAndCordonNode(t *testing.T) { //nolint:funlen
 		drainNodePayload.Cluster = minikubeName
 		drainNodePayload.NodeName = minikubeName
 
-		rr, err := getResponse(tc.handler, "POST", "/drain-node", drainNodePayload)
+		rr, err := getResponseFromRestrictedEndpoint(tc.handler, "POST", "/drain-node", drainNodePayload)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1118,7 +1127,7 @@ func TestDrainAndCordonNode(t *testing.T) { //nolint:funlen
 			drainNodePayload.Cluster, drainNodePayload.NodeName,
 		)
 
-		rr, err = getResponse(tc.handler, "GET", url, nil)
+		rr, err = getResponseFromRestrictedEndpoint(tc.handler, "GET", url, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1528,8 +1537,9 @@ func TestDeletePlugin(t *testing.T) {
 }
 
 // TestRestrictedEndpointsRequireToken is the canary for the backend-token gate:
-// dropping checkHeadlampBackendToken from any listed route would fail here.
-// PUT /cluster/{name} (renameCluster) is omitted because it isn't gated yet.
+// dropping the backend token middleware from any listed route would fail here.
+//
+//nolint:funlen
 func TestRestrictedEndpointsRequireToken(t *testing.T) {
 	const validToken = "valid-token-for-test"
 
@@ -1547,6 +1557,18 @@ func TestRestrictedEndpointsRequireToken(t *testing.T) {
 		body   interface{}
 	}{
 		{
+			name:   "GET /config",
+			method: http.MethodGet,
+			path:   "/config",
+			body:   nil,
+		},
+		{
+			name:   "GET /externalproxy",
+			method: http.MethodGet,
+			path:   "/externalproxy",
+			body:   nil,
+		},
+		{
 			name:   "POST /cluster (addCluster)",
 			method: http.MethodPost,
 			path:   "/cluster",
@@ -1559,6 +1581,36 @@ func TestRestrictedEndpointsRequireToken(t *testing.T) {
 			body:   nil,
 		},
 		{
+			name:   "PUT /cluster/{name} (renameCluster)",
+			method: http.MethodPut,
+			path:   "/cluster/" + minikubeName,
+			body:   nil,
+		},
+		{
+			name:   "POST /parseKubeConfig",
+			method: http.MethodPost,
+			path:   "/parseKubeConfig",
+			body:   KubeconfigRequest{Kubeconfigs: []string{kubeConfigB64}},
+		},
+		{
+			name:   "POST /auth/set-token",
+			method: http.MethodPost,
+			path:   "/auth/set-token",
+			body:   nil,
+		},
+		{
+			name:   "POST /drain-node",
+			method: http.MethodPost,
+			path:   "/drain-node",
+			body:   nil,
+		},
+		{
+			name:   "GET /drain-node-status",
+			method: http.MethodGet,
+			path:   "/drain-node-status?cluster=" + minikubeName + "&nodeName=test-node",
+			body:   nil,
+		},
+		{
 			name:   "DELETE /plugins/{name} (deletePlugin)",
 			method: http.MethodDelete,
 			path:   "/plugins/test-plugin",
@@ -1568,6 +1620,60 @@ func TestRestrictedEndpointsRequireToken(t *testing.T) {
 			name:   "GET /clusters/{name}/helm/releases (handleClusterHelm)",
 			method: http.MethodGet,
 			path:   "/clusters/" + minikubeName + "/helm/releases",
+			body:   nil,
+		},
+		{
+			name:   "GET /clusters/{name}/portforward/list",
+			method: http.MethodGet,
+			path:   "/clusters/" + minikubeName + "/portforward/list",
+			body:   nil,
+		},
+		{
+			name:   "POST /clusters/{name}/portforward",
+			method: http.MethodPost,
+			path:   "/clusters/" + minikubeName + "/portforward",
+			body:   nil,
+		},
+		{
+			name:   "DELETE /clusters/{name}/portforward",
+			method: http.MethodDelete,
+			path:   "/clusters/" + minikubeName + "/portforward",
+			body:   nil,
+		},
+		{
+			name:   "GET /clusters/{name}/portforward",
+			method: http.MethodGet,
+			path:   "/clusters/" + minikubeName + "/portforward",
+			body:   nil,
+		},
+		{
+			name:   "GET /clusters/{name}/me",
+			method: http.MethodGet,
+			path:   "/clusters/" + minikubeName + "/me",
+			body:   nil,
+		},
+		{
+			name:   "GET /clusters/{name}/serviceproxy/{namespace}/{name}",
+			method: http.MethodGet,
+			path:   "/clusters/" + minikubeName + "/serviceproxy/default/test?request=/",
+			body:   nil,
+		},
+		{
+			name:   "POST /clusters/{name}/set-token",
+			method: http.MethodPost,
+			path:   "/clusters/" + minikubeName + "/set-token",
+			body:   nil,
+		},
+		{
+			name:   "GET /clusters/{name}/{api}",
+			method: http.MethodGet,
+			path:   "/clusters/" + minikubeName + "/api/v1/pods",
+			body:   nil,
+		},
+		{
+			name:   "GET /wsMultiplexer",
+			method: http.MethodGet,
+			path:   "/wsMultiplexer",
 			body:   nil,
 		},
 	}
@@ -1599,6 +1705,7 @@ func newRestrictedEndpointsHandler(t *testing.T) http.Handler {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
+	kubeConfigStore := kubeconfig.NewContextStore()
 	c := HeadlampConfig{
 		HeadlampConfig: &headlampconfig.HeadlampConfig{
 			HeadlampCFG: &headlampconfig.HeadlampCFG{
@@ -1608,9 +1715,10 @@ func newRestrictedEndpointsHandler(t *testing.T) http.Handler {
 				EnableHelm:            true,
 				PluginDir:             devPluginDir,
 				UserPluginDir:         userPluginDir,
-				KubeConfigStore:       kubeconfig.NewContextStore(),
+				KubeConfigStore:       kubeConfigStore,
 			},
 			Cache:            cache.New[interface{}](),
+			Multiplexer:      NewMultiplexer(kubeConfigStore, false),
 			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
 			TelemetryHandler: &telemetry.RequestHandler{},
 		},
@@ -1658,17 +1766,14 @@ func assertRouteRequiresBackendToken(t *testing.T, method, path string, body int
 				assert.NotEqual(t, http.StatusForbidden, rr.Code,
 					"%s %s with a valid token must NOT be rejected by the backend-token gate",
 					method, path)
-				assert.NotEqual(t, http.StatusUnauthorized, rr.Code,
-					"%s %s with a valid token must NOT be rejected by the backend-token gate",
-					method, path)
 			}
 		})
 	}
 }
 
-// TestRestrictedEndpointsRejectEmptyEnvToken makes sure an empty env var doesn't
-// turn into a bypass when the client also sends an empty header.
-func TestRestrictedEndpointsRejectEmptyEnvToken(t *testing.T) {
+// TestRestrictedEndpointsBypassedWithoutConfiguredToken preserves standalone
+// development and test servers where backend-token enforcement is not configured.
+func TestRestrictedEndpointsBypassedWithoutConfiguredToken(t *testing.T) {
 	t.Setenv("HEADLAMP_BACKEND_TOKEN", "")
 
 	c := HeadlampConfig{
@@ -1692,6 +1797,7 @@ func TestRestrictedEndpointsRejectEmptyEnvToken(t *testing.T) {
 		method string
 		path   string
 	}{
+		{http.MethodGet, "/config"},
 		{http.MethodPost, "/cluster"},
 		{http.MethodDelete, "/cluster/" + minikubeName},
 		{http.MethodDelete, "/plugins/test-plugin"},
@@ -1699,18 +1805,15 @@ func TestRestrictedEndpointsRejectEmptyEnvToken(t *testing.T) {
 
 	for _, route := range routes {
 		t.Run(route.method+" "+route.path, func(t *testing.T) {
-			for _, headerValue := range []string{"" /* matches empty env */, "anything"} {
-				req, err := makeJSONReq(route.method, route.path, nil)
-				require.NoError(t, err)
+			req, err := makeJSONReq(route.method, route.path, nil)
+			require.NoError(t, err)
 
-				req.Header.Set("X-HEADLAMP_BACKEND-TOKEN", headerValue)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
 
-				rr := httptest.NewRecorder()
-				handler.ServeHTTP(rr, req)
-
-				assert.Equal(t, http.StatusForbidden, rr.Code,
-					"empty HEADLAMP_BACKEND_TOKEN env must reject all callers (header=%q)", headerValue)
-			}
+			assert.NotEqual(t, http.StatusForbidden, rr.Code,
+				"%s %s must remain available when no backend token is configured",
+				route.method, route.path)
 		})
 	}
 }
@@ -1770,6 +1873,9 @@ func TestRestrictedEndpointsBypassedInCluster(t *testing.T) {
 }
 
 func TestHandleClusterAPI_XForwardedHost(t *testing.T) {
+	const backendToken = "test-backend-token"
+	t.Setenv("HEADLAMP_BACKEND_TOKEN", backendToken)
+
 	// Create a new server for testing
 	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Verify that X-Forwarded-Host is set to r.Host
@@ -1813,6 +1919,7 @@ func TestHandleClusterAPI_XForwardedHost(t *testing.T) {
 	ctx := context.Background()
 	req, err := http.NewRequestWithContext(ctx, "GET", "/clusters/test/version", nil)
 	require.NoError(t, err)
+	req.Header.Set("X-HEADLAMP_BACKEND-TOKEN", backendToken)
 
 	// Create a response recorder to capture the response
 	rr := httptest.NewRecorder()
@@ -3010,7 +3117,15 @@ func httpRequestWithContext(ctx context.Context, url string, method string) (*ht
 		return nil, err
 	}
 
+	addBackendTokenHeader(req)
+
 	return http.DefaultClient.Do(req)
+}
+
+func addBackendTokenHeader(req *http.Request) {
+	if token := os.Getenv("HEADLAMP_BACKEND_TOKEN"); token != "" {
+		req.Header.Set("X-HEADLAMP_BACKEND-TOKEN", token)
+	}
 }
 
 const istrue = true
@@ -3334,6 +3449,7 @@ func newRealK8sHeadlampConfig(t *testing.T) (*HeadlampConfig, string) {
 	t.Helper()
 
 	resetCacheMiddlewareTestState()
+	t.Setenv("HEADLAMP_BACKEND_TOKEN", "integration-test-token")
 
 	kubeConfigPath := os.Getenv("KUBECONFIG")
 	if kubeConfigPath == "" {
@@ -3522,6 +3638,7 @@ func TestCacheMiddleware_CacheInvalidation_RealK8s(t *testing.T) {
 	createReq, err := http.NewRequestWithContext(ctx, "POST", ts.URL+listPath, bytes.NewReader(cmBody))
 	require.NoError(t, err)
 	createReq.Header.Set("Content-Type", "application/json")
+	addBackendTokenHeader(createReq)
 
 	createResp, err := http.DefaultClient.Do(createReq)
 	require.NoError(t, err)
@@ -3531,6 +3648,7 @@ func TestCacheMiddleware_CacheInvalidation_RealK8s(t *testing.T) {
 
 	t.Cleanup(func() {
 		delReq, _ := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+cmPath, nil)
+		addBackendTokenHeader(delReq)
 		resp, _ := http.DefaultClient.Do(delReq)
 
 		if resp != nil {
@@ -3581,6 +3699,9 @@ func TestCacheMiddleware_CacheInvalidation_RealK8s(t *testing.T) {
 
 //nolint:funlen
 func TestHandleClusterServiceProxy(t *testing.T) {
+	const backendToken = "test-backend-token"
+	t.Setenv("HEADLAMP_BACKEND_TOKEN", backendToken)
+
 	cfg := &HeadlampConfig{
 		HeadlampConfig: &headlampconfig.HeadlampConfig{
 			HeadlampCFG:      &headlampconfig.HeadlampCFG{KubeConfigStore: kubeconfig.NewContextStore()},
@@ -3673,6 +3794,8 @@ func TestHandleClusterServiceProxy(t *testing.T) {
 	{
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
 			"/clusters/"+cluster+"/serviceproxy/"+ns+"/"+svc+"?request=/healthz", nil)
+		req.Header.Set("X-HEADLAMP_BACKEND-TOKEN", backendToken)
+
 		rr := httptest.NewRecorder()
 		router.ServeHTTP(rr, req)
 		assert.Equal(t, http.StatusUnauthorized, rr.Code)
@@ -3685,6 +3808,7 @@ func TestHandleClusterServiceProxy(t *testing.T) {
 	{
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
 			"/clusters/"+cluster+"/serviceproxy/"+ns+"/"+svc+"?request=/healthz", nil)
+		req.Header.Set("X-HEADLAMP_BACKEND-TOKEN", backendToken)
 		req.Header.Set("Authorization", "Bearer test-token")
 
 		rr := httptest.NewRecorder()
@@ -4065,8 +4189,13 @@ func TestClusterRequestHandlerUsesServiceAccountToken(t *testing.T) { //nolint:f
 	assert.Empty(t, receivedProxyAuthToken)
 }
 
-func TestClusterRequestHandlerFallsBackToClusterContextForWebSocketCookie(t *testing.T) {
-	const cluster = "main"
+func TestClusterRequestHandlerFallsBackToClusterContextForWebSocketCookie(t *testing.T) { //nolint:funlen
+	const (
+		backendToken = "test-backend-token"
+		cluster      = "main"
+	)
+
+	t.Setenv("HEADLAMP_BACKEND_TOKEN", backendToken)
 
 	var receivedAuth, receivedProtocol string
 
@@ -4107,7 +4236,9 @@ func TestClusterRequestHandlerFallsBackToClusterContextForWebSocketCookie(t *tes
 	req.Header.Set("Upgrade", "websocket")
 	req.Header.Set(
 		"Sec-Websocket-Protocol",
-		"base64url.headlamp.authorization.k8s.io.stale-user, v4.channel.k8s.io",
+		"base64url.headlamp.backend.authorization.k8s.io."+
+			base64.RawURLEncoding.EncodeToString([]byte(backendToken))+
+			", base64url.headlamp.authorization.k8s.io.stale-user, v4.channel.k8s.io",
 	)
 	req.AddCookie(&http.Cookie{
 		Name:     "headlamp-auth-main.0",
@@ -4126,6 +4257,9 @@ func TestClusterRequestHandlerFallsBackToClusterContextForWebSocketCookie(t *tes
 }
 
 func TestClusterRequestHandlerStripsProxyAuthTokenHeader(t *testing.T) {
+	const backendToken = "test-backend-token"
+	t.Setenv("HEADLAMP_BACKEND_TOKEN", backendToken)
+
 	const cluster, proxyAuthTokenHeader = "main", "Impersonate-User"
 
 	var receivedAuth, receivedProxyAuthToken string
@@ -4166,6 +4300,7 @@ func TestClusterRequestHandlerStripsProxyAuthTokenHeader(t *testing.T) {
 	handleClusterAPI(c, router)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/clusters/main/api/v1/pods", nil)
+	req.Header.Set("X-HEADLAMP_BACKEND-TOKEN", backendToken)
 	req.Header.Set(proxyAuthTokenHeader, "proxy-token")
 
 	rr := httptest.NewRecorder()

--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -55,6 +55,8 @@ const (
 	CleanupRoutineInterval = 5 * time.Minute
 	// SecureWebSocketScheme is the secure WebSocket scheme.
 	SecureWebSocketScheme = "wss"
+	// MultiplexerProtocol is the public subprotocol selected for client connections.
+	MultiplexerProtocol = "headlamp.multiplexer.k8s.io"
 )
 
 // ConnectionState represents the current state of a connection.
@@ -214,6 +216,7 @@ func NewMultiplexer(kubeConfigStore kubeconfig.ContextStore, unsafeUseServiceAcc
 		unsafeUseServiceAccountToken: unsafeUseServiceAccountToken,
 		saTokenCache:                 make(map[string]saTokenCacheEntry),
 		upgrader: websocket.Upgrader{
+			Subprotocols: []string{MultiplexerProtocol},
 			CheckOrigin: func(r *http.Request) bool {
 				return true
 			},

--- a/backend/cmd/multiplexer_test.go
+++ b/backend/cmd/multiplexer_test.go
@@ -53,6 +53,7 @@ func TestNewMultiplexer(t *testing.T) {
 	assert.Equal(t, store, m.kubeConfigStore)
 	assert.NotNil(t, m.connections)
 	assert.NotNil(t, m.upgrader)
+	assert.Equal(t, []string{MultiplexerProtocol}, m.upgrader.Subprotocols)
 }
 
 func TestHandleClientWebSocket(t *testing.T) {

--- a/backend/pkg/auth/backendtoken.go
+++ b/backend/pkg/auth/backendtoken.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"os"
+	"strings"
+)
+
+const (
+	backendTokenHeader         = "X-HEADLAMP_BACKEND-TOKEN"                         // #nosec G101
+	backendTokenProtocolPrefix = "base64url.headlamp.backend.authorization.k8s.io." // #nosec G101
+)
+
+// CheckBackendToken verifies that a request carries the token configured by the desktop app.
+func CheckBackendToken(useInCluster bool, w http.ResponseWriter, r *http.Request) error {
+	backendTokenEnv := os.Getenv("HEADLAMP_BACKEND_TOKEN")
+	// An empty token leaves the optional desktop trust boundary disabled for
+	// standalone development and test servers; configuring a token opts in.
+	if useInCluster || backendTokenEnv == "" {
+		return nil
+	}
+
+	backendTokens := r.Header.Values(backendTokenHeader)
+
+	if len(backendTokens) != 1 ||
+		subtle.ConstantTimeCompare([]byte(backendTokens[0]), []byte(backendTokenEnv)) != 1 {
+		http.Error(w, "access denied", http.StatusForbidden)
+		return errors.New("X-HEADLAMP_BACKEND-TOKEN does not match HEADLAMP_BACKEND_TOKEN")
+	}
+
+	return nil
+}
+
+// NewBackendTokenMiddleware protects API requests when the desktop app configures
+// a per-launch token and removes the private credential before forwarding.
+func NewBackendTokenMiddleware(useInCluster bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if useInCluster || os.Getenv("HEADLAMP_BACKEND_TOKEN") == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if len(r.Header.Values(backendTokenHeader)) > 1 {
+				http.Error(w, "access denied", http.StatusForbidden)
+				return
+			}
+
+			if err := consumeBackendTokenProtocol(r); err != nil {
+				http.Error(w, "access denied", http.StatusForbidden)
+				return
+			}
+
+			if err := CheckBackendToken(false, w, r); err != nil {
+				return
+			}
+
+			r.Header.Del(backendTokenHeader)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// consumeBackendTokenProtocol extracts one base64url-encoded backend token from
+// the private WebSocket subprotocol, rejects conflicting credential transports,
+// and sets the decoded token header used by CheckBackendToken. It removes the
+// private credential protocol while preserving public protocols for downstream
+// WebSocket negotiation.
+func consumeBackendTokenProtocol(r *http.Request) error {
+	protocolHeader := strings.Join(r.Header.Values("Sec-WebSocket-Protocol"), ",")
+	if protocolHeader == "" {
+		return nil
+	}
+
+	var (
+		backendToken string
+		protocols    []string
+	)
+
+	for _, protocol := range strings.Split(protocolHeader, ",") {
+		protocol = strings.TrimSpace(protocol)
+		if !strings.HasPrefix(protocol, backendTokenProtocolPrefix) {
+			protocols = append(protocols, protocol)
+			continue
+		}
+
+		if backendToken != "" {
+			return errors.New("multiple backend token protocols")
+		}
+
+		encodedToken := strings.TrimPrefix(protocol, backendTokenProtocolPrefix)
+
+		decodedToken, err := base64.RawURLEncoding.DecodeString(encodedToken)
+		if err != nil || len(decodedToken) == 0 {
+			return errors.New("invalid backend token protocol")
+		}
+
+		backendToken = string(decodedToken)
+	}
+
+	if backendToken == "" {
+		return nil
+	}
+
+	if headerToken := r.Header.Get(backendTokenHeader); headerToken != "" && headerToken != backendToken {
+		return errors.New("conflicting backend token transports")
+	}
+
+	r.Header.Set(backendTokenHeader, backendToken)
+
+	if len(protocols) == 0 {
+		r.Header.Del("Sec-WebSocket-Protocol")
+	} else {
+		r.Header.Set("Sec-WebSocket-Protocol", strings.Join(protocols, ", "))
+	}
+
+	return nil
+}

--- a/backend/pkg/auth/backendtoken_test.go
+++ b/backend/pkg/auth/backendtoken_test.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth_test
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/auth"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	backendTokenHeader         = "X-HEADLAMP_BACKEND-TOKEN"                         // #nosec G101
+	backendTokenProtocolPrefix = "base64url.headlamp.backend.authorization.k8s.io." // #nosec G101
+)
+
+func TestCheckBackendToken(t *testing.T) {
+	tests := []struct {
+		name         string
+		useInCluster bool
+		envToken     string
+		headerToken  string
+		wantStatus   int
+		wantError    bool
+	}{
+		{
+			name:        "valid token",
+			envToken:    "desktop-token",
+			headerToken: "desktop-token",
+			wantStatus:  http.StatusOK,
+		},
+		{
+			name:        "wrong token",
+			envToken:    "desktop-token",
+			headerToken: "desktop-tokem",
+			wantStatus:  http.StatusForbidden,
+			wantError:   true,
+		},
+		{
+			name:        "standalone bypass",
+			headerToken: "desktop-token",
+			wantStatus:  http.StatusOK,
+		},
+		{
+			name:         "in-cluster bypass",
+			useInCluster: true,
+			envToken:     "desktop-token",
+			headerToken:  "wrong-token",
+			wantStatus:   http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HEADLAMP_BACKEND_TOKEN", tt.envToken)
+
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+			req.Header.Set(backendTokenHeader, tt.headerToken)
+
+			recorder := httptest.NewRecorder()
+
+			err := auth.CheckBackendToken(tt.useInCluster, recorder, req)
+
+			assert.Equal(t, tt.wantError, err != nil)
+			assert.Equal(t, tt.wantStatus, recorder.Code)
+		})
+	}
+}
+
+func TestCheckBackendTokenRejectsDuplicateHeaders(t *testing.T) {
+	const validToken = "desktop-token"
+
+	t.Setenv("HEADLAMP_BACKEND_TOKEN", validToken)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req.Header.Add(backendTokenHeader, validToken)
+	req.Header.Add(backendTokenHeader, validToken)
+
+	recorder := httptest.NewRecorder()
+
+	err := auth.CheckBackendToken(false, recorder, req)
+
+	assert.Error(t, err)
+	assert.Equal(t, http.StatusForbidden, recorder.Code)
+	assert.NotContains(t, recorder.Body.String(), validToken)
+}
+
+//nolint:funlen
+func TestNewBackendTokenMiddleware(t *testing.T) {
+	const validToken = "desktop-token"
+
+	tokenProtocol := backendTokenProtocolPrefix + base64.RawURLEncoding.EncodeToString([]byte(validToken))
+
+	tests := []struct {
+		name                string
+		useInCluster        bool
+		configuredToken     string
+		tokenHeader         string
+		extraTokenHeaders   []string
+		protocolHeaders     []string
+		wantStatus          int
+		wantProtocol        string
+		wantTokenDownstream string
+	}{
+		{
+			name:            "valid header",
+			configuredToken: validToken,
+			tokenHeader:     validToken,
+			wantStatus:      http.StatusNoContent,
+		},
+		{
+			name:            "valid protocol",
+			configuredToken: validToken,
+			protocolHeaders: []string{"v4.channel.k8s.io, " + tokenProtocol},
+			wantStatus:      http.StatusNoContent,
+			wantProtocol:    "v4.channel.k8s.io",
+		},
+		{
+			name:            "valid protocol across header values",
+			configuredToken: validToken,
+			protocolHeaders: []string{"v4.channel.k8s.io", tokenProtocol},
+			wantStatus:      http.StatusNoContent,
+			wantProtocol:    "v4.channel.k8s.io",
+		},
+		{
+			name:            "malformed protocol",
+			configuredToken: validToken,
+			protocolHeaders: []string{backendTokenProtocolPrefix + "%"},
+			wantStatus:      http.StatusForbidden,
+		},
+		{
+			name:            "duplicate protocol",
+			configuredToken: validToken,
+			protocolHeaders: []string{tokenProtocol + ", " + tokenProtocol},
+			wantStatus:      http.StatusForbidden,
+		},
+		{
+			name:              "duplicate header with protocol",
+			configuredToken:   validToken,
+			tokenHeader:       validToken,
+			extraTokenHeaders: []string{validToken},
+			protocolHeaders:   []string{tokenProtocol},
+			wantStatus:        http.StatusForbidden,
+		},
+		{
+			name:            "conflicting header and protocol",
+			configuredToken: validToken,
+			tokenHeader:     "different-token",
+			protocolHeaders: []string{tokenProtocol},
+			wantStatus:      http.StatusForbidden,
+		},
+		{
+			name:            "matching header and protocol",
+			configuredToken: validToken,
+			tokenHeader:     validToken,
+			protocolHeaders: []string{tokenProtocol},
+			wantStatus:      http.StatusNoContent,
+		},
+		{
+			name:            "missing token",
+			configuredToken: validToken,
+			wantStatus:      http.StatusForbidden,
+		},
+		{
+			name:                "standalone bypass preserves transports",
+			tokenHeader:         "unvalidated-token",
+			protocolHeaders:     []string{backendTokenProtocolPrefix + "%"},
+			wantStatus:          http.StatusNoContent,
+			wantProtocol:        backendTokenProtocolPrefix + "%",
+			wantTokenDownstream: "unvalidated-token",
+		},
+		{
+			name:                "in-cluster bypass preserves transports",
+			useInCluster:        true,
+			configuredToken:     validToken,
+			tokenHeader:         "unvalidated-token",
+			protocolHeaders:     []string{backendTokenProtocolPrefix + "%"},
+			wantStatus:          http.StatusNoContent,
+			wantProtocol:        backendTokenProtocolPrefix + "%",
+			wantTokenDownstream: "unvalidated-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HEADLAMP_BACKEND_TOKEN", tt.configuredToken)
+
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, tt.wantProtocol, r.Header.Get("Sec-WebSocket-Protocol"))
+				assert.Equal(t, tt.wantTokenDownstream, r.Header.Get(backendTokenHeader))
+				w.WriteHeader(http.StatusNoContent)
+			})
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+
+			if tt.tokenHeader != "" {
+				req.Header.Set(backendTokenHeader, tt.tokenHeader)
+			}
+
+			for _, tokenHeader := range tt.extraTokenHeaders {
+				req.Header.Add(backendTokenHeader, tokenHeader)
+			}
+
+			for _, protocolHeader := range tt.protocolHeaders {
+				req.Header.Add("Sec-WebSocket-Protocol", protocolHeader)
+			}
+
+			recorder := httptest.NewRecorder()
+			auth.NewBackendTokenMiddleware(tt.useInCluster)(next).ServeHTTP(recorder, req)
+
+			assert.Equal(t, tt.wantStatus, recorder.Code)
+
+			if tt.wantStatus == http.StatusForbidden {
+				assert.NotContains(t, recorder.Body.String(), validToken)
+			}
+		})
+	}
+}

--- a/docs/development/backend.md
+++ b/docs/development/backend.md
@@ -27,6 +27,25 @@ Once built, it can be run in development mode (insecure / don't use in productio
 npm run backend:start
 ```
 
+## Backend token protection
+
+`HEADLAMP_BACKEND_TOKEN` enables a local trust boundary around protected backend
+routes. The desktop app generates a random token for each launch and sends it to
+its backend and renderer. Development commands such as `npm run backend:start`
+set a predictable token for local use.
+
+When `HEADLAMP_BACKEND_TOKEN` is unset or empty, backend-token enforcement is
+disabled. This opt-in behavior preserves standalone development and test setups
+that start the backend directly. Do not expose a non-in-cluster server with an
+empty token: protected cluster, plugin, Helm, and proxy routes are then available
+without this additional credential check.
+
+When the variable is non-empty, clients must send the same value in the
+`X-HEADLAMP_BACKEND-TOKEN` header. WebSocket clients use Headlamp's private
+backend-token subprotocol instead. In-cluster mode does not use this desktop
+token boundary and continues to rely on its configured authentication and
+authorization mechanisms.
+
 ## Telemetry
 
 Headlamp's backend supports OpenTelemetry for distributed tracing and Prometheus metrics. See the [Telemetry guide](./telemetry.md) for configuration, local setup with Jaeger and Prometheus, and in-cluster deployment.
@@ -36,12 +55,14 @@ Headlamp's backend supports OpenTelemetry for distributed tracing and Prometheus
 Headlamp’s backend supports configurable log levels to control verbosity.
 
 Log level can be configured using either a flag or an environment variable:
+
 - the log level: `--log-level` or env var `HEADLAMP_CONFIG_LOG_LEVEL`
 
 Supported Values:
+
 - `debug`
 - `info` (default)
-- `warn` 
+- `warn`
 - `error`
 
 > **Note:** Headlamp uses zerolog defaults.  
@@ -90,6 +111,7 @@ npm run backend:coverage:html
 ```
 
 To just print a simpler coverage report to the console.
+
 ```bash
 npm run backend:coverage
 ```
@@ -107,4 +129,3 @@ npm run backend:fuzz
 This will run fuzz tests in the `backend/pkg/auth` package for 30 seconds. The fuzz corpus (interesting test cases discovered during fuzzing) is stored in `testdata/fuzz/` directories and committed to the repository for regression testing.
 
 For more information about Go fuzzing, see the [official Go fuzzing documentation](https://go.dev/security/fuzz/).
-

--- a/frontend/src/helpers/getHeadlampAPIHeaders.test.ts
+++ b/frontend/src/helpers/getHeadlampAPIHeaders.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  getHeadlampAPIHeaders,
+  getHeadlampWebSocketProtocol,
+  setBackendToken,
+} from './getHeadlampAPIHeaders';
+
+describe('Headlamp backend token transports', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    setBackendToken(null);
+  });
+
+  it('returns no credentials without a backend token', () => {
+    setBackendToken(null);
+
+    expect(getHeadlampAPIHeaders()).toEqual({});
+    expect(getHeadlampWebSocketProtocol()).toBeNull();
+  });
+
+  it('returns the token as a header and an encoded WebSocket protocol', () => {
+    setBackendToken('desktop-token');
+
+    expect(getHeadlampAPIHeaders()).toEqual({
+      'X-HEADLAMP_BACKEND-TOKEN': 'desktop-token',
+    });
+    expect(getHeadlampWebSocketProtocol()).toBe(
+      'base64url.headlamp.backend.authorization.k8s.io.ZGVza3RvcC10b2tlbg'
+    );
+    expect(getHeadlampWebSocketProtocol()).not.toContain('desktop-token');
+  });
+
+  it('supports unicode tokens and repeated updates', () => {
+    setBackendToken('first');
+    setBackendToken('tökén');
+
+    expect(getHeadlampWebSocketProtocol()).toBe(
+      'base64url.headlamp.backend.authorization.k8s.io.dMO2a8Opbg'
+    );
+  });
+
+  it('prefers the development environment token', () => {
+    vi.stubEnv('REACT_APP_HEADLAMP_BACKEND_TOKEN', 'environment-token');
+    setBackendToken('renderer-token');
+
+    expect(getHeadlampAPIHeaders()).toEqual({
+      'X-HEADLAMP_BACKEND-TOKEN': 'environment-token',
+    });
+  });
+});

--- a/frontend/src/helpers/getHeadlampAPIHeaders.ts
+++ b/frontend/src/helpers/getHeadlampAPIHeaders.ts
@@ -32,13 +32,18 @@ let backendToken: string | null = import.meta.env.REACT_APP_HEADLAMP_BACKEND_TOK
  * Sets the backend token to use when making API calls from Headlamp when running as an app.
  *
  * This is not a K8s or OIDC token, but one that protects headlamp-server APIs.
+ *
+ * @param token - The local backend token, or null to clear it.
+ * @returns Nothing.
  */
-export function setBackendToken(token: string | null) {
+export function setBackendToken(token: string | null): void {
   backendToken = import.meta.env.REACT_APP_HEADLAMP_BACKEND_TOKEN || token;
 }
 
 /**
  * Returns headers for making API calls to the headlamp-server backend.
+ *
+ * @returns The backend authorization header, or an empty object when no token is configured.
  */
 export function getHeadlampAPIHeaders(): { [key: string]: string } {
   if (backendToken === null) {
@@ -48,4 +53,23 @@ export function getHeadlampAPIHeaders(): { [key: string]: string } {
   return {
     'X-HEADLAMP_BACKEND-TOKEN': backendToken,
   };
+}
+
+/**
+ * Returns the private WebSocket subprotocol used to authenticate with the local Headlamp backend.
+ *
+ * @returns A namespaced, base64url-encoded subprotocol, or null when no backend token is configured.
+ */
+export function getHeadlampWebSocketProtocol(): string | null {
+  if (backendToken === null) {
+    return null;
+  }
+
+  const bytes = new TextEncoder().encode(backendToken);
+  const encodedToken = btoa(Array.from(bytes, byte => String.fromCharCode(byte)).join(''))
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replace(/=+$/, '');
+
+  return `base64url.headlamp.backend.authorization.k8s.io.${encodedToken}`;
 }

--- a/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
+++ b/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
@@ -23,6 +23,7 @@ import nock from 'nock';
 import { Mock, MockedFunction } from 'vitest';
 import WS from 'vitest-websocket-mock';
 import { getAppUrl } from '../../../../helpers/getAppUrl';
+import { setBackendToken } from '../../../../helpers/getHeadlampAPIHeaders';
 import * as cluster from '../../../cluster';
 import * as apiProxy from '../../apiProxy';
 
@@ -116,6 +117,7 @@ const newestConfigMap = {
 describe('apiProxy', () => {
   describe('clusterRequest', () => {
     afterEach(() => {
+      setBackendToken(null);
       nock.cleanAll();
     });
 
@@ -124,6 +126,21 @@ describe('apiProxy', () => {
 
       const response = await apiProxy.clusterRequest(testPath);
       expect(response).toEqual(mockResponse);
+    });
+
+    it('adds backend credentials to non-cluster requests', async () => {
+      let backendTokenHeader: string | string[] | undefined;
+      setBackendToken('desktop-token');
+      nock(baseApiUrl)
+        .get(testPath)
+        .reply(function () {
+          backendTokenHeader = this.req.headers['x-headlamp_backend-token'];
+          return [200, mockResponse];
+        });
+
+      await apiProxy.clusterRequest(testPath);
+
+      expect(backendTokenHeader).toBe('desktop-token');
     });
 
     it('Successfully handles clusterRequest with status 401', async () => {
@@ -149,6 +166,40 @@ describe('apiProxy', () => {
 
       const response = await apiProxy.clusterRequest(testPath, {}, queryParams);
       expect(response).toEqual(mockResponse);
+    });
+
+    it.each([
+      ['Headers', new Headers({ 'X-CUSTOM-HEADER': 'headers-value' }), 'headers-value'],
+      ['header tuples', [['X-CUSTOM-HEADER', 'tuple-value']] as [string, string][], 'tuple-value'],
+    ])('adds backend credentials to %s input', async (_name, headers, customHeader) => {
+      setBackendToken('desktop-token');
+      nock(baseApiUrl)
+        .get(`/clusters/${clusterName}${testPath}`)
+        .matchHeader('X-CUSTOM-HEADER', customHeader)
+        .matchHeader('X-HEADLAMP_BACKEND-TOKEN', 'desktop-token')
+        .reply(200, mockResponse);
+
+      const response = await apiProxy.clusterRequest(testPath, { cluster: clusterName, headers });
+
+      expect(response).toEqual(mockResponse);
+    });
+
+    it('auto-logs out after a 401 with a Headers authorization value', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      nock(baseApiUrl).get(testPath).reply(401, errorResponse401);
+      const logoutRequest = nock(baseApiUrl).post('/clusters/set-token').reply(200);
+
+      await expect(
+        apiProxy.clusterRequest(testPath, {
+          headers: new Headers({ Authorization: '******' }),
+        })
+      ).rejects.toThrow(errorResponse401.error);
+
+      expect(consoleError).toHaveBeenCalledWith(
+        'Logging out due to auth error',
+        expect.objectContaining({ status: 401, path: testPath })
+      );
+      await vi.waitFor(() => expect(logoutRequest.isDone()).toBe(true));
     });
   });
 
@@ -1167,11 +1218,13 @@ describe('apiProxy', () => {
     });
 
     afterEach(() => {
+      setBackendToken(null);
       vi.resetAllMocks();
     });
 
     describe('drainNode', () => {
       it('Successfully drains a node', async () => {
+        setBackendToken('desktop-token');
         const response = await apiProxy.drainNode(clusterName, nodeName);
         expect(response).toEqual(mockResponse);
 
@@ -1180,6 +1233,9 @@ describe('apiProxy', () => {
         expect(url).toContain('drain-node');
         expect(options.method).toBe('POST');
         expect(new Headers(options.headers).get('content-type')).toEqual('application/json');
+        expect(new Headers(options.headers).get('X-HEADLAMP_BACKEND-TOKEN')).toEqual(
+          'desktop-token'
+        );
         expect(options.body).toEqual(JSON.stringify({ cluster: clusterName, nodeName }));
       });
 
@@ -1200,6 +1256,7 @@ describe('apiProxy', () => {
 
     describe('drainNodeStatus', () => {
       it('Successfully gets drain node status', async () => {
+        setBackendToken('desktop-token');
         const response = await apiProxy.drainNodeStatus(clusterName, nodeName);
         expect(response).toEqual(mockResponse);
 
@@ -1208,6 +1265,9 @@ describe('apiProxy', () => {
         expect(url).toContain('drain-node-status');
         expect(options.method).toBe('GET');
         expect(new Headers(options.headers).get('content-type')).toEqual('application/json');
+        expect(new Headers(options.headers).get('X-HEADLAMP_BACKEND-TOKEN')).toEqual(
+          'desktop-token'
+        );
       });
 
       it('Successfully handles drainNodeStatus with error', async () => {

--- a/frontend/src/lib/k8s/api/v1/clusterRequests.test.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterRequests.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import { addBackstageAuthHeaders } from '../../../../helpers/addBackstageAuthHeaders';
+import { setBackendToken } from '../../../../helpers/getHeadlampAPIHeaders';
+import { isBackstage } from '../../../../helpers/isBackstage';
+import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
+import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
+import { clusterRequest } from './clusterRequests';
+
+vi.mock('../../../../helpers/addBackstageAuthHeaders', () => ({
+  addBackstageAuthHeaders: vi.fn(headers => headers),
+}));
+
+vi.mock('../../../../helpers/isBackstage', () => ({
+  isBackstage: vi.fn(() => false),
+}));
+
+vi.mock('../../../../stateless/findKubeconfigByClusterName', () => ({
+  findKubeconfigByClusterName: vi.fn(),
+}));
+
+vi.mock('../../../../stateless/getUserIdFromLocalStorage', () => ({
+  getUserIdFromLocalStorage: vi.fn(),
+}));
+
+vi.mock('../../../auth', () => ({
+  logout: vi.fn(),
+}));
+
+describe('clusterRequest transports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
+    setBackendToken('desktop-token');
+    vi.mocked(isBackstage).mockReturnValue(false);
+    vi.mocked(findKubeconfigByClusterName).mockResolvedValue(null);
+    vi.mocked(getUserIdFromLocalStorage).mockReturnValue('desktop-user');
+    vi.mocked(addBackstageAuthHeaders).mockImplementation(headers => headers ?? {});
+  });
+
+  afterEach(() => {
+    setBackendToken(null);
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('preserves caller and stateless headers with the backend token', async () => {
+    vi.mocked(findKubeconfigByClusterName).mockResolvedValue('encoded-kubeconfig');
+    (fetch as Mock).mockResolvedValue(
+      new Response(JSON.stringify({ kind: 'PodList' }), { status: 200 })
+    );
+
+    await clusterRequest('/api/v1/pods', {
+      cluster: 'desktop-cluster',
+      headers: new Headers({ 'X-Caller': 'caller-value' }),
+    });
+
+    const [url, init] = (fetch as Mock).mock.lastCall!;
+    const headers = new Headers(init.headers);
+    expect(url).toContain('/clusters/desktop-cluster/api/v1/pods');
+    expect(headers.get('X-Caller')).toBe('caller-value');
+    expect(headers.get('X-HEADLAMP_BACKEND-TOKEN')).toBe('desktop-token');
+    expect(headers.get('KUBECONFIG')).toBe('encoded-kubeconfig');
+    expect(headers.get('X-HEADLAMP-USER-ID')).toBe('desktop-user');
+  });
+
+  it('adds the backend token to requests without a cluster', async () => {
+    (fetch as Mock).mockResolvedValue(
+      new Response(JSON.stringify({ clusters: [] }), { status: 200 })
+    );
+
+    await clusterRequest('/config');
+
+    const [url, init] = (fetch as Mock).mock.lastCall!;
+    const headers = new Headers(init.headers);
+    expect(url).toContain('/config');
+    expect(headers.get('X-HEADLAMP_BACKEND-TOKEN')).toBe('desktop-token');
+  });
+
+  it('overwrites a caller backend token without creating a duplicate header', async () => {
+    (fetch as Mock).mockResolvedValue(
+      new Response(JSON.stringify({ clusters: [] }), { status: 200 })
+    );
+
+    await clusterRequest('/config', {
+      headers: { 'X-HEADLAMP_BACKEND-TOKEN': 'stale-token' },
+    });
+
+    const headers = new Headers((fetch as Mock).mock.lastCall![1].headers);
+    expect(headers.get('X-HEADLAMP_BACKEND-TOKEN')).toBe('desktop-token');
+    expect([...headers.keys()].filter(name => name === 'x-headlamp_backend-token')).toHaveLength(1);
+  });
+
+  it('preserves the backend token when Backstage headers are added', async () => {
+    vi.mocked(isBackstage).mockReturnValue(true);
+    vi.mocked(addBackstageAuthHeaders).mockImplementation(headers => {
+      const mergedHeaders = new Headers(headers);
+      mergedHeaders.set('X-Backstage', 'backstage-value');
+      return Object.fromEntries(mergedHeaders.entries());
+    });
+    (fetch as Mock).mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+    await clusterRequest('/version', { cluster: 'desktop-cluster' });
+
+    const headers = new Headers((fetch as Mock).mock.lastCall![1].headers);
+    expect(headers.get('X-Backstage')).toBe('backstage-value');
+    expect(headers.get('X-HEADLAMP_BACKEND-TOKEN')).toBe('desktop-token');
+  });
+
+  it('maps an aborted cluster request to a timeout response', async () => {
+    const abortError = new Error('aborted');
+    abortError.name = 'AbortError';
+    (fetch as Mock).mockRejectedValue(abortError);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(clusterRequest('/version', { cluster: 'desktop-cluster' })).rejects.toMatchObject({
+      status: 408,
+      message: expect.stringContaining('Request timed-out'),
+    });
+  });
+});

--- a/frontend/src/lib/k8s/api/v1/clusterRequests.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterRequests.ts
@@ -20,6 +20,7 @@ import type { OpPatch } from 'json-patch';
 import { addBackstageAuthHeaders } from '../../../../helpers/addBackstageAuthHeaders';
 import { isDebugVerbose } from '../../../../helpers/debugVerbose';
 import { getAppUrl } from '../../../../helpers/getAppUrl';
+import { getHeadlampAPIHeaders } from '../../../../helpers/getHeadlampAPIHeaders';
 import { isBackstage } from '../../../../helpers/isBackstage';
 import store from '../../../../redux/stores/store';
 import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
@@ -141,7 +142,14 @@ export async function clusterRequest(
   } = params;
 
   const userID = getUserIdFromLocalStorage();
-  const opts: { headers: RequestHeaders } = Object.assign({ headers: {} }, otherParams);
+  const headers: RequestHeaders = {};
+  new Headers(otherParams.headers).forEach((value, key) => {
+    headers[key] = value;
+  });
+  Object.entries(getHeadlampAPIHeaders()).forEach(([name, value]) => {
+    headers[name.toLowerCase()] = value;
+  });
+  const opts = { ...otherParams, headers };
   const cluster = paramsCluster || '';
 
   let fullPath = path;
@@ -190,7 +198,7 @@ export async function clusterRequest(
 
   if (!response.ok) {
     const { status, statusText } = response;
-    if (autoLogoutOnAuthError && status === 401 && opts.headers.Authorization) {
+    if (autoLogoutOnAuthError && status === 401 && opts.headers.authorization) {
       console.error('Logging out due to auth error', { status, statusText, path });
       logout(cluster);
     }

--- a/frontend/src/lib/k8s/api/v1/drainNode.ts
+++ b/frontend/src/lib/k8s/api/v1/drainNode.ts
@@ -15,6 +15,7 @@
  */
 
 import { addBackstageAuthHeaders } from '../../../../helpers/addBackstageAuthHeaders';
+import { getHeadlampAPIHeaders } from '../../../../helpers/getHeadlampAPIHeaders';
 import { backendFetch } from '../v2/fetch';
 import { JSON_HEADERS } from './constants';
 
@@ -34,7 +35,8 @@ import { JSON_HEADERS } from './constants';
  * to get the status of the drain node process.
  */
 export function drainNode(cluster: string, nodeName: string) {
-  const headers = addBackstageAuthHeaders(JSON_HEADERS);
+  const headers = new Headers(addBackstageAuthHeaders(JSON_HEADERS));
+  Object.entries(getHeadlampAPIHeaders()).forEach(([name, value]) => headers.set(name, value));
 
   return backendFetch('/drain-node', {
     method: 'POST',
@@ -78,7 +80,8 @@ interface DrainNodeStatus {
  * @throws {Error} if the response is not ok
  */
 export function drainNodeStatus(cluster: string, nodeName: string): Promise<DrainNodeStatus> {
-  const headers = addBackstageAuthHeaders(JSON_HEADERS);
+  const headers = new Headers(addBackstageAuthHeaders(JSON_HEADERS));
+  Object.entries(getHeadlampAPIHeaders()).forEach(([name, value]) => headers.set(name, value));
   return backendFetch(`/drain-node-status?cluster=${cluster}&nodeName=${nodeName}`, {
     method: 'GET',
     headers: headers,

--- a/frontend/src/lib/k8s/api/v1/streamingApi.test.ts
+++ b/frontend/src/lib/k8s/api/v1/streamingApi.test.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, Mock, vi } from 'vitest';
+import { isDebugVerbose } from '../../../../helpers/debugVerbose';
+import { setBackendToken } from '../../../../helpers/getHeadlampAPIHeaders';
+import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
+import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
+import { connectStreamWithParams } from './streamingApi';
+
+vi.mock('../../../../stateless/findKubeconfigByClusterName', () => ({
+  findKubeconfigByClusterName: vi.fn(),
+}));
+
+vi.mock('../../../../stateless/getUserIdFromLocalStorage', () => ({
+  getUserIdFromLocalStorage: vi.fn(),
+}));
+
+vi.mock('../../../../helpers/debugVerbose', () => ({
+  isDebugVerbose: vi.fn(() => false),
+}));
+
+describe('connectStreamWithParams protocols', () => {
+  afterEach(() => {
+    setBackendToken(null);
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    {
+      name: 'with a backend token',
+      token: 'desktop-token',
+      backendProtocol: 'base64url.headlamp.backend.authorization.k8s.io.ZGVza3RvcC10b2tlbg',
+    },
+    { name: 'without a backend token', token: null, backendProtocol: null },
+  ])('preserves Kubernetes, caller, and stateless protocols $name', async testCase => {
+    const socket = {
+      addEventListener: vi.fn(),
+      binaryType: '',
+    };
+    const WebSocketMock = vi.fn(function () {
+      return socket;
+    });
+    vi.stubGlobal('WebSocket', WebSocketMock);
+    (findKubeconfigByClusterName as Mock).mockResolvedValue({});
+    (getUserIdFromLocalStorage as Mock).mockReturnValue('stateless-user');
+    setBackendToken(testCase.token);
+
+    await connectStreamWithParams('/api/v1/pods', vi.fn(), vi.fn(), {
+      cluster: 'test-cluster',
+      additionalProtocols: ['caller.protocol'],
+    });
+
+    expect(WebSocketMock).toHaveBeenCalledWith(
+      expect.stringContaining('/clusters/test-cluster/api/v1/pods'),
+      [
+        'base64.binary.k8s.io',
+        'caller.protocol',
+        ...(testCase.backendProtocol ? [testCase.backendProtocol] : []),
+        'base64url.headlamp.authorization.k8s.io.stateless-user',
+      ]
+    );
+  });
+
+  it('uses default protocols and parses JSON messages', async () => {
+    const listeners: Record<string, EventListener> = {};
+    const socket = {
+      addEventListener: vi.fn((type: string, listener: EventListener) => {
+        listeners[type] = listener;
+      }),
+      binaryType: '',
+      close: vi.fn(),
+    };
+    vi.stubGlobal(
+      'WebSocket',
+      vi.fn(function () {
+        return socket;
+      })
+    );
+    (findKubeconfigByClusterName as Mock).mockResolvedValue(null);
+    const onMessage = vi.fn();
+
+    await connectStreamWithParams('/api/v1/pods', onMessage, vi.fn(), {
+      cluster: 'test-cluster',
+      isJson: true,
+    });
+    listeners.message(new MessageEvent('message', { data: JSON.stringify({ kind: 'Pod' }) }));
+
+    expect(onMessage).toHaveBeenCalledWith({ kind: 'Pod' });
+  });
+
+  it('returns a closable connection when socket construction fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.stubGlobal(
+      'WebSocket',
+      vi.fn(function () {
+        throw new Error('socket construction failed');
+      })
+    );
+    (findKubeconfigByClusterName as Mock).mockResolvedValue(null);
+
+    const connection = await connectStreamWithParams('/api/v1/pods', vi.fn(), vi.fn(), {
+      cluster: 'test-cluster',
+    });
+
+    expect(connection.socket).toBeNull();
+    expect(connection.close).not.toThrow();
+  });
+
+  it('delivers binary messages through the default parser', async () => {
+    const listeners: Record<string, EventListener> = {};
+    vi.mocked(isDebugVerbose).mockReturnValue(true);
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.stubGlobal(
+      'WebSocket',
+      vi.fn(function () {
+        return {
+          addEventListener: vi.fn((type: string, listener: EventListener) => {
+            listeners[type] = listener;
+          }),
+          binaryType: '',
+        };
+      })
+    );
+    (findKubeconfigByClusterName as Mock).mockResolvedValue(null);
+    const onMessage = vi.fn();
+
+    await connectStreamWithParams('/api/v1/pods', onMessage, vi.fn(), {
+      cluster: 'test-cluster',
+    });
+    listeners.message(new MessageEvent('message', { data: 'binary-data' }));
+
+    expect(onMessage).toHaveBeenCalledWith('binary-data');
+  });
+});

--- a/frontend/src/lib/k8s/api/v1/streamingApi.ts
+++ b/frontend/src/lib/k8s/api/v1/streamingApi.ts
@@ -16,6 +16,7 @@
 
 import { isDebugVerbose } from '../../../../helpers/debugVerbose';
 import { getAppUrl } from '../../../../helpers/getAppUrl';
+import { getHeadlampWebSocketProtocol } from '../../../../helpers/getHeadlampAPIHeaders';
 import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
 import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
 import { getCluster } from '../../../cluster';
@@ -441,6 +442,10 @@ export async function connectStreamWithParams<T>(
   const userID = getUserIdFromLocalStorage();
 
   const protocols = ['base64.binary.k8s.io', ...additionalProtocols];
+  const backendTokenProtocol = getHeadlampWebSocketProtocol();
+  if (backendTokenProtocol !== null) {
+    protocols.push(backendTokenProtocol);
+  }
 
   let fullPath = path;
   let url = '';

--- a/frontend/src/lib/k8s/api/v2/fetch.test.ts
+++ b/frontend/src/lib/k8s/api/v2/fetch.test.ts
@@ -16,6 +16,7 @@
 
 import nock from 'nock';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import { setBackendToken } from '../../../../helpers/getHeadlampAPIHeaders';
 import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
 import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
 import { getClusterAuthType } from '../v1/clusterRequests';
@@ -51,12 +52,14 @@ describe('clusterFetch', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    setBackendToken('desktop-token');
     (findKubeconfigByClusterName as Mock).mockResolvedValue(kubeconfig);
     (getUserIdFromLocalStorage as Mock).mockReturnValue(userID);
     (getClusterAuthType as Mock).mockReturnValue('serviceAccount');
   });
 
   afterEach(() => {
+    setBackendToken(null);
     nock.cleanAll();
   });
 
@@ -69,14 +72,42 @@ describe('clusterFetch', () => {
     expect(responseBody).toEqual(mockResponse);
   });
 
+  it('does not add backend credentials to non-cluster requests', async () => {
+    let backendTokenHeader: string | string[] | undefined;
+    nock(BASE_HTTP_URL)
+      .get(testUrl)
+      .reply(function () {
+        backendTokenHeader = this.req.headers['x-headlamp_backend-token'];
+        return [200, mockResponse];
+      });
+
+    await clusterFetch(testUrl, { cluster: '' });
+
+    expect(backendTokenHeader).toBeUndefined();
+  });
+
   it('Sets KUBECONFIG and X-HEADLAMP-USER-ID headers if kubeconfig exists', async () => {
     nock(BASE_HTTP_URL)
       .get(`/clusters/${clusterName}${testUrl}`)
       .matchHeader('KUBECONFIG', kubeconfig)
       .matchHeader('X-HEADLAMP-USER-ID', userID)
+      .matchHeader('X-HEADLAMP_BACKEND-TOKEN', 'desktop-token')
       .reply(200, mockResponse);
 
     await clusterFetch(testUrl, { cluster: clusterName });
+  });
+
+  it('preserves caller headers while adding the backend token', async () => {
+    nock(BASE_HTTP_URL)
+      .get(`/clusters/${clusterName}${testUrl}`)
+      .matchHeader('X-CUSTOM-HEADER', 'caller-value')
+      .matchHeader('X-HEADLAMP_BACKEND-TOKEN', 'desktop-token')
+      .reply(200, mockResponse);
+
+    await clusterFetch(testUrl, {
+      cluster: clusterName,
+      headers: { 'X-CUSTOM-HEADER': 'caller-value' },
+    });
   });
 
   it('Throws an error if response is not ok', async () => {

--- a/frontend/src/lib/k8s/api/v2/fetch.ts
+++ b/frontend/src/lib/k8s/api/v2/fetch.ts
@@ -16,6 +16,7 @@
 
 import { addBackstageAuthHeaders } from '../../../../helpers/addBackstageAuthHeaders';
 import { getAppUrl } from '../../../../helpers/getAppUrl';
+import { getHeadlampAPIHeaders } from '../../../../helpers/getHeadlampAPIHeaders';
 import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
 import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
 import { ApiError } from './ApiError';
@@ -79,6 +80,11 @@ export async function backendFetch(url: string | URL, init: RequestInit = {}) {
  */
 export async function clusterFetch(url: string | URL, init: RequestInit & { cluster: string }) {
   init.headers = new Headers(init.headers);
+  if (init.cluster) {
+    for (const [name, value] of Object.entries(getHeadlampAPIHeaders())) {
+      init.headers.set(name, value);
+    }
+  }
 
   // Set stateless kubeconfig if exists
   const kubeconfig = await findKubeconfigByClusterName(init.cluster);

--- a/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
@@ -17,6 +17,7 @@
 import { renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import WS from 'vitest-websocket-mock';
+import { setBackendToken } from '../../../../helpers/getHeadlampAPIHeaders';
 import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
 import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
 import { getCluster } from '../../../cluster';
@@ -63,6 +64,7 @@ describe('WebSocket Multiplexer', () => {
   beforeEach(() => {
     vi.stubEnv('REACT_APP_ENABLE_WEBSOCKET_MULTIPLEXER', 'true');
     vi.clearAllMocks();
+    setBackendToken(null);
     onMessage = vi.fn();
     onError = vi.fn();
     (getCluster as ReturnType<typeof vi.fn>).mockReturnValue(clusterName);
@@ -83,6 +85,8 @@ describe('WebSocket Multiplexer', () => {
     WS.clean();
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    setBackendToken(null);
     WebSocketManager.socketMultiplexer = null;
     WebSocketManager.connecting = false;
     WebSocketManager.isReconnecting = false;
@@ -94,6 +98,65 @@ describe('WebSocket Multiplexer', () => {
   });
 
   describe('WebSocketManager', () => {
+    it.each([
+      {
+        name: 'with a backend token',
+        token: 'desktop-token',
+        protocols: [
+          'headlamp.multiplexer.k8s.io',
+          'base64url.headlamp.backend.authorization.k8s.io.ZGVza3RvcC10b2tlbg',
+        ],
+      },
+      { name: 'without a backend token', token: null, protocols: null },
+    ])('constructs the multiplexer socket $name', async testCase => {
+      const socket = {
+        readyState: WebSocket.CONNECTING as number,
+        onopen: null as (() => void) | null,
+        onmessage: null,
+        onerror: null,
+        onclose: null,
+      };
+      const WebSocketMock = vi.fn(function () {
+        return socket;
+      });
+      Object.assign(WebSocketMock, {
+        CONNECTING: WebSocket.CONNECTING,
+        OPEN: WebSocket.OPEN,
+      });
+      vi.stubGlobal('WebSocket', WebSocketMock);
+      setBackendToken(testCase.token);
+
+      const connection = WebSocketManager.connect();
+
+      if (testCase.protocols) {
+        expect(WebSocketMock).toHaveBeenCalledWith(
+          `${BASE_WS_URL}${MULTIPLEXER_ENDPOINT}`,
+          testCase.protocols
+        );
+      } else {
+        expect(WebSocketMock).toHaveBeenCalledWith(`${BASE_WS_URL}${MULTIPLEXER_ENDPOINT}`);
+      }
+
+      socket.readyState = WebSocket.OPEN;
+      socket.onopen?.();
+      await connection;
+    });
+
+    it('clears the connecting state when socket construction fails', async () => {
+      const error = new Error('socket construction failed');
+      const WebSocketMock = vi.fn(function () {
+        throw error;
+      });
+      Object.assign(WebSocketMock, {
+        CONNECTING: WebSocket.CONNECTING,
+        OPEN: WebSocket.OPEN,
+      });
+      vi.stubGlobal('WebSocket', WebSocketMock);
+
+      await expect(WebSocketManager.connect()).rejects.toThrow(error);
+      expect(WebSocketManager.connecting).toBe(false);
+    });
+
     it('should establish connection and handle messages', async () => {
       const path = '/api/v1/pods';
       const query = 'watch=true';

--- a/frontend/src/lib/k8s/api/v2/multiplexer.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.ts
@@ -15,8 +15,11 @@
  */
 
 import { useCallback, useEffect, useMemo } from 'react';
+import { getHeadlampWebSocketProtocol } from '../../../../helpers/getHeadlampAPIHeaders';
 import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
 import { getBaseWsUrl } from './webSocket';
+
+const MULTIPLEXER_PROTOCOL = 'headlamp.multiplexer.k8s.io';
 
 /**
  * WebSocket manager to handle connections across the application.
@@ -106,7 +109,10 @@ export const WebSocketManager = {
     return new Promise((resolve, reject) => {
       let socket: WebSocket;
       try {
-        socket = new WebSocket(wsUrl);
+        const backendTokenProtocol = getHeadlampWebSocketProtocol();
+        socket = backendTokenProtocol
+          ? new WebSocket(wsUrl, [MULTIPLEXER_PROTOCOL, backendTokenProtocol])
+          : new WebSocket(wsUrl);
       } catch (e) {
         this.connecting = false;
         reject(e instanceof Error ? e : new Error(String(e)));

--- a/frontend/src/lib/k8s/api/v2/webSocket.test.ts
+++ b/frontend/src/lib/k8s/api/v2/webSocket.test.ts
@@ -15,9 +15,12 @@
  */
 
 import { renderHook, waitFor } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import WS from 'vitest-websocket-mock';
-import { useWebSockets } from './webSocket';
+import { setBackendToken } from '../../../../helpers/getHeadlampAPIHeaders';
+import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
+import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
+import { openWebSocket, useWebSockets } from './webSocket';
 import { BASE_WS_URL } from './webSocket';
 
 vi.mock('../../../cluster', () => ({
@@ -35,6 +38,78 @@ vi.mock('../../../../stateless/getUserIdFromLocalStorage', () => ({
 describe('useWebSockets', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe('openWebSocket protocols', () => {
+    afterEach(() => {
+      setBackendToken(null);
+      vi.unstubAllGlobals();
+      vi.restoreAllMocks();
+    });
+
+    it.each([
+      {
+        name: 'with a backend token',
+        token: 'desktop-token',
+        backendProtocol: 'base64url.headlamp.backend.authorization.k8s.io.ZGVza3RvcC10b2tlbg',
+      },
+      { name: 'without a backend token', token: null, backendProtocol: null },
+    ])('preserves Kubernetes, caller, and stateless protocols $name', async testCase => {
+      const socket = {
+        addEventListener: vi.fn(),
+        binaryType: '',
+      };
+      const WebSocketMock = vi.fn(function () {
+        return socket;
+      });
+      vi.stubGlobal('WebSocket', WebSocketMock);
+      (findKubeconfigByClusterName as Mock).mockResolvedValue({});
+      (getUserIdFromLocalStorage as Mock).mockReturnValue('stateless-user');
+      setBackendToken(testCase.token);
+
+      await openWebSocket('/api/v1/pods', {
+        cluster: 'test-cluster',
+        protocols: ['caller.protocol'],
+        type: 'binary',
+        onMessage: vi.fn(),
+      });
+
+      expect(WebSocketMock).toHaveBeenCalledWith(
+        expect.stringContaining('/clusters/test-cluster/api/v1/pods'),
+        [
+          'base64.binary.k8s.io',
+          'caller.protocol',
+          ...(testCase.backendProtocol ? [testCase.backendProtocol] : []),
+          'base64url.headlamp.authorization.k8s.io.stateless-user',
+        ]
+      );
+    });
+
+    it('uses default protocols without a cluster', async () => {
+      const listeners: Record<string, EventListener> = {};
+      const socket = {
+        addEventListener: vi.fn((type: string, listener: EventListener) => {
+          listeners[type] = listener;
+        }),
+        binaryType: '',
+      };
+      const WebSocketMock = vi.fn(function () {
+        return socket;
+      });
+      vi.stubGlobal('WebSocket', WebSocketMock);
+      const onMessage = vi.fn();
+
+      await openWebSocket('/api/v1/pods', {
+        type: 'binary',
+        onMessage,
+      });
+      listeners.message(new MessageEvent('message', { data: 'binary-data' }));
+
+      expect(WebSocketMock).toHaveBeenCalledWith(expect.not.stringContaining('/clusters/'), [
+        'base64.binary.k8s.io',
+      ]);
+      expect(onMessage).toHaveBeenCalledWith('binary-data');
+    });
   });
 
   afterEach(() => {

--- a/frontend/src/lib/k8s/api/v2/webSocket.ts
+++ b/frontend/src/lib/k8s/api/v2/webSocket.ts
@@ -16,6 +16,7 @@
 
 import { useEffect } from 'react';
 import { getAppUrl } from '../../../../helpers/getAppUrl';
+import { getHeadlampWebSocketProtocol } from '../../../../helpers/getHeadlampAPIHeaders';
 import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
 import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
 import { getCluster } from '../../../cluster';
@@ -103,6 +104,10 @@ export async function openWebSocket<T>(
   const connectionKey = cluster + url;
   const path = [url];
   const protocols = ['base64.binary.k8s.io', ...(moreProtocols ?? [])];
+  const backendTokenProtocol = getHeadlampWebSocketProtocol();
+  if (backendTokenProtocol !== null) {
+    protocols.push(backendTokenProtocol);
+  }
 
   if (cluster) {
     path.unshift('clusters', cluster);


### PR DESCRIPTION
## Summary

Protect desktop cluster REST and WebSocket APIs with the Electron per-launch backend token while preserving standalone and in-cluster behavior.


Desktop app creates a desktop-token, which prevents anyone else connecting to localhost backend services. So people on the same machine can not use their Kubernetes APIs.

## Changes

- Require the backend token only when the desktop app configures one.
- Protect desktop configuration, cluster routes, and the WebSocket multiplexer.
- Normalize and centrally add the token to v1 and v2 HTTP requests.
- Encode WebSocket credentials in a private namespaced subprotocol.
- Reject missing, invalid, duplicate, malformed, or conflicting credentials.
- Remove private credentials before forwarding requests upstream.
- Keep in-cluster deployments free of desktop token transport.
- Preserve Kubernetes authorization and public WebSocket subprotocols.

## Test coverage

- `go test ./pkg/auth ./cmd -count=1`: passed.
- Repository-pinned backend lint for `./cmd/...` and `./pkg/auth/...`: 0 issues.
- New backend token functions: 100%, 100%, and 96% statement coverage.
- Seven focused frontend suites: 125 tests passed.
- Changed frontend branches: 19/19 covered, 100% differential branch coverage.
- Electron tray suite: 9 tests passed.
- App and frontend TypeScript checks: passed.
- Desktop Playwright spec: two security flows discovered without compile or configuration errors.
- Container Playwright pod suite: eight tests discovered without configuration errors.
- Full desktop and container e2e runtimes are delegated to Linux CI because Docker is unavailable locally.

Implementation and unit tests are paired in eight coherent commits, followed by desktop e2e CI wiring.

## Manual steps to reproduce

1. Build and launch the desktop app with a configured Kubernetes cluster.
2. Find the local backend port in the app logs.
3. Request `/config` and `/clusters/<cluster>/version` without `X-HEADLAMP_BACKEND-TOKEN`; verify each returns `403`.
4. Repeat with an incorrect token; verify each returns `403`.
5. Use the desktop UI and verify cluster resources load normally with the renderer-provided token.
6. Start a resource watch and verify WebSocket updates continue while invalid or duplicate private credentials are rejected.
7. Launch the backend without `HEADLAMP_BACKEND_TOKEN`; verify standalone requests remain available without the desktop header.
8. Run an in-cluster deployment without a desktop token and verify watch updates continue.

## Screenshots

Not applicable. This changes an invisible local security boundary and has no visual difference.

Assisted by copilot