### PR TITLE
frontend: resourceMap: Keep node labels inside the node card

### DIFF
--- a/frontend/src/components/resourceMap/nodes/KubeObjectNode.test.tsx
+++ b/frontend/src/components/resourceMap/nodes/KubeObjectNode.test.tsx
@@ -217,6 +217,34 @@ describe('KubeObjectNodeComponent', () => {
     expect(label.parentElement).toHaveClass('label-container');
   });
 
+  it('clamps the label to two lines at rest, with a reveal hook for hover/focus', () => {
+    mocks.node = {
+      id: 'deployment',
+      kubeObject: makeKubeObject({
+        apiVersion: 'apps/v1',
+        kind: 'Deployment',
+        name: 'frontend-deployment-with-a-long-name',
+      }),
+      status: 'success',
+    };
+
+    render(<KubeObjectNodeComponent {...nodeProps('deployment')} />);
+
+    const label = screen.getByText('frontend-deployment-with-a-long-name');
+    // The clamp keeps the label within the node's fixed-size card at rest. The
+    // `node-title` class is targeted by Container's `:hover`/`:focus-within`
+    // styles to remove the clamp and reveal the full label (see
+    // KubeObjectNode.tsx `& .node-title` rules) -- jsdom does not evaluate
+    // those pseudo-class rules, so this only asserts the resting clamp and
+    // the hook the reveal relies on.
+    expect(label).toHaveClass('node-title');
+    expect(label).toHaveStyle({
+      display: '-webkit-box',
+      WebkitLineClamp: '2',
+      overflow: 'hidden',
+    });
+  });
+
   it('uses the highest-weight child object and shows a collapsed warning and count', () => {
     mocks.node = {
       id: 'group',

--- a/frontend/src/components/resourceMap/nodes/KubeObjectNode.tsx
+++ b/frontend/src/components/resourceMap/nodes/KubeObjectNode.tsx
@@ -57,15 +57,21 @@ const Container = styled('div')<{
   ':hover': {
     borderColor: isSelected ? undefined : alpha(theme.palette.action.active, 0.2),
     boxShadow: '4px 4px 6px rgba(0,0,0,0.06)',
-    zIndex: 10,
     '& .label-container': {
+      overflow: 'visible',
+    },
+    '& .node-title': {
+      WebkitLineClamp: 'unset',
       overflow: 'visible',
     },
   },
 
   ':focus-within': {
-    zIndex: 10,
     '& .label-container': {
+      overflow: 'visible',
+    },
+    '& .node-title': {
+      WebkitLineClamp: 'unset',
       overflow: 'visible',
     },
   },
@@ -148,6 +154,10 @@ const Subtitle = styled('div')({
 const Title = styled('div')({
   whiteSpace: 'normal',
   wordBreak: 'break-word',
+  display: '-webkit-box',
+  WebkitLineClamp: 2,
+  WebkitBoxOrient: 'vertical',
+  overflow: 'hidden',
 });
 
 const EXPAND_DELAY = 450;
@@ -289,7 +299,7 @@ export const KubeObjectNodeComponent = memo(({ id }: NodeProps) => {
         {icon}
         <LabelContainer className="label-container" isCollapsed={isCollapsed}>
           <Subtitle>{subtitle}</Subtitle>
-          <Title>{label}</Title>
+          <Title className="node-title">{label}</Title>
         </LabelContainer>
       </TextContainer>
       {isExpanded && <NodeGlance node={node} />}


### PR DESCRIPTION
## Summary

Follow-up to #6910, which replaced single-line ellipsis truncation on resource-map node labels with wrapping so content is not clipped at high text zoom. Two defects came out of that change; this PR fixes both.

## Related Issue

Fixes #7364

## Changes

- **Dropped `zIndex: 10` from `Container`'s `:hover` and `:focus-within` rules.** It turned `Container` into a stacking context. `Container` draws the offset "stacked cards" for grouped nodes via `::before` (z-index `-1`, `childrenCount > 1`) and `::after` (z-index `-2`, `childrenCount > 2`); inside its own stacking context, negative-z descendants paint *after* the element's own background and border, so hovering or focusing a grouped node drew the offset cards over the front card. The declarations were also redundant — `GraphView.css:19-22` already raises the `.react-flow__node` wrapper to `z-index: 10000 !important` on hover and focus, and the wrapper is what orders nodes against their siblings. The `.label-container` reveals that sat alongside them are unchanged.
- **Clamped the node title to two lines**, un-clamped under the existing `:hover` / `:focus-within` rules. ELK lays every node out at a fixed `220x70` (`graphLayout.tsx:139-140,200-201,235-244`) and React Flow writes that as an inline size, while `Container` is `height: 100%` with `overflow: visible`. An unbounded wrapped label therefore grew past the card, and with collapsed-layout `elk.spacing.nodeNode` of `1` it landed on the node below. The clamp keeps the resting state inside the card; the full name stays reachable by pointer and by keyboard.
- Added a focused component test for the resting clamp and the class hook the reveal targets.

## Steps to Test

1. Open the resource map for a namespace containing a resource with a long name (~45+ characters).
2. Observe the label wraps to at most two lines and stays within the node's card, rather than spilling onto the node below.
3. Hover the node, then tab to it — the full name is revealed in both cases.
4. Collapse a group so a node shows 2+ children, then hover it: the offset "stacked cards" stay behind the front card.

## Notes for the Reviewer

Measurements against the fixed 70px card with a long pod name, comparing the wrapped label's height (label bottom vs card bottom):

| | 100% zoom (16px/1.5) | 200% text-only zoom (32px/1.5) |
|---|---|---|
| Before this PR | 93px — 12px past the card | 261px — 96px past |
| After | 69px — inside the card | 117px — 24px past |

**Known limitation, deliberately not addressed here:** at 200% *text-only* zoom a long label still escapes the card by roughly 24px. It cannot be fully contained while the node box is a fixed 70px from ELK and the text scales independently — properly fixing that means making the layout node height scale with text, which is a larger change to the layout pipeline and is better done on its own. This PR is a 4x improvement on that case and a complete fix at normal zoom, and the keyboard-focus reveal from #6910 still works as the accessibility escape hatch throughout.

Two things are not covered by the unit test, since jsdom evaluates neither `:hover`/`:focus-within` rules nor paint order: the stacking-order fix and the hover/focus un-clamp. Both were verified by rendering the box model in headless Chromium (the table above) and by reading the cascade, not by an automated test in this repo — worth a visual check during review. The e2e assertions added in #6910 (`e2e-tests/tests/resourceMap.spec.ts:188-211`) still hold: they cover `white-space`, `word-break`, `.label-container` overflow, and `TextContainer` min-height, none of which this change touches.
