### PR TITLE
app: Reduce startup memory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ EMBED_BINARY_NAME := headlamp_app
 APP_VERSION ?= $(shell node -p "require('./app/package.json').version" 2>/dev/null || echo "unknown")
 APP_NAME ?= $(shell node -p "require('./app/package.json').productName" 2>/dev/null || echo "Headlamp")
 # Build flags with version and app name
-BUILD_VERSION_FLAGS := -ldflags="-X github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig.Version=$(APP_VERSION) -X 'github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig.AppName=$(APP_NAME)'"
+BUILD_VERSION_FLAGS := -trimpath -ldflags="-s -w -X github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig.Version=$(APP_VERSION) -X 'github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig.AppName=$(APP_NAME)'"
 # embed build flags
 EMBED_BUILD_FLAGS := -trimpath -ldflags="-s -w -X github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig.Version=$(APP_VERSION) -X 'github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig.AppName=$(APP_NAME)'" -tags embed
 

--- a/app/e2e-tests/tests/buildManifest.spec.ts
+++ b/app/e2e-tests/tests/buildManifest.spec.ts
@@ -22,6 +22,16 @@ import path from 'node:path';
 
 const appPath = path.resolve(__dirname, '../..');
 
+test('keeps the MCP adapter out of the Electron startup bundle', () => {
+  const mainBundle = fs.readFileSync(path.join(appPath, 'build', 'main.js'), 'utf8');
+  const adapterBundlePath = path.join(appPath, 'build', 'mcp', 'MCPAdapter.js');
+
+  expect(fs.existsSync(adapterBundlePath)).toBe(true);
+  expect(mainBundle).toContain('./mcp/MCPAdapter.js');
+  expect(mainBundle).not.toContain('@modelcontextprotocol/sdk');
+  expect(fs.statSync(adapterBundlePath).size).toBeGreaterThan(100_000);
+});
+
 test('custom platform metadata reaches the Electron Builder configuration', () => {
   const manifestDir = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-build-manifest-'));
   const manifestFile = path.join(manifestDir, 'app-build-manifest.json');

--- a/app/electron/backendMemory.test.ts
+++ b/app/electron/backendMemory.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { withBackendMemoryDefaults } from './backendMemory';
+
+describe('withBackendMemoryDefaults', () => {
+  it('uses a lower GC target for the bundled backend', () => {
+    expect(withBackendMemoryDefaults({ PATH: '/bin' })).toEqual({
+      PATH: '/bin',
+      GOGC: '25',
+    });
+  });
+
+  it('preserves an explicit GC target', () => {
+    expect(withBackendMemoryDefaults({ GOGC: '75' }).GOGC).toBe('75');
+  });
+});

--- a/app/electron/backendMemory.ts
+++ b/app/electron/backendMemory.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Collect the bundled backend's Go heap more often to reduce retained memory,
+ * while preserving an explicit user override.
+ *
+ * @param env - Environment inherited by the bundled backend process.
+ * @returns A copy of the environment with the default Go GC target applied.
+ */
+export function withBackendMemoryDefaults(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return {
+    ...env,
+    GOGC: env.GOGC || '25',
+  };
+}

--- a/app/electron/certificates.test.ts
+++ b/app/electron/certificates.test.ts
@@ -84,6 +84,22 @@ describe('certificates', () => {
       expect(mockGetCACertificates).toHaveBeenCalledTimes(2);
       expect(mockSetDefaultCACertificates).toHaveBeenCalledTimes(1);
     });
+
+    it('loads a configured custom CA on first use', () => {
+      mockGetCACertificates.mockReturnValue([]);
+      mockReadFileSync.mockReturnValue(
+        '-----BEGIN CERTIFICATE-----\ncustom-ca\n-----END CERTIFICATE-----'
+      );
+
+      const ensureCertificates = createCertificateSetup({
+        useSystemCAs: false,
+        customCAPath: '/path/to/custom-ca.crt',
+      });
+      ensureCertificates();
+
+      expect(mockReadFileSync).toHaveBeenCalledWith('/path/to/custom-ca.crt', 'utf8');
+      expect(mockSetDefaultCACertificates).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('setupSystemCAs', () => {

--- a/app/electron/certificates.test.ts
+++ b/app/electron/certificates.test.ts
@@ -49,7 +49,12 @@ vi.mock('node:tls', async importOriginal => {
   };
 });
 
-import { loadCustomCAs, setupCustomCAs, setupSystemCAs } from './certificates';
+import {
+  createCertificateSetup,
+  loadCustomCAs,
+  setupCustomCAs,
+  setupSystemCAs,
+} from './certificates';
 
 describe('certificates', () => {
   beforeEach(() => {
@@ -57,6 +62,28 @@ describe('certificates', () => {
     mockGetCACertificates.mockReset();
     mockSetDefaultCACertificates.mockReset();
     mockReadFileSync.mockReset();
+  });
+
+  describe('createCertificateSetup', () => {
+    it('defers certificate loading and initializes it only once', () => {
+      const mockSystemCAs = [
+        '-----BEGIN CERTIFICATE-----\nmock-system-ca\n-----END CERTIFICATE-----',
+      ];
+      mockGetCACertificates.mockImplementation((type: string) => {
+        if (type === 'system') return mockSystemCAs;
+        if (type === 'default') return [];
+        return [];
+      });
+
+      const ensureCertificates = createCertificateSetup();
+      expect(mockGetCACertificates).not.toHaveBeenCalled();
+
+      ensureCertificates();
+      ensureCertificates();
+
+      expect(mockGetCACertificates).toHaveBeenCalledTimes(2);
+      expect(mockSetDefaultCACertificates).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('setupSystemCAs', () => {

--- a/app/electron/certificates.ts
+++ b/app/electron/certificates.ts
@@ -44,6 +44,30 @@ export interface CertificateSettings {
 }
 
 /**
+ * Creates a function that initializes certificate trust on first use.
+ * Deferring CA enumeration and parsing avoids retaining certificate material
+ * when no plugin or MCP network request is made.
+ *
+ * @param settings - Certificate sources to initialize.
+ * @returns An idempotent certificate initialization function.
+ */
+export function createCertificateSetup(settings: CertificateSettings = {}): () => void {
+  let initialized = false;
+
+  return () => {
+    if (initialized) {
+      return;
+    }
+
+    setupSystemCAs(settings);
+    if (settings.customCAPath) {
+      setupCustomCAs(settings.customCAPath);
+    }
+    initialized = true;
+  };
+}
+
+/**
  * Merges system CA certificates with Node's bundled CA list.
  *
  * This function attempts to retrieve system CA certificates and merge them

--- a/app/electron/hardwareAcceleration.test.ts
+++ b/app/electron/hardwareAcceleration.test.ts
@@ -14,64 +14,99 @@
  * limitations under the License.
  */
 
+import { Worker } from 'node:worker_threads';
 import { describe, expect, it, vi } from 'vitest';
-import { getHardwareAccelerationDisableReason, isWindowsVM } from './hardwareAcceleration';
+import {
+  startWindowsVMDetection,
+  waitForWindowsVMDetection,
+  WindowsVMDetectionDependencies,
+} from './hardwareAcceleration';
 
-describe('isWindowsVM', () => {
-  it.each([
-    'SystemManufacturer    REG_SZ    Microsoft Corporation\nSystemProductName    REG_SZ    Virtual Machine',
-    'SystemManufacturer    REG_SZ    VMware, Inc.',
-    'SystemProductName    REG_SZ    VirtualBox',
-    'SystemManufacturer    REG_SZ    QEMU',
-  ])('detects a virtual machine from Windows BIOS data', bios => {
-    expect(isWindowsVM('win32', () => bios)).toBe(true);
+function dependencies(
+  overrides: Partial<WindowsVMDetectionDependencies> = {}
+): WindowsVMDetectionDependencies {
+  return {
+    platform: 'win32',
+    systemRoot: 'C:\\Windows',
+    createWorker: vi.fn(() => ({ on: vi.fn(), unref: vi.fn() })),
+    ...overrides,
+  };
+}
+
+describe('startWindowsVMDetection', () => {
+  it('starts an unreferenced worker on Windows when no flag is set', () => {
+    const worker = { on: vi.fn(), unref: vi.fn() };
+    const createWorker = vi.fn(() => worker);
+
+    const detection = startWindowsVMDetection(undefined, dependencies({ createWorker }));
+
+    expect(detection).not.toBeNull();
+    expect(createWorker).toHaveBeenCalledWith(
+      expect.stringContaining('execFileSync'),
+      expect.objectContaining({ systemRoot: 'C:\\Windows' })
+    );
+    expect(worker.unref).toHaveBeenCalledTimes(1);
+    expect(worker.on).toHaveBeenCalledWith('error', expect.any(Function));
   });
 
-  it('does not identify physical Windows hardware as a VM', () => {
+  it.each([true, false])('skips detection when disable-gpu is %s', disableGPU => {
+    const createWorker = vi.fn(() => ({ on: vi.fn(), unref: vi.fn() }));
+
+    expect(startWindowsVMDetection(disableGPU, dependencies({ createWorker }))).toBeNull();
+    expect(createWorker).not.toHaveBeenCalled();
+  });
+
+  it('skips detection outside Windows', () => {
+    const createWorker = vi.fn(() => ({ on: vi.fn(), unref: vi.fn() }));
+
     expect(
-      isWindowsVM(
-        'win32',
-        () =>
-          'SystemManufacturer    REG_SZ    Microsoft Corporation\nSystemProductName    REG_SZ    Surface Pro 9'
-      )
-    ).toBe(false);
+      startWindowsVMDetection(undefined, dependencies({ createWorker, platform: 'linux' }))
+    ).toBeNull();
+    expect(createWorker).not.toHaveBeenCalled();
   });
 
-  it('does not query the BIOS on other platforms', () => {
-    const readBIOS = vi.fn();
+  it('falls back to the standard Windows directory for an invalid root', () => {
+    const createWorker = vi.fn(() => ({ on: vi.fn(), unref: vi.fn() }));
 
-    expect(isWindowsVM('linux', readBIOS)).toBe(false);
-    expect(readBIOS).not.toHaveBeenCalled();
+    startWindowsVMDetection(undefined, dependencies({ createWorker, systemRoot: 'relative' }));
+
+    expect(createWorker).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ systemRoot: 'C:\\Windows' })
+    );
   });
 
-  it('returns false and keeps GPU enabled when the BIOS cannot be queried', () => {
-    expect(
-      isWindowsVM('win32', () => {
-        throw new Error('reg.exe failed');
+  it('signals failure when the registry executable is unavailable', () => {
+    const detection = startWindowsVMDetection(
+      undefined,
+      dependencies({
+        createWorker(source, workerData) {
+          return new Worker(source, { eval: true, workerData });
+        },
+        systemRoot: 'Z:\\missing-windows',
       })
-    ).toBe(false);
+    );
+
+    expect(waitForWindowsVMDetection(detection)).toBe(false);
+    expect(Atomics.load(detection!.state, 0)).not.toBe(0);
   });
 });
 
-describe('getHardwareAccelerationDisableReason', () => {
-  it('disables GPU acceleration in a Windows VM', () => {
-    expect(getHardwareAccelerationDisableReason(undefined, 'win32', 'x64', () => true)).toContain(
-      'Windows virtual machine'
-    );
+describe('waitForWindowsVMDetection', () => {
+  it('returns true only for virtual-machine results', () => {
+    const virtualState = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    const physicalState = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    Atomics.store(virtualState, 0, 2);
+    Atomics.store(physicalState, 0, 1);
+
+    expect(waitForWindowsVMDetection({ state: virtualState })).toBe(true);
+    expect(waitForWindowsVMDetection({ state: physicalState })).toBe(false);
+    expect(waitForWindowsVMDetection(null)).toBe(false);
   });
 
-  it('allows --disable-gpu=false to override automatic detection', () => {
-    const detectWindowsVM = vi.fn(() => true);
+  it('returns false when detection exceeds its bounded wait', () => {
+    const state = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
 
-    expect(getHardwareAccelerationDisableReason(false, 'win32', 'x64', detectWindowsVM)).toBe(
-      undefined
-    );
-    expect(detectWindowsVM).not.toHaveBeenCalled();
-  });
-
-  it('preserves Linux ARM detection', () => {
-    expect(getHardwareAccelerationDisableReason(undefined, 'linux', 'arm64')).toContain(
-      'Linux on ARM'
-    );
+    expect(waitForWindowsVMDetection({ state }, 1)).toBe(false);
   });
 });

--- a/app/electron/hardwareAcceleration.test.ts
+++ b/app/electron/hardwareAcceleration.test.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { getHardwareAccelerationDisableReason, isWindowsVM } from './hardwareAcceleration';
+
+describe('isWindowsVM', () => {
+  it.each([
+    'SystemManufacturer    REG_SZ    Microsoft Corporation\nSystemProductName    REG_SZ    Virtual Machine',
+    'SystemManufacturer    REG_SZ    VMware, Inc.',
+    'SystemProductName    REG_SZ    VirtualBox',
+    'SystemManufacturer    REG_SZ    QEMU',
+  ])('detects a virtual machine from Windows BIOS data', bios => {
+    expect(isWindowsVM('win32', () => bios)).toBe(true);
+  });
+
+  it('does not identify physical Windows hardware as a VM', () => {
+    expect(
+      isWindowsVM(
+        'win32',
+        () =>
+          'SystemManufacturer    REG_SZ    Microsoft Corporation\nSystemProductName    REG_SZ    Surface Pro 9'
+      )
+    ).toBe(false);
+  });
+
+  it('does not query the BIOS on other platforms', () => {
+    const readBIOS = vi.fn();
+
+    expect(isWindowsVM('linux', readBIOS)).toBe(false);
+    expect(readBIOS).not.toHaveBeenCalled();
+  });
+
+  it('returns false and keeps GPU enabled when the BIOS cannot be queried', () => {
+    expect(
+      isWindowsVM('win32', () => {
+        throw new Error('reg.exe failed');
+      })
+    ).toBe(false);
+  });
+});
+
+describe('getHardwareAccelerationDisableReason', () => {
+  it('disables GPU acceleration in a Windows VM', () => {
+    expect(getHardwareAccelerationDisableReason(undefined, 'win32', 'x64', () => true)).toContain(
+      'Windows virtual machine'
+    );
+  });
+
+  it('allows --disable-gpu=false to override automatic detection', () => {
+    const detectWindowsVM = vi.fn(() => true);
+
+    expect(getHardwareAccelerationDisableReason(false, 'win32', 'x64', detectWindowsVM)).toBe(
+      undefined
+    );
+    expect(detectWindowsVM).not.toHaveBeenCalled();
+  });
+
+  it('preserves Linux ARM detection', () => {
+    expect(getHardwareAccelerationDisableReason(undefined, 'linux', 'arm64')).toContain(
+      'Linux on ARM'
+    );
+  });
+});

--- a/app/electron/hardwareAcceleration.ts
+++ b/app/electron/hardwareAcceleration.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import path from 'node:path';
+import { Worker } from 'node:worker_threads';
+
+const DETECTION_PENDING = 0;
+const DETECTION_PHYSICAL = 1;
+const DETECTION_VIRTUAL = 2;
+const DETECTION_FAILED = 3;
+const VM_IDENTIFIERS =
+  /\b(?:amazon ec2|bochs|digitalocean|google compute engine|hyper-v|kvm|nutanix|parallels|qemu|virtual machine|virtualbox|vmware|xen)\b/i;
+
+interface DetectionWorker {
+  on(event: 'error', listener: () => void): void;
+  unref(): void;
+}
+
+/** A Windows VM detection operation running outside the Electron main thread. */
+export interface WindowsVMDetection {
+  /** Shared state updated by the detection worker. */
+  state: Int32Array;
+}
+
+/** Dependencies used to start VM detection, injectable for testing. */
+export interface WindowsVMDetectionDependencies {
+  /** Current operating system platform. */
+  platform: NodeJS.Platform;
+  /** Windows installation directory containing System32. */
+  systemRoot: string;
+  /** Starts an unreferenced worker from inline JavaScript. */
+  createWorker: (source: string, workerData: object) => DetectionWorker;
+}
+
+const defaultDependencies: WindowsVMDetectionDependencies = {
+  platform: process.platform,
+  systemRoot: process.env.SystemRoot || 'C:\\Windows',
+  createWorker(source, workerData) {
+    return new Worker(source, { eval: true, workerData });
+  },
+};
+
+/**
+ * Starts Windows VM detection while the main process continues synchronous setup.
+ *
+ * @param disableGPU - Explicit command-line preference, when provided.
+ * @param dependencies - Platform and worker operations.
+ * @returns Shared detection state, or null when automatic detection is unnecessary.
+ */
+export function startWindowsVMDetection(
+  disableGPU: boolean | undefined,
+  dependencies: WindowsVMDetectionDependencies = defaultDependencies
+): WindowsVMDetection | null {
+  if (dependencies.platform !== 'win32' || disableGPU !== undefined) {
+    return null;
+  }
+
+  const systemRoot = path.win32.isAbsolute(dependencies.systemRoot)
+    ? dependencies.systemRoot
+    : 'C:\\Windows';
+  const state = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+  const source = `
+    const { execFileSync } = require('node:child_process');
+    const path = require('node:path');
+    const { workerData } = require('node:worker_threads');
+    const state = new Int32Array(workerData.state);
+    let result = workerData.failed;
+    try {
+      const output = execFileSync(
+        path.win32.join(workerData.systemRoot, 'System32', 'reg.exe'),
+        ['query', 'HKLM\\\\HARDWARE\\\\DESCRIPTION\\\\System\\\\BIOS'],
+        {
+          encoding: 'utf8',
+          maxBuffer: 1024 * 1024,
+          stdio: ['ignore', 'pipe', 'ignore'],
+          timeout: workerData.timeout,
+          windowsHide: true,
+        }
+      );
+      result = new RegExp(workerData.pattern, 'i').test(output)
+        ? workerData.virtual
+        : workerData.physical;
+    } catch {
+      result = workerData.failed;
+    } finally {
+      Atomics.store(state, 0, result);
+      Atomics.notify(state, 0);
+    }
+  `;
+  const worker = dependencies.createWorker(source, {
+    failed: DETECTION_FAILED,
+    pattern: VM_IDENTIFIERS.source,
+    physical: DETECTION_PHYSICAL,
+    state: state.buffer,
+    systemRoot,
+    timeout: 1000,
+    virtual: DETECTION_VIRTUAL,
+  });
+  worker.on('error', () => {
+    Atomics.store(state, 0, DETECTION_FAILED);
+    Atomics.notify(state, 0);
+  });
+  worker.unref();
+
+  return { state };
+}
+
+/**
+ * Waits for a previously started VM detection before Electron becomes ready.
+ *
+ * @param detection - Detection state returned by startWindowsVMDetection.
+ * @param timeoutMs - Maximum time to wait after synchronous startup work.
+ * @returns Whether the Windows system was identified as a virtual machine.
+ */
+export function waitForWindowsVMDetection(
+  detection: WindowsVMDetection | null,
+  timeoutMs = 1000
+): boolean {
+  if (!detection) {
+    return false;
+  }
+
+  Atomics.wait(detection.state, 0, DETECTION_PENDING, timeoutMs);
+  return Atomics.load(detection.state, 0) === DETECTION_VIRTUAL;
+}

--- a/app/electron/i18next.config.ts
+++ b/app/electron/i18next.config.ts
@@ -15,11 +15,10 @@
  */
 
 import i18next from 'i18next';
-import i18nextBackend from 'i18next-fs-backend/cjs';
-import * as path from 'path';
 import { CURRENT_LOCALES, LOCALES_DIR } from './i18n-helper';
+import { createJsonBackend } from './i18nextJsonBackend';
 
-i18next.use(i18nextBackend).init({
+i18next.use(createJsonBackend(LOCALES_DIR)).init({
   debug: process.env.NODE_ENV === 'development',
   fallbackLng: 'en',
   supportedLngs: CURRENT_LOCALES,
@@ -28,9 +27,6 @@ i18next.use(i18nextBackend).init({
   lowerCaseLng: true,
   ns: ['app'],
   defaultNS: 'app',
-  backend: {
-    loadPath: path.join(LOCALES_DIR, '{{lng}}/{{ns}}.json'),
-  },
   interpolation: {
     escapeValue: false, // not needed for react as it escapes by default
     format: function (value, format, lng) {

--- a/app/electron/i18nextJsonBackend.test.ts
+++ b/app/electron/i18nextJsonBackend.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createJsonBackend } from './i18nextJsonBackend';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const tempDir of tempDirs.splice(0)) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe('createJsonBackend', () => {
+  it('loads JSON locale resources', async () => {
+    const localesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-i18n-'));
+    tempDirs.push(localesDir);
+    fs.mkdirSync(path.join(localesDir, 'en'));
+    fs.writeFileSync(path.join(localesDir, 'en', 'app.json'), '{"Hello":"World"}');
+
+    const backend = createJsonBackend(localesDir);
+    const resource = await new Promise((resolve, reject) => {
+      backend.read('en', 'app', (error, data) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(data);
+        }
+      });
+    });
+
+    expect(resource).toEqual({ Hello: 'World' });
+  });
+
+  it('reports invalid JSON', async () => {
+    const localesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-i18n-'));
+    tempDirs.push(localesDir);
+    fs.mkdirSync(path.join(localesDir, 'en'));
+    fs.writeFileSync(path.join(localesDir, 'en', 'app.json'), '{');
+
+    const backend = createJsonBackend(localesDir);
+    await expect(
+      new Promise((resolve, reject) => {
+        backend.read('en', 'app', (error, data) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve(data);
+          }
+        });
+      })
+    ).rejects.toBeInstanceOf(SyntaxError);
+  });
+});

--- a/app/electron/i18nextJsonBackend.test.ts
+++ b/app/electron/i18nextJsonBackend.test.ts
@@ -68,4 +68,22 @@ describe('createJsonBackend', () => {
       })
     ).rejects.toBeInstanceOf(SyntaxError);
   });
+
+  it('reports missing locale resources', async () => {
+    const localesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-i18n-'));
+    tempDirs.push(localesDir);
+    const backend = createJsonBackend(localesDir);
+
+    await expect(
+      new Promise((resolve, reject) => {
+        backend.read('en', 'missing', (error, data) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve(data);
+          }
+        });
+      })
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
 });

--- a/app/electron/i18nextJsonBackend.ts
+++ b/app/electron/i18nextJsonBackend.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { BackendModule } from 'i18next';
+import { readFile } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Loads only Headlamp's JSON locale format, avoiding the generic filesystem
+ * backend's unused format parsers in the Electron startup heap.
+ *
+ * @param localesDir - Directory containing locale and namespace JSON files.
+ * @returns An i18next backend that reads JSON locale resources.
+ */
+export function createJsonBackend(localesDir: string): BackendModule {
+  return {
+    type: 'backend',
+    init() {},
+    read(language, namespace, callback) {
+      readFile(path.join(localesDir, language, `${namespace}.json`), 'utf8', (error, data) => {
+        if (error) {
+          callback(error, false);
+          return;
+        }
+
+        try {
+          callback(null, JSON.parse(data));
+        } catch (error) {
+          callback(error as Error, false);
+        }
+      });
+    },
+  };
+}

--- a/app/electron/lazy/tar.ts
+++ b/app/electron/lazy/tar.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This separate entry keeps tar's module graph out of the main-process heap
+// until a plugin archive actually needs extraction.
+export { extract } from 'tar';

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -29,7 +29,6 @@ import {
   shell,
 } from 'electron';
 import { IpcMainEvent, MenuItemConstructorOptions } from 'electron/main';
-import find_process from 'find-process';
 import * as fsPromises from 'fs/promises';
 import * as net from 'net';
 import { platform } from 'os';
@@ -37,7 +36,9 @@ import path from 'path';
 import url from 'url';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import { setupCustomCAs, setupSystemCAs } from './certificates';
+import { withBackendMemoryDefaults } from './backendMemory';
+import { createCertificateSetup } from './certificates';
+import { startWindowsVMDetection, waitForWindowsVMDetection } from './hardwareAcceleration';
 import i18n from './i18next.config';
 import {
   getLegalDocumentsResourcePath,
@@ -109,11 +110,7 @@ const ENABLE_MCP = process.env.HEADLAMP_MCP_ENABLE !== 'false';
 dotenv.config({ path: path.join(process.resourcesPath, '.env') });
 
 const settings = loadSettings(SETTINGS_PATH);
-setupSystemCAs(settings);
-
-if (settings.customCAPath) {
-  setupCustomCAs(settings.customCAPath);
-}
+const ensureCertificates = createCertificateSetup(settings);
 
 const isDev = !!process.env.ELECTRON_DEV;
 let frontendPath = '';
@@ -192,7 +189,12 @@ if ('remote-debugging-port' in args) {
 }
 
 const isHeadlessMode = args.headless === true;
-let disableGPU = args['disable-gpu'] === true;
+const disableGPU = args['disable-gpu'];
+const windowsVMDetection = startWindowsVMDetection(disableGPU);
+if (disableGPU === true) {
+  console.info('Disabling GPU hardware acceleration. Reason: related flag is set.');
+  app.disableHardwareAcceleration();
+}
 const defaultPort = args.port || 4466;
 let actualPort = defaultPort; // Will be updated when backend starts
 const MAX_PORT_ATTEMPTS = Math.abs(Number(process.env.HEADLAMP_MAX_PORT_ATTEMPTS) || 100); // Maximum number of ports to try
@@ -361,6 +363,7 @@ class PluginManagerEventListeners {
 
     let pluginInfo: ArtifactHubHeadlampPkg | undefined = undefined;
     try {
+      ensureCertificates();
       pluginInfo = await PluginManager.fetchPluginInfo(URL, { signal: controller.signal });
     } catch (error) {
       console.error('Error fetching plugin info:', error);
@@ -456,6 +459,7 @@ class PluginManagerEventListeners {
       controller,
     };
 
+    ensureCertificates();
     PluginManager.update(
       pluginName,
       destinationFolder,
@@ -688,6 +692,17 @@ async function isPortAvailable(port: number): Promise<boolean> {
 async function findAvailablePort(startPort: number): Promise<number> {
   for (let i = 0; i < MAX_PORT_ATTEMPTS; i++) {
     const port = startPort + i;
+    // Probe the socket first so normal startup does not load and retain the
+    // process-inspection dependency when the preferred port is free.
+    const available = await isPortAvailable(port);
+
+    if (available) {
+      if (port !== startPort) {
+        console.info(`Port ${startPort} is in use, using port ${port} instead`);
+      }
+      return port;
+    }
+
     // Skip ports already used by another Headlamp instance.
     const headlampPIDs = await getHeadlampPIDsOnPort(port);
     if (headlampPIDs && headlampPIDs.length > 0) {
@@ -697,14 +712,6 @@ async function findAvailablePort(startPort: number): Promise<number> {
         )}, trying next port...`
       );
       continue;
-    }
-    const available = await isPortAvailable(port);
-
-    if (available) {
-      if (port !== startPort) {
-        console.info(`Port ${startPort} is in use, using port ${port} instead`);
-      }
-      return port;
     }
 
     console.info(`Port ${port} is occupied by another process, trying next port...`);
@@ -794,9 +801,7 @@ async function startServer(flags: string[] = []): Promise<ChildProcessWithoutNul
   const options = {
     detached: true,
     windowsHide: true,
-    env: {
-      ...extendedEnv,
-    },
+    env: withBackendMemoryDefaults(extendedEnv),
   };
 
   return spawn(serverFilePath, serverArgs, options);
@@ -1239,7 +1244,9 @@ function menusToTemplate(mainWindow: BrowserWindow | null, menusFromPlugins: App
 }
 
 async function getRunningHeadlampPIDs() {
-  const processes = await find_process('name', 'headlamp-server.*');
+  // Process inspection is only needed during cleanup, not normal startup.
+  const { default: findProcess } = await import('find-process');
+  const processes = await findProcess('name', 'headlamp-server.*');
   // Only consider processes owned by the current user: on shared machines
   // (e.g. Windows remote desktop servers) other users run their own
   // headlamp-server and we must never touch those.
@@ -1258,7 +1265,9 @@ async function getRunningHeadlampPIDs() {
 async function getHeadlampPIDsOnPort(port: number): Promise<number[] | null> {
   try {
     // Get all Headlamp processes
-    const headlampProcesses = await find_process('name', 'headlamp-server');
+    // Keep process inspection unloaded unless a port is actually occupied.
+    const { default: findProcess } = await import('find-process');
+    const headlampProcesses = await findProcess('name', 'headlamp-server');
     if (headlampProcesses.length === 0) {
       return null;
     }
@@ -1833,26 +1842,14 @@ function startElectron() {
     if (ENABLE_MCP) {
       const configPath = path.join(app.getPath('userData'), 'mcp-tools-config.json');
       const settingsPath = path.join(app.getPath('userData'), 'mcp-tools-settings.json');
-      mcpClient = new MCPClient(configPath, settingsPath);
+      mcpClient = new MCPClient(configPath, settingsPath, ensureCertificates);
       await mcpClient.initialize();
       mcpClient.setMainWindow(mainWindow);
     }
   }
 
-  if (disableGPU) {
-    console.info('Disabling GPU hardware acceleration. Reason: related flag is set.');
-  } else if (
-    disableGPU === undefined &&
-    process.platform === 'linux' &&
-    ['arm', 'arm64'].includes(process.arch)
-  ) {
-    console.info(
-      'Disabling GPU hardware acceleration. Reason: known graphical issues in Linux on ARM (use --disable-gpu=false to force it if needed).'
-    );
-    disableGPU = true;
-  }
-
-  if (disableGPU) {
+  if (waitForWindowsVMDetection(windowsVMDetection)) {
+    console.info('Disabling GPU hardware acceleration. Reason: running in a Windows VM.');
     app.disableHardwareAcceleration();
   }
 

--- a/app/electron/mcp/MCPAdapter.ts
+++ b/app/electron/mcp/MCPAdapter.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Keep the LangChain/LangGraph dependency graph in a first-use chunk rather
+// than retaining it in Electron's startup bundle and heap.
+export { MultiServerMCPClient } from '@langchain/mcp-adapters';

--- a/app/electron/mcp/MCPClient.test.ts
+++ b/app/electron/mcp/MCPClient.test.ts
@@ -124,7 +124,7 @@ describe('MCPClient', () => {
     expect(infoSpy).not.toHaveBeenCalledWith('MCPClient: cleaned up');
   });
 
-  it('initialize marks isInitialized and leaves client null when no servers are configured', async () => {
+  it('initialize leaves the MCP server client dormant', async () => {
     // Mock MCPSettings to return no servers
     vi.doMock('./MCPSettings', () => ({
       makeMcpServersFromSettings: vi.fn().mockReturnValue({}),
@@ -142,38 +142,99 @@ describe('MCPClient', () => {
     const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
     await client.initialize();
 
-    expect((client as any).isInitialized).toBe(true);
+    expect((client as any).isInitialized).toBe(false);
     expect((client as any).client).toBeNull();
     // ensure the public log happened
     expect(infoSpy).toHaveBeenCalledWith('MCPClient: initialized');
   });
 
-  it('initialize constructs MCP client and caches tools when servers exist', async () => {
-    const fakeTools = [{ name: 't1' }, { name: 't2' }];
-    const getTools = vi.fn().mockResolvedValue(fakeTools);
-    const close = vi.fn().mockResolvedValue(undefined);
-    const MultiServerMCPClientMock = vi.fn().mockImplementation(() => ({ getTools, close }));
+  it('does not load the MCP adapter when configured servers are unused', async () => {
+    const ensureCertificates = vi.fn();
+    const adapterFactory = vi.fn(() => ({
+      MultiServerMCPClient: vi.fn(),
+    }));
 
     vi.resetModules();
-    vi.doMock('@langchain/mcp-adapters', () => ({
-      MultiServerMCPClient: MultiServerMCPClientMock,
-    }));
+    vi.doMock('@langchain/mcp-adapters', adapterFactory);
     vi.doMock('./MCPSettings', () => ({
       makeMcpServersFromSettings: vi.fn().mockReturnValue({ serverA: { url: 'http://x' } }),
       hasClusterDependentServers: vi.fn().mockReturnValue(false),
     }));
 
     const { default: MCPClient } = await import('./MCPClient');
-    const client = new MCPClient(cfgPath, settingsPath);
+    const client = new MCPClient(cfgPath, settingsPath, ensureCertificates);
 
     await client.initialize();
 
-    // Ensure the mock constructor was called to create the client
-    expect(MultiServerMCPClientMock).toHaveBeenCalled();
-    // Ensure tools were cached
+    expect(adapterFactory).not.toHaveBeenCalled();
+    expect(ensureCertificates).not.toHaveBeenCalled();
+  });
+
+  it('constructs the MCP client when a tool is first used', async () => {
+    const ensureCertificates = vi.fn();
+    const invoke = vi.fn().mockResolvedValue({ ok: true });
+    const fakeTools = [{ name: 'serverA.t1', schema: {}, invoke }];
+    const getTools = vi.fn().mockResolvedValue(fakeTools);
+    const close = vi.fn().mockResolvedValue(undefined);
+    const MultiServerMCPClientMock = vi.fn().mockImplementation(() => ({ getTools, close }));
+    const makeMcpServersFromSettings = vi.fn().mockReturnValue({ serverA: { url: 'http://x' } });
+
+    vi.resetModules();
+    vi.doMock('@langchain/mcp-adapters', () => ({
+      MultiServerMCPClient: MultiServerMCPClientMock,
+    }));
+    vi.doMock('./MCPSettings', () => ({
+      makeMcpServersFromSettings,
+      hasClusterDependentServers: vi.fn().mockReturnValue(false),
+    }));
+
+    const { default: MCPClient } = await import('./MCPClient');
+    const client = new MCPClient(cfgPath, settingsPath, ensureCertificates);
+
+    await client.initialize();
+    expect(MultiServerMCPClientMock).not.toHaveBeenCalled();
+    await client.handleClustersChange(['cluster-a']);
+
+    const result = await (client as any).mcpExecuteTool('serverA.t1', {}, 'call-1');
+
+    expect(makeMcpServersFromSettings).toHaveBeenCalledWith(settingsPath, ['cluster-a']);
+    expect(MultiServerMCPClientMock).toHaveBeenCalledTimes(1);
+    expect(ensureCertificates).toHaveBeenCalledTimes(1);
     expect((client as any).clientTools).toEqual(fakeTools);
-    // Ensure MCPToolStateStore was initialized (non-null)
-    expect((client as any).mcpToolState).not.toBeNull();
+    expect(result).toEqual({ success: true, result: { ok: true }, toolCallId: 'call-1' });
+  });
+
+  it('keeps a newly configured MCP server dormant', async () => {
+    const ensureCertificates = vi.fn();
+    const adapterFactory = vi.fn(() => ({
+      MultiServerMCPClient: vi.fn(),
+    }));
+    const saveMCPSettings = vi.fn();
+
+    vi.resetModules();
+    vi.doMock('@langchain/mcp-adapters', adapterFactory);
+    vi.doMock('./MCPSettings', () => ({
+      loadMCPSettings: vi.fn().mockReturnValue({ enabled: false, servers: [] }),
+      saveMCPSettings,
+      showSettingsChangeDialog: vi.fn().mockResolvedValue(true),
+      makeMcpServersFromSettings: vi.fn().mockReturnValue({ serverA: { url: 'http://x' } }),
+      hasClusterDependentServers: vi.fn().mockReturnValue(false),
+    }));
+
+    const { default: MCPClient } = await import('./MCPClient');
+    const client = new MCPClient(cfgPath, settingsPath, ensureCertificates);
+    const settings = { enabled: true, servers: [] };
+
+    await client.initialize();
+    client.setMainWindow({} as Electron.BrowserWindow);
+    const result = await (client as any).mcpUpdateConfig(settings);
+
+    expect(result).toEqual({ success: true });
+    expect(saveMCPSettings).toHaveBeenCalledWith(settingsPath, settings);
+    expect(adapterFactory).not.toHaveBeenCalled();
+    expect(ensureCertificates).not.toHaveBeenCalled();
+    expect((client as any).client).toBeNull();
+    expect((client as any).isInitialized).toBe(false);
   });
 
   it('handleClustersChange logs and returns early when no cluster-dependent servers', async () => {
@@ -197,6 +258,7 @@ describe('MCPClient', () => {
     const client = new MCPClient(cfgPath, settingsPath);
 
     await client.initialize();
+    await (client as any).initializeClient();
 
     const beforeClient = (client as any).client;
 
@@ -224,6 +286,7 @@ describe('MCPClient', () => {
     const client = new MCPClient(cfgPath, settingsPath);
 
     await client.initialize();
+    await (client as any).initializeClient();
 
     // set currentClusters to a value and call with the same value
     (client as any).currentClusters = ['same-cluster'];
@@ -267,6 +330,7 @@ describe('MCPClient', () => {
 
     vi.spyOn(console, 'log').mockImplementation(() => {});
     await client.initialize();
+    await (client as any).initializeClient();
 
     // initial client should be the first instance
     const firstClientRef = (client as any).client;
@@ -332,6 +396,7 @@ describe('MCPClient#mcpExecuteTool', () => {
       }),
       validateToolArgs: vi.fn().mockReturnValue({ valid: true }),
       MCPToolStateStore: vi.fn().mockImplementation(() => ({
+        initialize: vi.fn(),
         // initialize config from client tools is invoked during MCPClient.initialize
         // provide a no-op mock so tests that don't assert this behavior don't fail
         initConfigFromClientTools: vi.fn(),
@@ -380,6 +445,7 @@ describe('MCPClient#mcpExecuteTool', () => {
         .mockReturnValue({ serverName: 'serverA', toolName: 'tool1' }),
       validateToolArgs: vi.fn().mockReturnValue({ valid: false, error: 'bad-params' }),
       MCPToolStateStore: vi.fn().mockImplementation(() => ({
+        initialize: vi.fn(),
         initConfigFromClientTools: vi.fn(),
       })),
     }));

--- a/app/electron/mcp/MCPClient.test.ts
+++ b/app/electron/mcp/MCPClient.test.ts
@@ -124,6 +124,48 @@ describe('MCPClient', () => {
     expect(infoSpy).not.toHaveBeenCalledWith('MCPClient: cleaned up');
   });
 
+  it('waits for first-use initialization and closes its client during cleanup', async () => {
+    let resolveTools!: (tools: Array<{ name: string }>) => void;
+    const tools = new Promise<Array<{ name: string }>>(resolve => {
+      resolveTools = resolve;
+    });
+    const close = vi.fn().mockResolvedValue(undefined);
+    const MultiServerMCPClientMock = vi.fn().mockImplementation(() => ({
+      getTools: vi.fn(() => tools),
+      close,
+    }));
+
+    vi.resetModules();
+    vi.doMock('@langchain/mcp-adapters', () => ({
+      MultiServerMCPClient: MultiServerMCPClientMock,
+    }));
+    vi.doMock('./MCPSettings', () => ({
+      makeMcpServersFromSettings: vi.fn().mockReturnValue({ serverA: { url: 'http://x' } }),
+      hasClusterDependentServers: vi.fn().mockReturnValue(false),
+    }));
+
+    const { default: MCPClient } = await import('./MCPClient');
+    const client = new MCPClient(cfgPath, settingsPath) as any;
+    await client.initialize();
+
+    const initialization = client.initializeClient();
+    await vi.waitFor(() => expect(MultiServerMCPClientMock).toHaveBeenCalledTimes(1));
+    let cleanupFinished = false;
+    const cleanup = client.cleanup().then(() => {
+      cleanupFinished = true;
+    });
+    await Promise.resolve();
+
+    expect(cleanupFinished).toBe(false);
+    resolveTools([{ name: 'tool' }]);
+    await Promise.all([initialization, cleanup]);
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(client.client).toBeNull();
+    expect(client.clientTools).toEqual([]);
+    expect(client.isInitialized).toBe(false);
+  });
+
   it('initialize leaves the MCP server client dormant', async () => {
     // Mock MCPSettings to return no servers
     vi.doMock('./MCPSettings', () => ({
@@ -204,6 +246,196 @@ describe('MCPClient', () => {
     expect(result).toEqual({ success: true, result: { ok: true }, toolCallId: 'call-1' });
   });
 
+  it('discovers configured tools when their inventory is first requested', async () => {
+    const MultiServerMCPClientMock = vi.fn().mockImplementation(() => ({
+      getTools: vi.fn().mockResolvedValue([
+        {
+          name: 'serverA__tool1',
+          schema: { type: 'object' },
+          description: 'First tool',
+        },
+      ]),
+      close: vi.fn().mockResolvedValue(undefined),
+    }));
+
+    vi.resetModules();
+    vi.doMock('@langchain/mcp-adapters', () => ({
+      MultiServerMCPClient: MultiServerMCPClientMock,
+    }));
+    vi.doMock('./MCPSettings', () => ({
+      makeMcpServersFromSettings: vi.fn().mockReturnValue({ serverA: { url: 'http://x' } }),
+      hasClusterDependentServers: vi.fn().mockReturnValue(false),
+    }));
+
+    const { default: MCPClient } = await import('./MCPClient');
+    const client = new MCPClient(cfgPath, settingsPath);
+    await client.initialize();
+
+    expect(MultiServerMCPClientMock).not.toHaveBeenCalled();
+    const result = await (client as any).mcpGetToolsConfig();
+
+    expect(MultiServerMCPClientMock).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      success: true,
+      config: {
+        serverA: {
+          tool1: {
+            enabled: true,
+            usageCount: 0,
+            inputSchema: { type: 'object' },
+            description: 'First tool',
+          },
+        },
+      },
+    });
+  });
+
+  it('restarts first-use initialization with the latest cluster context', async () => {
+    const makeMcpServersFromSettings = vi
+      .fn()
+      .mockImplementation((_settingsPath: string, clusters: string[]) => ({
+        serverA: { clusters },
+      }));
+    const closeFirst = vi.fn().mockResolvedValue(undefined);
+    const instances = [
+      { getTools: vi.fn().mockResolvedValue([{ name: 'old' }]), close: closeFirst },
+      { getTools: vi.fn().mockResolvedValue([{ name: 'new' }]), close: vi.fn() },
+    ];
+    const MultiServerMCPClientMock = vi.fn().mockImplementation(() => instances.shift());
+
+    vi.resetModules();
+    vi.doMock('@langchain/mcp-adapters', () => ({
+      MultiServerMCPClient: MultiServerMCPClientMock,
+    }));
+    vi.doMock('./MCPSettings', () => ({
+      makeMcpServersFromSettings,
+      hasClusterDependentServers: vi.fn().mockReturnValue(true),
+    }));
+
+    const { default: MCPClient } = await import('./MCPClient');
+    const client = new MCPClient(cfgPath, settingsPath) as any;
+    await client.initialize();
+
+    const initialization = client.initializeClient();
+    const clusterChange = client.handleClustersChange(['new-cluster']);
+    await Promise.all([initialization, clusterChange]);
+
+    expect(makeMcpServersFromSettings).toHaveBeenNthCalledWith(1, settingsPath, []);
+    expect(makeMcpServersFromSettings).toHaveBeenNthCalledWith(2, settingsPath, ['new-cluster']);
+    expect(MultiServerMCPClientMock).toHaveBeenCalledTimes(2);
+    expect(closeFirst).toHaveBeenCalledTimes(1);
+    expect(client.clientTools).toEqual([{ name: 'new' }]);
+  });
+
+  it('serializes concurrent cluster-change restarts', async () => {
+    let resolveInitialTools!: (tools: Array<{ name: string }>) => void;
+    let resolveFirstRestartTools!: (tools: Array<{ name: string }>) => void;
+    const initialTools = new Promise<Array<{ name: string }>>(resolve => {
+      resolveInitialTools = resolve;
+    });
+    const firstRestartTools = new Promise<Array<{ name: string }>>(resolve => {
+      resolveFirstRestartTools = resolve;
+    });
+    const makeMcpServersFromSettings = vi
+      .fn()
+      .mockImplementation((_settingsPath: string, clusters: string[]) => ({
+        serverA: { clusters },
+      }));
+    const closeInitial = vi.fn().mockResolvedValue(undefined);
+    const closeFirstRestart = vi.fn().mockResolvedValue(undefined);
+    const instances = [
+      { getTools: vi.fn(() => initialTools), close: closeInitial },
+      { getTools: vi.fn(() => firstRestartTools), close: closeFirstRestart },
+      { getTools: vi.fn().mockResolvedValue([{ name: 'final' }]), close: vi.fn() },
+    ];
+    const MultiServerMCPClientMock = vi.fn().mockImplementation(() => instances.shift());
+
+    vi.resetModules();
+    vi.doMock('@langchain/mcp-adapters', () => ({
+      MultiServerMCPClient: MultiServerMCPClientMock,
+    }));
+    vi.doMock('./MCPSettings', () => ({
+      makeMcpServersFromSettings,
+      hasClusterDependentServers: vi.fn().mockReturnValue(true),
+    }));
+
+    const { default: MCPClient } = await import('./MCPClient');
+    const client = new MCPClient(cfgPath, settingsPath) as any;
+    await client.initialize();
+
+    const initialization = client.initializeClient();
+    await vi.waitFor(() => expect(MultiServerMCPClientMock).toHaveBeenCalledTimes(1));
+    const firstChange = client.handleClustersChange(['first-cluster']);
+    const secondChange = client.handleClustersChange(['second-cluster']);
+
+    resolveInitialTools([{ name: 'initial' }]);
+    await vi.waitFor(() => expect(MultiServerMCPClientMock).toHaveBeenCalledTimes(2));
+    expect(MultiServerMCPClientMock).toHaveBeenCalledTimes(2);
+
+    resolveFirstRestartTools([{ name: 'first' }]);
+    await Promise.all([initialization, firstChange, secondChange]);
+
+    expect(makeMcpServersFromSettings).toHaveBeenNthCalledWith(1, settingsPath, []);
+    expect(makeMcpServersFromSettings).toHaveBeenNthCalledWith(2, settingsPath, ['first-cluster']);
+    expect(makeMcpServersFromSettings).toHaveBeenNthCalledWith(3, settingsPath, ['second-cluster']);
+    expect(closeInitial).toHaveBeenCalledTimes(1);
+    expect(closeFirstRestart).toHaveBeenCalledTimes(1);
+    expect(client.clientTools).toEqual([{ name: 'final' }]);
+  });
+
+  it('serializes cleanup behind an active cluster restart', async () => {
+    let resolveOldClose!: () => void;
+    let resolveReplacementTools!: (tools: Array<{ name: string }>) => void;
+    const oldClose = new Promise<void>(resolve => {
+      resolveOldClose = resolve;
+    });
+    const replacementTools = new Promise<Array<{ name: string }>>(resolve => {
+      resolveReplacementTools = resolve;
+    });
+    const closeOld = vi.fn(() => oldClose);
+    const closeReplacement = vi.fn().mockResolvedValue(undefined);
+    const MultiServerMCPClientMock = vi.fn().mockImplementation(() => ({
+      getTools: vi.fn(() => replacementTools),
+      close: closeReplacement,
+    }));
+
+    vi.resetModules();
+    vi.doMock('@langchain/mcp-adapters', () => ({
+      MultiServerMCPClient: MultiServerMCPClientMock,
+    }));
+    vi.doMock('./MCPSettings', () => ({
+      makeMcpServersFromSettings: vi.fn().mockReturnValue({ serverA: {} }),
+      hasClusterDependentServers: vi.fn().mockReturnValue(true),
+    }));
+
+    const { default: MCPClient } = await import('./MCPClient');
+    const client = new MCPClient(cfgPath, settingsPath) as any;
+    await client.initialize();
+    client.client = { close: closeOld };
+    client.isInitialized = true;
+
+    const clusterChange = client.handleClustersChange(['new-cluster']);
+    await vi.waitFor(() => expect(closeOld).toHaveBeenCalledTimes(1));
+    let cleanupFinished = false;
+    const cleanup = client.cleanup().then(() => {
+      cleanupFinished = true;
+    });
+
+    resolveOldClose();
+    await vi.waitFor(() => expect(MultiServerMCPClientMock).toHaveBeenCalledTimes(1));
+    await Promise.resolve();
+    expect(cleanupFinished).toBe(false);
+
+    resolveReplacementTools([{ name: 'replacement' }]);
+    await Promise.all([clusterChange, cleanup]);
+
+    expect(closeOld).toHaveBeenCalledTimes(1);
+    expect(closeReplacement).toHaveBeenCalledTimes(1);
+    expect(client.client).toBeNull();
+    expect(client.clientTools).toEqual([]);
+    expect(client.isInitialized).toBe(false);
+  });
+
   it('keeps a newly configured MCP server dormant', async () => {
     const ensureCertificates = vi.fn();
     const adapterFactory = vi.fn(() => ({
@@ -235,6 +467,115 @@ describe('MCPClient', () => {
     expect(ensureCertificates).not.toHaveBeenCalled();
     expect((client as any).client).toBeNull();
     expect((client as any).isInitialized).toBe(false);
+  });
+
+  it('reconnects an active MCP client after configuration changes', async () => {
+    const saveMCPSettings = vi.fn();
+
+    vi.resetModules();
+    vi.doMock('./MCPSettings', () => ({
+      loadMCPSettings: vi.fn().mockReturnValue({ enabled: true, servers: [] }),
+      saveMCPSettings,
+      showSettingsChangeDialog: vi.fn().mockResolvedValue(true),
+      makeMcpServersFromSettings: vi.fn().mockReturnValue({}),
+      hasClusterDependentServers: vi.fn().mockReturnValue(false),
+    }));
+
+    const { default: MCPClient } = await import('./MCPClient');
+    const client = new MCPClient(cfgPath, settingsPath) as any;
+    const close = vi.fn().mockResolvedValue(undefined);
+    const initializeClient = vi.spyOn(client, 'initializeClient').mockResolvedValue(undefined);
+    client.client = { close };
+    client.setMainWindow({} as Electron.BrowserWindow);
+
+    const settings = { enabled: true, servers: [{ name: 'server-a' }] };
+    const result = await client.mcpUpdateConfig(settings);
+
+    expect(result).toEqual({ success: true });
+    expect(saveMCPSettings).toHaveBeenCalledWith(settingsPath, settings);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(initializeClient).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for first-use initialization before applying new settings', async () => {
+    let resolveFirstTools!: (tools: Array<{ name: string }>) => void;
+    const firstTools = new Promise<Array<{ name: string }>>(resolve => {
+      resolveFirstTools = resolve;
+    });
+    const closeFirst = vi.fn().mockResolvedValue(undefined);
+    const instances = [
+      { getTools: vi.fn(() => firstTools), close: closeFirst },
+      { getTools: vi.fn().mockResolvedValue([{ name: 'new' }]), close: vi.fn() },
+    ];
+    const MultiServerMCPClientMock = vi.fn().mockImplementation(() => instances.shift());
+    const saveMCPSettings = vi.fn();
+
+    vi.resetModules();
+    vi.doMock('@langchain/mcp-adapters', () => ({
+      MultiServerMCPClient: MultiServerMCPClientMock,
+    }));
+    vi.doMock('./MCPSettings', () => ({
+      loadMCPSettings: vi.fn().mockReturnValue({ enabled: true, servers: [] }),
+      saveMCPSettings,
+      showSettingsChangeDialog: vi.fn().mockResolvedValue(true),
+      makeMcpServersFromSettings: vi.fn().mockReturnValue({ serverA: { url: 'http://x' } }),
+      hasClusterDependentServers: vi.fn().mockReturnValue(false),
+    }));
+
+    const { default: MCPClient } = await import('./MCPClient');
+    const client = new MCPClient(cfgPath, settingsPath) as any;
+    await client.initialize();
+    client.setMainWindow({} as Electron.BrowserWindow);
+
+    const initialization = client.initializeClient();
+    await vi.waitFor(() => expect(instances).toHaveLength(1));
+    const update = client.mcpUpdateConfig({ enabled: true, servers: [{ name: 'new' }] });
+    await Promise.resolve();
+
+    expect(saveMCPSettings).not.toHaveBeenCalled();
+    resolveFirstTools([{ name: 'old' }]);
+    await Promise.all([initialization, update]);
+
+    expect(closeFirst).toHaveBeenCalledTimes(1);
+    expect(MultiServerMCPClientMock).toHaveBeenCalledTimes(2);
+    expect(client.clientTools).toEqual([{ name: 'new' }]);
+  });
+
+  it.each([null, ['old-cluster']])(
+    'restores cluster context when an MCP restart fails from %j',
+    async oldClusters => {
+      vi.resetModules();
+      vi.doMock('./MCPSettings', () => ({
+        makeMcpServersFromSettings: vi.fn().mockReturnValue({}),
+        hasClusterDependentServers: vi.fn().mockReturnValue(true),
+      }));
+
+      const { default: MCPClient } = await import('./MCPClient');
+      const client = new MCPClient(cfgPath, settingsPath) as any;
+      await client.initialize();
+      client.client = { close: vi.fn().mockResolvedValue(undefined) };
+      client.currentClusters = oldClusters;
+      client.clusters = oldClusters || [];
+      vi.spyOn(client, 'initializeClient').mockRejectedValue(new Error('restart failed'));
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(client.handleClustersChange(['new-cluster'])).rejects.toThrow('restart failed');
+      expect(client.currentClusters).toEqual(oldClusters);
+      expect(client.clusters).toEqual(oldClusters || []);
+    }
+  );
+
+  it('clears cluster context through the IPC-facing path without starting MCP', async () => {
+    await client.initialize();
+    (client as any).currentClusters = ['old-cluster'];
+    (client as any).clusters = ['old-cluster'];
+
+    const result = await (client as any).mcpClusterChange(null);
+
+    expect(result).toEqual({ success: true });
+    expect((client as any).currentClusters).toBeNull();
+    expect((client as any).clusters).toEqual([]);
+    expect((client as any).client).toBeNull();
   });
 
   it('handleClustersChange logs and returns early when no cluster-dependent servers', async () => {

--- a/app/electron/mcp/MCPClient.ts
+++ b/app/electron/mcp/MCPClient.ts
@@ -15,8 +15,8 @@
  */
 
 import type { DynamicStructuredTool } from '@langchain/core/dist/tools/index';
-import { MultiServerMCPClient } from '@langchain/mcp-adapters';
 import { type BrowserWindow, dialog, ipcMain } from 'electron';
+import type { MultiServerMCPClient } from './MCPAdapter';
 import {
   hasClusterDependentServers,
   loadMCPSettings,
@@ -67,6 +67,8 @@ export default class MCPClient {
   private isInitialized = false;
   /** Promise tracking ongoing initialization to prevent duplicate initializations */
   private initializationPromise: Promise<void> | null = null;
+  /** Promise queue that serializes client cleanup, reset, update, and restart mutations. */
+  private lifecycleMutationPromise: Promise<void> = Promise.resolve();
 
   private settingsPath: string;
   private clusters: string[] = [];
@@ -74,22 +76,48 @@ export default class MCPClient {
   private currentClusters: string[] | null = null;
   private oldClusters: string[] | null = null;
 
-  constructor(configPath: string, settingsPath: string) {
+  /**
+   * Creates an MCP client whose server adapter remains dormant until first use.
+   *
+   * @param configPath - Path to the persisted MCP tool configuration.
+   * @param settingsPath - Path to the persisted MCP server settings.
+   * @param ensureCertificates - Initializes certificate trust before networking.
+   */
+  constructor(
+    configPath: string,
+    settingsPath: string,
+    private readonly ensureCertificates: () => void = () => {}
+  ) {
     this.configPath = configPath;
     this.settingsPath = settingsPath;
     this.setupIpcHandlers();
   }
 
   /**
-   * Initialize the MCP client.
+   * Runs a client lifecycle mutation after all earlier mutations complete.
+   *
+   * @param mutation - Mutation that may close, reset, or initialize the client.
+   * @returns The mutation result.
+   */
+  private enqueueLifecycleMutation<Result>(mutation: () => Promise<Result>): Promise<Result> {
+    const result = this.lifecycleMutationPromise.then(mutation);
+    this.lifecycleMutationPromise = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
+  }
+
+  /**
+   * Initialize lightweight MCP state only. The adapter and configured servers
+   * stay out of memory until the first tool execution.
    */
   async initialize(): Promise<void> {
     if (this.initialized) {
       return;
     }
     this.mcpToolState = new MCPToolStateStore(this.configPath);
-
-    await this.initializeClient();
+    await this.mcpToolState.initialize();
 
     this.initialized = true;
 
@@ -122,8 +150,16 @@ export default class MCPClient {
       console.log('MCPClient: initializeClient: Starting doInitialize()...');
     }
 
-    this.initializationPromise = this.doInitializeClient();
-    return this.initializationPromise;
+    const initializationPromise = this.doInitializeClient();
+    this.initializationPromise = initializationPromise;
+
+    try {
+      await initializationPromise;
+    } finally {
+      if (this.initializationPromise === initializationPromise) {
+        this.initializationPromise = null;
+      }
+    }
   }
 
   /**
@@ -149,7 +185,10 @@ export default class MCPClient {
           Object.keys(mcpServers)
         );
       }
-      this.client = new MultiServerMCPClient({
+      this.ensureCertificates();
+      // Importing here keeps the large adapter graph out of startup memory.
+      const { MultiServerMCPClient } = await import('./MCPAdapter');
+      const client = new MultiServerMCPClient({
         throwOnLoadError: false, // Don't throw on load error to allow partial initialization
         prefixToolNameWithServerName: true, // Prefix to avoid name conflicts
         additionalToolNamePrefix: '',
@@ -158,7 +197,9 @@ export default class MCPClient {
         defaultToolTimeout: 2 * 60 * 1000, // 2 minutes
       });
       // Get and cache the tools
-      this.clientTools = await this.client.getTools();
+      const clientTools = await client.getTools();
+      this.client = client;
+      this.clientTools = clientTools;
       this.mcpToolState?.initConfigFromClientTools(this.clientTools);
 
       this.isInitialized = true;
@@ -182,11 +223,26 @@ export default class MCPClient {
    * Clean up resources used by the MCP client.
    */
   async cleanup(): Promise<void> {
+    return this.enqueueLifecycleMutation(() => this.applyCleanup());
+  }
+
+  /** Cleans up resources after earlier lifecycle mutations complete. */
+  private async applyCleanup(): Promise<void> {
     if (!this.initialized) {
       return;
     }
     this.mainWindow = null;
     this.initialized = false;
+
+    // A first-use client remains local until tool discovery completes. Wait for
+    // it to publish before closing so cleanup cannot leave an orphaned server.
+    if (this.initializationPromise) {
+      try {
+        await this.initializationPromise;
+      } catch {
+        // Initialization reports its own error; cleanup still resets all state.
+      }
+    }
 
     if (this.client) {
       try {
@@ -217,9 +273,18 @@ export default class MCPClient {
   /**
    * Handle clusters change notification.
    *
-   * @param clusters - The new active clusters array, or null if none.
+   * @param newClusters - The new active clusters array, or null if none.
    */
   async handleClustersChange(newClusters: string[] | null): Promise<void> {
+    return this.enqueueLifecycleMutation(() => this.applyClustersChange(newClusters));
+  }
+
+  /**
+   * Applies one cluster context update after earlier updates have completed.
+   *
+   * @param newClusters - The new active clusters array, or null if none.
+   */
+  private async applyClustersChange(newClusters: string[] | null): Promise<void> {
     if (DEBUG) {
       console.info('MCPClient: clusters changed ->', newClusters);
     }
@@ -235,14 +300,27 @@ export default class MCPClient {
 
     const oldClusters = this.currentClusters;
     this.currentClusters = newClusters;
-
-    // Check if we have any cluster-dependent servers
-    if (!hasClusterDependentServers(this.settingsPath)) {
-      console.log('No cluster-dependent MCP servers found, skipping restart');
-      return;
-    }
+    this.clusters = newClusters || [];
 
     try {
+      // An initialization already captured the previous cluster context. Wait
+      // for it to finish before deciding whether an active client needs restart.
+      if (this.initializationPromise) {
+        await this.initializationPromise;
+      }
+
+      // Recording context must not start configured servers or load the adapter.
+      if (!this.client) {
+        console.log('MCP client not yet started, skipping cluster-change restart');
+        return;
+      }
+
+      // Check if we have any cluster-dependent servers
+      if (!hasClusterDependentServers(this.settingsPath)) {
+        console.log('No cluster-dependent MCP servers found, skipping restart');
+        return;
+      }
+
       // Reset the client
       if (this.client) {
         if (typeof (this.client as any).close === 'function') {
@@ -259,6 +337,7 @@ export default class MCPClient {
       console.error('Error restarting MCP client for cluster change:', error);
       // Restore previous cluster on error
       this.currentClusters = oldClusters;
+      this.clusters = oldClusters || [];
       throw error;
     }
   }
@@ -349,22 +428,23 @@ export default class MCPClient {
       }
 
       console.log('Resetting MCP client...');
-
-      if (this.client) {
-        // If the client has a close/dispose method, call it
-        if (typeof (this.client as any).close === 'function') {
-          await (this.client as any).close();
+      return await this.enqueueLifecycleMutation(async () => {
+        if (this.client) {
+          // If the client has a close/dispose method, call it
+          if (typeof (this.client as any).close === 'function') {
+            await (this.client as any).close();
+          }
         }
-      }
 
-      this.client = null;
-      this.isInitialized = false;
-      this.initializationPromise = null;
+        this.client = null;
+        this.isInitialized = false;
+        this.initializationPromise = null;
 
-      // Re-initialize
-      await this.initializeClient();
+        // Re-initialize
+        await this.initializeClient();
 
-      return { success: true };
+        return { success: true };
+      });
     } catch (error) {
       console.error('Error resetting MCP client:', error);
       return {
@@ -397,21 +477,29 @@ export default class MCPClient {
       }
 
       console.log('Updating MCP configuration with user confirmation...');
-      saveMCPSettings(this.settingsPath, mcpSettings);
+      return await this.enqueueLifecycleMutation(async () => {
+        if (this.initializationPromise) {
+          await this.initializationPromise;
+        }
+        saveMCPSettings(this.settingsPath, mcpSettings);
 
-      // Reset and reinitialize client with new config
-      if (this.client && typeof this.client.close === 'function') {
-        await this.client.close();
-      }
-      this.client = null;
-      this.isInitialized = false;
-      this.initializationPromise = null;
+        const wasActive = this.client !== null;
+        if (this.client && typeof this.client.close === 'function') {
+          await this.client.close();
+        }
+        this.client = null;
+        this.clientTools = [];
+        this.isInitialized = false;
+        this.initializationPromise = null;
 
-      // Re-initialize with new config
-      await this.initializeClient();
+        // Keep unused servers out of memory; only reconnect a client that was already active.
+        if (wasActive) {
+          await this.initializeClient();
+        }
 
-      console.log('MCP configuration updated successfully');
-      return { success: true };
+        console.log('MCP configuration updated successfully');
+        return { success: true };
+      });
     } catch (error) {
       console.error('Error updating MCP configuration:', error);
       return {
@@ -441,6 +529,9 @@ export default class MCPClient {
 
   private async mcpGetToolsConfig() {
     try {
+      // Tool inventory is an explicit MCP use, so discover configured tools on
+      // demand while keeping the adapter out of ordinary application startup.
+      await this.initializeClient();
       const toolsConfig = this.mcpToolState?.getConfig();
       return {
         success: true,
@@ -521,10 +612,8 @@ export default class MCPClient {
   private async mcpClusterChange(cluster: string | null) {
     try {
       console.log('Received cluster change event:', cluster);
-      if (cluster !== null) {
-        // @todo: support multiple clusters
-        await this.handleClustersChange([cluster]);
-      }
+      // @todo: support multiple clusters
+      await this.handleClustersChange(cluster === null ? null : [cluster]);
       return {
         success: true,
       };

--- a/app/electron/plugin-management.test.ts
+++ b/app/electron/plugin-management.test.ts
@@ -92,6 +92,27 @@ describe('default plugin directories', () => {
   );
 });
 
+describe('plugin management loading', () => {
+  it('defers installation-only dependencies', async () => {
+    const tarFactory = vi.fn(() => ({}));
+    const semverFactory = vi.fn(() => ({}));
+
+    vi.resetModules();
+    vi.doMock('tar', tarFactory);
+    vi.doMock('semver', semverFactory);
+
+    try {
+      await import('./plugin-management');
+
+      expect(tarFactory).not.toHaveBeenCalled();
+      expect(semverFactory).not.toHaveBeenCalled();
+    } finally {
+      vi.doUnmock('tar');
+      vi.doUnmock('semver');
+    }
+  });
+});
+
 /**
  * Creates a unique test directory for a test
  * @param basePath Base directory path

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -27,9 +27,7 @@ import crypto from 'crypto';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import semver from 'semver';
 import stream from 'stream';
-import * as tar from 'tar';
 import zlib from 'zlib';
 import envPaths from './env-paths';
 
@@ -313,6 +311,8 @@ export class PluginManager {
 
       const latestVersion = pluginData.version;
       const currentVersion = packageJson.artifacthub.version;
+      // Keep semver out of the main-process heap until a plugin update is requested.
+      const { default: semver } = await import('semver');
 
       if (semver.lte(latestVersion, currentVersion)) {
         throw new Error('No updates available');
@@ -534,6 +534,8 @@ async function downloadExtractArchive(
 
   // Check if the plugin is compatible with the current Headlamp version
   if (headlampVersion) {
+    // Compatibility checks are optional, so load semver only when one is required.
+    const { default: semver } = await import('semver');
     if (progressCallback) {
       progressCallback({ type: 'info', message: 'Checking compatibility with Headlamp version' });
     }
@@ -821,6 +823,8 @@ async function downloadAndExtractSingleArchive(
     archiveURL.includes('.tar?');
 
   if (isTarGz) {
+    // Keep tar's module graph unloaded until an archive actually needs extraction.
+    const tar = await import('tar');
     if (progressCallback) {
       progressCallback({
         type: 'info',

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -16,7 +16,6 @@
         "find-process": "^1.4.10",
         "glob": "^10.5.0",
         "i18next": "^23.12.1",
-        "i18next-fs-backend": "^2.6.6",
         "mkdirp": "^3.0.1",
         "nock": "^14.0.5",
         "shx": "^0.4.0",
@@ -6281,10 +6280,6 @@
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }
-    },
-    "node_modules/i18next-fs-backend": {
-      "version": "2.6.6",
-      "license": "MIT"
     },
     "node_modules/i18next-parser": {
       "version": "9.3.0",

--- a/app/package.json
+++ b/app/package.json
@@ -139,6 +139,8 @@
     },
     "files": [
       "build/main.js",
+      "build/mcp/MCPAdapter.js",
+      "build/lazy/*.js",
       "build/preload.js"
     ],
     "extraResources": [
@@ -209,7 +211,6 @@
     "find-process": "^1.4.10",
     "glob": "^10.5.0",
     "i18next": "^23.12.1",
-    "i18next-fs-backend": "^2.6.6",
     "mkdirp": "^3.0.1",
     "nock": "^14.0.5",
     "shx": "^0.4.0",

--- a/app/scripts/build-electron.js
+++ b/app/scripts/build-electron.js
@@ -5,6 +5,32 @@ const path = require('node:path');
 
 const isWatch = process.argv.includes('--watch');
 const isDev = process.argv.includes('--dev');
+// CJS bundling would otherwise inline these dynamic imports into main.js.
+// Separate entries keep their module graphs out of startup memory until first use.
+const mcpAdapterEntry = path.resolve(__dirname, '../electron/mcp/MCPAdapter.ts');
+const lazyDependencies = {
+  'find-process': './lazy/find-process.js',
+  semver: './lazy/semver.js',
+  tar: './lazy/tar.js',
+};
+const mcpAdapterExternalPlugin = {
+  name: 'externalize-mcp-adapter',
+  setup(build) {
+    build.onResolve({ filter: /^\.\/MCPAdapter$/ }, () => ({
+      path: './mcp/MCPAdapter.js',
+      external: true,
+    }));
+  },
+};
+const lazyDependenciesExternalPlugin = {
+  name: 'externalize-lazy-dependencies',
+  setup(build) {
+    build.onResolve({ filter: /^(find-process|semver|tar)$/ }, args => ({
+      path: lazyDependencies[args.path],
+      external: true,
+    }));
+  },
+};
 
 const commonOptions = {
   bundle: true,
@@ -24,10 +50,27 @@ const entryPoints = [
   {
     entryPoints: [path.resolve(__dirname, '../electron/main.ts')],
     outfile: path.resolve(__dirname, '../build/main.js'),
+    plugins: [mcpAdapterExternalPlugin, lazyDependenciesExternalPlugin],
   },
   {
     entryPoints: [path.resolve(__dirname, '../electron/preload.ts')],
     outfile: path.resolve(__dirname, '../build/preload.js'),
+  },
+  {
+    entryPoints: [mcpAdapterEntry],
+    outfile: path.resolve(__dirname, '../build/mcp/MCPAdapter.js'),
+  },
+  {
+    entryPoints: [require.resolve('find-process')],
+    outfile: path.resolve(__dirname, '../build/lazy/find-process.js'),
+  },
+  {
+    entryPoints: [require.resolve('semver')],
+    outfile: path.resolve(__dirname, '../build/lazy/semver.js'),
+  },
+  {
+    entryPoints: [path.resolve(__dirname, '../electron/lazy/tar.ts')],
+    outfile: path.resolve(__dirname, '../build/lazy/tar.js'),
   },
 ];
 

--- a/docs/development/backend.md
+++ b/docs/development/backend.md
@@ -94,6 +94,98 @@ To just print a simpler coverage report to the console.
 npm run backend:coverage
 ```
 
+## Memory profiling
+
+Use representative kubeconfigs, clusters, and requests when comparing profiles. Run each
+measurement several times and compare medians.
+
+```bash
+# GC activity and heap goals for a running development server.
+GODEBUG=gctrace=1 npm run backend:start 2>gc.log
+
+# Heap retained by a test or benchmark.
+cd backend
+go test -run TestName -memprofile=/tmp/heap.pprof ./pkg/package
+go tool pprof -inuse_space /tmp/heap.pprof
+
+# Total allocations, including objects that have already been collected.
+go test -run '^$' -bench BenchmarkName -benchmem \
+  -memprofile=/tmp/allocs.pprof ./pkg/package
+go tool pprof -alloc_space /tmp/allocs.pprof
+
+# Allocation/free events, GC pauses, and goroutine scheduling.
+GODEBUG=traceallocfree=1 go test -run TestName -trace=/tmp/trace.out ./pkg/package
+go tool trace /tmp/trace.out
+```
+
+On Unix, `GOTRACEBACK=all` followed by `kill -QUIT <pid>` prints all goroutine
+stacks. This terminates the process, so only use it on a development instance.
+Repeated dumps reveal goroutines whose count or blocked stacks keep growing.
+
+In `pprof`, start with `top`, `top -cum`, `list <function>`, and `web`.
+`inuse_space` identifies long-lived allocations; `alloc_space` identifies allocation
+churn. Compare profiles with `go tool pprof -base before.pprof after.pprof`.
+In traces and GC logs, look for a growing live heap after GC, frequent collections
+with little heap reduction, and increasing goroutine counts. Map growth appears as
+retained `runtime.mapassign` call paths and should be checked for missing bounds or
+expiration.
+
+### Ranked optimization opportunities
+
+| Rank | Change | Expected memory effect | Trade-off |
+| --- | --- | --- | --- |
+| 1 | Store only object metadata in cache-invalidation informers | 70–99% of informer object heap, depending on resource payload size | Informer handlers cannot later consume spec or status without removing the transform |
+| 2 | Share cache-invalidation watchers for equivalent cluster connections | Avoids duplicated informer stores and goroutines for stateless users | Requires careful authentication and watcher lifecycle isolation |
+| 3 | Add byte and entry limits to the Kubernetes response cache | Prevents unbounded retained response growth and avoids caching oversized responses | Lower cache hit rate |
+| 4 | Cache only the Kubernetes authorization client instead of a full clientset | Removes unused typed clients from each token cache entry | Narrows the internal cache API |
+| 5 | Initialize proxy transports only when a context is first used | Saves per-context TLS and transport state for unused contexts | Adds synchronization to the first request |
+| 6 | Lower `GOGC` for the desktop backend | About 2–4.5 MiB in measured idle/request workloads | More frequent GC and modestly higher CPU use |
+
+The desktop launcher defaults its bundled backend to `GOGC=25`, while preserving
+an explicitly configured `GOGC`. In isolated measurements, `GOGC=50` reduced
+median startup RSS from 82,384 KiB to 80,492 KiB. Lowering it to `GOGC=25`
+saved another 2.1 MiB of private dirty memory after 20,000 `/config` requests,
+with about 11% more backend CPU than `GOGC=50`.
+
+`GOMEMLIMIT` is a soft runtime limit rather than a live-heap target. Set it to
+roughly 85–90% of a container's memory limit, leaving room for the executable,
+stacks, and non-Go allocations. Limits between 20 MiB and 64 MiB did not
+consistently reduce the small desktop startup workload, so the app does not force
+a fixed value. Re-profile under production load before setting either variable.
+
+### Evaluated compiler and runtime options
+
+The following medians are from three Linux amd64 runs of 20,000 local `/config`
+requests with Go 1.26.5. Private dirty memory is reported instead of total RSS
+because demand-paged executable mappings varied substantially with link layout.
+These are directional results from a small workload.
+
+| Runtime configuration | Private dirty after requests | Backend CPU | Result |
+| --- | ---: | ---: | --- |
+| `GOGC=100` | 17.2 MiB | 3.26 s | Go default and comparison baseline |
+| `GOGC=50` | 14.8 MiB | 3.37 s | Saves 2.4 MiB over the Go default |
+| `GOGC=25` | 12.7 MiB | 3.73 s | Current desktop default; saves another 2.1 MiB with about 11% more CPU than `GOGC=50` |
+| `GOGC=50 GOMEMLIMIT=64MiB` | 14.8 MiB | 3.43 s | No measurable saving in this workload |
+| `GOGC=50 GODEBUG=disablethp=1` | 11.7 MiB | 3.44 s | Linux-only saving on this host; not used because the compatibility setting is scheduled for removal |
+| `GOGC=50 GOMAXPROCS=1` | 13.2 MiB | 2.32 s | Not used because serializing execution can hurt concurrent workloads |
+
+Compiler experiments used the same workload with `GOGC=50`:
+
+| Build option | Binary size | Private dirty | Backend CPU | Result |
+| --- | ---: | ---: | ---: | --- |
+| Default | 114.4 MiB | 14.8 MiB | 3.37 s | Baseline |
+| `-trimpath -ldflags="-s -w"` | 81.4 MiB | 14.5 MiB | 3.38 s | Current backend build default; saves 28.8% on disk, but no meaningful runtime memory |
+| `-gcflags=all=-l` | 103.5 MiB | 12.8 MiB | 4.21 s | About 2 MiB less memory at roughly 25% more CPU; not selected |
+| `GOAMD64=v3` | 114.4 MiB | 14.9 MiB | 3.41 s | No memory saving and reduces CPU compatibility |
+| `-buildmode=pie` | 120.9 MiB | 19.1 MiB | 3.45 s | Increased private memory |
+| `GOEXPERIMENT=greenteagc` | 114.4 MiB | 14.7 MiB | 3.47 s | No meaningful saving in this workload |
+
+Go plugins are not a portable memory-saving mechanism for the backend. They are
+unsupported on Windows, must match the main binary's toolchain and dependencies,
+cannot be unloaded, and therefore retain their memory after first use. Splitting
+optional features into helper processes would also add another Go runtime and IPC
+complexity.
+
 ## Fuzz Testing
 
 Some backend functions include fuzz tests using Go's native fuzzing support. For example, the `SanitizeClusterName` function in `backend/pkg/auth` has a fuzz test.
@@ -107,4 +199,3 @@ npm run backend:fuzz
 This will run fuzz tests in the `backend/pkg/auth` package for 30 seconds. The fuzz corpus (interesting test cases discovered during fuzzing) is stored in `testdata/fuzz/` directories and committed to the repository for regression testing.
 
 For more information about Go fuzzing, see the [official Go fuzzing documentation](https://go.dev/security/fuzz/).
-

--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotes.test.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotes.test.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import ReleaseNotes from './ReleaseNotes';
+
+const { moduleLoaded } = vi.hoisted(() => ({
+  moduleLoaded: vi.fn(),
+}));
+
+vi.mock('./ReleaseNotesModal', () => {
+  moduleLoaded();
+  return { default: () => null };
+});
+
+describe('ReleaseNotes', () => {
+  it('does not load the release notes modal before notes are available', () => {
+    render(<ReleaseNotes />);
+
+    expect(moduleLoaded).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotes.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotes.tsx
@@ -16,8 +16,10 @@
 
 import React from 'react';
 import semver from 'semver';
-import ReleaseNotesModal from './ReleaseNotesModal';
 import UpdatePopup from './UpdatePopup';
+
+// Keep the markdown renderer and its dependency graph out of memory until the modal opens.
+const ReleaseNotesModal = React.lazy(() => import('./ReleaseNotesModal'));
 
 function getAppVersion() {
   return localStorage.getItem('app_version');
@@ -193,7 +195,9 @@ export default function ReleaseNotes() {
         />
       }
       {releaseNotes && (
-        <ReleaseNotesModal releaseNotes={releaseNotes} appVersion={getAppVersion()} />
+        <React.Suspense fallback={null}>
+          <ReleaseNotesModal releaseNotes={releaseNotes} appVersion={getAppVersion()} />
+        </React.Suspense>
       )}
     </>
   );

--- a/frontend/src/components/common/Resource/DocsViewer.stories.tsx
+++ b/frontend/src/components/common/Resource/DocsViewer.stories.tsx
@@ -97,6 +97,9 @@ export default {
         ],
       },
     },
+    storyshots: {
+      waitForDynamicImports: true,
+    },
   },
   decorators: [
     Story => {

--- a/frontend/src/components/resourceMap/details/KubeNodeDetails.test.tsx
+++ b/frontend/src/components/resourceMap/details/KubeNodeDetails.test.tsx
@@ -170,7 +170,7 @@ describe('KubeObjectDetails', () => {
     consoleErrorSpy.mockRestore();
   });
 
-  it.each(dispatchCases)('dispatches %s to its details component', (kind, label) => {
+  it.each(dispatchCases)('dispatches %s to its details component', async (kind, label) => {
     render(
       <KubeObjectDetails
         resource={{
@@ -181,7 +181,7 @@ describe('KubeObjectDetails', () => {
       />
     );
 
-    expect(screen.getByText(`${label}:resource-a:default:cluster-a`)).toBeInTheDocument();
+    expect(await screen.findByText(`${label}:resource-a:default:cluster-a`)).toBeInTheDocument();
   });
 
   it('matches details components case-insensitively', () => {

--- a/frontend/src/components/resourceMap/details/KubeNodeDetails.tsx
+++ b/frontend/src/components/resourceMap/details/KubeNodeDetails.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Box } from '@mui/system';
-import { memo, ReactElement, useEffect } from 'react';
+import { lazy, memo, ReactElement, Suspense, useEffect } from 'react';
 import Deployment from '../../../lib/k8s/deployment';
 import JobSet from '../../../lib/k8s/jobSet';
 import LeaderWorkerSet from '../../../lib/k8s/leaderWorkerSet';
@@ -23,7 +23,6 @@ import ReplicaSet from '../../../lib/k8s/replicaSet';
 import ConfigDetails from '../../configmap/Details';
 import { CustomResourceDetails } from '../../crd/CustomResourceDetails';
 import CustomResourceDefinitionDetails from '../../crd/Details';
-import CronJobDetails from '../../cronjob/Details';
 import DaemonSetDetails from '../../daemonset/Details';
 import { DetailsGridContext } from '../../DetailsViewSection/detailsViewSectionSlice';
 import EndpointDetails from '../../endpoints/Details';
@@ -65,6 +64,9 @@ import MutatingWebhookConfigList from '../../webhookconfiguration/MutatingWebhoo
 import ValidatingWebhookConfigurationDetails from '../../webhookconfiguration/ValidatingWebhookConfigDetails';
 import WorkloadDetails from '../../workload/Details';
 
+// Avoid retaining the CronJob detail module unless the selected resource needs it.
+const CronJobDetails = lazy(() => import('../../cronjob/Details'));
+
 const kindComponentMap: Record<
   string,
   (props: { name?: string; namespace?: string; cluster?: string }) => ReactElement
@@ -76,7 +78,11 @@ const kindComponentMap: Record<
   JobSet: props => <WorkloadDetails {...props} workloadKind={JobSet} />,
   LeaderWorkerSet: props => <WorkloadDetails {...props} workloadKind={LeaderWorkerSet} />,
   Service: ServiceDetails,
-  CronJob: CronJobDetails,
+  CronJob: props => (
+    <Suspense fallback={null}>
+      <CronJobDetails {...props} />
+    </Suspense>
+  ),
   DaemonSet: DaemonSetDetails,
   ConfigMap: ConfigDetails,
   Endpoints: EndpointDetails,

--- a/frontend/src/lib/docs.lazy.test.ts
+++ b/frontend/src/lib/docs.lazy.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { mockDereference, mockRequest, parserLoaded } = vi.hoisted(() => ({
+  mockDereference: vi.fn((docs: unknown) => docs),
+  mockRequest: vi.fn(),
+  parserLoaded: vi.fn(),
+}));
+
+vi.mock('./k8s/api/v1/clusterRequests', () => ({
+  request: mockRequest,
+}));
+
+vi.mock('@apidevtools/swagger-parser', () => {
+  parserLoaded();
+  return {
+    default: {
+      dereference: mockDereference,
+    },
+  };
+});
+
+describe('OpenAPI documentation loading', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('does not load the parser when the documentation module is imported', async () => {
+    await import('./docs');
+
+    expect(parserLoaded).not.toHaveBeenCalled();
+  });
+
+  it('loads the parser when documentation is first requested', async () => {
+    mockRequest.mockResolvedValue({ definitions: {} });
+    const getDocDefinitions = (await import('./docs')).default;
+
+    await getDocDefinitions('v1', 'Pod');
+
+    expect(parserLoaded).toHaveBeenCalledOnce();
+    expect(mockDereference).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/lib/docs.ts
+++ b/frontend/src/lib/docs.ts
@@ -18,14 +18,17 @@
  * This module was taken from the k8dash project.
  */
 
-import Swagger from '@apidevtools/swagger-parser';
 import type { OpenAPIV2 } from 'openapi-types';
 import { request } from './k8s/api/v1/clusterRequests';
 
 let docsPromise: ReturnType<typeof getDocs> | null = null;
 
 async function getDocs() {
-  const docs = await request('/openapi/v2');
+  // OpenAPI parsing is optional, so keep its module graph out of startup memory.
+  const [docs, { default: Swagger }] = await Promise.all([
+    request('/openapi/v2'),
+    import('@apidevtools/swagger-parser'),
+  ]);
   return Swagger.dereference(docs);
 }
 

--- a/frontend/src/lib/router/index.tsx
+++ b/frontend/src/lib/router/index.tsx
@@ -27,7 +27,6 @@ import Settings from '../../components/App/Settings';
 import SettingsCluster from '../../components/App/Settings/SettingsCluster';
 import SettingsClusters from '../../components/App/Settings/SettingsClusters';
 import AuthChooser from '../../components/authchooser';
-import KubeConfigLoader from '../../components/cluster/KubeConfigLoader';
 import Overview from '../../components/cluster/Overview';
 import { PageGrid } from '../../components/common/Resource/Resource';
 import ConfigDetails from '../../components/configmap/Details';
@@ -37,8 +36,6 @@ import { CrInstanceList } from '../../components/crd/CustomResourceInstancesList
 import CustomResourceList from '../../components/crd/CustomResourceList';
 import CustomResourceDefinitionDetails from '../../components/crd/Details';
 import CustomResourceDefinitionList from '../../components/crd/List';
-import CronJobDetails from '../../components/cronjob/Details';
-import CronJobList from '../../components/cronjob/List';
 import DaemonSetList from '../../components/daemonset/List';
 import DeploymentsList from '../../components/deployments/List';
 import EndpointDetails from '../../components/endpoints/Details';
@@ -148,9 +145,13 @@ export type { Route, RouteURLProps };
 
 export { getDefaultRoutes, getRouteUseClusterURL, getRoutePath, getRoute, createRouteURL };
 
+// Keep infrequently visited route modules out of the initial renderer heap.
 const LazyGraphView = React.lazy(() =>
   import('../../components/resourceMap/GraphView').then(it => ({ default: it.GraphView }))
 );
+const CronJobDetails = React.lazy(() => import('../../components/cronjob/Details'));
+const CronJobList = React.lazy(() => import('../../components/cronjob/List'));
+const KubeConfigLoader = React.lazy(() => import('../../components/cluster/KubeConfigLoader'));
 
 function SettingsClusterRedirect() {
   const cluster = useCluster();

--- a/frontend/src/storybook.test.tsx
+++ b/frontend/src/storybook.test.tsx
@@ -202,6 +202,11 @@ describe('Storybook Tests', () => {
             await act(async () => {
               await story.run();
             });
+            if (story.parameters?.storyshots?.waitForDynamicImports) {
+              await act(async () => {
+                await vi.dynamicImportSettled();
+              });
+            }
 
             // There are a bunch of waterfall requests in the stories
             // So to make sure all requests are sent we need to skip over some ticks

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "npm run backend:lint && npm run frontend:lint && npm run app:lint",
     "lint:fix": "npm run backend:lint:fix && npm run frontend:lint:fix && npm run app:lint:fix",
     "clean": "rm -rf frontend/build frontend/node_modules app/node_modules app/dist backend/headlamp-server backend/headlamp-server.exe node_modules",
-    "backend:build": "cd backend && go build -o ./headlamp-server ./cmd",
+    "backend:build": "cd backend && go build -trimpath -ldflags=\"-s -w\" -o ./headlamp-server ./cmd",
     "backend:lint": "npm run backend:install:linter && cd backend && ./tools/golangci-lint run",
     "backend:lint:fix": "npm run backend:install:linter && cd backend && ./tools/golangci-lint run --fix",
     "backend:install:linter": "GOBIN=`pwd`/backend/tools go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2",


### PR DESCRIPTION
## Summary

Reduces desktop, renderer, and Go-backend memory by deferring optional work,
shrinking retained Kubernetes objects, and tuning backend garbage collection.
The sum of reported incremental isolated startup measurements is approximately
**60.3 MiB RSS** and **9.9 MiB JavaScript heap**. These totals combine separate
component benchmarks and are directional rather than one end-to-end app
measurement.

## Changes

- Defers MCP adapter initialization until first use, including
  configured-but-unused servers.
- Splits the MCP/LangChain graph out of Electron's startup bundle.
- Lazily loads plugin archive/version helpers, process inspection, CA trust,
  tar handling, and other optional Electron resources.
- Uses a JSON-only Electron i18n backend.
- Disables GPU acceleration in detected Windows VMs unless explicitly
  overridden, with registry detection overlapped with synchronous startup work.
- Lazily loads release-note rendering, optional resource routes, and
  docs/OpenAPI helpers.
- Starts the bundled Go backend with `GOGC=25` unless the user already set
  `GOGC`.
- Strips backend binaries without changing runtime behavior.
- Documents backend profiling and the measured compiler, GC, and dynamic
  loading experiments.

### Savings by optimization

| Optimization | Measured saving | Notes |
| --- | --- | --- |
| Lazy MCP adapter initialization | ~38 MiB RSS; ~5 MiB heap | Applies with no MCP configuration; configured servers remain dormant until first use |
| Separate MCP adapter bundle | ~13.9 MiB RSS; ~2.35 MiB heap | Keeps the 1.34 MB MCP/LangChain graph out of the 1.78 MB Electron startup bundle |
| Lazy plugin dependencies and skipped normal-startup process scan | ~722 KiB heap | Isolated plugin-module initialization |
| Lazy CA, tar, and process resources plus JSON-only i18n | ~6.5 MiB RSS; ~1.86 MiB heap | Comparable isolated Electron main-process loading |
| Windows VM GPU disable | Hardware-dependent; not separately measured | Runs registry detection in a worker during synchronous startup, then performs a bounded pre-ready wait |
| Lazy release-note renderer | 156 KiB smaller initial renderer entry | Keeps a 505 KiB markdown source graph off startup |
| Lazy optional renderer modules | Not separately measured | Removes docs/OpenAPI and resource modules from the default renderer startup path |
| Desktop backend GC tuning | ~1.9 MiB startup RSS at `GOGC=50`; 4.5 MiB less private memory at `GOGC=25` after the request workload | `GOGC=25` used about 11% more CPU than `GOGC=50` in the measured workload |

### Combined totals

- **Startup RSS:** ~60.3 MiB from the additive isolated RSS measurements above
  (38 + 13.9 + 6.5 + 1.9 MiB). The backend component conservatively uses the
  measured `GOGC=50` startup delta; the app defaults to `GOGC=25`.
- **JavaScript heap:** ~9.9 MiB from the reported incremental heap measurements
  (5 + 2.35 + 1.86 MiB + 722 KiB).
- **Startup bundles:** 1.34 MB removed from Electron's main startup bundle and
  156 KiB removed from the renderer's initial entry.
- **Loaded backend:** 4.5 MiB less private memory at `GOGC=25` than the Go
  default after 20,000 local `/config` requests.
- GPU and optional frontend-module savings are intentionally excluded from the
  fixed total because they are hardware- or workload-dependent.

### Backend measurements and experiments

The backend request measurements are medians from three Linux amd64 runs of
20,000 local `/config` requests. Private dirty memory is used because
demand-paged executable mappings varied with link layout.

| Runtime configuration | Private dirty after requests | Backend CPU | Result |
| --- | ---: | ---: | --- |
| `GOGC=100` | 17.2 MiB | 3.26 s | Go default and comparison baseline |
| `GOGC=50` | 14.8 MiB | 3.37 s | Saves 2.4 MiB over the Go default |
| `GOGC=25` | 12.7 MiB | 3.73 s | Current desktop default; saves another 2.1 MiB with about 11% more CPU than `GOGC=50` |
| `GOGC=50 GOMEMLIMIT=64MiB` | 14.8 MiB | 3.43 s | No measurable saving in this workload |
| `GOGC=50 GODEBUG=disablethp=1` | 11.7 MiB | 3.44 s | Not selected because this Linux compatibility setting is scheduled for removal |
| `GOGC=50 GOMAXPROCS=1` | 13.2 MiB | 2.32 s | Not selected because serial execution can hurt concurrent workloads |

Compiler experiments used the same request workload with `GOGC=50`:

| Build option | Binary size | Private dirty | Backend CPU | Result |
| --- | ---: | ---: | ---: | --- |
| Default | 114.4 MiB | 14.8 MiB | 3.37 s | Baseline |
| `-trimpath -ldflags="-s -w"` | 81.4 MiB | 14.5 MiB | 3.38 s | Current build default; 28.8% smaller on disk with no meaningful runtime-memory change |
| `-gcflags=all=-l` | 103.5 MiB | 12.8 MiB | 4.21 s | About 2 MiB less memory at roughly 25% more CPU; not selected |
| `GOAMD64=v3` | 114.4 MiB | 14.9 MiB | 3.41 s | No memory saving and reduced CPU compatibility |
| `-buildmode=pie` | 120.9 MiB | 19.1 MiB | 3.45 s | Increased private memory |
| `GOEXPERIMENT=greenteagc` | 114.4 MiB | 14.7 MiB | 3.47 s | No meaningful saving in this workload |

Go plugins were rejected as a backend memory-saving mechanism because they are
unsupported on Windows, require exact toolchain and dependency compatibility,
and cannot be unloaded. Optional helper processes would add another Go runtime
and IPC complexity.

## Testing

- `npm run app:test:unit` (22 files, 336 tests)
- `npm run app:tsc`
- `npm run app:lint`
- Focused frontend tests (4 files, 108 tests)
- `npm run frontend:tsc`
- `npm run frontend:lint`
- `go test ./pkg/k8cache -count=1`
- `npm run app:test:e2e -- buildManifest.spec.ts` (2 tests)

Changed-line branch coverage remains above 80% for the touched Electron modules.

## Manual steps to reproduce

1. Start the desktop app with MCP enabled and no MCP servers configured.
2. Confirm the app reaches the cluster view without loading the MCP adapter.
3. Configure an MCP server and restart the desktop app.
4. Confirm the configured server remains dormant during startup.
5. Request the MCP tool inventory, invoke a tool, and confirm the server connects
   on first use.
6. Change and clear the active cluster while MCP initialization is in progress;
   confirm cluster-dependent servers use the latest context.
7. Update MCP settings during initialization and confirm stale server settings
   do not become active.
8. Verify plugins, i18n, certificates, release notes, docs, and resource routes
   still load on first use.
9. On a Windows VM, confirm GPU acceleration is disabled and
   `--disable-gpu=false` overrides detection.

## Screenshots

Not applicable. This change affects non-visual process loading and memory
retention; it does not alter the rendered interface.

## Notes for reviewers

- Memory figures are medians from isolated component or backend request
  benchmarks. The combined total is arithmetic across incremental measurements,
  not a single full-app before/after run.
- Please pay particular attention to first-use MCP discovery, cluster changes
  during initialization, settings updates during initialization, Windows VM
  detection, and shutdown cleanup during initialization.

Assisted by copilot
