### PR TITLE
backend: telemetry: Fix data race in hijack test

### DIFF
--- a/backend/pkg/telemetry/metrics_test.go
+++ b/backend/pkg/telemetry/metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	tel "github.com/kubernetes-sigs/headlamp/backend/pkg/telemetry"
 	"github.com/stretchr/testify/assert"
@@ -224,19 +225,23 @@ func TestResponseWriterHijack_SucceedsWithUnderlyingHijacker(t *testing.T) {
 	metrics, err := tel.NewMetrics()
 	require.NoError(t, err)
 
-	called := false
+	type hijackOutcome struct {
+		isHijacker bool
+		hijackErr  error
+	}
+
+	outcome := make(chan hijackOutcome, 1)
 
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hj, ok := w.(http.Hijacker)
-		require.True(t, ok, "wrapped writer should implement http.Hijacker")
+		if !ok {
+			outcome <- hijackOutcome{}
 
-		conn, rw, err := hj.Hijack()
-		require.NoError(t, err, "expected Hijack to succeed when underlying supports it")
+			return
+		}
 
-		called = true
-
-		// rw is intentionally unused; we just ensure Hijack succeeded.
-		_ = rw
+		conn, _, hijackErr := hj.Hijack()
+		outcome <- hijackOutcome{isHijacker: true, hijackErr: hijackErr}
 
 		if conn != nil {
 			_ = conn.Close()
@@ -257,7 +262,13 @@ func TestResponseWriterHijack_SucceedsWithUnderlyingHijacker(t *testing.T) {
 
 	_ = doErr // ignore errors due to hijacking
 
-	assert.True(t, called, "handler should have executed and called Hijack")
+	select {
+	case result := <-outcome:
+		assert.True(t, result.isHijacker, "wrapped writer should implement http.Hijacker")
+		assert.NoError(t, result.hijackErr, "expected Hijack to succeed when underlying supports it")
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler did not execute")
+	}
 }
 
 func TestResponseWriterHijack_ReturnsErrorWhenUnderlyingNotHijacker(t *testing.T) {


### PR DESCRIPTION
## Summary

`TestResponseWriterHijack_SucceedsWithUnderlyingHijacker` races on the `called` flag: the handler runs on an `httptest.Server` goroutine and writes it, while the test goroutine reads it in the final assertion. The handler hijacks and closes the connection, so the client request returns without any happens-before edge to that write.

The handler also calls `require.True` and `require.NoError`, which call `t.FailNow()` from a non-test goroutine. The `testing` docs require `FailNow` to be called from the goroutine running the test.

This was the only data race in the backend.

## Related Issue

Fixes #7366

## Changes

- Publish the handler's result to the test goroutine over a buffered channel instead of a shared bool, which supplies the missing happens-before edge.
- Move the assertions onto the test goroutine, so `require`/`assert` are no longer called from the server goroutine.
- Fail with a timeout if the handler never runs, rather than asserting on an unset value.

## Steps to Test

1. `cd backend && go test -race -count=1 -run TestResponseWriterHijack ./pkg/telemetry/`
2. Confirm it passes. On `main` the same command reports `WARNING: DATA RACE` and fails.
3. Whole backend is race-clean: `cd backend && go test -race -p 1 -count=1 ./...`
