### PR TITLE
fix(frontend): validate container port is within 1-65535 range

### DIFF
--- a/frontend/src/components/common/Resource/CreateResourceForm/CreateResourceForm.test.tsx
+++ b/frontend/src/components/common/Resource/CreateResourceForm/CreateResourceForm.test.tsx
@@ -215,3 +215,93 @@ describe('CreateResourceForm – select field', () => {
     });
   });
 });
+
+// Regression coverage for container port range validation. The field previously
+// persisted out-of-range integers such as 99999, which Kubernetes rejected on
+// submit. It also used parseInt, so strings such as "65535.9" and "1e5" were
+// silently changed to 65535 and 1; the tests below ensure these inputs are not
+// persisted as different ports.
+describe('ContainerTextField container port validation', () => {
+  function renderContainersWithOnChange(value: unknown) {
+    const onChange = vi.fn();
+    const utils = render(<ContainerTextField value={value as any} onChange={onChange} />);
+    return { onChange, ...utils };
+  }
+
+  it('drops the port when the value exceeds the valid range (99999)', () => {
+    const { getByLabelText, onChange } = renderContainersWithOnChange([
+      { name: 'c1', image: 'nginx', ports: [{ containerPort: 80 }] },
+    ]);
+    fireEvent.change(getByLabelText('Container Port'), { target: { value: '99999' } });
+    const updated = onChange.mock.calls.at(-1)?.[0];
+    expect(updated[0].ports).toBeUndefined();
+    expect(updated[0].containerPort).toBeUndefined();
+  });
+
+  it('drops the port when the value is 0 or negative', () => {
+    const { getByLabelText, onChange } = renderContainersWithOnChange([
+      { name: 'c1', image: 'nginx', ports: [{ containerPort: 80 }] },
+    ]);
+    fireEvent.change(getByLabelText('Container Port'), { target: { value: '0' } });
+    let updated = onChange.mock.calls.at(-1)?.[0];
+    expect(updated[0].ports).toBeUndefined();
+
+    fireEvent.change(getByLabelText('Container Port'), { target: { value: '-1' } });
+    updated = onChange.mock.calls.at(-1)?.[0];
+    expect(updated[0].ports).toBeUndefined();
+  });
+
+  it('keeps a valid port at the upper boundary (65535)', () => {
+    const { getByLabelText, onChange } = renderContainersWithOnChange([
+      { name: 'c1', image: 'nginx', ports: [{ containerPort: 80 }] },
+    ]);
+    fireEvent.change(getByLabelText('Container Port'), { target: { value: '65535' } });
+    const updated = onChange.mock.calls.at(-1)?.[0];
+    expect(updated[0].ports).toEqual([{ containerPort: 65535 }]);
+  });
+
+  it('keeps a valid ordinary port (8080)', () => {
+    const { getByLabelText, onChange } = renderContainersWithOnChange([
+      { name: 'c1', image: 'nginx', ports: [{ containerPort: 80 }] },
+    ]);
+    fireEvent.change(getByLabelText('Container Port'), { target: { value: '8080' } });
+    const updated = onChange.mock.calls.at(-1)?.[0];
+    expect(updated[0].ports).toEqual([{ containerPort: 8080 }]);
+  });
+
+  it('drops the port for exponential notation input (1e5)', () => {
+    const { getByLabelText, onChange } = renderContainersWithOnChange([
+      { name: 'c1', image: 'nginx', ports: [{ containerPort: 80 }] },
+    ]);
+    fireEvent.change(getByLabelText('Container Port'), { target: { value: '1e5' } });
+    const updated = onChange.mock.calls.at(-1)?.[0];
+    expect(updated[0].ports).toBeUndefined();
+  });
+
+  it('drops the port for fractional input (65535.9)', () => {
+    const { getByLabelText, onChange } = renderContainersWithOnChange([
+      { name: 'c1', image: 'nginx', ports: [{ containerPort: 80 }] },
+    ]);
+    fireEvent.change(getByLabelText('Container Port'), { target: { value: '65535.9' } });
+    const updated = onChange.mock.calls.at(-1)?.[0];
+    expect(updated[0].ports).toBeUndefined();
+  });
+
+  it('drops the port when it is 1 above the max (65536)', () => {
+    const { getByLabelText, onChange } = renderContainersWithOnChange([
+      { name: 'c1', image: 'nginx', ports: [{ containerPort: 80 }] },
+    ]);
+    fireEvent.change(getByLabelText('Container Port'), { target: { value: '65536' } });
+    const updated = onChange.mock.calls.at(-1)?.[0];
+    expect(updated[0].ports).toBeUndefined();
+  });
+
+  it('keeps a valid port at the lower boundary (1)', () => {
+    const { getByLabelText, onChange } = renderContainersWithOnChange([
+      { name: 'c1', image: 'nginx', ports: [{ containerPort: 80 }] },
+    ]);
+    fireEvent.change(getByLabelText('Container Port'), { target: { value: '1' } });
+    const updated = onChange.mock.calls.at(-1)?.[0];
+    expect(updated[0].ports).toEqual([{ containerPort: 1 }]);
+  });
+});

--- a/frontend/src/components/common/Resource/CreateResourceForm/workloadFields.tsx
+++ b/frontend/src/components/common/Resource/CreateResourceForm/workloadFields.tsx
@@ -212,9 +212,10 @@ export function ContainerTextField(props: ContainerTextFieldProps) {
       safeValue.map((c, i) => {
         if (i !== index) return c;
         if (field === 'containerPort') {
-          const portNum = parseInt(newVal, 10);
+          const trimmed = newVal.trim();
+          const portNum = Number(trimmed);
           const rest = _.omit(c, ['containerPort', 'ports']);
-          if (!isNaN(portNum) && portNum > 0) {
+          if (trimmed !== '' && Number.isInteger(portNum) && portNum > 0 && portNum <= 65535) {
             return { ...rest, ports: [{ containerPort: portNum }] };
           }
           return rest;


### PR DESCRIPTION
## PR Summary

This PR fixes a validation bug in the CreateResourceForm container editor by rejecting container port values outside the valid TCP/UDP range (1-65535).

## Related Issue

Fixes #7354

## Changes

- Fixed the container port validation in `ContainerTextField`'s `handleEdit` function (`frontend/src/components/common/Resource/CreateResourceForm/workloadFields.tsx`)
- Previously the field only checked `portNum > 0`, so values like `99999` or `500000` were accepted with no error and silently stored, only to be rejected later by the Kubernetes API server on submit
- The condition now also checks `portNum <= 65535`, so out-of-range values are dropped the same way a non-numeric or non-positive value already was

## Steps to Test

1. Go to Workloads > Deployments (or any create form using this container editor, e.g. CreateJobForm, CreateCronJobForm, CreateDaemonSetForm) > Create
2. Click "New Container" to add a container row
3. In the "Container Port" field, enter `99999`
4. Before this fix: the value is accepted with no validation error
5. After this fix: the value is dropped/not persisted on the container entry
6. Enter a valid port like `8080` or the boundary value `65535` and confirm it is accepted as before

## Screenshots (if applicable) 
N/A



