### PR TITLE
ci: bump helm-chart-template-test Helm version to v3.21.4

### DIFF
--- a/.github/workflows/helm-chart-template-test.yml
+++ b/.github/workflows/helm-chart-template-test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
-          version: v3.18.4
+          version: v3.21.4
           
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:


### PR DESCRIPTION
I opened this PR to fix a Helm version mismatch that was causing confusing local test failures, changing the pinned Helm CLI in the helm chart template test workflow from v3.18.4 to v3.21.4, which is the newest v3 release and lines up nicely with the v3.21.0 Helm SDK the backend already depends on