### PR TITLE
frontend: debugVerbose: Match modules enabled at the string start

### DIFF
--- a/frontend/src/helpers/debugVerbose.test.ts
+++ b/frontend/src/helpers/debugVerbose.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { debugVerbose, isDebugVerbose, verboseModDebug } from './debugVerbose';
+
+describe('isDebugVerbose', () => {
+  beforeEach(() => {
+    verboseModDebug.length = 0;
+  });
+
+  it('matches the module it was enabled for', () => {
+    debugVerbose('k8s/apiProxy');
+
+    expect(isDebugVerbose('k8s/apiProxy')).toBe(true);
+  });
+
+  it('matches a function inside the module it was enabled for', () => {
+    debugVerbose('k8s/apiProxy');
+
+    expect(isDebugVerbose('k8s/apiProxy@refreshToken')).toBe(true);
+  });
+
+  it('does not match an unrelated module', () => {
+    debugVerbose('k8s/apiProxy');
+
+    expect(isDebugVerbose('i18n/config')).toBe(false);
+  });
+
+  it('returns false when nothing was enabled', () => {
+    expect(isDebugVerbose('k8s/apiProxy')).toBe(false);
+  });
+});

--- a/frontend/src/helpers/debugVerbose.ts
+++ b/frontend/src/helpers/debugVerbose.ts
@@ -74,7 +74,7 @@ export const verboseModDebug: string[] = [];
  * ```
  */
 export function isDebugVerbose(modName: string): boolean {
-  if (verboseModDebug.filter(mod => modName.indexOf(mod) > 0).length > 0) {
+  if (verboseModDebug.filter(mod => modName.indexOf(mod) !== -1).length > 0) {
     return true;
   }
 


### PR DESCRIPTION
## Summary

`isDebugVerbose` filters with `modName.indexOf(mod) > 0`, which rejects a match at index 0. Since the registered module name is normally a prefix of the queried name, the `debugVerbose()` registration path never matches, including the usage shown in the function's own doc comment.

The env-var branch in the same function already uses `indexOf(...) !== -1`.

## Related Issue

Fixes #7359

## Changes

- Use `indexOf(...) !== -1` so a match at the start of the string counts.
- Added `debugVerbose.test.ts` covering an exact module match, a function inside a registered module, an unrelated module, and nothing registered.

## Steps to Test

1. `cd frontend && npx vitest run src/helpers/debugVerbose.test.ts`
2. Confirm 4 tests pass. The first two fail on `main`.
