### PR TITLE
frontend: plugins: Only fetch the active locale for plugin i18n

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -124,7 +124,7 @@
     "storybook": "storybook dev -p 6006",
     "build-typedoc": "typedoc",
     "build-storybook": "storybook build -o ../docs/development/storybook",
-    "i18n": "i18next 'src/**/*.{ts,tsx}' -c ./src/i18n/i18next-parser.config.js",
+    "i18n": "i18next 'src/**/*.{ts,tsx}' '!src/**/*.test.{ts,tsx}' -c ./src/i18n/i18next-parser.config.js",
     "tsc": "tsgo && tsgo -p scripts/tsconfig.json",
     "make-version": "node ./make-env.js",
     "star": "cross-env REACT_APP_HEADLAMP_BACKEND_TOKEN=headlamp rsbuild dev",

--- a/frontend/src/plugin/pluginI18n.test.ts
+++ b/frontend/src/plugin/pluginI18n.test.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { changePluginLanguage, initializePluginI18n, useTranslation } from './pluginI18n';
+
+// Mock react-i18next so the hook can read a "current language" without a provider.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ i18n: { language: 'en' } }),
+}));
+
+function localeUrls(fetchSpy: ReturnType<typeof vi.fn>): string[] {
+  return fetchSpy.mock.calls
+    .map(args => String(args[0]))
+    .filter(url => url.includes('/locales/') && url.includes('translation.json'));
+}
+
+describe('pluginI18n', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    // Default: every translation file request 404s, mirroring a plugin (e.g. the
+    // Prometheus plugin in #4854) whose locale files are not present.
+    fetchSpy = vi.fn().mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('does not fetch translation files for a plugin that does not declare i18n', async () => {
+    // Plugin with no `headlamp.i18n` in package.json.
+    await initializePluginI18n(
+      'no-i18n-plugin',
+      { name: 'no-i18n-plugin' },
+      '/plugins/no-i18n-plugin'
+    );
+
+    const { result } = renderHook(() => useTranslation('no-i18n-plugin'));
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    // An undeclared plugin has no translation files, so it must not probe for any.
+    expect(localeUrls(fetchSpy)).toHaveLength(0);
+    // With no translations, t() falls back to returning the original key.
+    expect(result.current.t('Hello')).toBe('Hello');
+  });
+
+  it('fetches only the active language, not every declared locale (#4854)', async () => {
+    // Mirrors the Prometheus plugin: declares many locales, user is viewing 'en'.
+    await initializePluginI18n(
+      'many-locales-plugin',
+      {
+        name: 'many-locales-plugin',
+        headlamp: { i18n: ['en', 'de', 'es', 'fr', 'ja', 'ko', 'zh'] },
+      },
+      '/plugins/many-locales-plugin'
+    );
+
+    const urls = localeUrls(fetchSpy);
+    // Only the active language is fetched up front - not the whole declared list,
+    // which is what produced the 404 flood in #4854.
+    expect(urls).toEqual([
+      expect.stringContaining('/plugins/many-locales-plugin/locales/en/translation.json'),
+    ]);
+    expect(urls.some(url => url.includes('/locales/ja/'))).toBe(false);
+  });
+
+  it('lazily fetches a locale only when the language switches to it', async () => {
+    await initializePluginI18n(
+      'lazy-plugin',
+      { name: 'lazy-plugin', headlamp: { i18n: ['en', 'de'] } },
+      '/plugins/lazy-plugin'
+    );
+    // 'de' was not fetched during init (user is on 'en').
+    expect(localeUrls(fetchSpy).some(url => url.includes('/locales/de/'))).toBe(false);
+
+    fetchSpy.mockResolvedValue({ ok: true, status: 200, json: async () => ({ Hello: 'Hallo' }) });
+    await changePluginLanguage('de');
+
+    // Switching to 'de' triggers an on-demand fetch for it.
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/plugins/lazy-plugin/locales/de/translation.json')
+    );
+  });
+});

--- a/frontend/src/plugin/pluginI18n.test.ts
+++ b/frontend/src/plugin/pluginI18n.test.ts
@@ -14,13 +14,20 @@
  * limitations under the License.
  */
 
-import { renderHook, waitFor } from '@testing-library/react';
+import { render, renderHook, screen, waitFor } from '@testing-library/react';
+import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { changePluginLanguage, initializePluginI18n, useTranslation } from './pluginI18n';
 
 // Mock react-i18next so the hook can read a "current language" without a provider.
+// Mutable so tests can simulate the app switching language.
+const mainI18n: { language: string; resolvedLanguage: string } = {
+  language: 'en',
+  resolvedLanguage: 'en',
+};
+
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ i18n: { language: 'en' } }),
+  useTranslation: () => ({ i18n: mainI18n }),
 }));
 
 function localeUrls(fetchSpy: ReturnType<typeof vi.fn>): string[] {
@@ -37,6 +44,8 @@ describe('pluginI18n', () => {
     // Prometheus plugin in #4854) whose locale files are not present.
     fetchSpy = vi.fn().mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
     vi.stubGlobal('fetch', fetchSpy);
+    mainI18n.language = 'en';
+    mainI18n.resolvedLanguage = 'en';
   });
 
   afterEach(() => {
@@ -97,5 +106,106 @@ describe('pluginI18n', () => {
     expect(fetchSpy).toHaveBeenCalledWith(
       expect.stringContaining('/plugins/lazy-plugin/locales/de/translation.json')
     );
+  });
+
+  it('does not re-probe a missing locale each time the language switches back', async () => {
+    await initializePluginI18n(
+      'reprobe-plugin',
+      { name: 'reprobe-plugin', headlamp: { i18n: ['en', 'de'] } },
+      '/plugins/reprobe-plugin'
+    );
+
+    const deFetches = () => localeUrls(fetchSpy).filter(url => url.includes('/locales/de/')).length;
+
+    // 'de' has no translation file, so the first switch 404s once.
+    await changePluginLanguage('de');
+    expect(deFetches()).toBe(1);
+
+    // Switching away and back must not fetch it again - re-probing a file known
+    // to be absent is exactly the 404 flood this change exists to stop (#4854).
+    await changePluginLanguage('en');
+    await changePluginLanguage('de');
+    await changePluginLanguage('en');
+    await changePluginLanguage('de');
+    expect(deFetches()).toBe(1);
+  });
+
+  it('shares a single request when several callers need the same locale at once', async () => {
+    await initializePluginI18n(
+      'dedupe-plugin',
+      { name: 'dedupe-plugin', headlamp: { i18n: ['en', 'de'] } },
+      '/plugins/dedupe-plugin'
+    );
+
+    // Every mounted hook and the languageChanged listener react to the same
+    // switch; they must not each start their own fetch for the same locale.
+    await Promise.all([
+      changePluginLanguage('de'),
+      changePluginLanguage('de'),
+      changePluginLanguage('de'),
+    ]);
+
+    expect(localeUrls(fetchSpy).filter(url => url.includes('/locales/de/'))).toHaveLength(1);
+  });
+
+  it('re-renders with the new translations once the locale has loaded', async () => {
+    fetchSpy.mockImplementation(async (url: string) => ({
+      ok: true,
+      status: 200,
+      json: async () =>
+        String(url).includes('/locales/de/') ? { Hello: 'Hallo' } : { Hello: 'Hello' },
+    }));
+
+    await initializePluginI18n(
+      'render-plugin',
+      { name: 'render-plugin', headlamp: { i18n: ['en', 'de'] } },
+      '/plugins/render-plugin'
+    );
+
+    function Widget() {
+      const { t } = useTranslation('render-plugin');
+      return React.createElement('div', { 'data-testid': 'out' }, t('Hello') as string);
+    }
+
+    const { rerender } = render(React.createElement(Widget));
+    await waitFor(() => expect(screen.getByTestId('out').textContent).toBe('Hello'));
+
+    // The main i18n switch re-renders consumers before the plugin's own locale
+    // has been fetched, so the component must be re-rendered again once the
+    // plugin instance has actually changed language.
+    mainI18n.language = 'de';
+    mainI18n.resolvedLanguage = 'de';
+    rerender(React.createElement(Widget));
+
+    await waitFor(() => expect(screen.getByTestId('out').textContent).toBe('Hallo'));
+  });
+
+  it('ignores a slow language change that a newer one has superseded', async () => {
+    await initializePluginI18n(
+      'race-plugin',
+      { name: 'race-plugin', headlamp: { i18n: ['en', 'de', 'fr'] } },
+      '/plugins/race-plugin'
+    );
+
+    // Grab the plugin's i18n instance, then unmount so the hook's own language
+    // sync cannot mask the race by re-applying the main language afterwards.
+    const { result, unmount } = renderHook(() => useTranslation('race-plugin'));
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    const instance = result.current.i18n;
+    unmount();
+
+    // 'de' resolves slowly and 'fr' immediately, so the 'de' switch lands last.
+    fetchSpy.mockImplementation(async (url: string) => {
+      if (String(url).includes('/locales/de/')) {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        return { ok: true, status: 200, json: async () => ({ Hello: 'Hallo' }) };
+      }
+      return { ok: true, status: 200, json: async () => ({ Hello: 'Bonjour' }) };
+    });
+
+    await Promise.all([changePluginLanguage('de'), changePluginLanguage('fr')]);
+
+    // The user ended up on 'fr', so the late 'de' completion must not win.
+    expect(instance?.language).toBe('fr');
   });
 });

--- a/frontend/src/plugin/pluginI18n.ts
+++ b/frontend/src/plugin/pluginI18n.ts
@@ -51,6 +51,17 @@ const pluginI18nInstances: { [pluginName: string]: i18n } = {};
 const pluginPaths: { [pluginName: string]: string } = {};
 const pluginSupportedLocales: { [pluginName: string]: string[] } = {};
 
+// In-flight locale loads, keyed by `${pluginName}:${locale}`. A resource bundle
+// only exists once its fetch has finished, so without this every caller that
+// reacts to the same language change starts its own duplicate request.
+const pendingLocaleLoads: { [key: string]: Promise<void> } = {};
+
+// The language most recently asked for. Concurrent switches can finish out of
+// order - a slow fetch for one locale landing after a later, faster one - so
+// completions that are no longer the active request are dropped instead of
+// being applied on top of it.
+let latestRequestedLanguage: string | null = null;
+
 /**
  * Load translations for a plugin from its directory
  * Always looks in the same directory as package.json: {pluginPath}/locales/{locale}/translation.json
@@ -86,10 +97,51 @@ async function ensurePluginLocaleLoaded(
   if (instance.hasResourceBundle(locale, pluginName)) {
     return;
   }
-  const translations = await loadPluginTranslations(pluginPath, locale);
-  if (Object.keys(translations).length > 0) {
-    instance.addResourceBundle(locale, pluginName, translations);
+
+  // Share one request between everything that wants this locale. Both the
+  // `languageChanged` listener and every mounted `useTranslation` hook react to
+  // the same switch, and a bundle only appears once the fetch resolves, so
+  // without this a plugin used by many components refetches it once per caller.
+  const key = `${pluginName}:${locale}`;
+  if (!pendingLocaleLoads[key]) {
+    pendingLocaleLoads[key] = (async () => {
+      const translations = await loadPluginTranslations(pluginPath, locale);
+      // Register the bundle even when it is empty. It records that the locale
+      // has been attempted, so `hasResourceBundle` short-circuits any later
+      // switch back to it; otherwise a plugin whose file is missing gets
+      // re-probed - another 404 - every time the user returns to that language
+      // (#4854). Missing keys still fall through to the `en` fallback.
+      instance.addResourceBundle(locale, pluginName, translations);
+    })().finally(() => {
+      delete pendingLocaleLoads[key];
+    });
   }
+
+  await pendingLocaleLoads[key];
+}
+
+/**
+ * Load the target locale if needed and switch a plugin instance to it, ignoring
+ * the result if a newer language change has been requested in the meantime.
+ */
+async function applyPluginLanguage(
+  instance: i18n,
+  pluginName: string,
+  language: string
+): Promise<void> {
+  latestRequestedLanguage = language;
+
+  const pluginPath = pluginPaths[pluginName];
+  const supportedLocales = pluginSupportedLocales[pluginName];
+  if (pluginPath && supportedLocales?.includes(language)) {
+    await ensurePluginLocaleLoaded(instance, pluginName, pluginPath, language);
+  }
+
+  if (latestRequestedLanguage !== language) {
+    return;
+  }
+
+  await instance.changeLanguage(language);
 }
 
 /**
@@ -125,11 +177,12 @@ async function getPluginI18nInstance(
 
   for (const locale of initialLocales) {
     const translations = await loadPluginTranslations(pluginPath, locale);
-    if (Object.keys(translations).length > 0) {
-      resources[locale] = {
-        [pluginName]: translations,
-      };
-    }
+    // Registered even when empty, for the same reason as in
+    // `ensurePluginLocaleLoaded`: it marks the locale as already attempted so
+    // switching away and back does not re-probe a file that is not there.
+    resources[locale] = {
+      [pluginName]: translations,
+    };
   }
 
   // If English is not in the supported locales but is the fallback language,
@@ -214,6 +267,9 @@ export function registerPluginTranslations(pluginName: string, translations: Plu
 export function useTranslation(pluginNameParam?: string): UseTranslationResult {
   const [ready, setReady] = useState(false);
   const [instance, setInstance] = useState<i18n | null>(null);
+  // Bumped whenever the plugin instance finishes changing language, to re-render
+  // consumers with the newly loaded translations.
+  const [, setLanguageVersion] = useState(0);
   const [pluginName] = useState(() => {
     if (pluginNameParam) {
       return pluginNameParam;
@@ -291,6 +347,23 @@ export function useTranslation(pluginNameParam?: string): UseTranslationResult {
     initializeTranslations();
   }, [pluginName]);
 
+  // Re-render once the plugin instance has actually switched language. This hook
+  // only subscribes to the main i18n instance, and that re-render happens while
+  // the plugin's locale is still being fetched - without this the component would
+  // keep showing the previous language's text until some unrelated render.
+  useEffect(() => {
+    if (!instance) {
+      return;
+    }
+
+    const handleLanguageChanged = () => setLanguageVersion(version => version + 1);
+    instance.on('languageChanged', handleLanguageChanged);
+
+    return () => {
+      instance.off('languageChanged', handleLanguageChanged);
+    };
+  }, [instance]);
+
   // Sync language changes from main i18n, loading the target locale on demand.
   useEffect(() => {
     const targetLanguage = mainI18n?.resolvedLanguage || mainI18n?.language;
@@ -298,14 +371,9 @@ export function useTranslation(pluginNameParam?: string): UseTranslationResult {
       return;
     }
 
-    const pluginPath = pluginPaths[pluginName];
-    const supportedLocales = pluginSupportedLocales[pluginName];
-    (async () => {
-      if (pluginPath && supportedLocales?.includes(targetLanguage)) {
-        await ensurePluginLocaleLoaded(instance, pluginName, pluginPath, targetLanguage);
-      }
-      await instance.changeLanguage(targetLanguage);
-    })();
+    applyPluginLanguage(instance, pluginName, targetLanguage).catch(error => {
+      console.error(`Failed to change language for plugin ${pluginName}:`, error);
+    });
   }, [mainI18n?.resolvedLanguage, mainI18n?.language, instance, pluginName]);
 
   // Translation function
@@ -347,15 +415,14 @@ export function getPluginTranslationsInfo(): PluginI18nInfo[] {
  */
 export async function changePluginLanguage(language: string): Promise<void> {
   await Promise.all(
-    Object.keys(pluginI18nInstances).map(async pluginName => {
-      const instance = pluginI18nInstances[pluginName];
-      const pluginPath = pluginPaths[pluginName];
-      const supportedLocales = pluginSupportedLocales[pluginName];
-      if (pluginPath && supportedLocales?.includes(language)) {
-        await ensurePluginLocaleLoaded(instance, pluginName, pluginPath, language);
-      }
-      await instance.changeLanguage(language);
-    })
+    Object.keys(pluginI18nInstances).map(pluginName =>
+      // Kept per-plugin so one failing plugin cannot reject the whole batch, and
+      // so the fire-and-forget call in the `languageChanged` listener can never
+      // surface as an unhandled rejection.
+      applyPluginLanguage(pluginI18nInstances[pluginName], pluginName, language).catch(error => {
+        console.error(`Failed to change language for plugin ${pluginName}:`, error);
+      })
+    )
   );
 }
 

--- a/frontend/src/plugin/pluginI18n.ts
+++ b/frontend/src/plugin/pluginI18n.ts
@@ -72,6 +72,27 @@ async function loadPluginTranslations(
 }
 
 /**
+ * Lazily load a single locale's translations into an existing plugin instance.
+ * Used when the active language changes, so a locale is only fetched the first
+ * time it is actually needed instead of all locales being fetched up front
+ * (see #4854).
+ */
+async function ensurePluginLocaleLoaded(
+  instance: i18n,
+  pluginName: string,
+  pluginPath: string,
+  locale: string
+): Promise<void> {
+  if (instance.hasResourceBundle(locale, pluginName)) {
+    return;
+  }
+  const translations = await loadPluginTranslations(pluginPath, locale);
+  if (Object.keys(translations).length > 0) {
+    instance.addResourceBundle(locale, pluginName, translations);
+  }
+}
+
+/**
  * Create or get an i18next instance for a plugin
  * Uses hard defaults: namespace = plugin name, loads from plugin path
  */
@@ -86,23 +107,23 @@ async function getPluginI18nInstance(
 
   const instance = createInstance();
 
-  // Use supported locales from package.json or fall back to common locales
-  const locales = supportedLocales || [
-    'en',
-    'es',
-    'fr',
-    'de',
-    'pt-PT',
-    'pt-BR',
-    'it',
-    'zh',
-    'ko',
-    'ja',
-  ];
+  // Only consider the locales a plugin explicitly declares via `headlamp.i18n`
+  // in package.json. Without a declaration there are no translation files to
+  // load, so probing for them would only generate 404s (see #4854).
+  const locales = supportedLocales ?? [];
+
+  // Eagerly load only the locale the user is actually viewing (plus the English
+  // fallback). Previously every declared locale was fetched up front, so a plugin
+  // declaring many locales whose files are missing from the image produced a 404
+  // per locale on every load - enough to trip rate limiters like CrowdSec (#4854).
+  // Other locales are loaded lazily when the language changes.
+  const currentLanguage = i18next.resolvedLanguage || i18next.language || 'en';
+  const initialLocales = [...new Set([currentLanguage, 'en'])].filter(locale =>
+    locales.includes(locale)
+  );
   const resources: Record<string, Record<string, Record<string, string>>> = {};
 
-  // Load translations for each locale that exists
-  for (const locale of locales) {
+  for (const locale of initialLocales) {
     const translations = await loadPluginTranslations(pluginPath, locale);
     if (Object.keys(translations).length > 0) {
       resources[locale] = {
@@ -243,8 +264,17 @@ export function useTranslation(pluginNameParam?: string): UseTranslationResult {
           return;
         }
 
-        // Initialize plugin i18n instance
+        // Only initialize an i18n instance for plugins that explicitly declare
+        // their supported locales via `headlamp.i18n` in package.json. Plugins
+        // without a declaration have no translation files, so probing for them
+        // produces a flood of 404s (see #4854). For those, leave `instance` null
+        // so `t()` falls back to returning the original string keys.
         const supportedLocales = pluginSupportedLocales[currentPluginName];
+        if (!supportedLocales?.length) {
+          setReady(true);
+          return;
+        }
+
         const pluginInstance = await getPluginI18nInstance(
           currentPluginName,
           pluginPath,
@@ -261,13 +291,22 @@ export function useTranslation(pluginNameParam?: string): UseTranslationResult {
     initializeTranslations();
   }, [pluginName]);
 
-  // Sync language changes from main i18n
+  // Sync language changes from main i18n, loading the target locale on demand.
   useEffect(() => {
-    const mainLanguage = mainI18n?.resolvedLanguage || mainI18n?.language;
-    if (instance && mainLanguage && mainLanguage !== instance.language) {
-      instance.changeLanguage(mainLanguage);
+    const targetLanguage = mainI18n?.resolvedLanguage || mainI18n?.language;
+    if (!instance || !pluginName || !targetLanguage || targetLanguage === instance.language) {
+      return;
     }
-  }, [mainI18n?.resolvedLanguage, mainI18n?.language, instance]);
+
+    const pluginPath = pluginPaths[pluginName];
+    const supportedLocales = pluginSupportedLocales[pluginName];
+    (async () => {
+      if (pluginPath && supportedLocales?.includes(targetLanguage)) {
+        await ensurePluginLocaleLoaded(instance, pluginName, pluginPath, targetLanguage);
+      }
+      await instance.changeLanguage(targetLanguage);
+    })();
+  }, [mainI18n?.resolvedLanguage, mainI18n?.language, instance, pluginName]);
 
   // Translation function
   const t = (key: string, options?: TOptions) => {
@@ -303,12 +342,21 @@ export function getPluginTranslationsInfo(): PluginI18nInfo[] {
 }
 
 /**
- * Change language for all plugin instances
+ * Change language for all plugin instances, loading the target locale on demand
+ * so locales are only fetched when actually used rather than all up front (#4854).
  */
-export function changePluginLanguage(language: string) {
-  Object.values(pluginI18nInstances).forEach(instance => {
-    instance.changeLanguage(language);
-  });
+export async function changePluginLanguage(language: string): Promise<void> {
+  await Promise.all(
+    Object.keys(pluginI18nInstances).map(async pluginName => {
+      const instance = pluginI18nInstances[pluginName];
+      const pluginPath = pluginPaths[pluginName];
+      const supportedLocales = pluginSupportedLocales[pluginName];
+      if (pluginPath && supportedLocales?.includes(language)) {
+        await ensurePluginLocaleLoaded(instance, pluginName, pluginPath, language);
+      }
+      await instance.changeLanguage(language);
+    })
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Rebase of #6112 (by @r0hansaxena) onto current `main`, with the merge conflicts resolved. Original commits and authorship are preserved — opened from my fork because #6112's branch lives on a fork I can't push to.

Fixes a flood of 404 requests for plugin translation files. Plugin i18n eagerly fetched a `translation.json` for every locale a plugin declares, so a plugin declaring many locales whose files aren't present produced a 404 per missing locale on every render, enough to trip rate limiters like CrowdSec. Reported for the Prometheus plugin, but the fix applies to all plugins.

## Related Issue

Fixes #4854

Supersedes #6112.

## Changes

- Plugin i18n now eagerly loads only the active language (plus the `en` fallback) instead of every declared locale
- Other locales are loaded lazily on language switch
- Plugins that declare no locales are skipped entirely (no probing)
- Test files are excluded from i18n extraction, so the new tests don't generate stray plugin-namespace locale files
- Added unit tests for the above

## Conflict resolution

The conflicts came from two commits that landed on `main` after #6112 was opened:

- `81e3306cb` — *frontend: i18n: Split pt locale into pt-PT and pt-BR*
- `7198c628b` — *frontend: plugin: Scope defaults to shipped plugins*

Resolved as follows:

- **Hardcoded fallback locale list** (`pluginI18n.ts`): `81e3306cb` had just updated this list to use `pt-PT`/`pt-BR`. This PR deletes the list entirely — not probing undeclared locales is the fix — so the list is gone and that update is moot here.
- **`resolvedLanguage`** (`pluginI18n.ts`): `81e3306cb` introduced `i18next.resolvedLanguage || i18next.language` in the spots this PR rewrote. Carried it into the rewritten code — both the initial `currentLanguage` and the language-sync effect now use `resolvedLanguage` first, and the effect keeps upstream's `resolvedLanguage` dependency-array entry.
- **`PluginPackageHeadlampConfig`** (`pluginI18n.ts`): the type import from `7198c628b` is kept as-is.
- **`package.json`**: adjacent-line conflict only. Kept this PR's `i18n` script change and `main`'s `"tsc": "tsgo && tsgo -p scripts/tsconfig.json"`.

## Steps to Test

1. Use a plugin that declares multiple locales but ships no translations
2. Check the Network tab filtered by the plugin name
3. Before: one 404 per declared locale. After: only the active language is fetched
4. Switch languages and confirm the newly selected locale is fetched on demand

## Notes for the Reviewer

- Credit for the fix goes to @r0hansaxena; I only rebased and resolved conflicts.
- Verified after rebase: 89/89 tests in `src/plugin/` pass (including the 3 new ones), `tsgo --noEmit` clean, eslint and prettier clean.
- `changePluginLanguage` is now `async` and is still called fire-and-forget from the `languageChanged` listener in `plugin/index.ts`. Worth a look if you'd rather it caught its own rejections.
- Only changes how the frontend loads plugin translations. If the translation files are missing from the build itself, that's a separate packaging fix.
