### PR TITLE
frontend: workloads: Scope the overview lists to the namespace filter

### DIFF
--- a/frontend/src/components/workload/Overview.test.tsx
+++ b/frontend/src/components/workload/Overview.test.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Registers the app's routes before the k8s classes load. Without it importing a
+// resource class from a components/ test hits the router <-> KubeObject import
+// cycle. See https://github.com/kubernetes-sigs/headlamp/issues/7102
+import '../../lib/router';
+import { ThemeProvider } from '@mui/material/styles';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { createMuiTheme } from '../../lib/themes';
+import { TestContext } from '../../test';
+import { lightTheme } from '../App/defaultAppThemes';
+import Overview from './Overview';
+
+const { selectedNamespaces } = vi.hoisted(() => ({ selectedNamespaces: [] as string[] }));
+
+vi.mock('../../redux/filterSlice', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../redux/filterSlice')>()),
+  useNamespaces: () => selectedNamespaces,
+}));
+
+const server = setupServer();
+const requestedPaths: string[] = [];
+
+server.events.on('request:start', ({ request }) => {
+  requestedPaths.push(new URL(request.url).pathname);
+});
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
+afterEach(() => {
+  server.resetHandlers();
+  requestedPaths.length = 0;
+  selectedNamespaces.length = 0;
+});
+afterAll(() => server.close());
+
+/** Paths of the list requests the page made, ignoring anything else. */
+async function listPathsAfterRender() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={createMuiTheme(lightTheme)}>
+        <TestContext>
+          <Overview />
+        </TestContext>
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+
+  await waitFor(() => expect(requestedPaths.some(path => path.endsWith('/pods'))).toBe(true));
+
+  return requestedPaths;
+}
+
+describe('Workloads Overview', () => {
+  // The charts used to always count the whole cluster, so they disagreed with the
+  // table below them, and a user without cluster-wide list permission saw nothing.
+  // See https://github.com/kubernetes-sigs/headlamp/issues/7343
+  it('scopes its lists to the selected namespaces', async () => {
+    selectedNamespaces.push('team-a');
+
+    const paths = await listPathsAfterRender();
+
+    expect(paths).toContain('/api/v1/namespaces/team-a/pods');
+    expect(paths).toContain('/apis/apps/v1/namespaces/team-a/deployments');
+    expect(paths).not.toContain('/api/v1/pods');
+  });
+
+  it('lists cluster-wide when no namespace is selected', async () => {
+    const paths = await listPathsAfterRender();
+
+    expect(paths).toContain('/api/v1/pods');
+    expect(paths.some(path => path.includes('/namespaces/'))).toBe(false);
+  });
+});

--- a/frontend/src/components/workload/Overview.tsx
+++ b/frontend/src/components/workload/Overview.tsx
@@ -28,6 +28,7 @@ import ReplicaSet from '../../lib/k8s/replicaSet';
 import StatefulSet from '../../lib/k8s/statefulSet';
 import type { Workload, WorkloadClass } from '../../lib/k8s/Workload';
 import { getReadyReplicas, getTotalReplicas } from '../../lib/util';
+import { useNamespaces } from '../../redux/filterSlice';
 import Link from '../common/Link';
 import { PageGrid } from '../common/Resource';
 import ResourceListView from '../common/Resource/ResourceListView';
@@ -39,15 +40,19 @@ interface WorkloadDict {
 }
 
 export default function Overview() {
-  const [pods] = Pod.useList();
-  const [deployments] = Deployment.useList();
-  const [statefulSets] = StatefulSet.useList();
-  const [daemonSets] = DaemonSet.useList();
-  const [replicaSets] = ReplicaSet.useList();
-  const [jobs] = Job.useList();
-  const [cronJobs] = CronJob.useList();
-  const [jobSets] = JobSet.useList();
-  const [leaderWorkerSets] = LeaderWorkerSet.useList();
+  // Scope every list to the selected namespaces. Without this the charts always
+  // count the whole cluster, ignoring the filter the table below honours, and a
+  // user without cluster-wide list permission gets nothing at all.
+  const namespaces = useNamespaces();
+  const [pods] = Pod.useList({ namespace: namespaces });
+  const [deployments] = Deployment.useList({ namespace: namespaces });
+  const [statefulSets] = StatefulSet.useList({ namespace: namespaces });
+  const [daemonSets] = DaemonSet.useList({ namespace: namespaces });
+  const [replicaSets] = ReplicaSet.useList({ namespace: namespaces });
+  const [jobs] = Job.useList({ namespace: namespaces });
+  const [cronJobs] = CronJob.useList({ namespace: namespaces });
+  const [jobSets] = JobSet.useList({ namespace: namespaces });
+  const [leaderWorkerSets] = LeaderWorkerSet.useList({ namespace: namespaces });
 
   const workloadsData: WorkloadDict = useMemo(
     () => ({


### PR DESCRIPTION
## Summary

The workloads overview called `Pod.useList()`, `Deployment.useList()` and the rest without a namespace, so every list went cluster-wide. Two things followed from that: the charts counted the whole cluster while the table under them honoured the namespace filter, and a user without cluster-wide list permission got nothing at all, because the requests failed no matter which namespace they picked.

This passes the selected namespaces into those calls, the way the pods list already does, which fixes both symptoms at once. With no namespace selected the lists stay cluster-wide, so the admin view is unchanged.

## Related Issue

Fixes #7343

## Changes

- `components/workload/Overview.tsx`: take `useNamespaces()` and pass `{ namespace: namespaces }` into all nine `useList()` calls, matching the pattern in `components/pod/List.tsx`
- Added `components/workload/Overview.test.tsx`, which asserts the page requests the namespaced endpoints when a filter is set, and the cluster-wide ones when it isn't

## Steps to Test

1. Open the Workloads page as an admin and confirm the charts and table look as before
2. Pick a namespace in the filter — the charts should now follow it, matching the table below
3. As a user with access to only some namespaces, open Workloads and filter to a namespace you can access; resources and charts should both populate, where before both stayed empty
4. `cd frontend && npx vitest run src/components/workload/Overview.test.tsx`

## Screenshots (if applicable)

<!-- before/after of the charts with a namespace selected -->

## Notes for the Reviewer

- An empty namespace array falls through to a cluster-wide request in `buildListRequests` (`lib/k8s/api/v2/useKubeObjectList.ts`), so the unfiltered path is untouched
- The test starts with `import '../../lib/router'`. Without it, importing a resource class from a `components/` test hits the router ↔ KubeObject import cycle from #7102 and crashes on load. That line can come out once #7136 lands
- The existing `Overview.Workloads` storyshot is unchanged, since that story sets no namespace filter
- Full suite passes (227 files / 3046 tests), `tsc --noEmit` and lint clean
