### PR TITLE
frontend: k8s: Fix namespace selector regressions from #7361

### DIFF
--- a/frontend/src/components/App/AllowedNamespacesSelectorGate.test.tsx
+++ b/frontend/src/components/App/AllowedNamespacesSelectorGate.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { ReactNode, useEffect } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import App from '../../App';
+import { TestContext } from '../../test';
+import AllowedNamespacesSelectorGate from './AllowedNamespacesSelectorGate';
+
+// cyclic imports fix
+// eslint-disable-next-line no-unused-vars
+const _dont_delete_me = App;
+
+// Tracks how many times the wrapped child mounts, to catch a regression where
+// gating on a cluster list that starts empty and later gets populated
+// (e.g. while cluster config is still loading) remounts the routed subtree
+// and destroys its state instead of updating it in place.
+function MountCounter({ onMount }: { onMount: () => void }) {
+  useEffect(() => {
+    onMount();
+  }, [onMount]);
+
+  return <div>content</div>;
+}
+
+function renderWithProviders(children: ReactNode, queryClient: QueryClient) {
+  return render(
+    <TestContext>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </TestContext>
+  );
+}
+
+describe('AllowedNamespacesSelectorGate', () => {
+  it('does not remount children when the clusters prop changes from empty to populated', async () => {
+    const onMount = vi.fn();
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    const { rerender } = renderWithProviders(
+      <AllowedNamespacesSelectorGate clusters={[]}>
+        <MountCounter onMount={onMount} />
+      </AllowedNamespacesSelectorGate>,
+      queryClient
+    );
+
+    expect(await screen.findByText('content')).toBeInTheDocument();
+    expect(onMount).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <TestContext>
+        <QueryClientProvider client={queryClient}>
+          <AllowedNamespacesSelectorGate clusters={['cluster-a']}>
+            <MountCounter onMount={onMount} />
+          </AllowedNamespacesSelectorGate>
+        </QueryClientProvider>
+      </TestContext>
+    );
+
+    expect(await screen.findByText('content')).toBeInTheDocument();
+    expect(onMount).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders children directly when there are no clusters to resolve', () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    renderWithProviders(
+      <AllowedNamespacesSelectorGate clusters={[]}>
+        <div>gated content</div>
+      </AllowedNamespacesSelectorGate>,
+      queryClient
+    );
+
+    expect(screen.getByText('gated content')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/App/AllowedNamespacesSelectorGate.tsx
+++ b/frontend/src/components/App/AllowedNamespacesSelectorGate.tsx
@@ -100,6 +100,12 @@ export default function AllowedNamespacesSelectorGate({
   const waiting = resolutionKeys.some(key => key === null);
   const resolutionKey = JSON.stringify(resolutionKeys);
 
+  // With no clusters to resolve, `clusters.map` below renders no resolvers and
+  // `resolutionKeys` is empty, so `waiting` is always false and this collapses
+  // to rendering `children` directly (through the same Provider element).
+  // Keeping one return shape regardless of `clusters.length` avoids swapping
+  // the element type at this slot, which would otherwise remount `children`
+  // the moment `clusters` transitions from empty to populated.
   return (
     <>
       {clusters.map(cluster => (

--- a/frontend/src/components/App/Layout.tsx
+++ b/frontend/src/components/App/Layout.tsx
@@ -26,7 +26,6 @@ import { useQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
-import { useLocation } from 'react-router-dom';
 import { getCluster } from '../../lib/cluster';
 import { getSelectedClusters } from '../../lib/cluster';
 import { useCluster, useClustersConf, useSelectedClusters } from '../../lib/k8s';
@@ -238,11 +237,7 @@ export default function Layout({}: LayoutProps) {
   }, [cluster, dispatch]);
 
   const selectedClusters = useSelectedClusters();
-  const { pathname } = useLocation();
-  const configuredClusters = pathname.startsWith('/project/') ? Object.keys(allClusters || {}) : [];
-  const clustersToResolve = [
-    ...new Set([...configuredClusters, cluster || '', ...selectedClusters].filter(Boolean)),
-  ];
+  const clustersToResolve = [...new Set([cluster || '', ...selectedClusters].filter(Boolean))];
 
   const urlClusters = getSelectedClusters();
   const clustersNotInURL =
@@ -359,18 +354,8 @@ export default function Layout({}: LayoutProps) {
                 <Div />
                 <Container {...containerProps} sx={{ height: '100%' }}>
                   <NavigationTabs />
-                  {arePluginsLoaded &&
-                    (clustersToResolve.length > 0 ? (
-                      <AllowedNamespacesSelectorGate clusters={clustersToResolve}>
-                        <RouteSwitcher
-                          requiresToken={() => {
-                            const clusterName = getCluster() || '';
-                            const cluster = clusters ? clusters[clusterName] : undefined;
-                            return cluster?.useToken === undefined || cluster?.useToken;
-                          }}
-                        />
-                      </AllowedNamespacesSelectorGate>
-                    ) : (
+                  {arePluginsLoaded && (
+                    <AllowedNamespacesSelectorGate clusters={clustersToResolve}>
                       <RouteSwitcher
                         requiresToken={() => {
                           const clusterName = getCluster() || '';
@@ -378,7 +363,8 @@ export default function Layout({}: LayoutProps) {
                           return cluster?.useToken === undefined || cluster?.useToken;
                         }}
                       />
-                    ))}
+                    </AllowedNamespacesSelectorGate>
+                  )}
                 </Container>
               </Box>
             </Main>

--- a/frontend/src/components/common/Resource/ResourceTable.test.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import { ThemeProvider } from '@mui/material/styles';
-import { act, render } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { loadTableSettings, storeTableSettings } from '../../../helpers/tableSettings';
@@ -225,5 +225,53 @@ describe('ResourceTable Column Visibility', () => {
     );
 
     expect(lastTablePropsHolder.current.enableFacetedValues).toBe(true);
+  });
+});
+
+describe("ResourceTable shared 'age' column", () => {
+  beforeEach(() => {
+    lastTablePropsHolder.current = null;
+  });
+
+  function renderTableWithAgeColumn(data: any[]) {
+    render(
+      <TestContext>
+        <ThemeProvider theme={theme}>
+          <ResourceTable id="age-table" columns={['age']} data={data} />
+        </ThemeProvider>
+      </TestContext>
+    );
+    return lastTablePropsHolder.current.columns.find((c: any) => c.id === 'age');
+  }
+
+  // Regression test: a row lacking metadata.creationTimestamp (e.g. a
+  // namespace placeholder shown when its per-name GET was denied) used to
+  // make accessorFn compute -new Date(undefined).getTime(), which is NaN and
+  // breaks sorting, and hand the missing value straight to DateLabel.
+  it('sorts a row with no creationTimestamp as null instead of NaN', () => {
+    const ageColumn = renderTableWithAgeColumn([{ metadata: { name: 'placeholder' } }]);
+
+    expect(ageColumn.accessorFn({ metadata: { name: 'placeholder' } })).toBeNull();
+  });
+
+  it("renders 'Unknown' for a row with no creationTimestamp, without throwing", () => {
+    const ageColumn = renderTableWithAgeColumn([{ metadata: { name: 'placeholder' } }]);
+    const row = { original: { metadata: { name: 'placeholder' } } };
+
+    expect(() => render(<ageColumn.Cell row={row} />)).not.toThrow();
+    expect(screen.getByText('translation|Unknown')).toBeInTheDocument();
+  });
+
+  it('still renders a real date for a row with a creationTimestamp', () => {
+    const item = {
+      metadata: { name: 'mypod1', creationTimestamp: '2021-12-15T14:57:13Z' },
+    };
+    const ageColumn = renderTableWithAgeColumn([item]);
+    const row = { original: item };
+
+    expect(ageColumn.accessorFn(item)).toBe(-new Date(item.metadata.creationTimestamp).getTime());
+
+    render(<ageColumn.Cell row={row} />);
+    expect(screen.queryByText('translation|Unknown')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -499,19 +499,33 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
               header: t('translation|Age'),
               gridTemplate: 'min-content',
               responsivePriority: 1,
-              accessorFn: (item: RowItem) => -new Date(item.metadata.creationTimestamp).getTime(),
+              // Some rows (e.g. a namespace placeholder shown when its
+              // per-name GET was denied) have no known creationTimestamp.
+              // Sort them as null rather than computing -new Date(undefined)
+              // .getTime(), which is NaN and breaks sorting.
+              accessorFn: (item: RowItem) =>
+                item.metadata.creationTimestamp
+                  ? -new Date(item.metadata.creationTimestamp).getTime()
+                  : null,
               enableColumnFilter: false,
               muiTableBodyCellProps: {
                 align: 'right',
               },
-              Cell: ({ row }: { row: MRT_Row<RowItem> }) =>
-                row.original && (
+              Cell: ({ row }: { row: MRT_Row<RowItem> }) => {
+                if (!row.original) {
+                  return null;
+                }
+                if (!row.original.metadata.creationTimestamp) {
+                  return <>{t('translation|Unknown')}</>;
+                }
+                return (
                   <DateLabel
                     date={row.original.metadata.creationTimestamp}
                     format="mini"
                     iconProps={{ color: theme.palette.text.primary }}
                   />
-                ),
+                );
+              },
             };
 
           case 'labels':

--- a/frontend/src/components/namespace/List.test.tsx
+++ b/frontend/src/components/namespace/List.test.tsx
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import NamespacesList from './List';
+
+const { mockListView } = vi.hoisted(() => ({
+  mockListView: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/namespace', () => ({
+  default: { kind: 'Namespace' },
+}));
+
+// Avoid pulling in CreateNamespaceButton's heavy import chain (redux actions,
+// AuthVisible, etc.) -- it is irrelevant to these column-level tests, and
+// ResourceListView is mocked out below so it never actually renders anyway.
+vi.mock('./CreateNamespaceButton', () => ({
+  default: () => null,
+}));
+
+// List.tsx only needs MetadataDictGrid from this barrel, but the real barrel
+// re-exports the entire resource-forms module graph (every Create*Form for
+// every workload kind), which triggers a pre-existing circular-import
+// ordering hazard between the k8s resource classes when pulled in from a
+// fresh module graph. Stub just what's used to avoid that unrelated hazard.
+vi.mock('../common/Resource', () => ({
+  MetadataDictGrid: ({ dict }: { dict: Record<string, string> }) => (
+    <span>{JSON.stringify(dict)}</span>
+  ),
+}));
+
+vi.mock('../common/Resource/ResourceListView', () => ({
+  default: (props: any) => {
+    mockListView(props);
+    return null;
+  },
+}));
+
+function renderList() {
+  render(
+    <TestContext>
+      <NamespacesList />
+    </TestContext>
+  );
+  return mockListView.mock.calls[0][0];
+}
+
+const column = (props: any, id: string) => props.columns.find((c: any) => c?.id === id);
+
+describe('NamespacesList', () => {
+  beforeEach(() => {
+    mockListView.mockReset();
+  });
+
+  it('renders the expected columns', () => {
+    const props = renderList();
+    const columnIds = props.columns.map((c: any) => (typeof c === 'string' ? c : c.id));
+
+    expect(columnIds).toEqual(['name', 'cluster', 'status', 'labels', 'age']);
+  });
+
+  it('shows the namespace phase as the status', () => {
+    const props = renderList();
+    const status = column(props, 'status');
+    const active = { status: { phase: 'Active' } };
+
+    expect(status.getValue(active)).toBe('Active');
+
+    render(<TestContext>{status.render(active)}</TestContext>);
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+
+  // Regression test for a defect where a namespace object built as a
+  // name-only placeholder (used when a manually configured namespace's
+  // per-name GET fails, e.g. missing RBAC) has no `status`, and reading
+  // `namespace.status.phase` unconditionally threw `TypeError: Cannot read
+  // properties of undefined (reading 'phase')`, crashing the whole table via
+  // ResourceTable's accessorFn. This asserts both the render and the getValue
+  // used by the shared table tolerate a missing/empty status and fall back to
+  // "Unknown", matching what `main` rendered for these rows.
+  it('falls back to Unknown for a placeholder namespace with no status, without throwing', () => {
+    const props = renderList();
+    const status = column(props, 'status');
+    const placeholder = {
+      metadata: { name: 'team-b' },
+      status: {},
+    };
+
+    expect(status.getValue(placeholder)).toBe('translation|Unknown');
+
+    expect(() => render(<TestContext>{status.render(placeholder)}</TestContext>)).not.toThrow();
+    expect(screen.getByText('translation|Unknown')).toBeInTheDocument();
+  });
+
+  it('falls back to Unknown when status is entirely absent', () => {
+    const props = renderList();
+    const status = column(props, 'status');
+    const placeholder = { metadata: { name: 'team-b' } };
+
+    expect(status.getValue(placeholder)).toBe('translation|Unknown');
+
+    expect(() => render(<TestContext>{status.render(placeholder)}</TestContext>)).not.toThrow();
+    expect(screen.getByText('translation|Unknown')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/namespace/List.tsx
+++ b/frontend/src/components/namespace/List.tsx
@@ -25,7 +25,7 @@ export default function NamespacesList() {
   const { t } = useTranslation(['glossary', 'translation']);
 
   function makeStatusLabel(namespace: Namespace) {
-    const status = namespace.status.phase;
+    const status = namespace.status?.phase ?? t('translation|Unknown');
     return <StatusLabel status={status === 'Active' ? 'success' : 'error'}>{status}</StatusLabel>;
   }
 
@@ -45,7 +45,7 @@ export default function NamespacesList() {
           gridTemplate: 'auto',
           label: t('translation|Status'),
           filterVariant: 'multi-select',
-          getValue: ns => ns.status.phase,
+          getValue: ns => ns.status?.phase ?? t('translation|Unknown'),
           render: makeStatusLabel,
         },
         {

--- a/frontend/src/components/project/ProjectDetails.tsx
+++ b/frontend/src/components/project/ProjectDetails.tsx
@@ -27,6 +27,7 @@ import React, {
 } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
+import { useClustersConf } from '../../lib/k8s';
 import { KubeObject } from '../../lib/k8s/KubeObject';
 import ResourceQuota from '../../lib/k8s/resourceQuota';
 import Role from '../../lib/k8s/role';
@@ -40,6 +41,7 @@ import {
   ProjectOverviewSection,
 } from '../../redux/projectsSlice';
 import { Activity } from '../activity/Activity';
+import AllowedNamespacesSelectorGate from '../App/AllowedNamespacesSelectorGate';
 import { ButtonStyle, EditButton, EditorDialog, Loader, StatusLabel } from '../common';
 import Link from '../common/Link';
 import ResourceTable from '../common/Resource/ResourceTable';
@@ -95,7 +97,7 @@ const DEFAULT_TABS: Record<string, ProjectDetailsTab> = {
   },
 };
 
-export default function ProjectDetails() {
+function ProjectDetailsPage() {
   const { t } = useTranslation();
   const { name } = useParams<ProjectDetailsParams>();
   const { project, isLoading: isProjectLoading } = useProject(name);
@@ -109,6 +111,22 @@ export default function ProjectDetails() {
   // which is required because useProjectItems → useKubeLists calls hooks
   // per resource in a loop (the array length must stay stable per mount).
   return <ProjectDetailsContent key={`${name}-${pluginApiResources.length}`} project={project} />;
+}
+
+/**
+ * Resolves configured namespace selectors before querying the project details.
+ *
+ * @returns The gated project details page.
+ */
+export default function ProjectDetails() {
+  const clusterConf = useClustersConf();
+  const clusters = Object.values(clusterConf ?? {}).map(cluster => cluster.name);
+
+  return (
+    <AllowedNamespacesSelectorGate clusters={clusters}>
+      <ProjectDetailsPage />
+    </AllowedNamespacesSelectorGate>
+  );
 }
 
 function ProjectOverview({

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
@@ -741,6 +741,197 @@ describe('useKubeObjectList', () => {
     ]);
   });
 
+  it('excludes manually configured namespaces whose labels do not match the caller selector', async () => {
+    const namespaceClass = class {
+      static apiVersion = 'v1';
+      static apiName = 'namespaces';
+      static kind = 'Namespace';
+
+      constructor(public jsonData: any) {}
+    } as any;
+    localStorage.setItem(
+      'cluster_settings.restricted',
+      JSON.stringify({ allowedNamespaces: ['team-a', 'team-b'] })
+    );
+    mockClusterFetch
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve({ metadata: { name: 'team-a', labels: { project: 'apple' } } }),
+      } as Response)
+      .mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve({ metadata: { name: 'team-b', labels: { project: 'banana' } } }),
+      } as Response);
+
+    const query = kubeObjectListQuery(
+      namespaceClass,
+      { version: 'v1', resource: 'namespaces' },
+      undefined,
+      'restricted',
+      { labelSelector: 'project=apple' }
+    );
+    const response = await (query.queryFn as any)();
+
+    expect(response.list.items.map((item: any) => item.jsonData.metadata.name)).toEqual(['team-a']);
+  });
+
+  it('replaces a failed manually configured namespace GET with a placeholder when no caller selector is active', async () => {
+    const namespaceClass = class {
+      static apiVersion = 'v1';
+      static apiName = 'namespaces';
+      static kind = 'Namespace';
+
+      constructor(public jsonData: any) {}
+    } as any;
+    localStorage.setItem(
+      'cluster_settings.restricted',
+      JSON.stringify({ allowedNamespaces: ['team-a', 'team-b'] })
+    );
+    mockClusterFetch
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve({ metadata: { name: 'team-a' } }),
+      } as Response)
+      .mockRejectedValueOnce(new ApiError('Forbidden', { status: 403 }));
+
+    const query = kubeObjectListQuery(
+      namespaceClass,
+      { version: 'v1', resource: 'namespaces' },
+      undefined,
+      'restricted',
+      {}
+    );
+    const response = await (query.queryFn as any)();
+
+    expect(response.list.items.map((item: any) => item.jsonData.metadata.name)).toEqual([
+      'team-a',
+      'team-b',
+    ]);
+    // The placeholder must have a status object (so consumers can safely read
+    // `.status.phase` without crashing). It deliberately has no
+    // creationTimestamp -- the real value is unknown since the GET failed,
+    // and fabricating one (e.g. "now") would misrepresent the namespace's
+    // actual age. The Namespaces list renders a missing timestamp as
+    // "Unknown" instead of relying on the shared 'age' column.
+    expect(response.list.items[1].jsonData).toEqual({
+      kind: 'Namespace',
+      apiVersion: 'v1',
+      metadata: { name: 'team-b' },
+      status: {},
+    });
+  });
+
+  it('does not let a placeholder shadow a real object also returned by the selector list', async () => {
+    const namespaceClass = class {
+      static apiVersion = 'v1';
+      static apiName = 'namespaces';
+      static kind = 'Namespace';
+
+      constructor(public jsonData: any) {}
+    } as any;
+    localStorage.setItem(
+      'cluster_settings.restricted',
+      JSON.stringify({
+        allowedNamespaces: ['team-a'],
+        allowedNamespacesSelector: 'team=frontend',
+      })
+    );
+    mockClusterFetch.mockImplementation(async url => {
+      if (url === 'api/v1/namespaces/team-a') {
+        // The per-name GET for the manually configured namespace fails (e.g.
+        // missing RBAC on that specific name)...
+        throw new ApiError('Forbidden', { status: 403 });
+      }
+      // ...but the configured-selector LIST can still see it, with real
+      // status/labels attached.
+      return {
+        json: () =>
+          Promise.resolve(
+            makeListResponse({
+              kind: 'NamespaceList',
+              items: [
+                {
+                  metadata: { name: 'team-a', labels: { team: 'frontend' } },
+                  status: { phase: 'Active' },
+                },
+              ],
+            })
+          ),
+      } as Response;
+    });
+
+    const query = kubeObjectListQuery(
+      namespaceClass,
+      { version: 'v1', resource: 'namespaces' },
+      undefined,
+      'restricted',
+      {}
+    );
+    const response = await (query.queryFn as any)();
+
+    // Exactly one entry for 'team-a' -- the real object from the selector
+    // list, not a name-only placeholder shadowing it.
+    expect(response.list.items.map((item: any) => item.jsonData.metadata.name)).toEqual(['team-a']);
+    expect(response.list.items[0].jsonData.status).toEqual({ phase: 'Active' });
+    expect(response.list.items[0].jsonData.metadata.labels).toEqual({ team: 'frontend' });
+  });
+
+  it('omits a failed manually configured namespace GET when a caller selector is active', async () => {
+    const namespaceClass = class {
+      static apiVersion = 'v1';
+      static apiName = 'namespaces';
+      static kind = 'Namespace';
+
+      constructor(public jsonData: any) {}
+    } as any;
+    localStorage.setItem(
+      'cluster_settings.restricted',
+      JSON.stringify({ allowedNamespaces: ['team-a', 'team-b'] })
+    );
+    mockClusterFetch
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve({ metadata: { name: 'team-a', labels: { project: 'apple' } } }),
+      } as Response)
+      .mockRejectedValueOnce(new ApiError('Forbidden', { status: 403 }));
+
+    const query = kubeObjectListQuery(
+      namespaceClass,
+      { version: 'v1', resource: 'namespaces' },
+      undefined,
+      'restricted',
+      { labelSelector: 'project=apple' }
+    );
+    const response = await (query.queryFn as any)();
+
+    expect(response.list.items.map((item: any) => item.jsonData.metadata.name)).toEqual(['team-a']);
+  });
+
+  it('errors when every manually configured namespace GET fails and the selector list is empty', async () => {
+    const namespaceClass = class {
+      static apiVersion = 'v1';
+      static apiName = 'namespaces';
+      static kind = 'Namespace';
+
+      constructor(public jsonData: any) {}
+    } as any;
+    localStorage.setItem(
+      'cluster_settings.restricted',
+      JSON.stringify({ allowedNamespaces: ['team-a', 'team-b'] })
+    );
+    const firstError = new ApiError('Forbidden', { status: 403 });
+    mockClusterFetch
+      .mockRejectedValueOnce(firstError)
+      .mockRejectedValueOnce(new ApiError('Forbidden', { status: 403 }));
+
+    const query = kubeObjectListQuery(
+      namespaceClass,
+      { version: 'v1', resource: 'namespaces' },
+      undefined,
+      'restricted',
+      {}
+    );
+
+    await expect((query.queryFn as any)()).rejects.toBe(firstError);
+  });
+
   it('does not watch the synthesized allowed namespace list', async () => {
     const namespaceClass = class {
       static apiVersion = 'v1';

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -22,6 +22,7 @@ import {
   loadClusterSettings,
 } from '../../../../helpers/clusterSettings';
 import type { KubeObject, KubeObjectClass } from '../../KubeObject';
+import { matchesLabelSelector } from '../../labelSelectorMatch';
 import type { QueryParameters } from '../v1/queryParameters';
 import { ApiError } from './ApiError';
 import { clusterFetch } from './fetch';
@@ -76,6 +77,24 @@ export interface ListResponse<K extends KubeObject> {
  * Manually configured namespaces use per-name GET requests, while selector-based
  * restrictions retain LIST requests and intersect any selector from the caller.
  *
+ * The result is the intersection `(manual ∪ configured) ∩ requested`: manually
+ * configured namespaces are only included if their labels match the caller's
+ * `queryParams.labelSelector` (the selector-based LIST branch already intersects
+ * server-side, since its query joins the configured and requested selectors).
+ *
+ * Per-name GETs may fail individually (e.g. a manually-restricted user commonly
+ * lacks cluster-scoped `list namespaces` RBAC but may also lack `get` on some
+ * names). A single failure does not fail the whole query:
+ * - If no caller selector is active, a failed GET is replaced by a name-only
+ *   placeholder object so the namespace still appears (matching prior
+ *   behavior of callers that rendered these rows unconditionally).
+ * - If a caller selector is active, a failed GET is omitted instead, since we
+ *   cannot evaluate the selector without knowing the namespace's labels and
+ *   would rather fail closed than show a possibly non-matching row.
+ * If every manually configured namespace fails and the selector LIST yields no
+ * items, the first rejection is rethrown so a fully broken configuration still
+ * surfaces as an error.
+ *
  * @param kubeObjectClass - Class used to instantiate Namespace objects.
  * @param cluster - Cluster to query.
  * @param queryParams - Additional Namespace list filters.
@@ -108,8 +127,8 @@ function allowedNamespaceListQuery<K extends KubeObject>(
       { allowedNamespaces, selector },
     ],
     queryFn: async () => {
-      const [manualItems, selectorList] = await Promise.all([
-        Promise.all(
+      const [manualResults, selectorList] = await Promise.all([
+        Promise.allSettled(
           allowedNamespaces.map(async name => {
             try {
               const item = await clusterFetch(makeUrl(['api', 'v1', 'namespaces', name]), {
@@ -118,9 +137,7 @@ function allowedNamespaceListQuery<K extends KubeObject>(
               if (item.metadata?.managedFields) {
                 delete item.metadata.managedFields;
               }
-              const kubeObject = new kubeObjectClass(item) as K;
-              kubeObject.cluster = cluster;
-              return kubeObject;
+              return item;
             } catch (error) {
               if (error instanceof ApiError) {
                 error.cluster = cluster;
@@ -154,6 +171,69 @@ function allowedNamespaceListQuery<K extends KubeObject>(
         kubeObject.cluster = cluster;
         return kubeObject;
       });
+
+      const manualItems: K[] = [];
+      const selectorItemNames = new Set(
+        selectorItems.map((item: K) => item.jsonData.metadata.name)
+      );
+      manualResults.forEach((result, index) => {
+        if (result.status === 'fulfilled') {
+          const item = result.value;
+          // Intersect with the caller's selector: manual namespaces don't go
+          // through the server-side LIST filter, so we must check labels ourselves.
+          if (!matchesLabelSelector(item.metadata?.labels, requestedSelector)) {
+            return;
+          }
+          const kubeObject = new kubeObjectClass(item) as K;
+          kubeObject.cluster = cluster;
+          manualItems.push(kubeObject);
+          return;
+        }
+
+        // A failed per-name GET (commonly missing RBAC on that name) shouldn't
+        // fail the whole query. When no caller selector is active we can still
+        // show a name-only placeholder row, matching prior behavior. When a
+        // selector is active we can't evaluate it without labels, so we fail
+        // closed and omit the namespace rather than risk showing a
+        // non-matching row.
+        const name = allowedNamespaces[index];
+        // Don't shadow a real object: if the configured-selector LIST already
+        // returned this namespace (with real status/labels), prefer that over
+        // a placeholder.
+        if (!requestedSelector && !selectorItemNames.has(name)) {
+          const placeholder = new kubeObjectClass({
+            kind: 'Namespace',
+            apiVersion: 'v1',
+            // The creation timestamp is genuinely unknown since the GET
+            // failed, so it is left unset rather than invented -- a fabricated
+            // date would render as a real age and misrepresent the namespace.
+            // Views that surface these rows render the age as unknown.
+            metadata: { name },
+            // Likewise, Namespace list views read status.phase directly;
+            // an empty status resolves to a defined-but-empty phase so
+            // consumers can fall back to an "Unknown" label instead of
+            // throwing on `undefined.phase`.
+            status: {},
+          }) as K;
+          placeholder.cluster = cluster;
+          manualItems.push(placeholder);
+        }
+      });
+
+      // If every manually configured namespace failed and the selector LIST
+      // (if any) produced nothing, this is a genuinely broken configuration
+      // rather than a partial failure -- surface it as an error.
+      if (
+        allowedNamespaces.length > 0 &&
+        selectorItems.length === 0 &&
+        manualResults.every(result => result.status === 'rejected')
+      ) {
+        const firstRejected = manualResults.find(
+          (result): result is PromiseRejectedResult => result.status === 'rejected'
+        );
+        throw firstRejected!.reason;
+      }
+
       const items = [...manualItems, ...selectorItems].filter(
         (item, index, allItems) =>
           allItems.findIndex(

--- a/frontend/src/lib/k8s/labelSelectorMatch.test.ts
+++ b/frontend/src/lib/k8s/labelSelectorMatch.test.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { matchesLabelSelector } from './labelSelectorMatch';
+
+describe('matchesLabelSelector', () => {
+  it('matches everything when the selector is undefined', () => {
+    expect(matchesLabelSelector(undefined, undefined)).toBe(true);
+    expect(matchesLabelSelector({ foo: 'bar' }, undefined)).toBe(true);
+  });
+
+  it('matches everything when the selector is empty or blank', () => {
+    expect(matchesLabelSelector({ foo: 'bar' }, '')).toBe(true);
+    expect(matchesLabelSelector({ foo: 'bar' }, '   ')).toBe(true);
+    expect(matchesLabelSelector(undefined, '')).toBe(true);
+  });
+
+  it('handles undefined labels with a non-empty selector', () => {
+    expect(matchesLabelSelector(undefined, 'foo=bar')).toBe(false);
+    expect(matchesLabelSelector(undefined, 'foo!=bar')).toBe(true);
+    expect(matchesLabelSelector(undefined, '!foo')).toBe(true);
+    expect(matchesLabelSelector(undefined, 'foo')).toBe(false);
+  });
+
+  describe('equality operator', () => {
+    it('matches key=value', () => {
+      expect(matchesLabelSelector({ foo: 'bar' }, 'foo=bar')).toBe(true);
+      expect(matchesLabelSelector({ foo: 'baz' }, 'foo=bar')).toBe(false);
+      expect(matchesLabelSelector({}, 'foo=bar')).toBe(false);
+    });
+
+    it('matches key==value', () => {
+      expect(matchesLabelSelector({ foo: 'bar' }, 'foo==bar')).toBe(true);
+      expect(matchesLabelSelector({ foo: 'baz' }, 'foo==bar')).toBe(false);
+    });
+
+    it('tolerates whitespace around the operator', () => {
+      expect(matchesLabelSelector({ foo: 'bar' }, ' foo = bar ')).toBe(true);
+      expect(matchesLabelSelector({ foo: 'bar' }, 'foo  ==  bar')).toBe(true);
+    });
+  });
+
+  describe('inequality operator', () => {
+    it('matches when the value differs', () => {
+      expect(matchesLabelSelector({ foo: 'baz' }, 'foo!=bar')).toBe(true);
+      expect(matchesLabelSelector({ foo: 'bar' }, 'foo!=bar')).toBe(false);
+    });
+
+    it('matches when the key is absent (apiserver behavior)', () => {
+      expect(matchesLabelSelector({}, 'foo!=bar')).toBe(true);
+      expect(matchesLabelSelector({ other: 'x' }, 'foo!=bar')).toBe(true);
+    });
+
+    it('tolerates whitespace', () => {
+      expect(matchesLabelSelector({ foo: 'baz' }, ' foo != bar ')).toBe(true);
+    });
+  });
+
+  describe('exists operator', () => {
+    it('matches when the key is present regardless of value', () => {
+      expect(matchesLabelSelector({ foo: 'anything' }, 'foo')).toBe(true);
+      expect(matchesLabelSelector({}, 'foo')).toBe(false);
+    });
+
+    it('tolerates surrounding whitespace', () => {
+      expect(matchesLabelSelector({ foo: 'bar' }, '  foo  ')).toBe(true);
+    });
+  });
+
+  describe('does-not-exist operator', () => {
+    it('matches when the key is absent', () => {
+      expect(matchesLabelSelector({}, '!foo')).toBe(true);
+      expect(matchesLabelSelector({ foo: 'bar' }, '!foo')).toBe(false);
+    });
+
+    it('tolerates whitespace after the !', () => {
+      expect(matchesLabelSelector({}, '! foo')).toBe(true);
+      expect(matchesLabelSelector({}, '  !foo  ')).toBe(true);
+    });
+  });
+
+  describe('in operator', () => {
+    it('matches when the value is a member of the set', () => {
+      expect(matchesLabelSelector({ foo: 'a' }, 'foo in (a,b,c)')).toBe(true);
+      expect(matchesLabelSelector({ foo: 'z' }, 'foo in (a,b,c)')).toBe(false);
+      expect(matchesLabelSelector({}, 'foo in (a,b,c)')).toBe(false);
+    });
+
+    it('tolerates whitespace around members and parens', () => {
+      expect(matchesLabelSelector({ foo: 'b' }, 'foo in ( a , b , c )')).toBe(true);
+      expect(matchesLabelSelector({ foo: 'b' }, 'foo  in  (a,b,c)')).toBe(true);
+    });
+  });
+
+  describe('notin operator', () => {
+    it('matches when the value is not a member of the set', () => {
+      expect(matchesLabelSelector({ foo: 'z' }, 'foo notin (a,b,c)')).toBe(true);
+      expect(matchesLabelSelector({ foo: 'a' }, 'foo notin (a,b,c)')).toBe(false);
+    });
+
+    it('matches when the key is absent', () => {
+      expect(matchesLabelSelector({}, 'foo notin (a,b,c)')).toBe(true);
+    });
+
+    it('tolerates whitespace', () => {
+      expect(matchesLabelSelector({ foo: 'z' }, 'foo  notin  ( a , b , c )')).toBe(true);
+    });
+  });
+
+  describe('multiple ANDed requirements', () => {
+    it('requires every requirement to hold', () => {
+      const labels = { env: 'prod', tier: 'backend' };
+      expect(matchesLabelSelector(labels, 'env=prod,tier=backend')).toBe(true);
+      expect(matchesLabelSelector(labels, 'env=prod,tier=frontend')).toBe(false);
+      expect(matchesLabelSelector(labels, 'env=prod, tier in (backend,frontend), !missing')).toBe(
+        true
+      );
+    });
+
+    it('tolerates whitespace between requirements', () => {
+      expect(
+        matchesLabelSelector({ env: 'prod', tier: 'backend' }, ' env=prod , tier=backend ')
+      ).toBe(true);
+    });
+  });
+
+  describe('malformed input', () => {
+    it('fails closed without throwing on an unbalanced set', () => {
+      expect(() => matchesLabelSelector({ foo: 'a' }, 'foo in (a,b')).not.toThrow();
+      expect(matchesLabelSelector({ foo: 'a' }, 'foo in (a,b')).toBe(false);
+    });
+
+    it('fails closed without throwing on a stray operator', () => {
+      expect(() => matchesLabelSelector({ foo: 'a' }, 'foo===bar')).not.toThrow();
+      expect(matchesLabelSelector({ foo: 'a' }, 'foo===bar')).toBe(false);
+    });
+
+    it('fails closed on an empty requirement produced by a stray comma', () => {
+      expect(matchesLabelSelector({ foo: 'a' }, 'foo=a,,bar=b')).toBe(false);
+    });
+  });
+});

--- a/frontend/src/lib/k8s/labelSelectorMatch.ts
+++ b/frontend/src/lib/k8s/labelSelectorMatch.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** A single parsed requirement out of a label selector string, e.g. `key in (v1, v2)`. */
+type Requirement =
+  | { operator: 'equals' | 'notEquals'; key: string; value: string }
+  | { operator: 'exists' | 'notExists'; key: string }
+  | { operator: 'in' | 'notIn'; key: string; values: string[] };
+
+const KEY_RE = /^[A-Za-z0-9]([-A-Za-z0-9_./]*[A-Za-z0-9])?$/;
+const VALUE_RE = /^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$/;
+
+/**
+ * Splits a selector string on top-level commas, i.e. commas that are not
+ * inside a `(...)` set (as used by the `in`/`notin` operators).
+ */
+function splitRequirements(selector: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const char of selector) {
+    if (char === '(') {
+      depth += 1;
+    } else if (char === ')') {
+      depth -= 1;
+    }
+    if (char === ',' && depth === 0) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  parts.push(current);
+  if (depth !== 0) {
+    throw new Error(`unbalanced parentheses: ${selector}`);
+  }
+  return parts;
+}
+
+/** Parses a single trimmed requirement string, throwing on anything malformed. */
+function parseRequirement(raw: string): Requirement {
+  const text = raw.trim();
+  if (!text) {
+    throw new Error('empty requirement');
+  }
+
+  if (text.startsWith('!')) {
+    const key = text.slice(1).trim();
+    if (!KEY_RE.test(key)) {
+      throw new Error(`invalid key: ${key}`);
+    }
+    return { operator: 'notExists', key };
+  }
+
+  const setMatch = text.match(/^(.+?)\s+(in|notin)\s*\((.*)\)$/);
+  if (setMatch) {
+    const key = setMatch[1].trim();
+    const operator = setMatch[2] === 'in' ? 'in' : 'notIn';
+    const values = setMatch[3]
+      .split(',')
+      .map(value => value.trim())
+      .filter(value => value.length > 0);
+    if (!KEY_RE.test(key) || values.length === 0 || !values.every(value => VALUE_RE.test(value))) {
+      throw new Error(`invalid set requirement: ${text}`);
+    }
+    return { operator, key, values };
+  }
+
+  const notEqualsMatch = text.match(/^(.+?)\s*!=\s*(.+)$/);
+  if (notEqualsMatch) {
+    const key = notEqualsMatch[1].trim();
+    const value = notEqualsMatch[2].trim();
+    if (!KEY_RE.test(key) || !VALUE_RE.test(value)) {
+      throw new Error(`invalid requirement: ${text}`);
+    }
+    return { operator: 'notEquals', key, value };
+  }
+
+  const equalsMatch = text.match(/^(.+?)\s*==?\s*(.+)$/);
+  if (equalsMatch) {
+    const key = equalsMatch[1].trim();
+    const value = equalsMatch[2].trim();
+    if (!KEY_RE.test(key) || !VALUE_RE.test(value)) {
+      throw new Error(`invalid requirement: ${text}`);
+    }
+    return { operator: 'equals', key, value };
+  }
+
+  if (!KEY_RE.test(text)) {
+    throw new Error(`invalid key: ${text}`);
+  }
+  return { operator: 'exists', key: text };
+}
+
+/** Returns whether `labels` satisfies a single parsed requirement. */
+function matchesRequirement(labels: Record<string, string>, requirement: Requirement): boolean {
+  switch (requirement.operator) {
+    case 'exists':
+      return Object.prototype.hasOwnProperty.call(labels, requirement.key);
+    case 'notExists':
+      return !Object.prototype.hasOwnProperty.call(labels, requirement.key);
+    case 'equals':
+      return labels[requirement.key] === requirement.value;
+    case 'notEquals':
+      return labels[requirement.key] !== requirement.value;
+    case 'in':
+      return (
+        Object.prototype.hasOwnProperty.call(labels, requirement.key) &&
+        requirement.values.includes(labels[requirement.key])
+      );
+    case 'notIn':
+      return (
+        !Object.prototype.hasOwnProperty.call(labels, requirement.key) ||
+        !requirement.values.includes(labels[requirement.key])
+      );
+    default:
+      return false;
+  }
+}
+
+/**
+ * Returns true if `labels` satisfies every requirement in the selector string.
+ * An empty/blank selector matches everything.
+ *
+ * Supports the standard Kubernetes label selector grammar: comma-separated
+ * requirements ANDed together, using the `=`/`==`, `!=`, bare key (exists),
+ * `!key` (does not exist), `in (...)` and `notin (...)` forms. A malformed
+ * requirement fails closed (returns false for the whole selector) rather than
+ * throwing.
+ *
+ * @param labels - The labels to test, or undefined if the object has none.
+ * @param selector - The label selector string to evaluate (may be undefined/empty).
+ * @returns Whether `labels` matches every requirement of `selector`.
+ */
+export function matchesLabelSelector(
+  labels: Record<string, string> | undefined,
+  selector: string | undefined
+): boolean {
+  const trimmedSelector = (selector ?? '').trim();
+  if (!trimmedSelector) {
+    return true;
+  }
+
+  const effectiveLabels = labels ?? {};
+
+  try {
+    const requirements = splitRequirements(trimmedSelector).map(parseRequirement);
+    return requirements.every(requirement => matchesRequirement(effectiveLabels, requirement));
+  } catch {
+    // Fail closed on malformed selectors rather than throwing or logging.
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes three regressions introduced by #7361. That PR made namespace restrictions fail closed, which is correct and is preserved here; these are follow-on defects in the paths it changed.

Fixes #7380

## Changes

**Caller `labelSelector` is now intersected with manually configured namespaces.** `allowedNamespaceListQuery` applied the caller's selector only to the selector-based `LIST`, returning manual namespaces unconditionally. Per-name `GET` results are now filtered through a new `matchesLabelSelector` helper, so the result is `(manual ∪ configured) ∩ requested`. This is what made the Projects pages list every allowed namespace as a project under a manual `allowedNamespaces` restriction.

The helper (`frontend/src/lib/k8s/labelSelectorMatch.ts`) implements the standard selector grammar (`=`, `==`, `!=`, `in`, `notin`, exists, not-exists), treats an absent key as matching for `!=` and `notin` as the apiserver does, and returns `false` on malformed input so it fails closed. Client-side evaluation is deliberate: intersecting server-side would require a namespace `LIST`, which is exactly the RBAC the per-name `GET` path exists to avoid.

**A denied namespace `GET` no longer empties the list.** The per-name fan-out used `Promise.all`, so one 403 failed the whole query — newly reachable because #7361 routed the Namespaces page through this path, where it previously rendered static rows with no request. It now uses `Promise.allSettled`:

- a denied name becomes a name-only placeholder row, restoring the pre-#7361 behaviour;
- if a caller selector is active the name is omitted instead, since the selector cannot be evaluated without labels — failing closed;
- a placeholder is never emitted for a name the selector `LIST` already returned, so it cannot shadow a real object;
- if every name fails and the selector list is empty, the first error is rethrown so a genuinely broken configuration still surfaces.

Partial failure therefore resolves successfully without an error banner, matching what the page did before #7361.

**Placeholders made renderable.** Placeholders have no `creationTimestamp` and an empty `status`. `namespace/List.tsx` read `status.phase` unguarded, and the shared `age` column in `ResourceTable.tsx` passed a missing timestamp straight to `DateLabel` — the former threw through the table's accessor, the latter renders `Invalid Date` (and throws under test). Both now render `Unknown`. The `age` change is in the shared column rather than a local one so sorting, alignment and filtering stay identical; an earlier local column silently lost the table's initial sort, which the `Namespace/ListView` storyshot caught.

**Routes are no longer remounted by the gate.** `Layout.tsx` swapped element types at the `RouteSwitcher` slot, remounting the routed subtree whenever the condition flipped — which it did on every `/project/` route, since `useClustersConf()` is empty on first render. The gate is now always rendered, the `/project/` path sniffing is gone, and project gating lives in `ProjectList` and `ProjectDetails` alongside the `useProject` call that needs it.

## Testing

- `frontend/src/lib/k8s/labelSelectorMatch.test.ts` — 23 cases covering each operator, absent-key semantics, whitespace, and malformed input.
- `useKubeObjectList.test.tsx` — selector intersection for manual namespaces, placeholder on a denied `GET`, omission when a selector is active, placeholder-does-not-shadow, and total-failure rethrow.
- `namespace/List.test.tsx`, `ResourceTable.test.tsx` — status and age render `Unknown` instead of throwing; rows with real values are unchanged.
- `AllowedNamespacesSelectorGate.test.tsx` — children are not remounted when `clusters` goes from empty to populated.

Each new test was confirmed to fail against the unfixed code.

Full frontend suite: 3137 passed, 1 failed — `Storybook Tests > Version Dialog > VersionDialog`, which also fails on an unmodified `main` (d5ffa35ff) and is unrelated to this change. No snapshot was regenerated. `npm run lint` and `npm run tsc` are clean.

The e2e Playwright scenarios added by #7361 were not run locally.
