### PR TITLE
app: pin feed-compatible AI dependencies

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8,6 +8,8 @@
       "name": "headlamp",
       "version": "0.44.0",
       "dependencies": {
+        "@langchain/core": "1.2.7",
+        "@langchain/langgraph": "1.4.9",
         "@langchain/mcp-adapters": "^1.0.0",
         "copyfiles": "^2.4.1",
         "cross-env": "^7.0.3",
@@ -64,8 +66,7 @@
     },
     "node_modules/@cfworker/json-schema": {
       "version": "4.1.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@electron/asar": {
       "version": "3.4.1",
@@ -1203,11 +1204,10 @@
       "license": "MIT"
     },
     "node_modules/@langchain/core": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.9.tgz",
-      "integrity": "sha512-conzSEj9Zu1AyXJLXsSbgrtxtxinmI1yGqQ5CIJZSoV5rvv+yvQE/vgBnoySpBQ/bl3YPgj2FL/gbDjWykLSfg==",
+      "version": "1.2.7",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@langchain/core/-/core-1.2.7.tgz",
+      "integrity": "sha1-tbjDmcD8XjNwg/fWXxdA9rve5Jg=",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "@standard-schema/spec": "^1.1.0",
@@ -1222,14 +1222,13 @@
       }
     },
     "node_modules/@langchain/langgraph": {
-      "version": "1.4.12",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.12.tgz",
-      "integrity": "sha512-63iH/igH5Fh5fHqmWp09YYWaDKKB9v4RCmYNJBrnQ224rFRbjebgyYW6o5RCczN5FZxIhQj+xT51rrNmG0zi5A==",
+      "version": "1.4.9",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@langchain/langgraph/-/langgraph-1.4.9.tgz",
+      "integrity": "sha1-jsbyqxIA9W3Pe55E2DjJVrI7enM=",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@langchain/langgraph-checkpoint": "^1.1.5",
-        "@langchain/langgraph-sdk": "~1.9.30",
+        "@langchain/langgraph-checkpoint": "^1.1.3",
+        "@langchain/langgraph-sdk": "~1.9.28",
         "@langchain/protocol": "^0.0.18",
         "@standard-schema/spec": "1.1.0"
       },
@@ -1241,12 +1240,11 @@
         "zod": "^3.25.32 || ^4.2.0"
       }
     },
-    "node_modules/@langchain/langgraph-checkpoint": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.5.tgz",
-      "integrity": "sha512-BwDwl5VeTOh6CVuiIPgsUgfK51vTJDMSbFcSCUfjJWsl8/DPdK/mbv+ejxJstkSk/BlSPMP4JfXWcN6jD2ea2Q==",
+    "node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-checkpoint": {
+      "version": "1.1.3",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.3.tgz",
+      "integrity": "sha1-iR8vmi6Wzyqwkg+SQPmtHgqGpKs=",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1254,12 +1252,11 @@
         "@langchain/core": "^1.1.48"
       }
     },
-    "node_modules/@langchain/langgraph-sdk": {
-      "version": "1.9.30",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.30.tgz",
-      "integrity": "sha512-hPzbhenvvFRn46PHnlkad3E+TuUIfRhNGpekR5cY12D1WKh3Viwfyz9HpzCbfVebChU9Kgk494V9RJTnh1jrPQ==",
+    "node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk": {
+      "version": "1.9.29",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.29.tgz",
+      "integrity": "sha1-VyO9Io/hRcsNq2Pe9IWzmk7r9Vc=",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@langchain/protocol": "^0.0.18",
         "@types/json-schema": "^7.0.15",
@@ -1288,19 +1285,17 @@
         }
       }
     },
-    "node_modules/@langchain/langgraph-sdk/node_modules/eventemitter3": {
+    "node_modules/@langchain/langgraph/node_modules/eventemitter3": {
       "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "license": "MIT",
-      "peer": true
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha1-qG1mFwQzcS3egUcHrFK1JxzrH+s=",
+      "license": "MIT"
     },
-    "node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
+    "node_modules/@langchain/langgraph/node_modules/p-queue": {
       "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.3.tgz",
-      "integrity": "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-queue/-/p-queue-9.3.3.tgz",
+      "integrity": "sha1-xeUox+s2G3uo61qUBpAvfy51/I8=",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventemitter3": "^5.0.4",
         "p-timeout": "^7.0.0"
@@ -1312,12 +1307,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@langchain/langgraph-sdk/node_modules/p-timeout": {
+    "node_modules/@langchain/langgraph/node_modules/p-timeout": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
-      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha1-lWgKaqaTxTDxSsM3uL0y1Oxq5PA=",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -1356,8 +1350,7 @@
       "version": "0.0.18",
       "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.18.tgz",
       "integrity": "sha512-XW1egQtPfsGI41w2AMZNFZrUIwFSQHTjVMZs0OaTpCAvht/QLoaPN8FQcsysMVypOhupG28J29yOorrc70otBQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "1.1.1",
@@ -1563,21 +1556,6 @@
       "version": "2.1.0",
       "license": "MIT"
     },
-    "node_modules/@peculiar/asn1-schema": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.9.4.tgz",
-      "integrity": "sha512-GjzePcT9Iw8NzeOPf73iNS9xM+TBhd/FilAfP+RQGkTMQJTVWtytN3JHJACCjf/ABNau5S7mS3g+DcuxmRgYEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/utils": "^2.0.2",
-        "asn1js": "^3.0.10",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@peculiar/json-schema": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
@@ -1616,6 +1594,18 @@
       },
       "engines": {
         "node": ">=14.18.0"
+      }
+    },
+    "node_modules/@peculiar/webcrypto/node_modules/@peculiar/asn1-schema": {
+      "version": "2.8.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+      "integrity": "sha1-aWmfhCWbIWFgfKv8NOUSpAI9vvk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1987,8 +1977,7 @@
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -2066,8 +2055,7 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -5478,8 +5466,7 @@
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
@@ -6315,9 +6302,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.13.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
-      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
+      "version": "4.13.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hono/-/hono-4.13.2.tgz",
+      "integrity": "sha1-aS1ADSoOoIbj7sXHOqMgfLU/l7U=",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -6882,7 +6869,6 @@
       "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
       "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -7168,7 +7154,6 @@
     "node_modules/js-tiktoken": {
       "version": "1.0.21",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.5.1"
       }
@@ -7277,11 +7262,10 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.9.0.tgz",
-      "integrity": "sha512-tlg/aG7qezAKY6G3fgADSX7PkRj+JKoF3z7QNkCMsAOvwvuzhiwP9Amn1Z+zAIxuKoWuXQdIjtFN0LVmUC1oUQ==",
+      "version": "0.8.10",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/langsmith/-/langsmith-0.8.10.tgz",
+      "integrity": "sha1-XYcunmiYZM0oR5+aosbUJP6P+go=",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-queue": "6.6.2"
       },
@@ -7612,7 +7596,6 @@
     "node_modules/mustache": {
       "version": "4.2.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "mustache": "bin/mustache"
       }
@@ -8024,7 +8007,6 @@
     "node_modules/p-queue": {
       "version": "6.6.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventemitter3": "^4.0.4",
         "p-timeout": "^3.2.0"
@@ -8041,7 +8023,6 @@
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
       "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-network-error": "^1.1.0"
       },
@@ -8055,7 +8036,6 @@
     "node_modules/p-timeout": {
       "version": "3.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-finally": "^1.0.0"
       },
@@ -11215,6 +11195,18 @@
       "dependencies": {
         "@peculiar/asn1-schema": "^2.7.0",
         "@peculiar/json-schema": "^1.1.12",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/webcrypto-core/node_modules/@peculiar/asn1-schema": {
+      "version": "2.8.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+      "integrity": "sha1-aWmfhCWbIWFgfKv8NOUSpAI9vvk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "@peculiar/utils": "^2.0.2",
         "asn1js": "^3.0.10",
         "tslib": "^2.8.1"

--- a/app/package.json
+++ b/app/package.json
@@ -200,10 +200,17 @@
   },
   "overrides": {
     "typescript": "5.5.4",
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^4.1.1",
+    "langsmith": "0.8.10",
+    "hono": "4.13.2",
+    "@peculiar/asn1-schema": "2.8.0",
+    "@langchain/langgraph-sdk": "1.9.29",
+    "@langchain/langgraph-checkpoint": "1.1.3"
   },
   "dependencies": {
+    "@langchain/core": "1.2.7",
     "@langchain/mcp-adapters": "^1.0.0",
+    "@langchain/langgraph": "1.4.9",
     "copyfiles": "^2.4.1",
     "cross-env": "^7.0.3",
     "dotenv": "^16.4.5",


### PR DESCRIPTION
## Summary

- pin LangChain peers to versions available from the package feed
- override transitive dependencies whose latest tarballs are unavailable
- keep clean app installs reproducible through the Microsoft feed proxy

## Testing

- `cd app && npm ci`