### PR TITLE
frontend: e2e-tests: Fail closed for empty namespace selectors

### DIFF
--- a/e2e-tests/tests/namespaceRestrictions.spec.ts
+++ b/e2e-tests/tests/namespaceRestrictions.spec.ts
@@ -310,6 +310,30 @@ test('a global project route resolves configured cluster selectors', async ({ pa
   await expect(page).toHaveTitle(/Project Details/);
 });
 
+test('the home Projects view resolves configured cluster selectors', async ({ page }) => {
+  const selectorRequests = new Set<string>();
+
+  await page.addInitScript(selector => {
+    for (const cluster of ['test', 'test2']) {
+      localStorage.setItem(
+        `cluster_settings.${cluster}`,
+        JSON.stringify({ allowedNamespacesSelector: selector })
+      );
+    }
+  }, selector);
+  await mockHeadlamp(page, ['test', 'test2'], async cluster => {
+    selectorRequests.add(cluster);
+    return ['project-namespace'];
+  });
+
+  await page.goto('/');
+  await page.getByRole('tab', { name: 'Projects' }).click();
+
+  await expect
+    .poll(() => [...selectorRequests].sort(), { timeout: 10_000 })
+    .toEqual(['test', 'test2']);
+});
+
 test('a cluster route does not resolve unselected cluster selectors', async ({ page }) => {
   const selectorRequests = new Set<string>();
 

--- a/e2e-tests/tests/namespaceRestrictions.spec.ts
+++ b/e2e-tests/tests/namespaceRestrictions.spec.ts
@@ -1,0 +1,418 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, Page, test } from '@playwright/test';
+
+const selector = 'team=headlamp';
+
+function namespaceList(names: string[]) {
+  return {
+    apiVersion: 'v1',
+    kind: 'NamespaceList',
+    metadata: { resourceVersion: '1' },
+    items: names.map(name => ({
+      apiVersion: 'v1',
+      kind: 'Namespace',
+      metadata: { name, resourceVersion: '1' },
+      status: { phase: 'Active' },
+    })),
+  };
+}
+
+async function mockHeadlamp(
+  page: Page,
+  clusters: string[],
+  resolveSelector: (cluster: string) => Promise<string[]>
+) {
+  await page.route('**/config', route =>
+    route.fulfill({
+      json: {
+        clusters: clusters.map(name => ({ name, auth_type: '', useToken: false })),
+      },
+    })
+  );
+  await page.route('**/plugins', route => route.fulfill({ json: [] }));
+  await page.route('**/clusters/**', async route => {
+    const url = new URL(route.request().url());
+    const [cluster, ...clusterPathParts] = url.pathname.split('/clusters/')[1].split('/');
+    const clusterPath = `/${clusterPathParts.join('/')}`;
+
+    if (clusterPath === '/api') {
+      await route.fulfill({
+        json: {
+          items: [
+            {
+              metadata: {},
+              versions: [
+                {
+                  version: 'v1',
+                  resources: [
+                    {
+                      resource: 'namespaces',
+                      verbs: ['list'],
+                      responseKind: { kind: 'Namespace' },
+                      scope: 'Cluster',
+                    },
+                    {
+                      resource: 'pods',
+                      verbs: ['list'],
+                      responseKind: { kind: 'Pod' },
+                      scope: 'Namespaced',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+      return;
+    }
+
+    if (clusterPath === '/apis') {
+      await route.fulfill({ json: { items: [] } });
+      return;
+    }
+
+    if (
+      clusterPath === '/api/v1/namespaces' &&
+      url.searchParams.get('labelSelector') === selector
+    ) {
+      await route.fulfill({ json: namespaceList(await resolveSelector(cluster)) });
+      return;
+    }
+
+    const projectSelector = url.searchParams.get('labelSelector');
+    if (
+      clusterPath === '/api/v1/namespaces' &&
+      projectSelector?.startsWith('headlamp.dev/project-id=')
+    ) {
+      const project = projectSelector.slice('headlamp.dev/project-id='.length);
+      await route.fulfill({
+        json: {
+          ...namespaceList([`${project}-namespace`]),
+          items: [
+            {
+              apiVersion: 'v1',
+              kind: 'Namespace',
+              metadata: {
+                name: `${project}-namespace`,
+                labels: { 'headlamp.dev/project-id': project },
+                resourceVersion: '1',
+              },
+            },
+          ],
+        },
+      });
+      return;
+    }
+
+    await route.fulfill({
+      json: {
+        apiVersion: 'v1',
+        kind: 'List',
+        metadata: { resourceVersion: '1' },
+        items: [],
+      },
+    });
+  });
+}
+
+test('an empty namespace selector suppresses namespaced requests', async ({ page }) => {
+  const podRequests: string[] = [];
+
+  await page.addInitScript(selector => {
+    localStorage.setItem(
+      'cluster_settings.test',
+      JSON.stringify({ allowedNamespacesSelector: selector })
+    );
+    localStorage.setItem(
+      'cluster_allowed_namespaces_selector_cache.test',
+      JSON.stringify({ selector, namespaces: [], resolvedAt: Date.now() })
+    );
+  }, selector);
+  await mockHeadlamp(page, ['test'], async () => []);
+  page.on('request', request => {
+    const url = new URL(request.url());
+    if (/\/api\/v1\/(?:namespaces\/[^/]+\/)?pods$/.test(url.pathname)) {
+      podRequests.push(`${url.pathname}${url.search}`);
+    }
+  });
+
+  await page.goto('/c/test/pods?namespace=default');
+  await expect
+    .poll(() =>
+      page.evaluate(() => localStorage.getItem('cluster_allowed_namespaces_selector_cache.test'))
+    )
+    .not.toBeNull();
+
+  await expect(page).toHaveTitle(/Pods/);
+  await expect(page.getByText('No data to be shown.').first()).toBeVisible();
+  expect(podRequests).toEqual([]);
+});
+
+test('an empty namespace selector suppresses the unrestricted Namespaces query', async ({
+  page,
+}) => {
+  const unrestrictedNamespaceRequests: string[] = [];
+
+  await page.addInitScript(selector => {
+    localStorage.setItem(
+      'cluster_settings.test',
+      JSON.stringify({ allowedNamespacesSelector: selector })
+    );
+    localStorage.setItem(
+      'cluster_allowed_namespaces_selector_cache.test',
+      JSON.stringify({ selector, namespaces: [], resolvedAt: Date.now() })
+    );
+  }, selector);
+  await mockHeadlamp(page, ['test'], async () => []);
+  page.on('request', request => {
+    const url = new URL(request.url());
+    if (
+      url.pathname.endsWith('/clusters/test/api/v1/namespaces') &&
+      !url.searchParams.has('labelSelector')
+    ) {
+      unrestrictedNamespaceRequests.push(`${url.pathname}${url.search}`);
+    }
+  });
+
+  await page.goto('/c/test/namespaces');
+  await expect
+    .poll(() =>
+      page.evaluate(() => localStorage.getItem('cluster_allowed_namespaces_selector_cache.test'))
+    )
+    .not.toBeNull();
+
+  await expect(page).toHaveTitle(/Namespaces/);
+  await expect(page.getByText('No data to be shown.').first()).toBeVisible();
+  expect(unrestrictedNamespaceRequests).toEqual([]);
+});
+
+test('a disjoint cluster allow-list does not become a cluster-wide request', async ({ page }) => {
+  const podRequests: string[] = [];
+
+  await page.addInitScript(selector => {
+    for (const [cluster, namespaces] of [
+      ['test', ['team-a']],
+      ['test2', ['team-b']],
+    ] as const) {
+      localStorage.setItem(
+        `cluster_settings.${cluster}`,
+        JSON.stringify({ allowedNamespacesSelector: selector })
+      );
+      localStorage.setItem(
+        `cluster_allowed_namespaces_selector_cache.${cluster}`,
+        JSON.stringify({ selector, namespaces, resolvedAt: Date.now() })
+      );
+    }
+  }, selector);
+  await mockHeadlamp(page, ['test', 'test2'], async cluster =>
+    cluster === 'test' ? ['team-a'] : ['team-b']
+  );
+  page.on('request', request => {
+    const url = new URL(request.url());
+    if (/\/api\/v1\/(?:namespaces\/[^/]+\/)?pods$/.test(url.pathname)) {
+      podRequests.push(`${url.pathname}${url.search}`);
+    }
+  });
+
+  await page.goto('/c/test+test2/pods?namespace=team-a');
+
+  await expect(page).toHaveTitle(/Pods/);
+  await expect
+    .poll(() =>
+      podRequests.some(request => request.includes('/clusters/test/api/v1/namespaces/team-a/pods'))
+    )
+    .toBe(true);
+  expect(podRequests.some(request => /\/api\/v1\/pods(?:\?|$)/.test(request))).toBe(false);
+});
+
+test('all selected cluster selectors start resolving before routes render', async ({ page }) => {
+  const selectorRequests = new Set<string>();
+  let releaseFirstSelector!: () => void;
+  const firstSelectorReleased = new Promise<void>(resolve => {
+    releaseFirstSelector = resolve;
+  });
+
+  await page.addInitScript(selector => {
+    for (const cluster of ['test', 'test2']) {
+      localStorage.setItem(
+        `cluster_settings.${cluster}`,
+        JSON.stringify({ allowedNamespacesSelector: selector })
+      );
+    }
+  }, selector);
+  await mockHeadlamp(page, ['test', 'test2'], async cluster => {
+    selectorRequests.add(cluster);
+    if (cluster === 'test') {
+      await firstSelectorReleased;
+    }
+    return [];
+  });
+
+  try {
+    await page.goto('/c/test+test2/pods', { waitUntil: 'domcontentloaded' });
+    await expect.poll(() => [...selectorRequests].sort()).toEqual(['test', 'test2']);
+    await expect(page).toHaveTitle('Headlamp');
+  } finally {
+    releaseFirstSelector();
+  }
+
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() =>
+          ['test', 'test2'].every(cluster =>
+            localStorage.getItem(`cluster_allowed_namespaces_selector_cache.${cluster}`)
+          )
+        ),
+      { timeout: 10_000 }
+    )
+    .toBe(true);
+  await expect(page).toHaveTitle(/Pods/);
+});
+
+test('a global project route resolves configured cluster selectors', async ({ page }) => {
+  const selectorRequests = new Set<string>();
+
+  await page.addInitScript(selector => {
+    for (const cluster of ['test', 'test2']) {
+      localStorage.setItem(
+        `cluster_settings.${cluster}`,
+        JSON.stringify({ allowedNamespacesSelector: selector })
+      );
+    }
+  }, selector);
+  await mockHeadlamp(page, ['test', 'test2'], async cluster => {
+    selectorRequests.add(cluster);
+    return ['project-namespace'];
+  });
+
+  await page.goto('/project/example');
+
+  await expect
+    .poll(() => [...selectorRequests].sort(), { timeout: 10_000 })
+    .toEqual(['test', 'test2']);
+  await expect(page).toHaveTitle(/Project Details/);
+});
+
+test('a cluster route does not resolve unselected cluster selectors', async ({ page }) => {
+  const selectorRequests = new Set<string>();
+
+  await page.addInitScript(selector => {
+    for (const cluster of ['test', 'test2']) {
+      localStorage.setItem(
+        `cluster_settings.${cluster}`,
+        JSON.stringify({ allowedNamespacesSelector: selector })
+      );
+    }
+  }, selector);
+  await mockHeadlamp(page, ['test', 'test2'], async cluster => {
+    selectorRequests.add(cluster);
+    return [];
+  });
+
+  await page.goto('/c/test/pods');
+
+  await expect(page).toHaveTitle(/Pods/);
+  expect([...selectorRequests]).toEqual(['test']);
+});
+
+test('a selector refresh preserves routed page state', async ({ page }) => {
+  const podRequests: string[] = [];
+  let releaseSelector!: () => void;
+  const selectorReleased = new Promise<void>(resolve => {
+    releaseSelector = resolve;
+  });
+
+  await page.addInitScript(selector => {
+    localStorage.setItem(
+      'cluster_settings.test',
+      JSON.stringify({ allowedNamespacesSelector: selector })
+    );
+    localStorage.setItem(
+      'cluster_allowed_namespaces_selector_cache.test',
+      JSON.stringify({
+        selector,
+        namespaces: ['stale'],
+        resolvedAt: Date.now(),
+      })
+    );
+  }, selector);
+  await mockHeadlamp(page, ['test'], async () => {
+    await selectorReleased;
+    return ['fresh'];
+  });
+  await page.route('**/clusters/test/api/v1/namespaces/*/pods**', route => {
+    const namespace = new URL(route.request().url()).pathname
+      .split('/namespaces/')[1]
+      .split('/')[0];
+    return route.fulfill({
+      json: {
+        apiVersion: 'v1',
+        kind: 'PodList',
+        metadata: { resourceVersion: '1' },
+        items: [
+          {
+            apiVersion: 'v1',
+            kind: 'Pod',
+            metadata: {
+              name: `keep-state-visible-${namespace}`,
+              namespace,
+              resourceVersion: '1',
+              creationTimestamp: '2026-01-01T00:00:00Z',
+            },
+            spec: { containers: [{ name: 'main', image: 'busybox' }] },
+            status: { phase: 'Running' },
+          },
+        ],
+      },
+    });
+  });
+  page.on('request', request => {
+    const url = new URL(request.url());
+    if (/\/api\/v1\/namespaces\/[^/]+\/pods$/.test(url.pathname)) {
+      podRequests.push(`${url.pathname}${url.search}`);
+    }
+  });
+
+  try {
+    await page.goto('/c/test/pods', { waitUntil: 'domcontentloaded' });
+    await expect(page).toHaveTitle(/Pods/);
+    await page.getByRole('button', { name: 'Show/Hide search' }).click();
+    const search = page.locator('#table-search-field');
+    await search.fill('keep this filter');
+
+    releaseSelector();
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const cache = localStorage.getItem('cluster_allowed_namespaces_selector_cache.test');
+          return cache ? JSON.parse(cache).namespaces : null;
+        })
+      )
+      .toEqual(['fresh']);
+    await expect
+      .poll(() =>
+        podRequests.some(request => request.includes('/clusters/test/api/v1/namespaces/fresh/pods'))
+      )
+      .toBe(true);
+    await expect(search).toHaveValue('keep this filter');
+  } finally {
+    releaseSelector();
+  }
+});

--- a/frontend/src/components/App/AllowedNamespacesSelectorGate.tsx
+++ b/frontend/src/components/App/AllowedNamespacesSelectorGate.tsx
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactNode, useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { loadClusterSettings, loadResolvedAllowedNamespaces } from '../../helpers/clusterSettings';
+import { useAllowedNamespacesFromSelector } from '../../lib/k8s/allowedNamespaces';
+import { AllowedNamespacesResolutionContext } from '../../lib/k8s/allowedNamespacesContext';
+import { Loader } from '../common';
+
+/** Result state for a single allowed namespace selector. */
+interface SelectorResolution {
+  /** Selector associated with the result. */
+  selector: string;
+  /** Stable key for the selector result or error. */
+  resultKey: string;
+  /** Whether selector resolution failed. */
+  isError: boolean;
+}
+
+/**
+ * Resolves one cluster's namespace selector and reports stable result changes.
+ *
+ * @param props - Cluster and result callback.
+ * @returns No rendered content.
+ */
+function AllowedNamespacesSelectorResolver({
+  cluster,
+  onResolved,
+}: {
+  cluster: string;
+  onResolved: (cluster: string, resolution: SelectorResolution) => void;
+}) {
+  const selector = (loadClusterSettings(cluster).allowedNamespacesSelector || '').trim();
+  const resolution = useAllowedNamespacesFromSelector(cluster, selector);
+  const resultKey = resolution.error
+    ? JSON.stringify([selector, 'error', resolution.error.message])
+    : resolution.isSuccess
+    ? JSON.stringify([selector, 'success', resolution.namespaces])
+    : '';
+
+  useEffect(() => {
+    if (selector && resultKey) {
+      onResolved(cluster, { selector, resultKey, isError: Boolean(resolution.error) });
+    }
+  }, [cluster, selector, resultKey, resolution.error, onResolved]);
+
+  return null;
+}
+
+/**
+ * Delays child rendering until every relevant namespace selector has resolved.
+ *
+ * @param props - Relevant clusters and selector-dependent content.
+ * @returns Selector resolvers followed by a loader or the child content.
+ */
+export default function AllowedNamespacesSelectorGate({
+  clusters,
+  children,
+}: {
+  clusters: string[];
+  children: ReactNode;
+}) {
+  const { t } = useTranslation();
+  const [resolutions, setResolutions] = useState<Record<string, SelectorResolution>>({});
+  const onResolved = useCallback((cluster: string, resolution: SelectorResolution) => {
+    setResolutions(current =>
+      current[cluster]?.resultKey === resolution.resultKey
+        ? current
+        : { ...current, [cluster]: resolution }
+    );
+  }, []);
+
+  const resolutionKeys = clusters.map(cluster => {
+    const selector = (loadClusterSettings(cluster).allowedNamespacesSelector || '').trim();
+    const cache = selector ? loadResolvedAllowedNamespaces(cluster) : null;
+    const cachedResultKey =
+      cache?.selector === selector ? JSON.stringify([selector, 'success', cache.namespaces]) : '';
+    const resolution = resolutions[cluster];
+
+    if (!selector || cachedResultKey) {
+      return cachedResultKey;
+    }
+
+    return resolution?.selector === selector && resolution.isError ? resolution.resultKey : null;
+  });
+  const waiting = resolutionKeys.some(key => key === null);
+  const resolutionKey = JSON.stringify(resolutionKeys);
+
+  return (
+    <>
+      {clusters.map(cluster => (
+        <AllowedNamespacesSelectorResolver
+          key={cluster}
+          cluster={cluster}
+          onResolved={onResolved}
+        />
+      ))}
+      {waiting ? (
+        <Loader title={t('Loading')} />
+      ) : (
+        <AllowedNamespacesResolutionContext.Provider value={resolutionKey}>
+          {children}
+        </AllowedNamespacesResolutionContext.Provider>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/App/Layout.tsx
+++ b/frontend/src/components/App/Layout.tsx
@@ -23,16 +23,13 @@ import Link from '@mui/material/Link';
 import { styled } from '@mui/material/styles';
 import { Dispatch, UnknownAction } from '@reduxjs/toolkit';
 import { useQuery } from '@tanstack/react-query';
-import { ReactNode, useCallback, useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { useLocation } from 'react-router-dom';
-import { loadClusterSettings, loadResolvedAllowedNamespaces } from '../../helpers/clusterSettings';
 import { getCluster } from '../../lib/cluster';
 import { getSelectedClusters } from '../../lib/cluster';
 import { useCluster, useClustersConf, useSelectedClusters } from '../../lib/k8s';
-import { useAllowedNamespacesFromSelector } from '../../lib/k8s/allowedNamespaces';
-import { AllowedNamespacesResolutionContext } from '../../lib/k8s/allowedNamespacesContext';
 import { request } from '../../lib/k8s/api/v1/clusterRequests';
 import { Cluster } from '../../lib/k8s/cluster';
 import { getSavedNamespaces } from '../../lib/storage';
@@ -49,6 +46,7 @@ import ActionsNotifier from '../common/ActionsNotifier';
 import AlertNotification from '../common/AlertNotification';
 import DetailsDrawer from '../common/Resource/DetailsDrawer';
 import Sidebar, { NavigationTabs } from '../Sidebar';
+import AllowedNamespacesSelectorGate from './AllowedNamespacesSelectorGate';
 import RouteSwitcher from './RouteSwitcher';
 import ShortcutsSettings from './Settings/ShortcutsSettings';
 import { applyBackendThemeConfig } from './themeSlice';
@@ -199,109 +197,6 @@ const fetchConfig = (dispatch: Dispatch<UnknownAction>) => {
 };
 
 const disableBackendLoader = true;
-
-/**
- * Resolves and caches the namespaces matching a single cluster's allowed
- * namespaces label selector. Rendered once per relevant cluster so the resolution
- * (which relies on a hook) runs for every cluster whose resources may be listed.
- */
-interface SelectorResolution {
-  /** Selector associated with the result. */
-  selector: string;
-  /** Stable key for the selector result or error. */
-  resultKey: string;
-  /** Whether selector resolution failed. */
-  isError: boolean;
-}
-
-/**
- * Resolves one cluster's namespace selector and reports stable result changes.
- *
- * @param props - Cluster and result callback.
- * @returns No rendered content.
- */
-function AllowedNamespacesSelectorResolver({
-  cluster,
-  onResolved,
-}: {
-  cluster: string;
-  onResolved: (cluster: string, resolution: SelectorResolution) => void;
-}) {
-  const selector = (loadClusterSettings(cluster).allowedNamespacesSelector || '').trim();
-  const resolution = useAllowedNamespacesFromSelector(cluster, selector);
-  const resultKey = resolution.error
-    ? JSON.stringify([selector, 'error', resolution.error.message])
-    : resolution.isSuccess
-    ? JSON.stringify([selector, 'success', resolution.namespaces])
-    : '';
-
-  useEffect(() => {
-    if (selector && resultKey) {
-      onResolved(cluster, { selector, resultKey, isError: Boolean(resolution.error) });
-    }
-  }, [cluster, selector, resultKey, resolution.error, onResolved]);
-
-  return null;
-}
-
-/**
- * Delays route rendering until every relevant namespace selector has resolved.
- *
- * @param props - Relevant clusters and routed content.
- * @returns Selector resolvers followed by a loader or the routed content.
- */
-function AllowedNamespacesSelectorGate({
-  clusters,
-  children,
-}: {
-  clusters: string[];
-  children: ReactNode;
-}) {
-  const { t } = useTranslation();
-  const [resolutions, setResolutions] = useState<Record<string, SelectorResolution>>({});
-  const onResolved = useCallback((cluster: string, resolution: SelectorResolution) => {
-    setResolutions(current =>
-      current[cluster]?.resultKey === resolution.resultKey
-        ? current
-        : { ...current, [cluster]: resolution }
-    );
-  }, []);
-
-  const resolutionKeys = clusters.map(cluster => {
-    const selector = (loadClusterSettings(cluster).allowedNamespacesSelector || '').trim();
-    const cache = selector ? loadResolvedAllowedNamespaces(cluster) : null;
-    const cachedResultKey =
-      cache?.selector === selector ? JSON.stringify([selector, 'success', cache.namespaces]) : '';
-    const resolution = resolutions[cluster];
-
-    if (!selector || cachedResultKey) {
-      return cachedResultKey;
-    }
-
-    return resolution?.selector === selector && resolution.isError ? resolution.resultKey : null;
-  });
-  const waiting = resolutionKeys.some(key => key === null);
-  const resolutionKey = JSON.stringify(resolutionKeys);
-
-  return (
-    <>
-      {clusters.map(cluster => (
-        <AllowedNamespacesSelectorResolver
-          key={cluster}
-          cluster={cluster}
-          onResolved={onResolved}
-        />
-      ))}
-      {waiting ? (
-        <Loader title={t('Loading')} />
-      ) : (
-        <AllowedNamespacesResolutionContext.Provider value={resolutionKey}>
-          {children}
-        </AllowedNamespacesResolutionContext.Provider>
-      )}
-    </>
-  );
-}
 
 export default function Layout({}: LayoutProps) {
   const arePluginsLoaded = useTypedSelector(state => state.plugins.loaded);

--- a/frontend/src/components/App/Layout.tsx
+++ b/frontend/src/components/App/Layout.tsx
@@ -23,14 +23,16 @@ import Link from '@mui/material/Link';
 import { styled } from '@mui/material/styles';
 import { Dispatch, UnknownAction } from '@reduxjs/toolkit';
 import { useQuery } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { ReactNode, useCallback, useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
+import { useLocation } from 'react-router-dom';
 import { loadClusterSettings, loadResolvedAllowedNamespaces } from '../../helpers/clusterSettings';
 import { getCluster } from '../../lib/cluster';
 import { getSelectedClusters } from '../../lib/cluster';
 import { useCluster, useClustersConf, useSelectedClusters } from '../../lib/k8s';
 import { useAllowedNamespacesFromSelector } from '../../lib/k8s/allowedNamespaces';
+import { AllowedNamespacesResolutionContext } from '../../lib/k8s/allowedNamespacesContext';
 import { request } from '../../lib/k8s/api/v1/clusterRequests';
 import { Cluster } from '../../lib/k8s/cluster';
 import { getSavedNamespaces } from '../../lib/storage';
@@ -200,12 +202,105 @@ const disableBackendLoader = true;
 
 /**
  * Resolves and caches the namespaces matching a single cluster's allowed
- * namespaces label selector. Rendered once per selected cluster so the resolution
+ * namespaces label selector. Rendered once per relevant cluster so the resolution
  * (which relies on a hook) runs for every cluster whose resources may be listed.
  */
-function AllowedNamespacesSelectorSync({ cluster }: { cluster: string }) {
-  useAllowedNamespacesFromSelector(cluster, loadClusterSettings(cluster).allowedNamespacesSelector);
+interface SelectorResolution {
+  /** Selector associated with the result. */
+  selector: string;
+  /** Stable key for the selector result or error. */
+  resultKey: string;
+  /** Whether selector resolution failed. */
+  isError: boolean;
+}
+
+/**
+ * Resolves one cluster's namespace selector and reports stable result changes.
+ *
+ * @param props - Cluster and result callback.
+ * @returns No rendered content.
+ */
+function AllowedNamespacesSelectorResolver({
+  cluster,
+  onResolved,
+}: {
+  cluster: string;
+  onResolved: (cluster: string, resolution: SelectorResolution) => void;
+}) {
+  const selector = (loadClusterSettings(cluster).allowedNamespacesSelector || '').trim();
+  const resolution = useAllowedNamespacesFromSelector(cluster, selector);
+  const resultKey = resolution.error
+    ? JSON.stringify([selector, 'error', resolution.error.message])
+    : resolution.isSuccess
+    ? JSON.stringify([selector, 'success', resolution.namespaces])
+    : '';
+
+  useEffect(() => {
+    if (selector && resultKey) {
+      onResolved(cluster, { selector, resultKey, isError: Boolean(resolution.error) });
+    }
+  }, [cluster, selector, resultKey, resolution.error, onResolved]);
+
   return null;
+}
+
+/**
+ * Delays route rendering until every relevant namespace selector has resolved.
+ *
+ * @param props - Relevant clusters and routed content.
+ * @returns Selector resolvers followed by a loader or the routed content.
+ */
+function AllowedNamespacesSelectorGate({
+  clusters,
+  children,
+}: {
+  clusters: string[];
+  children: ReactNode;
+}) {
+  const { t } = useTranslation();
+  const [resolutions, setResolutions] = useState<Record<string, SelectorResolution>>({});
+  const onResolved = useCallback((cluster: string, resolution: SelectorResolution) => {
+    setResolutions(current =>
+      current[cluster]?.resultKey === resolution.resultKey
+        ? current
+        : { ...current, [cluster]: resolution }
+    );
+  }, []);
+
+  const resolutionKeys = clusters.map(cluster => {
+    const selector = (loadClusterSettings(cluster).allowedNamespacesSelector || '').trim();
+    const cache = selector ? loadResolvedAllowedNamespaces(cluster) : null;
+    const cachedResultKey =
+      cache?.selector === selector ? JSON.stringify([selector, 'success', cache.namespaces]) : '';
+    const resolution = resolutions[cluster];
+
+    if (!selector || cachedResultKey) {
+      return cachedResultKey;
+    }
+
+    return resolution?.selector === selector && resolution.isError ? resolution.resultKey : null;
+  });
+  const waiting = resolutionKeys.some(key => key === null);
+  const resolutionKey = JSON.stringify(resolutionKeys);
+
+  return (
+    <>
+      {clusters.map(cluster => (
+        <AllowedNamespacesSelectorResolver
+          key={cluster}
+          cluster={cluster}
+          onResolved={onResolved}
+        />
+      ))}
+      {waiting ? (
+        <Loader title={t('Loading')} />
+      ) : (
+        <AllowedNamespacesResolutionContext.Provider value={resolutionKey}>
+          {children}
+        </AllowedNamespacesResolutionContext.Provider>
+      )}
+    </>
+  );
 }
 
 export default function Layout({}: LayoutProps) {
@@ -247,29 +342,12 @@ export default function Layout({}: LayoutProps) {
     }
   }, [cluster, dispatch]);
 
-  // Keep the namespaces resolved from each selected cluster's label selector (if
-  // any) in sync so getCombinedAllowedNamespaces stays up to date. Resource lists
-  // span every selected cluster, so we resolve them all, not just the active one.
   const selectedClusters = useSelectedClusters();
-
-  // Resolve the active cluster's selector directly (the other selected clusters
-  // are synced by the components below). We use its state to gate the resource
-  // routes on the first resolution.
-  const activeSelector = (
-    loadClusterSettings(cluster || '').allowedNamespacesSelector || ''
-  ).trim();
-  const activeResolution = useAllowedNamespacesFromSelector(cluster || '', activeSelector);
-  const activeResolvedCache = activeSelector ? loadResolvedAllowedNamespaces(cluster || '') : null;
-  // Wait for the first resolution before rendering resource routes, so views build
-  // their requests from the resolved namespaces instead of a not-yet-populated
-  // cache (which would otherwise fall back to cluster-wide requests). Steady state
-  // (cache already present for this selector) and clusters without a selector
-  // never wait.
-  const waitingForAllowedNamespaces =
-    !!activeSelector &&
-    !(activeResolvedCache && activeResolvedCache.selector === activeSelector) &&
-    !activeResolution.isSuccess &&
-    !activeResolution.error;
+  const { pathname } = useLocation();
+  const configuredClusters = pathname.startsWith('/project/') ? Object.keys(allClusters || {}) : [];
+  const clustersToResolve = [
+    ...new Set([...configuredClusters, cluster || '', ...selectedClusters].filter(Boolean)),
+  ];
 
   const urlClusters = getSelectedClusters();
   const clustersNotInURL =
@@ -337,11 +415,6 @@ export default function Layout({}: LayoutProps) {
       >
         {t('Skip to main content')}
       </Link>
-      {selectedClusters
-        .filter(clusterName => clusterName && clusterName !== cluster)
-        .map(clusterName => (
-          <AllowedNamespacesSelectorSync key={clusterName} cluster={clusterName} />
-        ))}
       <VersionDialog />
       <ShortcutsSettings />
       <CssBaseline enableColorScheme />
@@ -392,8 +465,16 @@ export default function Layout({}: LayoutProps) {
                 <Container {...containerProps} sx={{ height: '100%' }}>
                   <NavigationTabs />
                   {arePluginsLoaded &&
-                    (waitingForAllowedNamespaces ? (
-                      <Loader title={t('Loading')} />
+                    (clustersToResolve.length > 0 ? (
+                      <AllowedNamespacesSelectorGate clusters={clustersToResolve}>
+                        <RouteSwitcher
+                          requiresToken={() => {
+                            const clusterName = getCluster() || '';
+                            const cluster = clusters ? clusters[clusterName] : undefined;
+                            return cluster?.useToken === undefined || cluster?.useToken;
+                          }}
+                        />
+                      </AllowedNamespacesSelectorGate>
                     ) : (
                       <RouteSwitcher
                         requiresToken={() => {

--- a/frontend/src/components/namespace/List.tsx
+++ b/frontend/src/components/namespace/List.tsx
@@ -14,87 +14,30 @@
  * limitations under the License.
  */
 
-import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { getCombinedAllowedNamespaces } from '../../helpers/clusterSettings';
-import { useCluster } from '../../lib/k8s';
 import Namespace from '../../lib/k8s/namespace';
 import { StatusLabel } from '../common/Label';
-import Link from '../common/Link';
 import { MetadataDictGrid } from '../common/Resource';
 import ResourceListView from '../common/Resource/ResourceListView';
-import {
-  ResourceTableFromResourceClassProps,
-  ResourceTableProps,
-} from '../common/Resource/ResourceTable';
 import CreateNamespaceButton from './CreateNamespaceButton';
 
 export default function NamespacesList() {
   const { t } = useTranslation(['glossary', 'translation']);
-  const cluster = useCluster();
-  // Use the metadata.name field to match the expected format of the ResourceTable component.
-  const [allowedNamespaces, setAllowedNamespaces] = React.useState<
-    { metadata: { name: string } }[]
-  >([]);
-
-  React.useEffect(() => {
-    if (cluster) {
-      const namespaces = getCombinedAllowedNamespaces(cluster);
-      setAllowedNamespaces(
-        namespaces.map(namespace => ({
-          metadata: {
-            name: namespace,
-          },
-        }))
-      );
-    }
-  }, [cluster]);
 
   function makeStatusLabel(namespace: Namespace) {
     const status = namespace.status.phase;
     return <StatusLabel status={status === 'Active' ? 'success' : 'error'}>{status}</StatusLabel>;
   }
 
-  const resourceTableProps:
-    | ResourceTableProps<Namespace>
-    | ResourceTableFromResourceClassProps<typeof Namespace> = React.useMemo(() => {
-    if (allowedNamespaces.length > 0) {
-      return {
-        columns: [
-          {
-            id: 'name',
-            label: t('translation|Name'),
-            getValue: ns => ns.metadata.name,
-            render: ({ metadata }) => (
-              <Link
-                routeName={'namespace'}
-                params={{
-                  name: metadata.name,
-                }}
-              >
-                {metadata.name}
-              </Link>
-            ),
-          },
-          'cluster',
-          {
-            id: 'status',
-            gridTemplate: 'auto',
-            label: t('translation|Status'),
-            getValue: () => 'Unknown',
-          },
-          {
-            id: 'age',
-            label: t('translation|Age'),
-            getValue: () => 'Unknown',
-          },
-        ],
-        data: allowedNamespaces as unknown as Namespace[],
-      } satisfies ResourceTableProps<Namespace>;
-    }
-    return {
-      resourceClass: Namespace,
-      columns: [
+  return (
+    <ResourceListView
+      title={t('Namespaces')}
+      headerProps={{
+        titleSideActions: [<CreateNamespaceButton />],
+        noNamespaceFilter: true,
+      }}
+      resourceClass={Namespace}
+      columns={[
         'name',
         'cluster',
         {
@@ -117,19 +60,7 @@ export default function NamespacesList() {
             ns.metadata.labels ? <MetadataDictGrid dict={ns.metadata.labels} /> : null,
         },
         'age',
-      ],
-    } satisfies ResourceTableFromResourceClassProps<typeof Namespace>;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [allowedNamespaces]);
-
-  return (
-    <ResourceListView
-      title={t('Namespaces')}
-      headerProps={{
-        titleSideActions: [<CreateNamespaceButton />],
-        noNamespaceFilter: true,
-      }}
-      {...(resourceTableProps as ResourceTableProps<Namespace>)}
+      ]}
     />
   );
 }

--- a/frontend/src/components/project/ProjectList.test.tsx
+++ b/frontend/src/components/project/ProjectList.test.tsx
@@ -16,7 +16,7 @@
 
 import { ThemeProvider } from '@mui/material/styles';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, waitFor } from '@testing-library/react';
+import { render, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('./useProjectResources', () => ({
@@ -28,7 +28,7 @@ import Namespace from '../../lib/k8s/namespace';
 import { createMuiTheme } from '../../lib/themes';
 import { HeadlampEventType } from '../../redux/headlampEventSlice';
 import { recordHeadlampEvents, TestContext } from '../../test';
-import ProjectList, { groupNamespacesIntoProjects } from './ProjectList';
+import ProjectList, { groupNamespacesIntoProjects, useProject } from './ProjectList';
 import { PROJECT_ID_LABEL } from './projectUtils';
 
 // cyclic imports fix
@@ -95,6 +95,24 @@ describe('groupNamespacesIntoProjects', () => {
       ns('mine', { project: 'app' }),
     ]);
     expect(projects).toEqual([{ id: 'app', namespaces: ['mine'], clusters: ['cluster-a'] }]);
+  });
+});
+
+describe('useProject', () => {
+  it('returns a loaded empty project when no matching namespaces exist', () => {
+    vi.spyOn(Namespace, 'useList').mockReturnValue({
+      items: [],
+      isLoading: false,
+    } as any);
+
+    const { result } = renderHook(() => useProject('missing-project'), {
+      wrapper: ({ children }) => <TestContext>{children}</TestContext>,
+    });
+
+    expect(result.current).toEqual({
+      isLoading: false,
+      project: { id: 'missing-project', clusters: [], namespaces: [] },
+    });
   });
 });
 

--- a/frontend/src/components/project/ProjectList.tsx
+++ b/frontend/src/components/project/ProjectList.tsx
@@ -77,11 +77,7 @@ export const useProject = (name: string) => {
     () => ({
       isLoading,
       project: namespaces
-        ? ({
-            clusters: uniq(namespaces.map(it => it.cluster)),
-            namespaces: uniq(namespaces.map(it => it.metadata.name)),
-            id: name,
-          } as ProjectDefinition)
+        ? groupNamespacesIntoProjects(namespaces).find(project => project.id === name)
         : undefined,
     }),
     [namespaces, name, isLoading]

--- a/frontend/src/components/project/ProjectList.tsx
+++ b/frontend/src/components/project/ProjectList.tsx
@@ -24,6 +24,7 @@ import Namespace from '../../lib/k8s/namespace';
 import { HeadlampEventType, useEventCallback } from '../../redux/headlampEventSlice';
 import { useTypedSelector } from '../../redux/hooks';
 import { ProjectDefinition } from '../../redux/projectsSlice';
+import AllowedNamespacesSelectorGate from '../App/AllowedNamespacesSelectorGate';
 import { StatusLabel } from '../common';
 import Link from '../common/Link';
 import Table, { TableColumn } from '../common/Table/Table';
@@ -77,14 +78,18 @@ export const useProject = (name: string) => {
     () => ({
       isLoading,
       project: namespaces
-        ? groupNamespacesIntoProjects(namespaces).find(project => project.id === name)
+        ? groupNamespacesIntoProjects(namespaces).find(project => project.id === name) ?? {
+            id: name,
+            clusters: [],
+            namespaces: [],
+          }
         : undefined,
     }),
     [namespaces, name, isLoading]
   );
 };
 
-export default function ProjectList() {
+function ProjectListContent() {
   const { t } = useTranslation();
   const [showCreate, setShowCreate] = useState(false);
   const pluginApiResources = useTypedSelector(state => state.projects.apiResources);
@@ -227,5 +232,21 @@ export default function ProjectList() {
 
       <Table key={pluginApiResources.length} columns={columns} data={projects} />
     </>
+  );
+}
+
+/**
+ * Resolves configured namespace selectors before querying the project list.
+ *
+ * @returns The gated project list.
+ */
+export default function ProjectList() {
+  const clusterConf = useClustersConf();
+  const clusters = Object.values(clusterConf ?? {}).map(cluster => cluster.name);
+
+  return (
+    <AllowedNamespacesSelectorGate clusters={clusters}>
+      <ProjectListContent />
+    </AllowedNamespacesSelectorGate>
   );
 }

--- a/frontend/src/helpers/clusterSettings.test.ts
+++ b/frontend/src/helpers/clusterSettings.test.ts
@@ -19,6 +19,7 @@ import {
   clearResolvedAllowedNamespaces,
   ClusterSettings,
   getCombinedAllowedNamespaces,
+  hasAllowedNamespacesRestriction,
   isResolvedAllowedNamespacesStale,
   loadClusterSettings,
   loadResolvedAllowedNamespaces,
@@ -237,6 +238,24 @@ describe('clusterSettings', () => {
       storeClusterSettings('prod', { allowedNamespaces: ['a'] });
       storeResolvedAllowedNamespaces('prod', 'team=frontend', ['x', 'y']);
       expect(getCombinedAllowedNamespaces('prod')).toEqual(['a']);
+    });
+  });
+
+  describe('hasAllowedNamespacesRestriction', () => {
+    it('is false when no allowed namespaces are configured', () => {
+      storeClusterSettings('prod', { allowedNamespaces: [] });
+      expect(hasAllowedNamespacesRestriction('prod')).toBe(false);
+    });
+
+    it('is true when allowed namespaces are configured explicitly', () => {
+      storeClusterSettings('prod', { allowedNamespaces: ['team-a'] });
+      expect(hasAllowedNamespacesRestriction('prod')).toBe(true);
+    });
+
+    it('is true when a selector is configured but resolves to no namespaces', () => {
+      storeClusterSettings('prod', { allowedNamespacesSelector: 'team=frontend' });
+      storeResolvedAllowedNamespaces('prod', 'team=frontend', []);
+      expect(hasAllowedNamespacesRestriction('prod')).toBe(true);
     });
   });
 

--- a/frontend/src/helpers/clusterSettings.ts
+++ b/frontend/src/helpers/clusterSettings.ts
@@ -224,3 +224,17 @@ export function getCombinedAllowedNamespaces(cluster: string): string[] {
   const resolved = cache && cache.selector === selector ? cache.namespaces : [];
   return [...new Set([...(settings.allowedNamespaces || []), ...resolved])].sort();
 }
+
+/**
+ * Checks whether a cluster has an explicit or selector-based namespace restriction.
+ *
+ * @param cluster - Cluster whose settings should be checked.
+ * @returns Whether namespace access is restricted, including when a selector resolves empty.
+ */
+export function hasAllowedNamespacesRestriction(cluster: string): boolean {
+  const settings = loadClusterSettings(cluster);
+  return (
+    (settings.allowedNamespaces?.length ?? 0) > 0 ||
+    Boolean(settings.allowedNamespacesSelector?.trim())
+  );
+}

--- a/frontend/src/lib/k8s/KubeObject.ts
+++ b/frontend/src/lib/k8s/KubeObject.ts
@@ -18,10 +18,14 @@ import { JSONPath } from 'jsonpath-plus';
 import cloneDeep from 'lodash/cloneDeep';
 import unset from 'lodash/unset';
 import React, { useMemo } from 'react';
-import { getCombinedAllowedNamespaces } from '../../helpers/clusterSettings';
+import {
+  getCombinedAllowedNamespaces,
+  hasAllowedNamespacesRestriction,
+} from '../../helpers/clusterSettings';
 import { formatClusterPathParam, getCluster, getSelectedClusters } from '../cluster';
 import { createRouteURL } from '../router/createRouteURL';
 import { timeAgo } from '../util';
+import { AllowedNamespacesResolutionContext } from './allowedNamespacesContext';
 import { post } from './api/v1/clusterRequests';
 import type { DeleteParameters } from './api/v1/deleteParameters';
 import type {
@@ -390,10 +394,13 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
   ) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const fallbackClusters = useSelectedClusters();
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const allowedNamespacesResolutionKey = React.useContext(AllowedNamespacesResolutionContext);
+    const isNamespaced = this.isNamespaced;
 
     // Create requests for each cluster and namespace
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    const requests = useMemo(() => {
+    const { requests, emptyWhenNoRequests } = useMemo(() => {
       const clusterList = cluster
         ? [cluster]
         : clusters || (fallbackClusters.length === 0 ? [''] : fallbackClusters);
@@ -405,20 +412,34 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
           ? namespace
           : undefined;
 
-      return makeListRequests(
+      const requests = makeListRequests(
         clusterList,
         getAllowedNamespaces,
-        this.isNamespaced,
-        namespacesFromParams
+        isNamespaced,
+        namespacesFromParams,
+        hasAllowedNamespacesRestriction
       );
+      return {
+        requests,
+        emptyWhenNoRequests:
+          requests.length === 0 && clusterList.some(hasAllowedNamespacesRestriction),
+      };
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [cluster, clusters, fallbackClusters, namespace, this.isNamespaced]);
+    }, [
+      cluster,
+      clusters,
+      fallbackClusters,
+      namespace,
+      isNamespaced,
+      allowedNamespacesResolutionKey,
+    ]);
 
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const result = useKubeObjectList<K>({
       queryParams: queryParams,
       kubeObjectClass: this,
       requests,
+      emptyWhenNoRequests,
       refetchInterval,
     });
 

--- a/frontend/src/lib/k8s/allowedNamespaces.test.ts
+++ b/frontend/src/lib/k8s/allowedNamespaces.test.ts
@@ -73,6 +73,7 @@ describe('useAllowedNamespacesFromSelector', () => {
       expect.objectContaining({ clusters: ['prod'], labelSelector: 'team=frontend' })
     );
     expect(result.current.namespaces).toEqual(['a', 'b']);
+    expect(result.current.isSuccess).toBe(true);
     const cache = loadResolvedAllowedNamespaces('prod');
     expect(cache?.selector).toBe('team=frontend');
     expect(cache?.namespaces).toEqual(['a', 'b']);

--- a/frontend/src/lib/k8s/allowedNamespaces.test.ts
+++ b/frontend/src/lib/k8s/allowedNamespaces.test.ts
@@ -64,6 +64,22 @@ describe('useAllowedNamespacesFromSelector', () => {
     expect(result.current.namespaces).toEqual([]);
   });
 
+  it('does not query when no cluster is selected', () => {
+    mockList({ items: [], isFetching: true });
+
+    const { result } = renderHook(() => useAllowedNamespacesFromSelector('', 'team=frontend'));
+
+    expect(mockUseList).toHaveBeenCalledWith(
+      expect.objectContaining({ clusters: [], labelSelector: undefined })
+    );
+    expect(result.current).toEqual({
+      namespaces: [],
+      isFetching: false,
+      isSuccess: false,
+      error: null,
+    });
+  });
+
   it('caches the resolved namespaces on success, tagged with the selector', () => {
     mockList({ items: [ns('b'), ns('a')], isFetching: false });
 
@@ -108,5 +124,15 @@ describe('useAllowedNamespacesFromSelector', () => {
 
     expect(loadResolvedAllowedNamespaces('prod')?.namespaces).toEqual(['keep']);
     expect(result.current.isFetching).toBe(true);
+  });
+
+  it('keeps a fresh cache when the resolved namespaces are unchanged', () => {
+    storeResolvedAllowedNamespaces('prod', 'team=frontend', ['a']);
+    const resolvedAt = loadResolvedAllowedNamespaces('prod')?.resolvedAt;
+    mockList({ items: [ns('a')] });
+
+    renderHook(() => useAllowedNamespacesFromSelector('prod', 'team=frontend'));
+
+    expect(loadResolvedAllowedNamespaces('prod')?.resolvedAt).toBe(resolvedAt);
   });
 });

--- a/frontend/src/lib/k8s/allowedNamespaces.ts
+++ b/frontend/src/lib/k8s/allowedNamespaces.ts
@@ -61,7 +61,7 @@ export function useAllowedNamespacesFromSelector(
   const trimmedSelector = (selector ?? '').trim();
   const enabled = Boolean(cluster && trimmedSelector);
 
-  const { items, error, isError, isFetching, isSuccess } = Namespace.useList({
+  const { items, error, isError, isFetching } = Namespace.useList({
     clusters: enabled ? [cluster] : [],
     labelSelector: enabled ? trimmedSelector : undefined,
   });
@@ -98,7 +98,7 @@ export function useAllowedNamespacesFromSelector(
   return {
     namespaces: enabled ? namespaces : [],
     isFetching: enabled && isFetching,
-    isSuccess: enabled && isSuccess && !isError,
+    isSuccess: enabled && items !== null && !isError,
     error: isError ? error : null,
   };
 }

--- a/frontend/src/lib/k8s/allowedNamespacesContext.ts
+++ b/frontend/src/lib/k8s/allowedNamespacesContext.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+/** Identifies the current allowed-namespace selector resolution state. */
+export const AllowedNamespacesResolutionContext = React.createContext('');

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
@@ -565,7 +565,7 @@ describe('useKubeObjectList', () => {
     expect(response.skipWatch).toBeUndefined();
   });
 
-  it('returns an empty namespace list without fetching when a selector resolves empty', async () => {
+  it('uses a selector list when a namespace restriction resolves empty', async () => {
     const namespaceClass = class {
       static apiVersion = 'v1';
       static apiName = 'namespaces';
@@ -585,6 +585,9 @@ describe('useKubeObjectList', () => {
         resolvedAt: Date.now(),
       })
     );
+    mockClusterFetch.mockResolvedValueOnce({
+      json: () => Promise.resolve(makeListResponse({ kind: 'NamespaceList' })),
+    } as Response);
 
     const query = kubeObjectListQuery(
       namespaceClass,
@@ -597,7 +600,57 @@ describe('useKubeObjectList', () => {
 
     expect(response.list.items).toEqual([]);
     expect(response.skipWatch).toBe(true);
-    expect(mockClusterFetch).not.toHaveBeenCalled();
+    expect(mockClusterFetch).toHaveBeenCalledWith(
+      'api/v1/namespaces?labelSelector=team%3Dfrontend',
+      { cluster: 'restricted' }
+    );
+  });
+
+  it('lists selector-restricted namespaces without requiring per-name get access', async () => {
+    const namespaceClass = class {
+      static apiVersion = 'v1';
+      static apiName = 'namespaces';
+      static kind = 'Namespace';
+
+      constructor(public jsonData: any) {}
+    } as any;
+    localStorage.setItem(
+      'cluster_settings.restricted',
+      JSON.stringify({ allowedNamespacesSelector: 'team=frontend' })
+    );
+    localStorage.setItem(
+      'cluster_allowed_namespaces_selector_cache.restricted',
+      JSON.stringify({
+        selector: 'team=frontend',
+        namespaces: ['team-a'],
+        resolvedAt: Date.now(),
+      })
+    );
+    mockClusterFetch.mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve(
+          makeListResponse({
+            kind: 'NamespaceList',
+            items: [{ metadata: { name: 'team-a', labels: { team: 'frontend' } } }],
+          })
+        ),
+    } as Response);
+
+    const query = kubeObjectListQuery(
+      namespaceClass,
+      { version: 'v1', resource: 'namespaces' },
+      undefined,
+      'restricted',
+      {}
+    );
+    const response = await (query.queryFn as any)();
+
+    expect(mockClusterFetch).toHaveBeenCalledTimes(1);
+    expect(mockClusterFetch).toHaveBeenCalledWith(
+      'api/v1/namespaces?labelSelector=team%3Dfrontend',
+      { cluster: 'restricted' }
+    );
+    expect(response.list.items.map((item: any) => item.jsonData.metadata.name)).toEqual(['team-a']);
   });
 
   it('uses the labeled namespace query while resolving a selector', async () => {
@@ -634,7 +687,7 @@ describe('useKubeObjectList', () => {
     );
   });
 
-  it('does not use a cluster-wide query for an unrelated namespace selector', async () => {
+  it('intersects view selectors and only gets manually configured namespaces by name', async () => {
     const namespaceClass = class {
       static apiVersion = 'v1';
       static apiName = 'namespaces';
@@ -649,9 +702,22 @@ describe('useKubeObjectList', () => {
         allowedNamespacesSelector: 'team=frontend',
       })
     );
-    mockClusterFetch.mockResolvedValueOnce({
-      json: () => Promise.resolve({ metadata: { name: 'manual' } }),
-    } as Response);
+    mockClusterFetch.mockImplementation(async url => {
+      if (url === 'api/v1/namespaces/manual') {
+        return {
+          json: () => Promise.resolve({ metadata: { name: 'manual' } }),
+        } as Response;
+      }
+      return {
+        json: () =>
+          Promise.resolve(
+            makeListResponse({
+              kind: 'NamespaceList',
+              items: [{ metadata: { name: 'manual' } }, { metadata: { name: 'selected' } }],
+            })
+          ),
+      } as Response;
+    });
 
     const query = kubeObjectListQuery(
       namespaceClass,
@@ -660,11 +726,19 @@ describe('useKubeObjectList', () => {
       'restricted',
       { labelSelector: 'headlamp.dev/project-id' }
     );
-    await (query.queryFn as any)();
+    const response = await (query.queryFn as any)();
 
     expect(mockClusterFetch).toHaveBeenCalledWith('api/v1/namespaces/manual', {
       cluster: 'restricted',
     });
+    expect(mockClusterFetch).toHaveBeenCalledWith(
+      'api/v1/namespaces?labelSelector=team%3Dfrontend%2Cheadlamp.dev%2Fproject-id',
+      { cluster: 'restricted' }
+    );
+    expect(response.list.items.map((item: any) => item.jsonData.metadata.name)).toEqual([
+      'manual',
+      'selected',
+    ]);
   });
 
   it('does not watch the synthesized allowed namespace list', async () => {

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
@@ -66,6 +66,28 @@ describe('makeListRequests', () => {
       expect(requests).toEqual([{ cluster: 'default', namespaces: [] }]);
     });
 
+    it('should not make a cluster-wide request when a namespace restriction resolves empty', () => {
+      const requests = makeListRequests(
+        ['default'],
+        () => [],
+        true,
+        [],
+        () => true
+      );
+      expect(requests).toEqual([]);
+    });
+
+    it('should reject requested namespaces when a namespace restriction resolves empty', () => {
+      const requests = makeListRequests(
+        ['default'],
+        () => [],
+        true,
+        ['namespace-a'],
+        () => true
+      );
+      expect(requests).toEqual([]);
+    });
+
     it('should make requests for allowed namespaces only', () => {
       const requests = makeListRequests(['default'], () => ['namespace-a'], true);
       expect(requests).toEqual([{ cluster: 'default', namespaces: ['namespace-a'] }]);
@@ -77,6 +99,17 @@ describe('makeListRequests', () => {
         'namespace-b',
       ]);
       expect(requests).toEqual([{ cluster: 'default', namespaces: ['namespace-a'] }]);
+    });
+
+    it('should skip a cluster when requested namespaces do not intersect its allow-list', () => {
+      const requests = makeListRequests(
+        ['cluster-a', 'cluster-b'],
+        cluster => (cluster === 'cluster-a' ? ['namespace-a'] : ['namespace-b']),
+        true,
+        ['namespace-a'],
+        () => true
+      );
+      expect(requests).toEqual([{ cluster: 'cluster-a', namespaces: ['namespace-a'] }]);
     });
 
     it('should make requests for allowed namespaces per cluster', () => {
@@ -370,6 +403,46 @@ describe('useKubeObjectList', () => {
     localStorage.clear();
   });
 
+  it('returns an empty result without fetching when no list requests are allowed', () => {
+    const result = renderHook(
+      () =>
+        useKubeObjectList({
+          kubeObjectClass: mockClass,
+          requests: [],
+          emptyWhenNoRequests: true,
+        }),
+      { wrapper: queryClientWrapper(new QueryClient()) }
+    );
+
+    expect(result.result.current.items).toEqual([]);
+    expect(mockClusterFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not probe endpoints when no list requests are allowed', async () => {
+    const multiVersionClass = class {
+      static apiVersion = 'v1';
+      static apiName = 'ingresses';
+      static apiEndpoint = {
+        apiInfo: [
+          { group: 'networking.k8s.io', resource: 'ingresses', version: 'v1' },
+          { group: 'extensions', resource: 'ingresses', version: 'v1beta1' },
+        ],
+      };
+    } as any;
+
+    renderHook(
+      () =>
+        useKubeObjectList({
+          kubeObjectClass: multiVersionClass,
+          requests: [],
+          emptyWhenNoRequests: true,
+        }),
+      { wrapper: queryClientWrapper(new QueryClient()) }
+    );
+
+    await waitFor(() => expect(mockClusterFetch).not.toHaveBeenCalled());
+  });
+
   it('fetches allowed namespaces individually without starting a cluster-wide watch', async () => {
     const namespaceClass = class {
       static apiVersion = 'v1';
@@ -490,6 +563,108 @@ describe('useKubeObjectList', () => {
       cluster: 'unrestricted',
     });
     expect(response.skipWatch).toBeUndefined();
+  });
+
+  it('returns an empty namespace list without fetching when a selector resolves empty', async () => {
+    const namespaceClass = class {
+      static apiVersion = 'v1';
+      static apiName = 'namespaces';
+      static kind = 'Namespace';
+
+      constructor(public jsonData: any) {}
+    } as any;
+    localStorage.setItem(
+      'cluster_settings.restricted',
+      JSON.stringify({ allowedNamespacesSelector: 'team=frontend' })
+    );
+    localStorage.setItem(
+      'cluster_allowed_namespaces_selector_cache.restricted',
+      JSON.stringify({
+        selector: 'team=frontend',
+        namespaces: [],
+        resolvedAt: Date.now(),
+      })
+    );
+
+    const query = kubeObjectListQuery(
+      namespaceClass,
+      { version: 'v1', resource: 'namespaces' },
+      undefined,
+      'restricted',
+      {}
+    );
+    const response = await (query.queryFn as any)();
+
+    expect(response.list.items).toEqual([]);
+    expect(response.skipWatch).toBe(true);
+    expect(mockClusterFetch).not.toHaveBeenCalled();
+  });
+
+  it('uses the labeled namespace query while resolving a selector', async () => {
+    const namespaceClass = class {
+      static apiVersion = 'v1';
+      static apiName = 'namespaces';
+      static kind = 'Namespace';
+
+      constructor(public jsonData: any) {}
+    } as any;
+    localStorage.setItem(
+      'cluster_settings.restricted',
+      JSON.stringify({
+        allowedNamespaces: ['manual'],
+        allowedNamespacesSelector: 'team=frontend',
+      })
+    );
+    mockClusterFetch.mockResolvedValueOnce({
+      json: () => Promise.resolve(makeListResponse({ kind: 'NamespaceList' })),
+    } as Response);
+
+    const query = kubeObjectListQuery(
+      namespaceClass,
+      { version: 'v1', resource: 'namespaces' },
+      undefined,
+      'restricted',
+      { labelSelector: 'team=frontend' }
+    );
+    await (query.queryFn as any)();
+
+    expect(mockClusterFetch).toHaveBeenCalledWith(
+      'api/v1/namespaces?labelSelector=team%3Dfrontend',
+      { cluster: 'restricted' }
+    );
+  });
+
+  it('does not use a cluster-wide query for an unrelated namespace selector', async () => {
+    const namespaceClass = class {
+      static apiVersion = 'v1';
+      static apiName = 'namespaces';
+      static kind = 'Namespace';
+
+      constructor(public jsonData: any) {}
+    } as any;
+    localStorage.setItem(
+      'cluster_settings.restricted',
+      JSON.stringify({
+        allowedNamespaces: ['manual'],
+        allowedNamespacesSelector: 'team=frontend',
+      })
+    );
+    mockClusterFetch.mockResolvedValueOnce({
+      json: () => Promise.resolve({ metadata: { name: 'manual' } }),
+    } as Response);
+
+    const query = kubeObjectListQuery(
+      namespaceClass,
+      { version: 'v1', resource: 'namespaces' },
+      undefined,
+      'restricted',
+      { labelSelector: 'headlamp.dev/project-id' }
+    );
+    await (query.queryFn as any)();
+
+    expect(mockClusterFetch).toHaveBeenCalledWith('api/v1/namespaces/manual', {
+      cluster: 'restricted',
+    });
   });
 
   it('does not watch the synthesized allowed namespace list', async () => {

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -18,7 +18,6 @@ import type { QueryObserverOptions } from '@tanstack/react-query';
 import { useQueries, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  getCombinedAllowedNamespaces,
   hasAllowedNamespacesRestriction,
   loadClusterSettings,
 } from '../../../../helpers/clusterSettings';
@@ -72,12 +71,28 @@ export interface ListResponse<K extends KubeObject> {
   skipWatch?: boolean;
 }
 
+/**
+ * Builds a restricted Namespace query without broadening RBAC requirements.
+ * Manually configured namespaces use per-name GET requests, while selector-based
+ * restrictions retain LIST requests and intersect any selector from the caller.
+ *
+ * @param kubeObjectClass - Class used to instantiate Namespace objects.
+ * @param cluster - Cluster to query.
+ * @param queryParams - Additional Namespace list filters.
+ * @param refetchInterval - Optional query refetch interval.
+ * @returns Query options for the synthesized restricted Namespace list.
+ */
 function allowedNamespaceListQuery<K extends KubeObject>(
   kubeObjectClass: KubeObjectClass,
   cluster: string,
+  queryParams: QueryParameters,
   refetchInterval?: number
 ): QueryObserverOptions<ListResponse<K> | undefined | null, ApiError> {
-  const allowedNamespaces = getCombinedAllowedNamespaces(cluster);
+  const settings = loadClusterSettings(cluster);
+  const allowedNamespaces = settings.allowedNamespaces ?? [];
+  const configuredSelector = settings.allowedNamespacesSelector?.trim();
+  const requestedSelector = queryParams.labelSelector?.trim();
+  const selector = [configuredSelector, requestedSelector].filter(Boolean).join(',');
 
   return {
     placeholderData: null,
@@ -90,37 +105,68 @@ function allowedNamespaceListQuery<K extends KubeObject>(
       kubeObjectClass.apiName,
       cluster,
       '',
-      { allowedNamespaces },
+      { allowedNamespaces, selector },
     ],
     queryFn: async () => {
-      const items = await Promise.all(
-        allowedNamespaces.map(async name => {
-          try {
-            const item = await clusterFetch(makeUrl(['api', 'v1', 'namespaces', name]), {
+      const [manualItems, selectorList] = await Promise.all([
+        Promise.all(
+          allowedNamespaces.map(async name => {
+            try {
+              const item = await clusterFetch(makeUrl(['api', 'v1', 'namespaces', name]), {
+                cluster,
+              }).then(response => response.json());
+              if (item.metadata?.managedFields) {
+                delete item.metadata.managedFields;
+              }
+              const kubeObject = new kubeObjectClass(item) as K;
+              kubeObject.cluster = cluster;
+              return kubeObject;
+            } catch (error) {
+              if (error instanceof ApiError) {
+                error.cluster = cluster;
+                error.namespace = name;
+              }
+              throw error;
+            }
+          })
+        ),
+        configuredSelector
+          ? clusterFetch(makeUrl(['api', 'v1', 'namespaces'], { labelSelector: selector }), {
               cluster,
-            }).then(response => response.json());
-            if (item.metadata?.managedFields) {
-              delete item.metadata.managedFields;
-            }
-            const kubeObject = new kubeObjectClass(item) as K;
-            kubeObject.cluster = cluster;
-            return kubeObject;
-          } catch (error) {
-            if (error instanceof ApiError) {
-              error.cluster = cluster;
-              error.namespace = name;
-            }
-            throw error;
-          }
-        })
+            })
+              .then(response => response.json())
+              .catch(error => {
+                if (error instanceof ApiError) {
+                  error.cluster = cluster;
+                }
+                throw error;
+              })
+          : Promise.resolve(null),
+      ]);
+
+      const selectorItems = (selectorList?.items ?? []).map((item: any) => {
+        if (item.metadata?.managedFields) {
+          delete item.metadata.managedFields;
+        }
+        item.kind = selectorList.kind.replace(/List$/, '');
+        item.apiVersion = selectorList.apiVersion;
+        const kubeObject = new kubeObjectClass(item) as K;
+        kubeObject.cluster = cluster;
+        return kubeObject;
+      });
+      const items = [...manualItems, ...selectorItems].filter(
+        (item, index, allItems) =>
+          allItems.findIndex(
+            candidate => candidate.jsonData.metadata.name === item.jsonData.metadata.name
+          ) === index
       );
 
       return {
         list: {
           items,
-          kind: 'NamespaceList',
-          apiVersion: 'v1',
-          metadata: { resourceVersion: '0' },
+          kind: selectorList?.kind ?? 'NamespaceList',
+          apiVersion: selectorList?.apiVersion ?? 'v1',
+          metadata: { resourceVersion: selectorList?.metadata?.resourceVersion ?? '0' },
         } as KubeList<K>,
         cluster,
         skipWatch: true,
@@ -157,7 +203,7 @@ export function kubeObjectListQuery<K extends KubeObject>(
     !isResolvingAllowedNamespaces &&
     hasAllowedNamespacesRestriction(cluster)
   ) {
-    return allowedNamespaceListQuery<K>(kubeObjectClass, cluster, refetchInterval);
+    return allowedNamespaceListQuery<K>(kubeObjectClass, cluster, queryParams, refetchInterval);
   }
 
   return {

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -17,7 +17,11 @@
 import type { QueryObserverOptions } from '@tanstack/react-query';
 import { useQueries, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { loadClusterSettings } from '../../../../helpers/clusterSettings';
+import {
+  getCombinedAllowedNamespaces,
+  hasAllowedNamespacesRestriction,
+  loadClusterSettings,
+} from '../../../../helpers/clusterSettings';
 import type { KubeObject, KubeObjectClass } from '../../KubeObject';
 import type { QueryParameters } from '../v1/queryParameters';
 import { ApiError } from './ApiError';
@@ -73,7 +77,7 @@ function allowedNamespaceListQuery<K extends KubeObject>(
   cluster: string,
   refetchInterval?: number
 ): QueryObserverOptions<ListResponse<K> | undefined | null, ApiError> {
-  const allowedNamespaces = loadClusterSettings(cluster).allowedNamespaces ?? [];
+  const allowedNamespaces = getCombinedAllowedNamespaces(cluster);
 
   return {
     placeholderData: null,
@@ -143,9 +147,15 @@ export function kubeObjectListQuery<K extends KubeObject>(
   queryParams: QueryParameters,
   refetchInterval?: number
 ): QueryObserverOptions<ListResponse<K> | undefined | null, ApiError> {
+  const configuredSelector =
+    loadClusterSettings(cluster).allowedNamespacesSelector?.trim() || undefined;
+  const isResolvingAllowedNamespaces =
+    configuredSelector !== undefined && queryParams.labelSelector?.trim() === configuredSelector;
+
   if (
     kubeObjectClass.kind === 'Namespace' &&
-    (loadClusterSettings(cluster).allowedNamespaces?.length ?? 0) > 0
+    !isResolvingAllowedNamespaces &&
+    hasAllowedNamespacesRestriction(cluster)
   ) {
     return allowedNamespaceListQuery<K>(kubeObjectClass, cluster, refetchInterval);
   }
@@ -507,6 +517,7 @@ function useWatchKubeObjectListsLegacy<K extends KubeObject>({
  * @param getAllowedNamespaces -  function to get allowed namespaces for a cluster
  * @param isResourceNamespaced - if the resource is namespaced
  * @param requestedNamespaces - requested namespaces(optional)
+ * @param hasAllowedNamespacesRestriction - checks whether each cluster has an active restriction
  *
  * @returns list of requests for clusters and appropriate namespaces
  */
@@ -514,15 +525,27 @@ export function makeListRequests(
   clusters: string[],
   getAllowedNamespaces: (cluster: string | null) => string[],
   isResourceNamespaced: boolean,
-  requestedNamespaces: string[] = []
+  requestedNamespaces: string[] = [],
+  hasAllowedNamespacesRestriction: (cluster: string) => boolean = () => false
 ): Array<{ cluster: string; namespaces?: string[] }> {
-  return clusters.map(cluster => {
+  return clusters.flatMap(cluster => {
     const allowedNamespaces = getAllowedNamespaces(cluster);
+
+    if (
+      isResourceNamespaced &&
+      allowedNamespaces.length === 0 &&
+      hasAllowedNamespacesRestriction(cluster)
+    ) {
+      return [];
+    }
 
     let namespaces = requestedNamespaces.length > 0 ? requestedNamespaces : allowedNamespaces;
 
     if (allowedNamespaces.length) {
       namespaces = namespaces.filter(ns => allowedNamespaces.includes(ns));
+      if (isResourceNamespaced && namespaces.length === 0) {
+        return [];
+      }
     }
 
     return { cluster, namespaces: isResourceNamespaced ? namespaces : undefined };
@@ -594,6 +617,7 @@ export function useKubeObjectList<K extends KubeObject>({
   queryParams,
   watch = true,
   refetchInterval,
+  emptyWhenNoRequests = false,
 }: {
   requests: Array<{ cluster: string; namespaces?: string[] }>;
   /** Class to instantiate the object with */
@@ -603,6 +627,8 @@ export function useKubeObjectList<K extends KubeObject>({
   watch?: boolean;
   /** How often to refetch the list. Won't refetch by default. Disables watching if set. */
   refetchInterval?: number;
+  /** Return an empty list instead of a loading state when requests were intentionally suppressed. */
+  emptyWhenNoRequests?: boolean;
 }): [Array<K> | null, ApiError | null] &
   QueryListResponse<Array<ListResponse<K> | undefined | null>, K, ApiError> {
   const maybeNamespace = requests.find(it => it.namespaces)?.namespaces?.[0];
@@ -610,7 +636,7 @@ export function useKubeObjectList<K extends KubeObject>({
   // Get working endpoint from the first cluster
   // Now if clusters have different apiVersions for the same resource for example, this will not work
   const { endpoint, error: endpointError } = useEndpoints(
-    kubeObjectClass.apiEndpoint.apiInfo,
+    requests.length === 0 ? [] : kubeObjectClass.apiEndpoint.apiInfo,
     requests[0]?.cluster,
     maybeNamespace
   );
@@ -683,9 +709,12 @@ export function useKubeObjectList<K extends KubeObject>({
           }
           return acc;
         }, {} as Record<string, QueryListResponse<any, K, ApiError>>),
-        items: results.every(result => result.data === null)
-          ? null
-          : results.flatMap(result => result?.data?.list?.items ?? []),
+        items:
+          emptyWhenNoRequests && results.length === 0
+            ? []
+            : results.every(result => result.data === null)
+            ? null
+            : results.flatMap(result => result?.data?.list?.items ?? []),
         errors: results.map(result => result.error).filter(Boolean),
         isError: results.some(result => result.isError),
         isLoading: results.some(result => result.isLoading),


### PR DESCRIPTION
## Summary

An active namespace selector that resolved to no namespaces could be treated as an unrestricted configuration. Namespaced resource lists then fell back to cluster-wide requests.

This change preserves the distinction between unrestricted access and an active empty restriction, and waits for relevant selector results before rendering resource routes.

Related:
- https://github.com/kubernetes-sigs/headlamp/pull/6759


## Changes

- Detect explicit and selector-based namespace restrictions independently from their resolved namespace count.
- Suppress namespaced list requests and endpoint probes when an active restriction resolves empty.
- Resolve relevant multi-cluster selectors before rendering routes and refresh list requests without remounting routed page state.
- Use the shared restricted namespace query path for namespace and project views.

## Test coverage

- Added focused unit regression coverage before the implementation commits.
- Added seven Playwright scenarios for empty selectors, disjoint allow-lists,
  multi-cluster resolution, project routes, and selector refreshes.
- Full frontend suite: 225 files and 3,031 tests passed.
- Full-suite branch coverage for affected modules:
  - `clusterSettings.ts`: 95.91%
  - `allowedNamespaces.ts`: 97.22%
  - `useKubeObjectList.ts`: 85.65%

## Manual steps to reproduce

1. Configure a cluster with an allowed namespace selector that matches no namespaces.
2. Open the Pods page with a namespace query parameter, such as `/c/<cluster>/pods?namespace=default`.
3. Observe that no cluster-wide or namespaced Pod request is sent and the page displays an empty result.
4. Open the Namespaces page for the same cluster.
5. Observe that no unrestricted namespace list request is sent.
6. Change the selector so it resolves to an allowed namespace and confirm the current page state is preserved while resource requests refresh.

## Screenshots

Not applicable. The regression affects request authorization and suppression; the intended visible state remains the existing empty-list view.

Assisted by copilot