### PR TITLE
backend: Add live federated cluster registrations

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -49,6 +49,7 @@ import (
 	"github.com/gorilla/mux"
 	auth "github.com/kubernetes-sigs/headlamp/backend/pkg/auth"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/clusterapi"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/clusterinventory"
 	cfg "github.com/kubernetes-sigs/headlamp/backend/pkg/config"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
@@ -177,15 +178,16 @@ const (
 )
 
 type clientConfig struct {
-	Clusters                  []Cluster `json:"clusters"`
-	IsDynamicClusterEnabled   bool      `json:"isDynamicClusterEnabled"`
-	AllowKubeconfigChanges    bool      `json:"allowKubeconfigChanges"`
-	DefaultPodDebugImage      string    `json:"defaultPodDebugImage"`
-	DefaultNodeShellImage     string    `json:"defaultNodeShellImage"`
-	DefaultNodeShellNamespace string    `json:"defaultNodeShellNamespace"`
-	DefaultLightTheme         string    `json:"defaultLightTheme,omitempty"`
-	DefaultDarkTheme          string    `json:"defaultDarkTheme,omitempty"`
-	ForceTheme                string    `json:"forceTheme,omitempty"`
+	Clusters                    []Cluster `json:"clusters"`
+	IsDynamicClusterEnabled     bool      `json:"isDynamicClusterEnabled"`
+	AllowKubeconfigChanges      bool      `json:"allowKubeconfigChanges"`
+	ClusterRegistrationsEnabled bool      `json:"clusterRegistrationsEnabled"`
+	DefaultPodDebugImage        string    `json:"defaultPodDebugImage"`
+	DefaultNodeShellImage       string    `json:"defaultNodeShellImage"`
+	DefaultNodeShellNamespace   string    `json:"defaultNodeShellNamespace"`
+	DefaultLightTheme           string    `json:"defaultLightTheme,omitempty"`
+	DefaultDarkTheme            string    `json:"defaultDarkTheme,omitempty"`
+	ForceTheme                  string    `json:"forceTheme,omitempty"`
 }
 
 type OauthConfig struct {
@@ -523,40 +525,115 @@ func validateServiceAccountNamespace(data []byte) (string, error) {
 	return namespace, nil
 }
 
-func startClusterInventory(ctx context.Context, config *HeadlampConfig) error {
+// discoveryHub is the in-cluster config, namespace and identity the discovery sources share.
+type discoveryHub struct {
+	restConfig *rest.Config
+	namespace  string
+	cluster    string
+	oidcConfig *kubeconfig.OidcConfig
+}
+
+func (c *HeadlampConfig) resolveDiscoveryHub() (discoveryHub, error) {
+	var hub discoveryHub
+
+	if !c.UseInCluster {
+		return hub, nil
+	}
+
+	restConfig, err := rest.InClusterConfig()
+	if err != nil {
+		return hub, fmt.Errorf("get in-cluster config: %w", err)
+	}
+
+	namespace, err := readServiceAccountNamespace()
+	if err != nil {
+		return hub, fmt.Errorf("get pod namespace: %w", err)
+	}
+
+	hub.restConfig, hub.namespace = restConfig, namespace
+
+	contexts, err := c.KubeConfigStore.GetContexts()
+	if err != nil {
+		return hub, fmt.Errorf("read the in-cluster context: %w", err)
+	}
+
+	for _, headlampContext := range contexts {
+		if headlampContext.Source == kubeconfig.InCluster {
+			hub.cluster, hub.oidcConfig = headlampContext.Name, headlampContext.OidcConf
+
+			break
+		}
+	}
+
+	return hub, nil
+}
+
+// startClusterDiscovery starts the enabled discovery sources.
+func startClusterDiscovery(ctx context.Context, config *HeadlampConfig) error {
+	if config.ClusterRegistrationStore == nil {
+		return nil
+	}
+
+	hub, err := config.resolveDiscoveryHub()
+	if err != nil {
+		return err
+	}
+
+	if err := startClusterInventory(ctx, config, hub); err != nil {
+		return err
+	}
+
+	return startClusterAPI(ctx, config, hub)
+}
+
+func startClusterInventory(ctx context.Context, config *HeadlampConfig, hub discoveryHub) error {
 	if !config.EnableClusterInventory {
 		return nil
 	}
 
-	var (
-		hubConfig    *rest.Config
-		hubNamespace string
-	)
-
-	if config.UseInCluster {
-		var err error
-
-		hubConfig, err = rest.InClusterConfig()
-		if err != nil {
-			return fmt.Errorf("get in-cluster config for cluster inventory: %w", err)
-		}
-
-		hubNamespace, err = readServiceAccountNamespace()
-		if err != nil {
-			return fmt.Errorf("get pod namespace for cluster inventory: %w", err)
-		}
-	}
-
-	runner, err := clusterinventory.NewRunner(clusterinventory.Options{
-		Store:                 config.KubeConfigStore,
+	opts := clusterinventory.Options{
+		Registry:              config.ClusterRegistrationStore,
 		ProviderFile:          config.ClusterInventoryProviderFile,
+		AuthType:              config.ClusterInventoryAuthType,
+		AccessProviders:       config.ClusterInventoryAccessProviders,
+		OIDCConfig:            hub.oidcConfig,
 		LabelSelector:         config.ClusterInventoryLabelSelector,
 		Namespaces:            config.ClusterInventoryNamespaces,
 		RootReconcileInterval: config.ClusterInventoryRootReconcileInterval,
 		NoCRDCacheTTL:         config.ClusterInventoryNoCRDCacheTTL,
-		HubConfig:             hubConfig,
-		HubNamespace:          hubNamespace,
-		DiscoverFromStore:     !config.UseInCluster,
+		HubConfig:             hub.restConfig,
+		HubNamespace:          hub.namespace,
+		HubCluster:            hub.cluster,
+	}
+
+	// Outside a cluster there is no hub, so the configured contexts are the discovery roots.
+	if !config.UseInCluster {
+		opts.SeedStore = config.KubeConfigStore
+	}
+
+	runner, err := clusterinventory.NewRunner(opts)
+	if err != nil {
+		return err
+	}
+
+	go runner.Run(ctx)
+
+	return nil
+}
+
+func startClusterAPI(ctx context.Context, config *HeadlampConfig, hub discoveryHub) error {
+	if !config.EnableClusterAPI {
+		return nil
+	}
+
+	runner, err := clusterapi.NewRunner(clusterapi.Options{
+		Registry:         config.ClusterRegistrationStore,
+		RESTConfig:       hub.restConfig,
+		OriginCluster:    hub.cluster,
+		DefaultNamespace: hub.namespace,
+		Namespaces:       config.ClusterAPINamespaces,
+		LabelSelector:    config.ClusterAPILabelSelector,
+		OIDCConfig:       hub.oidcConfig,
 	})
 	if err != nil {
 		return err
@@ -968,6 +1045,13 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 	r.Handle("/config", auth.NewBackendTokenMiddleware(config.UseInCluster)(
 		http.HandlerFunc(config.getConfig))).Methods("GET")
 
+	if config.ClusterRegistrationStore != nil {
+		r.Handle("/cluster-registrations", auth.NewBackendTokenMiddleware(config.UseInCluster)(
+			http.HandlerFunc(config.ClusterRegistrationStore.ServeSnapshot))).Methods("GET")
+		r.Handle("/cluster-registrations/events", auth.NewBackendTokenMiddleware(config.UseInCluster)(
+			http.HandlerFunc(config.ClusterRegistrationStore.ServeEvents))).Methods("GET")
+	}
+
 	// Auth token management
 	r.Handle("/auth/set-token", auth.NewBackendTokenMiddleware(config.UseInCluster)(
 		http.HandlerFunc(config.handleSetToken))).Methods("POST")
@@ -1366,11 +1450,15 @@ func (c *HeadlampConfig) requestTokenForContext(
 	return token
 }
 
-func applyRequestTokenToContext(r *http.Request, clusterName string, context *kubeconfig.Context) {
+func setTokenFromCookieIfUnset(r *http.Request, clusterName string) {
 	// Only promote a cookie token when the request does not already provide Authorization.
 	if strings.TrimSpace(r.Header.Get("Authorization")) == "" {
 		auth.SetTokenFromCookie(r, clusterName)
 	}
+}
+
+func applyRequestTokenToContext(r *http.Request, clusterName string, context *kubeconfig.Context) {
+	setTokenFromCookieIfUnset(r, clusterName)
 
 	bearerToken := auth.BearerTokenValue(r.Header.Get("Authorization"))
 	if bearerToken == "" {
@@ -1520,7 +1608,7 @@ func hostValidationMiddleware(listenAddr string, port uint) func(http.Handler) h
 func serverHandler(ctx context.Context, config *HeadlampConfig) (http.Handler, error) {
 	handler := createHeadlampHandler(ctx, config)
 
-	if err := startClusterInventory(ctx, config); err != nil {
+	if err := startClusterDiscovery(ctx, config); err != nil {
 		return nil, err
 	}
 
@@ -1570,7 +1658,7 @@ func StartHeadlampServer(config *HeadlampConfig) {
 
 	handler, err := serverHandler(ctx, config)
 	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "starting cluster inventory discovery")
+		logger.Log(logger.LevelError, nil, err, "starting cluster discovery")
 		return
 	}
 
@@ -1981,23 +2069,7 @@ func clusterRequestHandler(c *HeadlampConfig) http.Handler { //nolint:funlen
 		// Process WebSocket protocol headers if present
 		processWebSocketProtocolHeader(r)
 
-		if c.shouldUseUnsafeServiceAccountTokenForContext(kContext) {
-			clearRequestAuthorization(r)
-		} else {
-			var token string
-
-			if c.ProxyAuthEnabled && c.ProxyAuthTokenHeader != "" {
-				token = strings.TrimSpace(r.Header.Get(c.ProxyAuthTokenHeader))
-			}
-
-			if token == "" {
-				token, _ = auth.GetTokenFromCookie(r, mux.Vars(r)["clusterName"])
-			}
-
-			if token != "" {
-				r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-			}
-		}
+		c.authorizeClusterRequest(r, kContext)
 
 		clearConfiguredProxyTokenHeader(r, c.ProxyAuthTokenHeader)
 
@@ -2031,7 +2103,49 @@ func handleClusterAPI(c *HeadlampConfig, router *mux.Router) {
 		handler = CacheMiddleWare(c)(handler)
 	}
 
+	if c.ClusterRegistrationStore != nil {
+		router.PathPrefix("/clusters/{clusterName}/federated/{targetName}/{api:.*}").Handler(
+			auth.NewBackendTokenMiddleware(c.UseInCluster)(federatedClusterMiddleware(c)(handler)),
+		)
+	}
+
 	router.PathPrefix("/clusters/{clusterName}/{api:.*}").Handler(auth.NewBackendTokenMiddleware(c.UseInCluster)(handler))
+}
+
+// federatedClusterMiddleware routes a request to the target registration it names, if that
+// registration was discovered from the origin cluster.
+func federatedClusterMiddleware(c *HeadlampConfig) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			vars := mux.Vars(r)
+			originCluster, targetCluster := vars["clusterName"], vars["targetName"]
+
+			registration, found := c.ClusterRegistrationStore.Get(targetCluster)
+			if !found || registration.Origin.Cluster != originCluster {
+				http.NotFound(w, r)
+
+				return
+			}
+
+			c.delegateOriginToken(r, originCluster, targetCluster)
+
+			next.ServeHTTP(w, mux.SetURLVars(r, map[string]string{
+				"clusterName": targetCluster,
+				"api":         vars["api"],
+			}))
+		})
+	}
+}
+
+// delegateOriginToken authorizes a federated request with the origin cluster's auth cookie,
+// which is only safe when the target authenticates the end user.
+func (c *HeadlampConfig) delegateOriginToken(r *http.Request, originCluster, targetCluster string) {
+	kContext, err := c.KubeConfigStore.GetContext(targetCluster)
+	if err != nil || kContext.AuthType() != kubeconfig.AuthTypeOIDC {
+		return
+	}
+
+	setTokenFromCookieIfUnset(r, originCluster)
 }
 
 func recordRequestCompletion(c *HeadlampConfig, ctx context.Context,
@@ -2082,6 +2196,24 @@ func processWebSocketProtocolHeader(r *http.Request) {
 	} else {
 		r.Header.Del("Sec-WebSocket-Protocol")
 	}
+}
+
+func (c *HeadlampConfig) authorizeClusterRequest(r *http.Request, kContext *kubeconfig.Context) {
+	if c.shouldUseUnsafeServiceAccountTokenForContext(kContext) {
+		clearRequestAuthorization(r)
+
+		return
+	}
+
+	if c.ProxyAuthEnabled && c.ProxyAuthTokenHeader != "" {
+		if token := strings.TrimSpace(r.Header.Get(c.ProxyAuthTokenHeader)); token != "" {
+			r.Header.Set("Authorization", "Bearer "+token)
+
+			return
+		}
+	}
+
+	auth.SetTokenFromCookie(r, mux.Vars(r)["clusterName"])
 }
 
 // processTokenProtocol extracts a bearer token from a WebSocket protocol string
@@ -2141,7 +2273,7 @@ func (c *HeadlampConfig) getClusters() []Cluster {
 			continue
 		}
 
-		// Dynamic clusters should not be visible to other users.
+		// Dynamic clusters and registrations should not be visible to other users.
 		if context.Internal {
 			continue
 		}
@@ -2280,15 +2412,16 @@ func (c *HeadlampConfig) getConfig(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	clientConfig := clientConfig{
-		Clusters:                  c.getClusters(),
-		IsDynamicClusterEnabled:   c.EnableDynamicClusters,
-		AllowKubeconfigChanges:    c.AllowKubeconfigChanges,
-		DefaultPodDebugImage:      c.PodDebugImage,
-		DefaultNodeShellImage:     c.NodeShellImage,
-		DefaultNodeShellNamespace: c.NodeShellNamespace,
-		DefaultLightTheme:         c.DefaultLightTheme,
-		DefaultDarkTheme:          c.DefaultDarkTheme,
-		ForceTheme:                c.ForceTheme,
+		Clusters:                    c.getClusters(),
+		IsDynamicClusterEnabled:     c.EnableDynamicClusters,
+		AllowKubeconfigChanges:      c.AllowKubeconfigChanges,
+		ClusterRegistrationsEnabled: c.ClusterRegistrationStore != nil,
+		DefaultPodDebugImage:        c.PodDebugImage,
+		DefaultNodeShellImage:       c.NodeShellImage,
+		DefaultNodeShellNamespace:   c.NodeShellNamespace,
+		DefaultLightTheme:           c.DefaultLightTheme,
+		DefaultDarkTheme:            c.DefaultDarkTheme,
+		ForceTheme:                  c.ForceTheme,
 	}
 
 	if err := json.NewEncoder(w).Encode(&clientConfig); err != nil {

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -45,6 +46,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	inventorymetadata "github.com/kubernetes-sigs/headlamp/backend/pkg/clusterinventory/metadata"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/clusterregistration"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
@@ -437,6 +439,62 @@ func TestGetConfigIncludesDefaultNodeShellNamespace(t *testing.T) {
 	err := json.Unmarshal(recorder.Body.Bytes(), &config)
 	require.NoError(t, err)
 	assert.Equal(t, "custom-ns", config.DefaultNodeShellNamespace)
+}
+
+func registerSpoke(
+	t *testing.T, registry *clusterregistration.Registry, name string, kubeContext *kubeconfig.Context,
+) string {
+	t.Helper()
+
+	id, err := registry.Upsert(clusterregistration.Candidate{
+		DisplayName: name,
+		Source:      "cluster-inventory",
+		Origin: clusterregistration.Origin{
+			Cluster: "hub",
+			Resource: clusterregistration.Resource{
+				APIVersion: "multicluster.x-k8s.io/v1alpha1",
+				Kind:       "ClusterProfile",
+				Namespace:  "headlamp",
+				Name:       name,
+				UID:        "uid-" + name,
+			},
+		},
+		Context: kubeContext,
+	})
+	require.NoError(t, err)
+
+	return id
+}
+
+func TestGetConfigAnnouncesRegistrationsWithoutPublishingThem(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+	registry := clusterregistration.New(store)
+
+	registerSpoke(t, registry, "spoke", &kubeconfig.Context{
+		Name:        "temporary",
+		KubeContext: &api.Context{Cluster: "temporary", AuthInfo: "temporary"},
+		Cluster:     &api.Cluster{Server: "https://private-spoke.example"},
+		AuthInfo:    &api.AuthInfo{},
+		OidcConf: &kubeconfig.OidcConfig{
+			ClientID:     "headlamp",
+			ClientSecret: "private-client-secret",
+		},
+	})
+
+	c := &HeadlampConfig{HeadlampConfig: &headlampconfig.HeadlampConfig{
+		HeadlampCFG:              &headlampconfig.HeadlampCFG{KubeConfigStore: store},
+		ClusterRegistrationStore: registry,
+	}}
+	recorder := httptest.NewRecorder()
+	c.getConfig(recorder, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/config", nil))
+
+	assert.NotContains(t, recorder.Body.String(), "private-spoke.example")
+	assert.NotContains(t, recorder.Body.String(), "private-client-secret")
+
+	var result clientConfig
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &result))
+	assert.Empty(t, result.Clusters)
+	assert.True(t, result.ClusterRegistrationsEnabled)
 }
 
 //nolint:gocognit,funlen
@@ -2704,8 +2762,7 @@ func TestStartHeadlampServer(t *testing.T) {
 	config := &HeadlampConfig{
 		HeadlampConfig: &headlampconfig.HeadlampConfig{
 			HeadlampCFG: &headlampconfig.HeadlampCFG{
-				// port comes from net.TCPAddr.Port and is always in [0, 65535], so uint conversion is safe.
-				Port:            uint(port),
+				Port:            uint(port), //nolint:gosec // net.TCPAddr.Port is always in [0, 65535]
 				PluginDir:       tempDir,
 				KubeConfigStore: kubeconfig.NewContextStore(),
 			},
@@ -4257,6 +4314,97 @@ func TestClusterRequestHandlerFallsBackToClusterContextForWebSocketCookie(t *tes
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, "Bearer cookie-token", receivedAuth)
 	assert.Equal(t, "v4.channel.k8s.io", receivedProtocol)
+}
+
+func TestFederatedClusterRequest(t *testing.T) { //nolint:funlen
+	var receivedAuth string
+
+	kubeAPI := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"kind":"PodList","items":[]}`))
+	}))
+	t.Cleanup(kubeAPI.Close)
+
+	spokeCluster := &api.Cluster{Server: kubeAPI.URL, InsecureSkipTLSVerify: true}
+	store := kubeconfig.NewContextStore()
+	registry := clusterregistration.New(store)
+
+	oidcTarget := registerSpoke(t, registry, "spoke", &kubeconfig.Context{
+		Name:        "temporary",
+		KubeContext: &api.Context{Cluster: "temporary", AuthInfo: "temporary"},
+		Cluster:     spokeCluster,
+		AuthInfo:    &api.AuthInfo{},
+		OidcConf:    &kubeconfig.OidcConfig{ClientID: "headlamp"},
+	})
+	plainTarget := registerSpoke(t, registry, "access-provider-spoke", &kubeconfig.Context{
+		KubeContext: &api.Context{},
+		Cluster:     spokeCluster,
+		AuthInfo:    &api.AuthInfo{},
+	})
+
+	router := mux.NewRouter()
+	handleClusterAPI(&HeadlampConfig{HeadlampConfig: &headlampconfig.HeadlampConfig{
+		HeadlampCFG:              &headlampconfig.HeadlampCFG{UseInCluster: true, KubeConfigStore: store},
+		ClusterRegistrationStore: registry,
+		Cache:                    cache.New[interface{}](),
+		TelemetryConfig:          GetDefaultTestTelemetryConfig(),
+		TelemetryHandler:         &telemetry.RequestHandler{},
+	}}, router)
+
+	tests := []struct {
+		name              string
+		origin            string
+		target            string
+		headers           http.Header
+		wantCode          int
+		wantAuthorization string
+	}{
+		{
+			name: "uses the origin cookie", origin: "hub", target: oidcTarget,
+			wantCode: http.StatusOK, wantAuthorization: "Bearer hub-user-token",
+		},
+		{
+			name: "keeps an explicit authorization header", origin: "hub", target: oidcTarget,
+			headers:  http.Header{"Authorization": []string{"Bearer explicit-token"}},
+			wantCode: http.StatusOK, wantAuthorization: "Bearer explicit-token",
+		},
+		{
+			name: "withholds the origin cookie from a non-OIDC target", origin: "hub", target: plainTarget,
+			wantCode: http.StatusOK, wantAuthorization: "",
+		},
+		{
+			name: "rejects a mismatched origin", origin: "other", target: oidcTarget,
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name: "rejects an unknown target", origin: "hub", target: "hr-v1-unknown",
+			wantCode: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+				"/clusters/"+tt.origin+"/federated/"+tt.target+"/api/v1/pods", nil)
+			maps.Copy(req.Header, tt.headers)
+			req.AddCookie(&http.Cookie{
+				Name:     "headlamp-auth-hub.0",
+				Value:    "hub-user-token",
+				Secure:   true,
+				HttpOnly: true,
+				SameSite: http.SameSiteStrictMode,
+			})
+
+			receivedAuth = ""
+
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, req)
+
+			assert.Equal(t, tt.wantCode, recorder.Code)
+			assert.Equal(t, tt.wantAuthorization, receivedAuth)
+		})
+	}
 }
 
 func TestClusterRequestHandlerStripsProxyAuthTokenHeader(t *testing.T) {

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cli/browser"
 	"github.com/gorilla/mux"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/clusterregistration"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
@@ -99,6 +100,7 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 		EnableHelm:             conf.EnableHelm,
 		EnableDynamicClusters:  conf.EnableDynamicClusters,
 		EnableClusterInventory: conf.EnableClusterInventory,
+		EnableClusterAPI:       conf.EnableClusterAPI,
 		AllowKubeconfigChanges: conf.AllowKubeconfigChanges,
 		WatchPluginsChanges:    conf.WatchPluginsChanges,
 		KubeConfigStore:        kubeConfigStore,
@@ -111,10 +113,14 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 			return strings.Split(conf.ProxyURLs, ",")
 		}(),
 		ClusterInventoryProviderFile:          conf.ClusterInventoryProviderFile,
+		ClusterInventoryAuthType:              conf.ClusterInventoryAuthType,
+		ClusterInventoryAccessProviders:       conf.ClusterInventoryAccessProviders,
 		ClusterInventoryLabelSelector:         conf.ClusterInventoryLabelSelector,
 		ClusterInventoryNamespaces:            conf.ClusterInventoryNamespaces,
 		ClusterInventoryRootReconcileInterval: conf.ClusterInventoryRootReconcileInterval,
 		ClusterInventoryNoCRDCacheTTL:         conf.ClusterInventoryNoCRDCacheTTL,
+		ClusterAPILabelSelector:               conf.ClusterAPILabelSelector,
+		ClusterAPINamespaces:                  conf.ClusterAPINamespaces,
 		TLSCertPath:                           conf.TLSCertPath,
 		TLSKeyPath:                            conf.TLSKeyPath,
 		SessionTTL:                            conf.SessionTTL,
@@ -206,6 +212,11 @@ func createHeadlampConfig(conf *config.Config) *HeadlampConfig {
 
 	multiplexer := NewMultiplexer(kubeConfigStore, conf.InCluster && conf.UnsafeUseServiceAccountToken)
 
+	var registrationStore *clusterregistration.Registry
+	if conf.EnableClusterInventory || conf.EnableClusterAPI {
+		registrationStore = clusterregistration.New(kubeConfigStore)
+	}
+
 	cfg := &headlampconfig.HeadlampConfig{
 		HeadlampCFG:               buildHeadlampCFG(conf, kubeConfigStore),
 		OidcClientID:              conf.OidcClientID,
@@ -226,6 +237,7 @@ func createHeadlampConfig(conf *config.Config) *HeadlampConfig {
 		Multiplexer:               multiplexer,
 		TelemetryConfig:           buildTelemetryConfig(conf),
 		OidcCACert:                loadOidcCACert(conf.OidcCAFile),
+		ClusterRegistrationStore:  registrationStore,
 	}
 
 	cfg.ProxyAuthEnabled = conf.ProxyAuthEnabled

--- a/backend/cmd/server_config_test.go
+++ b/backend/cmd/server_config_test.go
@@ -29,19 +29,24 @@ func TestBuildHeadlampCFG(t *testing.T) {
 
 	t.Run("maps basic fields and splits proxy urls", func(t *testing.T) {
 		conf := &config.Config{
-			AppName:                    "Branded Headlamp",
-			Port:                       4444,
-			InCluster:                  true,
-			InClusterContextName:       "test-incluster",
-			InsecureSsl:                true,
-			KubeConfigDir:              "/kubeconfigs",
-			PluginsDir:                 "/plugins",
-			UserPluginsDir:             "/user-plugins",
-			AllowKubeconfigChanges:     true,
-			WatchPluginsChanges:        false,
-			BaseURL:                    "/headlamp",
-			ProxyURLs:                  "http://proxy1,http://proxy2",
-			ClusterInventoryNamespaces: "team-a,team-b",
+			AppName:                         "Branded Headlamp",
+			Port:                            4444,
+			InCluster:                       true,
+			InClusterContextName:            "test-incluster",
+			InsecureSsl:                     true,
+			KubeConfigDir:                   "/kubeconfigs",
+			PluginsDir:                      "/plugins",
+			UserPluginsDir:                  "/user-plugins",
+			AllowKubeconfigChanges:          true,
+			WatchPluginsChanges:             false,
+			BaseURL:                         "/headlamp",
+			ProxyURLs:                       "http://proxy1,http://proxy2",
+			ClusterInventoryNamespaces:      "team-a,team-b",
+			ClusterInventoryAuthType:        "oidc",
+			ClusterInventoryAccessProviders: "trusted-a,trusted-b",
+			EnableClusterAPI:                true,
+			ClusterAPILabelSelector:         "environment=prod",
+			ClusterAPINamespaces:            "clusters-a,clusters-b",
 		}
 
 		headlampCFG := buildHeadlampCFG(conf, store)
@@ -60,6 +65,11 @@ func TestBuildHeadlampCFG(t *testing.T) {
 		assert.Equal(t, []string{"http://proxy1", "http://proxy2"}, headlampCFG.ProxyURLs)
 		assert.Equal(t, store, headlampCFG.KubeConfigStore)
 		assert.Equal(t, "team-a,team-b", headlampCFG.ClusterInventoryNamespaces)
+		assert.Equal(t, "oidc", headlampCFG.ClusterInventoryAuthType)
+		assert.Equal(t, "trusted-a,trusted-b", headlampCFG.ClusterInventoryAccessProviders)
+		assert.True(t, headlampCFG.EnableClusterAPI)
+		assert.Equal(t, "environment=prod", headlampCFG.ClusterAPILabelSelector)
+		assert.Equal(t, "clusters-a,clusters-b", headlampCFG.ClusterAPINamespaces)
 	})
 
 	t.Run("empty proxy urls yields empty slice", func(t *testing.T) {

--- a/backend/pkg/clusterapi/clusterapi.go
+++ b/backend/pkg/clusterapi/clusterapi.go
@@ -1,0 +1,292 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package clusterapi discovers Cluster API Cluster resources and registers them as
+// Headlamp clusters, without reading their kubeconfig Secrets.
+package clusterapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/clusterregistration"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
+)
+
+const (
+	registrationSource = "cluster-api"
+	clusterGroup       = "cluster.x-k8s.io"
+
+	defaultAPIPort         = int64(6443)
+	discoveryRetryInterval = 5 * time.Minute
+
+	logFieldCluster = "cluster"
+)
+
+// preferredClusterVersions are the Cluster API versions tried, most preferred first.
+var preferredClusterVersions = []string{"v1beta2", "v1beta1"}
+
+func clusterGVR(version string) schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: clusterGroup, Version: version, Resource: "clusters"}
+}
+
+// Options controls Cluster API discovery from a management cluster.
+type Options struct {
+	// Registry stores source-independent, routable cluster registrations.
+	Registry *clusterregistration.Registry
+	// RESTConfig connects to the management cluster hosting the Cluster resources.
+	RESTConfig *rest.Config
+	// OriginCluster is the Headlamp cluster ID of the management cluster.
+	OriginCluster string
+	// DefaultNamespace is watched when Namespaces is empty.
+	DefaultNamespace string
+	// Namespaces limits discovery as parsed by [clusterregistration.ParseNamespaces].
+	// Empty watches DefaultNamespace.
+	Namespaces string
+	// LabelSelector filters Cluster resources before they are registered.
+	LabelSelector string
+	// OIDCConfig is copied to discovered contexts.
+	OIDCConfig *kubeconfig.OidcConfig
+}
+
+// Runner watches Cluster API Cluster resources and updates the shared registry.
+type Runner struct {
+	registry      *clusterregistration.Registry
+	discovery     discovery.DiscoveryInterface
+	client        dynamic.Interface
+	originCluster string
+	namespaces    []string
+	labelSelector labels.Selector
+	oidcConfig    *kubeconfig.OidcConfig
+}
+
+// NewRunner validates options and creates a Cluster API discovery runner.
+func NewRunner(opts Options) (*Runner, error) {
+	if opts.RESTConfig == nil {
+		return nil, errors.New("management cluster config is required")
+	}
+
+	if opts.OriginCluster == "" {
+		return nil, errors.New("origin cluster is required")
+	}
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(rest.CopyConfig(opts.RESTConfig))
+	if err != nil {
+		return nil, fmt.Errorf("create discovery client: %w", err)
+	}
+
+	client, err := dynamic.NewForConfig(rest.CopyConfig(opts.RESTConfig))
+	if err != nil {
+		return nil, fmt.Errorf("create dynamic client: %w", err)
+	}
+
+	return newRunner(opts, discoveryClient, client)
+}
+
+// resolveClusterGVR returns the most preferred Cluster API version the management
+// cluster serves.
+func resolveClusterGVR(client discovery.DiscoveryInterface) (schema.GroupVersionResource, error) {
+	for _, version := range preferredClusterVersions {
+		candidate := clusterGVR(version)
+
+		enabled, err := discovery.IsResourceEnabled(client, candidate)
+		if err != nil {
+			return schema.GroupVersionResource{}, fmt.Errorf("%s clusters: %w", clusterGroup, err)
+		}
+
+		if enabled {
+			return candidate, nil
+		}
+	}
+
+	return schema.GroupVersionResource{}, fmt.Errorf("no served %s clusters resource", clusterGroup)
+}
+
+func newRunner(
+	opts Options,
+	discoveryClient discovery.DiscoveryInterface,
+	client dynamic.Interface,
+) (*Runner, error) {
+	labelSelector, namespaces, err := clusterregistration.ParseSelectors(opts.LabelSelector, opts.Namespaces)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Runner{
+		registry:      opts.Registry,
+		discovery:     discoveryClient,
+		client:        client,
+		originCluster: opts.OriginCluster,
+		namespaces:    clusterregistration.NamespacesOrDefault(namespaces, opts.DefaultNamespace),
+		labelSelector: labelSelector,
+		oidcConfig:    opts.OIDCConfig,
+	}, nil
+}
+
+// Run blocks until ctx is cancelled, retrying until the management cluster serves a
+// Cluster resource.
+func (r *Runner) Run(ctx context.Context) {
+	var clusterGVR schema.GroupVersionResource
+
+	err := wait.PollUntilContextCancel(ctx, discoveryRetryInterval, true,
+		func(context.Context) (bool, error) {
+			var err error
+
+			clusterGVR, err = resolveClusterGVR(r.discovery)
+			if err != nil {
+				logger.Log(logger.LevelWarn, nil, err, "cluster-api: waiting for a served Cluster resource")
+			}
+
+			return err == nil, nil
+		})
+	if err != nil {
+		return
+	}
+
+	r.watchClusters(ctx, clusterGVR)
+}
+
+func (r *Runner) watchClusters(ctx context.Context, clusterGVR schema.GroupVersionResource) {
+	selector := r.labelSelector.String()
+
+	factories := make([]dynamicinformer.DynamicSharedInformerFactory, 0, len(r.namespaces))
+	for _, namespace := range r.namespaces {
+		factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(
+			r.client,
+			0,
+			namespace,
+			func(options *metav1.ListOptions) { options.LabelSelector = selector },
+		)
+
+		_, err := factory.ForResource(clusterGVR).Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc:    r.handleUpsert,
+			UpdateFunc: func(_, newObj interface{}) { r.handleUpsert(newObj) },
+			DeleteFunc: r.handleDelete,
+		})
+		if err != nil {
+			logger.Log(logger.LevelWarn, nil, err, "cluster-api: failed to add Cluster event handler")
+			continue
+		}
+
+		factories = append(factories, factory)
+
+		factory.Start(ctx.Done())
+	}
+
+	<-ctx.Done()
+
+	for _, factory := range factories {
+		factory.Shutdown()
+	}
+}
+
+func (r *Runner) handleUpsert(obj interface{}) {
+	cluster, ok := clusterregistration.ObjectFromEvent[*unstructured.Unstructured](obj)
+	if !ok {
+		return
+	}
+
+	origin := r.originFor(cluster)
+
+	server, ok := controlPlaneServer(cluster)
+	if !ok {
+		r.remove(origin)
+		return
+	}
+
+	_, err := r.registry.Upsert(clusterregistration.Candidate{
+		DisplayName: cluster.GetName(),
+		Source:      registrationSource,
+		Origin:      origin,
+		Context: &kubeconfig.Context{
+			Cluster:  &clientcmdapi.Cluster{Server: server},
+			OidcConf: r.oidcConfig,
+			Source:   kubeconfig.ClusterAPI,
+		},
+	})
+	if err != nil {
+		logger.Log(logger.LevelWarn, map[string]string{logFieldCluster: clusterKey(origin)}, err,
+			"cluster-api: failed to register cluster")
+	}
+}
+
+func (r *Runner) handleDelete(obj interface{}) {
+	cluster, ok := clusterregistration.ObjectFromEvent[*unstructured.Unstructured](obj)
+	if !ok {
+		return
+	}
+
+	r.remove(r.originFor(cluster))
+}
+
+func (r *Runner) originFor(cluster *unstructured.Unstructured) clusterregistration.Origin {
+	return clusterregistration.OriginFor(r.originCluster, cluster.GroupVersionKind(), cluster)
+}
+
+// clusterKey returns the namespaced name of the Cluster an origin was discovered from.
+func clusterKey(origin clusterregistration.Origin) string {
+	return cache.NewObjectName(origin.Resource.Namespace, origin.Resource.Name).String()
+}
+
+func (r *Runner) remove(origin clusterregistration.Origin) {
+	if err := r.registry.RemoveOrigin(registrationSource, origin); err != nil {
+		logger.Log(logger.LevelWarn, map[string]string{logFieldCluster: clusterKey(origin)}, err,
+			"cluster-api: failed to prune registration")
+	}
+}
+
+func controlPlaneServer(cluster *unstructured.Unstructured) (string, bool) {
+	host, found, err := unstructured.NestedString(cluster.Object, "spec", "controlPlaneEndpoint", "host")
+
+	host = strings.TrimSpace(host)
+	if err != nil || !found || host == "" {
+		return "", false
+	}
+
+	port, found, err := unstructured.NestedInt64(cluster.Object, "spec", "controlPlaneEndpoint", "port")
+	if err != nil {
+		return "", false
+	}
+
+	if !found || port == 0 {
+		port = defaultAPIPort
+	}
+
+	if errs := validation.IsValidPortNum(int(port)); len(errs) > 0 {
+		return "", false
+	}
+
+	return "https://" + net.JoinHostPort(host, strconv.FormatInt(port, 10)), true
+}

--- a/backend/pkg/clusterapi/clusterapi_internal_test.go
+++ b/backend/pkg/clusterapi/clusterapi_internal_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterapi
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/clusterregistration"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+)
+
+func discoveryFor(groupVersions ...string) *discoveryfake.FakeDiscovery {
+	resources := make([]*metav1.APIResourceList, 0, len(groupVersions))
+	for _, groupVersion := range groupVersions {
+		resources = append(resources, &metav1.APIResourceList{
+			GroupVersion: groupVersion,
+			APIResources: []metav1.APIResource{{Name: "clusters"}},
+		})
+	}
+
+	return &discoveryfake.FakeDiscovery{Fake: &clienttesting.Fake{Resources: resources}}
+}
+
+func capiCluster(name, host string) *unstructured.Unstructured {
+	cluster := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "cluster.x-k8s.io/v1beta1",
+		"kind":       "Cluster",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": "headlamp",
+			"uid":       "uid-" + name,
+		},
+	}}
+	if host != "" {
+		cluster.Object["spec"] = map[string]interface{}{
+			"controlPlaneEndpoint": map[string]interface{}{
+				"host": host,
+				"port": int64(6443),
+			},
+		}
+	}
+
+	return cluster
+}
+
+func TestRunnerListsWatchesAndExcludesEndpointlessClusters(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+	registry := clusterregistration.New(store)
+
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{clusterGVR("v1beta1"): "ClusterList"},
+		capiCluster("ready", "ready.example.com"),
+		capiCluster("pending", ""),
+	)
+	runner, err := newRunner(Options{
+		Registry:      registry,
+		OriginCluster: "hub",
+		Namespaces:    "headlamp",
+		OIDCConfig:    &kubeconfig.OidcConfig{ClientID: "headlamp"},
+	}, discoveryFor("cluster.x-k8s.io/v1beta1"), client)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	go runner.Run(ctx)
+
+	require.Eventually(t, func() bool {
+		return len(registry.Snapshot().Items) == 1
+	}, 5*time.Second, 20*time.Millisecond)
+
+	registration := registry.Snapshot().Items[0]
+	assert.Equal(t, "ready", registration.DisplayName)
+	assert.Equal(t, registrationSource, registration.Source)
+	assert.Equal(t, "hub", registration.Origin.Cluster)
+	assert.Equal(t, "Cluster", registration.Origin.Resource.Kind)
+	assert.Equal(t, "uid-ready", registration.Origin.Resource.UID)
+
+	pending := capiCluster("pending", "pending.example.com")
+	pending.SetUID(types.UID("uid-pending"))
+	_, err = client.Resource(clusterGVR("v1beta1")).Namespace("headlamp").Update(ctx, pending, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return len(registry.Snapshot().Items) == 2
+	}, 5*time.Second, 20*time.Millisecond)
+
+	err = client.Resource(clusterGVR("v1beta1")).Namespace("headlamp").Delete(ctx, "ready", metav1.DeleteOptions{})
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		registrations := registry.Snapshot().Items
+		return len(registrations) == 1 && registrations[0].DisplayName == "pending"
+	}, 5*time.Second, 20*time.Millisecond)
+}
+
+func TestResolveClusterGVRPrefersV1Beta2AndFallsBackToV1Beta1(t *testing.T) {
+	t.Run("prefers v1beta2", func(t *testing.T) {
+		got, err := resolveClusterGVR(discoveryFor("cluster.x-k8s.io/v1beta2", "cluster.x-k8s.io/v1beta1"))
+		require.NoError(t, err)
+		assert.Equal(t, clusterGVR("v1beta2"), got)
+	})
+
+	t.Run("falls back to v1beta1", func(t *testing.T) {
+		got, err := resolveClusterGVR(discoveryFor("cluster.x-k8s.io/v1beta1"))
+		require.NoError(t, err)
+		assert.Equal(t, clusterGVR("v1beta1"), got)
+	})
+
+	t.Run("fails without a clusters resource", func(t *testing.T) {
+		_, err := resolveClusterGVR(discoveryFor())
+		require.Error(t, err)
+	})
+}
+
+func TestRunReturnsWithoutAServedClusterResource(t *testing.T) {
+	runner, err := newRunner(Options{
+		Registry:      clusterregistration.New(kubeconfig.NewContextStore()),
+		OriginCluster: "hub",
+		Namespaces:    "headlamp",
+	}, discoveryFor(), nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		runner.Run(ctx)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after its context was cancelled")
+	}
+}
+
+func TestControlPlaneServer(t *testing.T) {
+	const (
+		host        = "ready.example.com"
+		defaultedTo = "https://ready.example.com:6443"
+	)
+
+	endpoint := func(host string, port int64) map[string]interface{} {
+		return map[string]interface{}{"host": host, "port": port}
+	}
+
+	tests := []struct {
+		name     string
+		endpoint map[string]interface{}
+		want     string
+		wantOK   bool
+	}{
+		{name: "host and port", endpoint: endpoint(host, 6443), want: defaultedTo, wantOK: true},
+		{
+			name:     "ipv6 host",
+			endpoint: endpoint("2001:db8::1", 8443),
+			want:     "https://[2001:db8::1]:8443",
+			wantOK:   true,
+		},
+		{name: "zero port defaults", endpoint: endpoint(host, 0), want: defaultedTo, wantOK: true},
+		{
+			name:     "missing port defaults",
+			endpoint: map[string]interface{}{"host": host},
+			want:     defaultedTo,
+			wantOK:   true,
+		},
+		{name: "missing endpoint"},
+		{name: "blank host", endpoint: endpoint("   ", 6443)},
+		{name: "port out of range", endpoint: endpoint(host, 70000)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := capiCluster("cluster", "")
+			if tc.endpoint != nil {
+				cluster.Object["spec"] = map[string]interface{}{"controlPlaneEndpoint": tc.endpoint}
+			}
+
+			server, ok := controlPlaneServer(cluster)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.want, server)
+		})
+	}
+}

--- a/backend/pkg/clusterinventory/clusterinventory.go
+++ b/backend/pkg/clusterinventory/clusterinventory.go
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package clusterinventory discovers ClusterProfile resources and adds them to
-// Headlamp's context store as Cluster Inventory contexts.
+// Package clusterinventory discovers ClusterProfile resources and registers the
+// clusters they publish.
 package clusterinventory
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -39,12 +40,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd/api"
+	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
 
 	inventorymetadata "github.com/kubernetes-sigs/headlamp/backend/pkg/clusterinventory/metadata"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/clusterregistration"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 	apisv1alpha1 "sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
@@ -59,12 +61,15 @@ const (
 	// DefaultNoCRDCacheTTL is the default TTL for API servers that do not have the ClusterProfile CRD.
 	DefaultNoCRDCacheTTL = 2 * time.Hour
 
-	clusterInventoryContextPrefix = "cluster-inventory-"
-	clusterInventoryIDPrefix      = "cluster-inventory/"
-	inClusterRootID               = "in-cluster"
-	storeRootPrefix               = "store/"
+	inClusterRootID = "in-cluster"
+	storeRootPrefix = "store/"
 
 	clusterExecConfigExtensionKey = "client.authentication.k8s.io/exec"
+
+	// AuthTypeAccessProvider uses the configured Cluster Inventory exec provider.
+	AuthTypeAccessProvider = "access-provider"
+
+	registrationSource = "cluster-inventory"
 )
 
 // Structured-log field names that recur across many log sites.
@@ -73,18 +78,28 @@ const (
 	logFieldClusterProfile = "clusterprofile"
 	logFieldServer         = "server"
 	logFieldNamespace      = "namespace"
+	logFieldRegistration   = "registration"
 )
 
 // Options controls Cluster Inventory discovery.
 type Options struct {
-	// Store is the Headlamp context store that receives discovered contexts.
-	Store kubeconfig.ContextStore
+	// SeedStore holds the non-internal contexts that seed discovery roots. Nil discovers
+	// from HubConfig only.
+	SeedStore kubeconfig.ContextStore
+	// Registry stores source-independent, routable cluster registrations.
+	Registry *clusterregistration.Registry
 	// ProviderFile is the Cluster Inventory access provider configuration file.
 	ProviderFile string
+	// AuthType selects per-user OIDC or access-provider authentication.
+	AuthType string
+	// AccessProviders is a comma-separated, ordered, exact provider-name allowlist.
+	AccessProviders string
+	// OIDCConfig is copied to OIDC-backed discovered contexts.
+	OIDCConfig *kubeconfig.OidcConfig
 	// LabelSelector filters ClusterProfile resources before they are synced.
 	LabelSelector string
-	// Namespaces limits ClusterProfile discovery to a comma-separated list of namespaces.
-	// A value of "*" watches all namespaces; empty watches each root's default namespace.
+	// Namespaces limits ClusterProfile discovery as parsed by
+	// [clusterregistration.ParseNamespaces]. Empty watches each root's default namespace.
 	Namespaces string
 	// RootReconcileInterval controls how often root clusters are reconciled.
 	// Values less than or equal to zero use DefaultRootReconcileInterval.
@@ -96,40 +111,44 @@ type Options struct {
 	HubConfig *rest.Config
 	// HubNamespace is the default namespace for the in-cluster root.
 	HubNamespace string
-	// DiscoverFromStore enables discovery from non-internal contexts already in Store.
-	DiscoverFromStore bool
+	// HubCluster is the Headlamp cluster ID for the in-cluster discovery root.
+	HubCluster string
 }
 
-// Runner watches ClusterProfile resources and syncs them into Headlamp's context store.
+// Runner watches ClusterProfile resources and syncs them into the shared registry.
 type Runner struct {
-	store                 kubeconfig.ContextStore
+	seedStore             kubeconfig.ContextStore
+	registry              *clusterregistration.Registry
 	accessConfig          *access.Config
+	accessProviders       []string
+	oidcConfig            *kubeconfig.OidcConfig
 	rootReconcileInterval time.Duration
 	noCRDCacheTTL         time.Duration
 	labelSelector         labels.Selector
 	namespaces            []string
 	hubConfig             *rest.Config
 	hubNamespace          string
-	discoverFromStore     bool
+	hubCluster            string
 
 	clientForConfig func(*rest.Config) (ciaclient.Interface, error)
 	now             func() time.Time
 
 	mu                sync.Mutex
 	roots             map[string]*rootState
-	profiles          map[string]profileState
+	profiles          map[string]string
 	profileKeysByRoot map[string]map[string]string
 	noCRD             map[string]time.Time
 }
 
 // rootState tracks the active informers and identity for one discovery root.
 type rootState struct {
-	rootID      string
-	serverURL   string
-	fingerprint string
-	ctx         context.Context
-	cancel      context.CancelFunc
-	watches     []rootWatch
+	rootID        string
+	serverURL     string
+	fingerprint   string
+	ctx           context.Context
+	cancel        context.CancelFunc
+	watches       []rootWatch
+	originCluster string
 }
 
 // rootWatch pairs a ClusterProfile informer with the factory that owns it.
@@ -141,36 +160,29 @@ type rootWatch struct {
 
 // rootConfig contains the Kubernetes client config and watched namespaces for one root.
 type rootConfig struct {
-	restConfig *rest.Config
-	namespaces []string
+	restConfig    *rest.Config
+	namespaces    []string
+	originCluster string
 }
 
-// profileState tracks the Headlamp context created from one ClusterProfile.
-type profileState struct {
-	contextName string
-}
-
-// NewRunner validates options, parses the provider file, and returns a discovery runner.
+// NewRunner validates options and returns a discovery runner.
 func NewRunner(opts Options) (*Runner, error) {
-	if opts.Store == nil {
-		return nil, errors.New("context store is required")
+	if opts.HubConfig != nil && opts.HubCluster == "" {
+		return nil, errors.New("hub cluster is required for in-cluster discovery")
 	}
 
-	if opts.ProviderFile == "" {
-		return nil, errors.New("cluster inventory provider file is required")
+	var accessConfig *access.Config
+
+	if opts.AuthType == AuthTypeAccessProvider {
+		var err error
+
+		accessConfig, err = access.NewFromFile(opts.ProviderFile)
+		if err != nil {
+			return nil, fmt.Errorf("load provider file: %w", err)
+		}
 	}
 
-	accessConfig, err := access.NewFromFile(opts.ProviderFile)
-	if err != nil {
-		return nil, fmt.Errorf("load cluster inventory provider file: %w", err)
-	}
-
-	labelSelector, err := normalizeLabelSelector(opts.LabelSelector)
-	if err != nil {
-		return nil, err
-	}
-
-	namespaces, err := normalizeNamespaces(opts.Namespaces)
+	labelSelector, namespaces, err := clusterregistration.ParseSelectors(opts.LabelSelector, opts.Namespaces)
 	if err != nil {
 		return nil, err
 	}
@@ -186,21 +198,24 @@ func NewRunner(opts Options) (*Runner, error) {
 	}
 
 	return &Runner{
-		store:                 opts.Store,
+		seedStore:             opts.SeedStore,
+		registry:              opts.Registry,
 		accessConfig:          accessConfig,
+		accessProviders:       parseAccessProviders(opts.AccessProviders),
+		oidcConfig:            opts.OIDCConfig,
 		rootReconcileInterval: rootReconcileInterval,
 		noCRDCacheTTL:         noCRDCacheTTL,
 		labelSelector:         labelSelector,
 		namespaces:            namespaces,
 		hubConfig:             opts.HubConfig,
 		hubNamespace:          opts.HubNamespace,
-		discoverFromStore:     opts.DiscoverFromStore,
+		hubCluster:            opts.HubCluster,
 		clientForConfig: func(config *rest.Config) (ciaclient.Interface, error) {
 			return ciaclient.NewForConfig(config)
 		},
 		now:               time.Now,
 		roots:             map[string]*rootState{},
-		profiles:          map[string]profileState{},
+		profiles:          map[string]string{},
 		profileKeysByRoot: map[string]map[string]string{},
 		noCRD:             map[string]time.Time{},
 	}, nil
@@ -238,12 +253,13 @@ func (r *Runner) reconcileRoots(ctx context.Context) {
 	if r.hubConfig != nil {
 		presentRoots[inClusterRootID] = struct{}{}
 		desiredRoots[inClusterRootID] = rootConfig{
-			restConfig: r.hubConfig,
-			namespaces: r.namespacesForRoot(r.hubNamespace),
+			restConfig:    r.hubConfig,
+			namespaces:    clusterregistration.NamespacesOrDefault(r.namespaces, r.hubNamespace),
+			originCluster: r.hubCluster,
 		}
 	}
 
-	if r.discoverFromStore {
+	if r.seedStore != nil {
 		storeRootsLoaded = r.collectStoreSeedRoots(desiredRoots, presentRoots)
 	}
 
@@ -266,7 +282,7 @@ func (r *Runner) collectStoreSeedRoots(
 	desiredRoots map[string]rootConfig,
 	presentRoots map[string]struct{},
 ) bool {
-	contexts, err := r.store.GetContexts()
+	contexts, err := r.seedStore.GetContexts()
 	if err != nil {
 		logger.Log(logger.LevelWarn, nil, err, "cluster-inventory: failed to get seed contexts")
 
@@ -278,10 +294,6 @@ func (r *Runner) collectStoreSeedRoots(
 	})
 
 	for _, headlampContext := range contexts {
-		if headlampContext.Source == kubeconfig.ClusterInventory {
-			continue
-		}
-
 		if headlampContext.Internal {
 			continue
 		}
@@ -299,7 +311,9 @@ func (r *Runner) collectStoreSeedRoots(
 
 		desiredRoots[rootID] = rootConfig{
 			restConfig: seedConfig,
-			namespaces: r.namespacesForRoot(headlampContext.KubeContext.Namespace),
+			namespaces: clusterregistration.NamespacesOrDefault(
+				r.namespaces, headlampContext.KubeContext.Namespace),
+			originCluster: headlampContext.Name,
 		}
 	}
 
@@ -375,12 +389,13 @@ func (r *Runner) newRootState(
 
 	rootCtx, cancel := context.WithCancel(ctx)
 	state := &rootState{
-		rootID:      rootID,
-		serverURL:   serverURL,
-		fingerprint: fingerprint,
-		ctx:         rootCtx,
-		cancel:      cancel,
-		watches:     make([]rootWatch, 0, len(root.namespaces)),
+		rootID:        rootID,
+		serverURL:     serverURL,
+		fingerprint:   fingerprint,
+		ctx:           rootCtx,
+		cancel:        cancel,
+		watches:       make([]rootWatch, 0, len(root.namespaces)),
+		originCluster: root.originCluster,
 	}
 
 	for _, namespace := range root.namespaces {
@@ -439,18 +454,14 @@ func (r *Runner) newRootWatch(
 
 // clusterProfileInformerOptions returns informer options for one namespace of a root.
 func (r *Runner) clusterProfileInformerOptions(namespace string) []externalversions.SharedInformerOption {
-	options := make([]externalversions.SharedInformerOption, 0, 2)
-	options = append(options, externalversions.WithNamespace(namespace))
-
-	if r.labelSelector == nil {
-		return options
-	}
-
 	selector := r.labelSelector.String()
 
-	return append(options, externalversions.WithTweakListOptions(func(listOptions *metav1.ListOptions) {
-		listOptions.LabelSelector = selector
-	}))
+	return []externalversions.SharedInformerOption{
+		externalversions.WithNamespace(namespace),
+		externalversions.WithTweakListOptions(func(listOptions *metav1.ListOptions) {
+			listOptions.LabelSelector = selector
+		}),
+	}
 }
 
 // activateRoot records a root as active and returns any previous active root.
@@ -484,6 +495,7 @@ func (r *Runner) runRootInformer(state *rootState) {
 		}, nil, "cluster-inventory: starting ClusterProfile watch")
 
 		watch.factory.Start(state.ctx.Done())
+
 		go r.waitForRootWatchSync(state, watch)
 	}
 
@@ -499,9 +511,9 @@ func (r *Runner) waitForRootWatchSync(state *rootState, watch rootWatch) {
 	r.completeRootWatchSyncFromCache(state, watch)
 }
 
-// handleClusterProfileUpsert syncs an added or updated ClusterProfile into the context store.
+// handleClusterProfileUpsert registers an added or updated ClusterProfile.
 func (r *Runner) handleClusterProfileUpsert(state *rootState, obj interface{}) {
-	cp, ok := clusterProfileFromObject(obj)
+	cp, ok := clusterregistration.ObjectFromEvent[*apisv1alpha1.ClusterProfile](obj)
 	if !ok {
 		logger.Log(logger.LevelWarn, map[string]string{logFieldRoot: state.rootID}, nil,
 			"cluster-inventory: ignored non-ClusterProfile informer event")
@@ -509,9 +521,9 @@ func (r *Runner) handleClusterProfileUpsert(state *rootState, obj interface{}) {
 		return
 	}
 
-	profileKey := makeProfileKey(state.rootID, cp.Namespace+"/"+cp.Name)
-	if !r.clusterProfileMatchesSelector(cp) {
-		r.pruneClusterProfile(state, profileKey)
+	profileKey := makeProfileKey(state.rootID, cp)
+	if !r.labelSelector.Matches(labels.Set(cp.Labels)) {
+		r.dropClusterProfile(state, profileKey, true)
 
 		return
 	}
@@ -523,9 +535,9 @@ func (r *Runner) handleClusterProfileUpsert(state *rootState, obj interface{}) {
 	r.syncClusterProfile(state.ctx, state, profileKey, cp)
 }
 
-// handleClusterProfileDelete removes context state for a deleted ClusterProfile.
+// handleClusterProfileDelete removes the registration of a deleted ClusterProfile.
 func (r *Runner) handleClusterProfileDelete(state *rootState, obj interface{}) {
-	cp, ok := clusterProfileFromObject(obj)
+	cp, ok := clusterregistration.ObjectFromEvent[*apisv1alpha1.ClusterProfile](obj)
 	if !ok {
 		logger.Log(logger.LevelWarn, map[string]string{logFieldRoot: state.rootID}, nil,
 			"cluster-inventory: ignored non-ClusterProfile delete event")
@@ -533,8 +545,8 @@ func (r *Runner) handleClusterProfileDelete(state *rootState, obj interface{}) {
 		return
 	}
 
-	profileKey := makeProfileKey(state.rootID, cp.Namespace+"/"+cp.Name)
-	r.pruneClusterProfile(state, profileKey)
+	profileKey := makeProfileKey(state.rootID, cp)
+	r.dropClusterProfile(state, profileKey, true)
 }
 
 // handleRootWatchError reacts to ClusterProfile watch errors for one namespace of a root.
@@ -552,7 +564,7 @@ func (r *Runner) handleRootWatchError(state *rootState, namespace string, err er
 	}, err, "cluster-inventory: ClusterProfile watch error")
 }
 
-// syncClusterProfile converts a ClusterProfile to a Headlamp context and stores it.
+// syncClusterProfile converts a ClusterProfile to a Headlamp context and registers it.
 func (r *Runner) syncClusterProfile(
 	ctx context.Context,
 	state *rootState,
@@ -569,21 +581,32 @@ func (r *Runner) syncClusterProfile(
 
 	headlampContext, ok := r.contextFromClusterProfile(profileKey, cp)
 	if !ok {
+		// Keep tracking the profile, so it is registered again once it recovers.
+		r.dropClusterProfile(state, profileKey, false)
+
 		return
 	}
 
-	if !r.isCurrentRoot(state) {
-		return
-	}
-
-	if err := r.store.AddContext(headlampContext); err != nil {
+	registrationID, err := r.registry.Upsert(clusterregistration.Candidate{
+		DisplayName: cmp.Or(strings.TrimSpace(cp.Spec.DisplayName), cp.Name),
+		Source:      registrationSource,
+		Origin: clusterregistration.OriginFor(
+			state.originCluster,
+			apisv1alpha1.GroupVersion.WithKind(apisv1alpha1.ClusterProfileKind),
+			cp,
+		),
+		Context: headlampContext,
+	})
+	if err != nil {
 		logger.Log(logger.LevelWarn, map[string]string{logFieldClusterProfile: profileKey}, err,
-			"cluster-inventory: failed to add context")
+			"cluster-inventory: failed to register cluster")
 
 		return
 	}
 
-	r.recordSyncedProfile(state, profileKey, headlampContext.Name)
+	if orphaned := r.recordSyncedProfile(state, profileKey, registrationID); orphaned != "" {
+		r.removeRegistrations(orphaned)
+	}
 }
 
 // contextFromClusterProfile builds a Headlamp context from a ClusterProfile access provider.
@@ -591,34 +614,25 @@ func (r *Runner) contextFromClusterProfile(
 	profileKey string,
 	cp *apisv1alpha1.ClusterProfile,
 ) (*kubeconfig.Context, bool) {
-	if len(cp.Status.AccessProviders) == 0 {
+	provider, ok := selectAccessProvider(cp, r.accessProviders)
+	if !ok {
 		logger.Log(logger.LevelInfo, map[string]string{logFieldClusterProfile: profileKey}, nil,
-			"cluster-inventory: ClusterProfile has no access providers")
+			"cluster-inventory: ClusterProfile has no allowed access provider")
 
 		return nil, false
 	}
 
-	restConfig, err := copyAccessConfig(r.accessConfig).BuildConfigFromCP(accessOnlyClusterProfile(cp))
+	if strings.TrimSpace(provider.Cluster.Server) == "" {
+		logger.Log(logger.LevelInfo, map[string]string{logFieldClusterProfile: profileKey}, nil,
+			"cluster-inventory: ClusterProfile access provider has no API server endpoint")
+
+		return nil, false
+	}
+
+	headlampContext, err := r.clusterContext(provider, cp)
 	if err != nil {
 		logger.Log(logger.LevelWarn, map[string]string{logFieldClusterProfile: profileKey}, err,
-			"cluster-inventory: failed to build rest config")
-
-		return nil, false
-	}
-
-	contextName := contextNameFromProfileKey(profileKey)
-
-	headlampContext, err := restConfigToContext(restConfig, contextName, profileKey)
-	if err != nil {
-		logger.Log(logger.LevelWarn, map[string]string{logFieldClusterProfile: profileKey}, err,
-			"cluster-inventory: failed to convert rest config")
-
-		return nil, false
-	}
-
-	if err := headlampContext.SetupProxy(); err != nil {
-		logger.Log(logger.LevelWarn, map[string]string{logFieldClusterProfile: profileKey}, err,
-			"cluster-inventory: failed to setup proxy")
+			"cluster-inventory: failed to build cluster connection")
 
 		return nil, false
 	}
@@ -662,16 +676,24 @@ func clusterInventoryMetadataFromProfile(
 	return metadata
 }
 
-// recordSyncedProfile stores the context name for a successfully synced ClusterProfile.
-func (r *Runner) recordSyncedProfile(state *rootState, profileKey string, contextName string) {
+// recordSyncedProfile stores the registration ID of a successfully synced ClusterProfile
+// and returns the registration that is now orphaned, if any.
+func (r *Runner) recordSyncedProfile(state *rootState, profileKey, registrationID string) string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	if r.roots[state.rootID] != state {
-		return
+		return registrationID
 	}
 
-	r.profiles[profileKey] = profileState{contextName: contextName}
+	previousID := r.profiles[profileKey]
+	r.profiles[profileKey] = registrationID
+
+	if previousID == registrationID {
+		return ""
+	}
+
+	return previousID
 }
 
 // completeRootWatchSyncFromCache prunes profiles missing from one synced namespace cache.
@@ -687,29 +709,29 @@ func (r *Runner) completeRootWatchSyncFromCache(state *rootState, watch rootWatc
 
 	previous := r.profileKeysByRoot[state.rootID]
 
-	var contextNames []string
+	var registrationIDs []string
 
 	if watch.namespace == metav1.NamespaceAll {
-		contextNames = r.syncAllNamespaceProfilesLocked(state.rootID, previous, seen)
+		registrationIDs = r.syncAllNamespaceProfilesLocked(state.rootID, previous, seen)
 	} else {
-		contextNames = r.syncNamedNamespaceProfilesLocked(state, watch.namespace, previous, seen)
+		registrationIDs = r.syncNamedNamespaceProfilesLocked(state, watch.namespace, previous, seen)
 	}
 
 	r.mu.Unlock()
 
-	r.removeContexts(contextNames)
+	r.removeRegistrations(registrationIDs...)
 }
 
 func (r *Runner) profileKeysFromRootWatch(rootID string, watch rootWatch) map[string]string {
 	seen := map[string]string{}
 
 	for _, obj := range watch.informer.GetIndexer().List() {
-		cp, ok := clusterProfileFromObject(obj)
-		if !ok || !r.clusterProfileMatchesSelector(cp) {
+		cp, ok := clusterregistration.ObjectFromEvent[*apisv1alpha1.ClusterProfile](obj)
+		if !ok || !r.labelSelector.Matches(labels.Set(cp.Labels)) {
 			continue
 		}
 
-		profileKey := makeProfileKey(rootID, cp.Namespace+"/"+cp.Name)
+		profileKey := makeProfileKey(rootID, cp)
 		seen[profileKey] = cp.Namespace
 	}
 
@@ -722,17 +744,17 @@ func (r *Runner) syncAllNamespaceProfilesLocked(
 	seen map[string]string,
 ) []string {
 	r.profileKeysByRoot[rootID] = seen
-	contextNames := []string{}
+	registrationIDs := []string{}
 
 	for profileKey := range previous {
 		if _, ok := seen[profileKey]; ok {
 			continue
 		}
 
-		contextNames = append(contextNames, r.pruneProfileLocked(profileKey)...)
+		registrationIDs = append(registrationIDs, r.pruneProfileLocked(profileKey)...)
 	}
 
-	return contextNames
+	return registrationIDs
 }
 
 func (r *Runner) syncNamedNamespaceProfilesLocked(
@@ -746,7 +768,7 @@ func (r *Runner) syncNamedNamespaceProfilesLocked(
 		next[profileKey] = profileNamespace
 	}
 
-	contextNames := []string{}
+	registrationIDs := []string{}
 
 	for profileKey, profileNamespace := range previous {
 		_, stillPresent := seen[profileKey]
@@ -760,7 +782,7 @@ func (r *Runner) syncNamedNamespaceProfilesLocked(
 		}
 
 		delete(next, profileKey)
-		contextNames = append(contextNames, r.pruneProfileLocked(profileKey)...)
+		registrationIDs = append(registrationIDs, r.pruneProfileLocked(profileKey)...)
 	}
 
 	for profileKey, profileNamespace := range seen {
@@ -769,7 +791,7 @@ func (r *Runner) syncNamedNamespaceProfilesLocked(
 
 	r.profileKeysByRoot[state.rootID] = next
 
-	return contextNames
+	return registrationIDs
 }
 
 // rootWatchesNamespace reports whether a root state intentionally watches a namespace.
@@ -801,25 +823,22 @@ func (r *Runner) recordRootProfile(state *rootState, profileKey string, namespac
 	return true
 }
 
-// clusterProfileMatchesSelector reports whether a ClusterProfile passes the configured selector.
-func (r *Runner) clusterProfileMatchesSelector(cp *apisv1alpha1.ClusterProfile) bool {
-	return r.labelSelector == nil || r.labelSelector.Matches(labels.Set(cp.Labels))
-}
+// dropClusterProfile removes the registration of one ClusterProfile of a current root,
+// and stops tracking the profile unless it is expected to come back.
+func (r *Runner) dropClusterProfile(state *rootState, profileKey string, stopTracking bool) {
+	var registrationIDs []string
 
-// pruneClusterProfile removes tracking and context state for one ClusterProfile.
-func (r *Runner) pruneClusterProfile(state *rootState, profileKey string) {
 	r.mu.Lock()
+	if r.roots[state.rootID] == state {
+		if stopTracking {
+			delete(r.profileKeysByRoot[state.rootID], profileKey)
+		}
 
-	if r.roots[state.rootID] != state {
-		r.mu.Unlock()
-		return
+		registrationIDs = r.pruneProfileLocked(profileKey)
 	}
-
-	delete(r.profileKeysByRoot[state.rootID], profileKey)
-	contextNames := r.pruneProfileLocked(profileKey)
 	r.mu.Unlock()
 
-	r.removeContexts(contextNames)
+	r.removeRegistrations(registrationIDs...)
 }
 
 // stopMissingRoots stops roots that are no longer present in the desired root set.
@@ -828,7 +847,7 @@ func (r *Runner) stopMissingRoots(presentRoots map[string]struct{}, storeRootsLo
 
 	cancels := make([]context.CancelFunc, 0, len(r.roots))
 
-	var contextNames []string
+	var registrationIDs []string
 
 	for rootID, state := range r.roots {
 		if _, ok := presentRoots[rootID]; ok {
@@ -842,23 +861,23 @@ func (r *Runner) stopMissingRoots(presentRoots map[string]struct{}, storeRootsLo
 		cancels = append(cancels, state.cancel)
 
 		delete(r.roots, rootID)
-		contextNames = append(contextNames, r.pruneRootLocked(rootID)...)
+		registrationIDs = append(registrationIDs, r.pruneRootLocked(rootID)...)
 	}
 
 	r.mu.Unlock()
 
-	r.removeContexts(contextNames)
+	r.removeRegistrations(registrationIDs...)
 
 	for _, cancel := range cancels {
 		cancel()
 	}
 }
 
-// stopRoot stops one active root and optionally prunes its discovered contexts.
+// stopRoot stops one active root and optionally prunes its registrations.
 func (r *Runner) stopRoot(rootID string, prune bool) {
 	var (
-		cancel       context.CancelFunc
-		contextNames []string
+		cancel          context.CancelFunc
+		registrationIDs []string
 	)
 
 	r.mu.Lock()
@@ -869,18 +888,18 @@ func (r *Runner) stopRoot(rootID string, prune bool) {
 	}
 
 	if prune {
-		contextNames = r.pruneRootLocked(rootID)
+		registrationIDs = r.pruneRootLocked(rootID)
 	}
 	r.mu.Unlock()
 
-	r.removeContexts(contextNames)
+	r.removeRegistrations(registrationIDs...)
 
 	if cancel != nil {
 		cancel()
 	}
 }
 
-// stopAllRoots cancels all active root informers without pruning their contexts.
+// stopAllRoots cancels all active root informers without pruning their registrations.
 func (r *Runner) stopAllRoots() {
 	r.mu.Lock()
 
@@ -898,37 +917,37 @@ func (r *Runner) stopAllRoots() {
 	}
 }
 
-// pruneRootLocked removes all profile tracking for a root and returns contexts to remove.
+// pruneRootLocked removes all profile tracking for a root and returns the registrations to remove.
 func (r *Runner) pruneRootLocked(rootID string) []string {
-	contextNames := make([]string, 0, len(r.profileKeysByRoot[rootID]))
+	registrationIDs := make([]string, 0, len(r.profileKeysByRoot[rootID]))
 
 	for profileKey := range r.profileKeysByRoot[rootID] {
-		contextNames = append(contextNames, r.pruneProfileLocked(profileKey)...)
+		registrationIDs = append(registrationIDs, r.pruneProfileLocked(profileKey)...)
 	}
 
 	delete(r.profileKeysByRoot, rootID)
 
-	return contextNames
+	return registrationIDs
 }
 
-// pruneProfileLocked removes one profile from tracking and returns its context to remove.
+// pruneProfileLocked removes one profile from tracking and returns its registration to remove.
 func (r *Runner) pruneProfileLocked(profileKey string) []string {
-	state, ok := r.profiles[profileKey]
+	registrationID, ok := r.profiles[profileKey]
 	if !ok {
 		return nil
 	}
 
 	delete(r.profiles, profileKey)
 
-	return []string{state.contextName}
+	return []string{registrationID}
 }
 
-// removeContexts removes contexts from the store and logs failures.
-func (r *Runner) removeContexts(contextNames []string) {
-	for _, contextName := range contextNames {
-		if err := r.store.RemoveContext(contextName); err != nil {
-			logger.Log(logger.LevelWarn, map[string]string{"context": contextName}, err,
-				"cluster-inventory: failed to prune context")
+// removeRegistrations removes registrations and their materialized contexts.
+func (r *Runner) removeRegistrations(registrationIDs ...string) {
+	for _, registrationID := range registrationIDs {
+		if err := r.registry.Remove(registrationID); err != nil {
+			logger.Log(logger.LevelWarn, map[string]string{logFieldRegistration: registrationID}, err,
+				"cluster-inventory: failed to prune registration")
 		}
 	}
 }
@@ -951,19 +970,11 @@ func (r *Runner) hasNoCRD(serverURL string) bool {
 	return true
 }
 
-// markNoCRD caches a server as missing the ClusterProfile CRD.
-func (r *Runner) markNoCRD(serverURL string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	r.noCRD[serverURL] = r.now().Add(r.noCRDCacheTTL)
-}
-
 // markRootNoCRD stops a root once and caches its server as missing the ClusterProfile CRD.
 func (r *Runner) markRootNoCRD(state *rootState) {
 	var (
-		cancel       context.CancelFunc
-		contextNames []string
+		cancel          context.CancelFunc
+		registrationIDs []string
 	)
 
 	r.mu.Lock()
@@ -971,11 +982,11 @@ func (r *Runner) markRootNoCRD(state *rootState) {
 		r.noCRD[state.serverURL] = r.now().Add(r.noCRDCacheTTL)
 		cancel = state.cancel
 		delete(r.roots, state.rootID)
-		contextNames = r.pruneRootLocked(state.rootID)
+		registrationIDs = r.pruneRootLocked(state.rootID)
 	}
 	r.mu.Unlock()
 
-	r.removeContexts(contextNames)
+	r.removeRegistrations(registrationIDs...)
 
 	if cancel != nil {
 		cancel()
@@ -992,90 +1003,9 @@ func (r *Runner) isCurrentRoot(state *rootState) bool {
 	return r.roots[state.rootID] == state
 }
 
-// makeProfileKey combines a root ID and ClusterProfile path into a stable profile key.
-func makeProfileKey(rootID, profilePath string) string {
-	return rootID + "/" + profilePath
-}
-
-// normalizeLabelSelector parses a user-provided label selector.
-func normalizeLabelSelector(selector string) (labels.Selector, error) {
-	selector = strings.TrimSpace(selector)
-	if selector == "" {
-		return nil, nil
-	}
-
-	parsed, err := labels.Parse(selector)
-	if err != nil {
-		return nil, fmt.Errorf("invalid cluster-inventory-label-selector: %w", err)
-	}
-
-	return parsed, nil
-}
-
-// normalizeNamespaces parses a user-provided comma-separated namespace list.
-func normalizeNamespaces(value string) ([]string, error) {
-	if strings.TrimSpace(value) == "" {
-		return nil, nil
-	}
-
-	var (
-		namespaces    = make([]string, 0, strings.Count(value, ",")+1)
-		allNamespaces bool
-	)
-
-	for _, namespace := range strings.Split(value, ",") {
-		namespace = strings.TrimSpace(namespace)
-
-		switch namespace {
-		case "":
-			return nil, errors.New("invalid cluster-inventory-namespaces: namespace must not be empty")
-		case "*":
-			if allNamespaces {
-				return nil, errors.New(`invalid cluster-inventory-namespaces: "*" must be used on its own`)
-			}
-
-			allNamespaces = true
-		default:
-			if errs := validation.IsDNS1123Label(namespace); len(errs) > 0 {
-				return nil, fmt.Errorf("invalid cluster-inventory-namespaces: %q: %s",
-					namespace, strings.Join(errs, "; "))
-			}
-
-			namespaces = append(namespaces, namespace)
-		}
-	}
-
-	if allNamespaces {
-		if len(namespaces) > 0 {
-			return nil, errors.New(`invalid cluster-inventory-namespaces: "*" must be used on its own`)
-		}
-
-		return []string{metav1.NamespaceAll}, nil
-	}
-
-	slices.Sort(namespaces)
-
-	return slices.Compact(namespaces), nil
-}
-
-// ValidateNamespaces validates a comma-separated Cluster Inventory namespace list.
-func ValidateNamespaces(value string) error {
-	_, err := normalizeNamespaces(value)
-
-	return err
-}
-
-// namespacesForRoot returns the configured namespaces, or the root's default namespace.
-func (r *Runner) namespacesForRoot(defaultNamespace string) []string {
-	if len(r.namespaces) > 0 {
-		return r.namespaces
-	}
-
-	if defaultNamespace == "" {
-		defaultNamespace = metav1.NamespaceDefault
-	}
-
-	return []string{defaultNamespace}
+// makeProfileKey combines a root ID and ClusterProfile into a stable profile key.
+func makeProfileKey(rootID string, cp *apisv1alpha1.ClusterProfile) string {
+	return rootID + "/" + cache.NewObjectName(cp.Namespace, cp.Name).String()
 }
 
 // namespaceLogValue renders the all-namespace sentinel in a human-readable form.
@@ -1085,21 +1015,6 @@ func namespaceLogValue(namespace string) string {
 	}
 
 	return namespace
-}
-
-// contextNameFromProfileKey builds a stable Headlamp context name for a profile key.
-func contextNameFromProfileKey(profileKey string) string {
-	return clusterInventoryContextPrefix +
-		kubeconfig.MakeDNSFriendly(profileKey) +
-		"--" +
-		profileKeyHashSuffix(profileKey)
-}
-
-// profileKeyHashSuffix returns the hash suffix used to avoid context name collisions.
-func profileKeyHashSuffix(profileKey string) string {
-	sum := sha256.Sum256([]byte(profileKey))
-
-	return hex.EncodeToString(sum[:6])
 }
 
 // normalizeServerURL normalizes a REST config host for root identity and CRD caching.
@@ -1120,6 +1035,7 @@ func normalizeServerURL(host string) string {
 func rootFingerprint(root rootConfig) string {
 	fingerprintHash := sha256.New()
 
+	writeHashString(fingerprintHash, root.originCluster)
 	writeRestConfigFingerprint(fingerprintHash, root.restConfig)
 	writeTLSConfigFingerprint(fingerprintHash, root.restConfig)
 	writeImpersonateFingerprint(fingerprintHash, root.restConfig)
@@ -1231,48 +1147,87 @@ func writeHashBytes(fingerprintHash hash.Hash, value []byte) {
 	_, _ = fingerprintHash.Write([]byte{0})
 }
 
-// clusterProfileFromObject extracts a ClusterProfile from informer event objects.
-func clusterProfileFromObject(obj interface{}) (*apisv1alpha1.ClusterProfile, bool) {
-	switch typed := obj.(type) {
-	case *apisv1alpha1.ClusterProfile:
-		return typed, true
-	case cache.DeletedFinalStateUnknown:
-		return clusterProfileFromObject(typed.Obj)
-	case *cache.DeletedFinalStateUnknown:
-		return clusterProfileFromObject(typed.Obj)
-	default:
-		return nil, false
-	}
-}
+// parseAccessProviders parses a comma-separated, ordered provider allowlist. Names are
+// matched exactly, so they are neither sorted nor deduplicated.
+func parseAccessProviders(value string) []string {
+	var providers []string
 
-// accessOnlyClusterProfile returns a copy containing only access-provider status.
-func accessOnlyClusterProfile(cp *apisv1alpha1.ClusterProfile) *apisv1alpha1.ClusterProfile {
-	return &apisv1alpha1.ClusterProfile{
-		TypeMeta:   cp.TypeMeta,
-		ObjectMeta: *cp.ObjectMeta.DeepCopy(),
-		Spec:       cp.Spec,
-		Status: apisv1alpha1.ClusterProfileStatus{
-			AccessProviders: append([]apisv1alpha1.AccessProvider(nil), cp.Status.AccessProviders...),
-		},
-	}
-}
-
-// copyAccessConfig returns a shallow access config copy with independent exec slices.
-func copyAccessConfig(in *access.Config) *access.Config {
-	out := &access.Config{Providers: make([]access.Provider, len(in.Providers))}
-	for i, provider := range in.Providers {
-		out.Providers[i] = provider
-		if provider.ExecConfig == nil {
-			continue
+	for _, item := range strings.Split(value, ",") {
+		if name := strings.TrimSpace(item); name != "" {
+			providers = append(providers, name)
 		}
-
-		execConfig := *provider.ExecConfig
-		execConfig.Args = append([]string(nil), provider.ExecConfig.Args...)
-		execConfig.Env = append([]api.ExecEnvVar(nil), provider.ExecConfig.Env...)
-		out.Providers[i].ExecConfig = &execConfig
 	}
 
-	return out
+	return providers
+}
+
+// selectAccessProvider returns the first exact allowlist match. AccessProviders
+// takes precedence over the deprecated CredentialProviders field.
+func selectAccessProvider(
+	cp *apisv1alpha1.ClusterProfile,
+	allowed []string,
+) (apisv1alpha1.AccessProvider, bool) {
+	providers := slices.Concat(cp.Status.AccessProviders, cp.Status.CredentialProviders)
+
+	for _, name := range allowed {
+		for _, provider := range providers {
+			if provider.Name == name {
+				return provider, true
+			}
+		}
+	}
+
+	return apisv1alpha1.AccessProvider{}, false
+}
+
+// accessConfigForProvider returns an access config holding only the named provider.
+func accessConfigForProvider(in *access.Config, providerName string) *access.Config {
+	index := slices.IndexFunc(in.Providers, func(provider access.Provider) bool {
+		return provider.Name == providerName
+	})
+	if index < 0 {
+		return access.New(nil)
+	}
+
+	provider := in.Providers[index]
+	provider.ExecConfig = provider.ExecConfig.DeepCopy()
+
+	return access.New([]access.Provider{provider})
+}
+
+// clusterContext builds the connection for an access provider. It uses the configured
+// Cluster Inventory exec provider when there is one, and the end user's OIDC token otherwise.
+func (r *Runner) clusterContext(
+	provider apisv1alpha1.AccessProvider,
+	cp *apisv1alpha1.ClusterProfile,
+) (*kubeconfig.Context, error) {
+	if r.accessConfig == nil {
+		return oidcContextFromAccessProvider(provider, r.oidcConfig)
+	}
+
+	restConfig, err := accessConfigForProvider(r.accessConfig, provider.Name).BuildConfigFromCP(cp)
+	if err != nil {
+		return nil, fmt.Errorf("build rest config: %w", err)
+	}
+
+	return restConfigToContext(restConfig)
+}
+
+// oidcContextFromAccessProvider builds a context that forwards the end user's OIDC token.
+func oidcContextFromAccessProvider(
+	provider apisv1alpha1.AccessProvider,
+	oidcConfig *kubeconfig.OidcConfig,
+) (*kubeconfig.Context, error) {
+	cluster := api.NewCluster()
+	if err := clientcmdlatest.Scheme.Convert(&provider.Cluster, cluster, nil); err != nil {
+		return nil, fmt.Errorf("convert access provider cluster: %w", err)
+	}
+
+	return &kubeconfig.Context{
+		Cluster:  cluster,
+		OidcConf: oidcConfig,
+		Source:   kubeconfig.ClusterInventory,
+	}, nil
 }
 
 // isNoCRDError reports whether an error means the ClusterProfile CRD is unavailable.
@@ -1345,19 +1300,7 @@ func proxyURLFromRestConfig(restConfig *rest.Config) (string, error) {
 }
 
 // restConfigToContext builds a Headlamp kubeconfig.Context from a generated rest.Config.
-func restConfigToContext(restConfig *rest.Config, contextName, profileKey string) (*kubeconfig.Context, error) {
-	if restConfig == nil {
-		return nil, errors.New("restConfig is nil")
-	}
-
-	if contextName == "" {
-		return nil, errors.New("contextName is empty")
-	}
-
-	if profileKey == "" {
-		return nil, errors.New("profileKey is empty")
-	}
-
+func restConfigToContext(restConfig *rest.Config) (*kubeconfig.Context, error) {
 	cluster := &api.Cluster{
 		Server:                   restConfig.Host,
 		CertificateAuthorityData: restConfig.CAData,
@@ -1387,18 +1330,9 @@ func restConfigToContext(restConfig *rest.Config, contextName, profileKey string
 		authInfo.Exec.InteractiveMode = api.NeverExecInteractiveMode
 	}
 
-	kubeContext := &api.Context{
-		Cluster:  contextName,
-		AuthInfo: contextName,
-	}
-
 	return &kubeconfig.Context{
-		Name:           contextName,
-		KubeContext:    kubeContext,
-		Cluster:        cluster,
-		AuthInfo:       authInfo,
-		Source:         kubeconfig.ClusterInventory,
-		KubeConfigPath: "",
-		ClusterID:      clusterInventoryIDPrefix + profileKey,
+		Cluster:  cluster,
+		AuthInfo: authInfo,
+		Source:   kubeconfig.ClusterInventory,
 	}, nil
 }

--- a/backend/pkg/clusterinventory/clusterinventory_test.go
+++ b/backend/pkg/clusterinventory/clusterinventory_test.go
@@ -24,7 +24,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -35,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	clientfeatures "k8s.io/client-go/features"
 	clientfeaturestesting "k8s.io/client-go/features/testing"
@@ -44,6 +44,7 @@ import (
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 
 	inventorymetadata "github.com/kubernetes-sigs/headlamp/backend/pkg/clusterinventory/metadata"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/clusterregistration"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	apisv1alpha1 "sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
 	ciaclient "sigs.k8s.io/cluster-inventory-api/client/clientset/versioned"
@@ -76,15 +77,29 @@ func writeProviderFile(t *testing.T) string {
 	return path
 }
 
-func newTestRunner(t *testing.T, opts Options) *Runner {
+// newTestRunner applies the option defaults NewRunner requires and registers discovered
+// contexts in store.
+func newTestRunner(t *testing.T, store kubeconfig.ContextStore, opts Options) *Runner {
 	t.Helper()
-
-	if opts.Store == nil {
-		opts.Store = kubeconfig.NewContextStore()
-	}
 
 	if opts.ProviderFile == "" {
 		opts.ProviderFile = writeProviderFile(t)
+	}
+
+	if opts.AuthType == "" {
+		opts.AuthType = AuthTypeAccessProvider
+	}
+
+	if opts.AccessProviders == "" {
+		opts.AccessProviders = "static-token"
+	}
+
+	if opts.HubCluster == "" {
+		opts.HubCluster = kubeconfig.DefaultInClusterContextName
+	}
+
+	if opts.Registry == nil {
+		opts.Registry = clusterregistration.New(store)
 	}
 
 	runner, err := NewRunner(opts)
@@ -98,6 +113,7 @@ func clusterProfile(name, providerName, server string) *apisv1alpha1.ClusterProf
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      name,
+			UID:       types.UID("uid-" + name),
 		},
 	}
 
@@ -154,7 +170,19 @@ func namespacedProfileClient() *ciafake.Clientset {
 }
 
 func getProfileContext(store kubeconfig.ContextStore, profileKey string) (*kubeconfig.Context, error) {
-	return store.GetContext(contextNameFromProfileKey(profileKey))
+	contexts, err := store.GetContexts()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, headlampContext := range contexts {
+		if headlampContext.ClusterInventory != nil &&
+			headlampContext.ClusterInventory.Profile.Key == profileKey {
+			return headlampContext, nil
+		}
+	}
+
+	return nil, errors.New("profile context not found")
 }
 
 func testStoreContext(name string, source int, server, token string, internal bool) *kubeconfig.Context {
@@ -173,10 +201,9 @@ func testRunnerContext(t *testing.T, runner *Runner) context.Context {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	t.Cleanup(func() {
-		cancel()
-		runner.stopAllRoots()
-	})
+	// Cleanups run last-registered-first, so this cancels before stopping the roots.
+	t.Cleanup(runner.stopAllRoots)
+	t.Cleanup(cancel)
 
 	return ctx
 }
@@ -251,110 +278,60 @@ func (watchListClient) IsWatchListSemanticsUnSupported() bool {
 	return false
 }
 
-type removeLockDetectingStore struct {
-	kubeconfig.ContextStore
-	runner            *Runner
-	removeWhileLocked atomic.Bool
+func TestNewRunnerAllowsOIDCWithoutProviderFile(t *testing.T) {
+	_, err := NewRunner(Options{AuthType: kubeconfig.AuthTypeOIDC})
+	require.NoError(t, err)
 }
 
-func (s *removeLockDetectingStore) RemoveContext(name string) error {
-	if s.runner != nil {
-		if s.runner.mu.TryLock() {
-			s.runner.mu.Unlock()
-		} else {
-			s.removeWhileLocked.Store(true)
-		}
-	}
-
-	return s.ContextStore.RemoveContext(name)
+func TestNewRunnerRequiresHubClusterForInClusterDiscovery(t *testing.T) {
+	_, err := NewRunner(Options{HubConfig: &rest.Config{}})
+	require.ErrorContains(t, err, "hub cluster is required")
 }
 
-func TestNewRunnerValidatesProviderFile(t *testing.T) {
-	store := kubeconfig.NewContextStore()
-
-	_, err := NewRunner(Options{Store: store})
-	require.ErrorContains(t, err, "provider file is required")
-
-	_, err = NewRunner(Options{Store: store, ProviderFile: "/does/not/exist"})
-	require.ErrorContains(t, err, "load cluster inventory provider file")
-
-	malformed := filepath.Join(t.TempDir(), "malformed.json")
-	require.NoError(t, os.WriteFile(malformed, []byte("{"), 0o600))
-
-	_, err = NewRunner(Options{Store: store, ProviderFile: malformed})
-	require.ErrorContains(t, err, "load cluster inventory provider file")
-
-	_, err = NewRunner(Options{
-		Store:         store,
-		ProviderFile:  writeProviderFile(t),
-		LabelSelector: "headlamp.dev/ignore in (",
-	})
-	require.ErrorContains(t, err, "invalid cluster-inventory-label-selector")
-
-	_, err = NewRunner(Options{
-		Store:        store,
-		ProviderFile: writeProviderFile(t),
-		Namespaces:   "team-a,Team B",
-	})
-	require.ErrorContains(t, err, "invalid cluster-inventory-namespaces")
-
-	_, err = NewRunner(Options{
-		Store:        store,
-		ProviderFile: writeProviderFile(t),
-		Namespaces:   "team-a,*",
-	})
-	require.ErrorContains(t, err, `"*" must be used on its own`)
-}
-
-func TestNormalizeNamespaces(t *testing.T) {
+func TestParseAccessProviders(t *testing.T) {
 	tests := []struct {
-		name    string
-		value   string
-		want    []string
-		wantErr string
+		name  string
+		value string
+		want  []string
 	}{
 		{name: "unset", value: "  "},
 		{
-			name:  "trimmed, sorted and deduplicated",
-			value: " team-b,team-a, team-b ",
-			want:  []string{"team-a", "team-b"},
+			name:  "trimmed and case-sensitive, in the configured order",
+			value: " OIDC,oidc,static-token ",
+			want:  []string{"OIDC", "oidc", "static-token"},
 		},
-		{name: "all namespaces", value: "*", want: []string{metav1.NamespaceAll}},
-		{
-			name:    "repeated all namespaces are rejected",
-			value:   "*,*",
-			wantErr: `"*" must be used on its own`,
-		},
-		{
-			name:    "all namespaces cannot be combined with a listed namespace",
-			value:   "team-a,*",
-			wantErr: `"*" must be used on its own`,
-		},
-		{
-			name:    "empty entries are rejected",
-			value:   "team-a,,team-b",
-			wantErr: "namespace must not be empty",
-		},
-		{
-			name:    "invalid namespaces are rejected",
-			value:   "Team-A",
-			wantErr: "invalid cluster-inventory-namespaces",
-		},
+		{name: "empty entries are skipped", value: "oidc,,static-token", want: []string{"oidc", "static-token"}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := normalizeNamespaces(tt.value)
-			if tt.wantErr != "" {
-				require.ErrorContains(t, err, tt.wantErr)
-
-				return
-			}
-
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.want, parseAccessProviders(tt.value))
 		})
 	}
+}
+
+func TestOIDCContextUsesFirstAllowedAccessProvider(t *testing.T) {
+	runner := newTestRunner(t, kubeconfig.NewContextStore(), Options{
+		AuthType:        kubeconfig.AuthTypeOIDC,
+		AccessProviders: "preferred,fallback",
+		OIDCConfig:      &kubeconfig.OidcConfig{ClientID: "headlamp"},
+	})
+	cp := clusterProfile("spoke-a", "fallback", "https://fallback.example.com")
+	cp.Status.AccessProviders = append(cp.Status.AccessProviders, apisv1alpha1.AccessProvider{
+		Name: "preferred",
+		Cluster: clientcmdv1.Cluster{
+			Server:                   "https://preferred.example.com",
+			CertificateAuthorityData: []byte("preferred-ca"),
+		},
+	})
+
+	headlampContext, ok := runner.contextFromClusterProfile("hub/default/spoke-a", cp)
+	require.True(t, ok)
+	assert.Equal(t, "https://preferred.example.com", headlampContext.Cluster.Server)
+	assert.Equal(t, []byte("preferred-ca"), headlampContext.Cluster.CertificateAuthorityData)
+	require.NotNil(t, headlampContext.OidcConf)
+	assert.Equal(t, "headlamp", headlampContext.OidcConf.ClientID)
+	assert.Nil(t, headlampContext.AuthInfo, "the OIDC path must not materialize provider credentials")
 }
 
 func TestRestConfigToContextPreservesConfig(t *testing.T) {
@@ -386,10 +363,9 @@ func TestRestConfigToContextPreservesConfig(t *testing.T) {
 		},
 	}
 
-	ctx, err := restConfigToContext(restConfig, "ctx-name", "root/ns/spoke")
+	ctx, err := restConfigToContext(restConfig)
 	require.NoError(t, err)
 
-	assert.Equal(t, "ctx-name", ctx.Name)
 	assert.Equal(t, "https://spoke.example.com", ctx.Cluster.Server)
 	assert.Equal(t, []byte("ca-data"), ctx.Cluster.CertificateAuthorityData)
 	assert.Equal(t, "/tmp/ca.pem", ctx.Cluster.CertificateAuthority)
@@ -397,7 +373,6 @@ func TestRestConfigToContextPreservesConfig(t *testing.T) {
 	assert.Equal(t, "spoke.internal", ctx.Cluster.TLSServerName)
 	assert.Equal(t, "http://proxy.example.com:8080", ctx.Cluster.ProxyURL)
 	assert.Equal(t, kubeconfig.ClusterInventory, ctx.Source)
-	assert.Equal(t, "cluster-inventory/root/ns/spoke", ctx.ClusterID)
 	require.NotNil(t, ctx.AuthInfo.Exec)
 	assert.Equal(t, "/bin/token", ctx.AuthInfo.Exec.Command)
 	assert.Equal(t, clientcmdapi.NeverExecInteractiveMode, ctx.AuthInfo.Exec.InteractiveMode)
@@ -405,7 +380,7 @@ func TestRestConfigToContextPreservesConfig(t *testing.T) {
 }
 
 func TestContextFromClusterProfilePreservesInventoryMetadata(t *testing.T) {
-	runner := newTestRunner(t, Options{})
+	runner := newTestRunner(t, kubeconfig.NewContextStore(), Options{})
 	profileKey := "in-cluster/default/spoke-a"
 	cp := clusterProfile("spoke-a", "static-token", "https://spoke-a.example.com")
 	cp.Status.Conditions = []metav1.Condition{
@@ -448,35 +423,37 @@ func TestContextFromClusterProfilePreservesInventoryMetadata(t *testing.T) {
 	}, headlampContext.ClusterInventory.Properties)
 }
 
-func TestClusterProfileDeletePrunesContextOutsideRunnerLock(t *testing.T) {
-	store := &removeLockDetectingStore{ContextStore: kubeconfig.NewContextStore()}
-	runner := newTestRunner(t, Options{
-		Store:     store,
+func TestClusterProfileDeletePrunesRegistrationAndTracking(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+	runner := newTestRunner(t, store, Options{
 		HubConfig: &rest.Config{Host: "https://hub.example.com"},
 	})
-	store.runner = runner
 
-	state := &rootState{rootID: inClusterRootID}
-	profileKey := makeProfileKey(state.rootID, "default/spoke-a")
-	contextName := contextNameFromProfileKey(profileKey)
-	require.NoError(t, store.AddContext(&kubeconfig.Context{Name: contextName}))
+	state := &rootState{rootID: inClusterRootID, originCluster: kubeconfig.DefaultInClusterContextName}
+	cp := clusterProfile("spoke-a", "", "")
+	profileKey := makeProfileKey(state.rootID, cp)
+	registrationID, err := runner.registry.Upsert(clusterregistration.Candidate{
+		DisplayName: "spoke-a",
+		Source:      registrationSource,
+		Origin: clusterregistration.OriginFor(
+			kubeconfig.DefaultInClusterContextName,
+			apisv1alpha1.GroupVersion.WithKind(apisv1alpha1.ClusterProfileKind),
+			cp,
+		),
+		Context: testStoreContext("temporary", kubeconfig.ClusterInventory,
+			"https://spoke-a.example.com", "", false),
+	})
+	require.NoError(t, err)
 
 	runner.mu.Lock()
 	runner.roots[state.rootID] = state
 	runner.profileKeysByRoot[state.rootID] = map[string]string{profileKey: "default"}
-	runner.profiles[profileKey] = profileState{contextName: contextName}
+	runner.profiles[profileKey] = registrationID
 	runner.mu.Unlock()
 
-	runner.handleClusterProfileDelete(state, &apisv1alpha1.ClusterProfile{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "spoke-a",
-		},
-	})
+	runner.handleClusterProfileDelete(state, cp)
 
-	assert.False(t, store.removeWhileLocked.Load())
-
-	_, err := store.GetContext(contextName)
+	_, err = store.GetContext(registrationID)
 	require.Error(t, err)
 
 	runner.mu.Lock()
@@ -488,37 +465,9 @@ func TestClusterProfileDeletePrunesContextOutsideRunnerLock(t *testing.T) {
 	assert.False(t, rootProfileExists)
 }
 
-func TestContextNameFromProfileKey(t *testing.T) {
-	tests := []struct {
-		profileKey string
-		want       string
-	}{
-		{"in-cluster/ns/name", "cluster-inventory-in-cluster--ns--name--c2adabb8b734"},
-		{"store/minikube/ns/name", "cluster-inventory-store--minikube--ns--name--f8b7bcd1f9fb"},
-		{"store/seed/ns/name with space", "cluster-inventory-store--seed--ns--name__with__space--86a59f47f71a"},
-		{"ns/a--b", "cluster-inventory-ns--a--b--3a9038b84ee9"},
-		{"ns--a/b", "cluster-inventory-ns--a--b--7bc90dd90ccb"},
-		{"ns/a_b + c", "cluster-inventory-ns--a_b__+__c--b955996621e2"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.profileKey, func(t *testing.T) {
-			assert.Equal(t, tt.want, contextNameFromProfileKey(tt.profileKey))
-		})
-	}
-}
-
-func TestContextNameFromProfileKeyAvoidsSeparatorCollisions(t *testing.T) {
-	assert.NotEqual(t,
-		contextNameFromProfileKey("ns/a--b"),
-		contextNameFromProfileKey("ns--a/b"),
-	)
-}
-
 func TestInformerInitialSyncUsesAccessProviders(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	runner := newTestRunner(t, Options{
-		Store:     store,
+	runner := newTestRunner(t, store, Options{
 		HubConfig: &rest.Config{Host: "https://hub.example.com"},
 	})
 
@@ -570,8 +519,7 @@ func TestInformerWatchesNamespaces(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			store := kubeconfig.NewContextStore()
-			runner := newTestRunner(t, Options{
-				Store:        store,
+			runner := newTestRunner(t, store, Options{
 				HubConfig:    &rest.Config{Host: "https://hub.example.com"},
 				HubNamespace: tt.hubNamespace,
 				Namespaces:   tt.namespaces,
@@ -599,8 +547,7 @@ func TestInformerInitialSyncIgnoresLabelSelectedProfiles(t *testing.T) {
 	ignoredProfile := clusterProfile("ignored", "static-token", "https://ignored.example.com")
 	ignoredProfile.Labels = map[string]string{"headlamp.dev/ignore": "true"}
 
-	runner := newTestRunner(t, Options{
-		Store:         store,
+	runner := newTestRunner(t, store, Options{
 		HubConfig:     &rest.Config{Host: "https://hub.example.com"},
 		LabelSelector: "!headlamp.dev/ignore",
 	})
@@ -621,8 +568,7 @@ func TestInformerInitialSyncIgnoresLabelSelectedProfiles(t *testing.T) {
 
 func TestTransientWatchFailureDoesNotPrunePreviousContexts(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	runner := newTestRunner(t, Options{
-		Store:     store,
+	runner := newTestRunner(t, store, Options{
 		HubConfig: &rest.Config{Host: "https://hub.example.com"},
 	})
 
@@ -645,8 +591,7 @@ func TestTransientWatchFailureDoesNotPrunePreviousContexts(t *testing.T) {
 
 func TestInitialSyncFailureDoesNotPrunePreviousContexts(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	runner := newTestRunner(t, Options{
-		Store:     store,
+	runner := newTestRunner(t, store, Options{
 		HubConfig: &rest.Config{Host: "https://hub.example.com"},
 	})
 
@@ -672,8 +617,7 @@ func TestInitialSyncFailureDoesNotPrunePreviousContexts(t *testing.T) {
 
 func TestNamespaceSyncFailureOnlyPreservesFailedNamespace(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	runner := newTestRunner(t, Options{
-		Store:      store,
+	runner := newTestRunner(t, store, Options{
 		HubConfig:  &rest.Config{Host: "https://hub.example.com"},
 		Namespaces: "team-a,team-b",
 	})
@@ -725,38 +669,47 @@ func TestNamespaceSyncFailureOnlyPreservesFailedNamespace(t *testing.T) {
 	requireProfileContextEventually(t, store, "in-cluster/team-b/from-b")
 }
 
-func TestProviderFailureDoesNotPrunePreviousContext(t *testing.T) {
-	store := kubeconfig.NewContextStore()
-	runner := newTestRunner(t, Options{
-		Store:     store,
-		HubConfig: &rest.Config{Host: "https://hub.example.com"},
-	})
-
-	client := ciafake.NewSimpleClientset(
-		clusterProfile("spoke-a", "static-token", "https://spoke-a.example.com"),
-	)
-
-	runner.clientForConfig = func(*rest.Config) (ciaclient.Interface, error) {
-		return client, nil
+func TestRoutabilityLossPrunesPreviousContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		server   string
+	}{
+		{name: "provider removed", provider: "missing-provider", server: "https://spoke-a-updated.example.com"},
+		{name: "endpoint removed", provider: "static-token", server: ""},
 	}
 
-	ctx := testRunnerContext(t, runner)
-	reconcileAndWaitForRoot(t, ctx, runner, inClusterRootID)
-	headlampContext := requireProfileContextEventually(t, store, "in-cluster/default/spoke-a")
-	require.Equal(t, "https://spoke-a.example.com", headlampContext.Cluster.Server)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := kubeconfig.NewContextStore()
+			runner := newTestRunner(t, store, Options{
+				HubConfig: &rest.Config{Host: "https://hub.example.com"},
+			})
 
-	updated := clusterProfile("spoke-a", "missing-provider", "https://spoke-a-updated.example.com")
-	_, err := client.ApisV1alpha1().ClusterProfiles("default").Update(ctx, updated, metav1.UpdateOptions{})
-	require.NoError(t, err)
+			client := ciafake.NewSimpleClientset(
+				clusterProfile("spoke-a", "static-token", "https://spoke-a.example.com"),
+			)
+			runner.clientForConfig = func(*rest.Config) (ciaclient.Interface, error) {
+				return client, nil
+			}
 
-	headlampContext = requireProfileContextEventually(t, store, "in-cluster/default/spoke-a")
-	assert.Equal(t, "https://spoke-a.example.com", headlampContext.Cluster.Server)
+			ctx := testRunnerContext(t, runner)
+			reconcileAndWaitForRoot(t, ctx, runner, inClusterRootID)
+			headlampContext := requireProfileContextEventually(t, store, "in-cluster/default/spoke-a")
+			require.Equal(t, "https://spoke-a.example.com", headlampContext.Cluster.Server)
+
+			updated := clusterProfile("spoke-a", tt.provider, tt.server)
+			_, err := client.ApisV1alpha1().ClusterProfiles("default").Update(ctx, updated, metav1.UpdateOptions{})
+			require.NoError(t, err)
+
+			requireNoProfileContextEventually(t, store, "in-cluster/default/spoke-a")
+		})
+	}
 }
 
 func TestInformerDoesNotDiscoverClusterProfilesFromDiscoveredClusters(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	runner := newTestRunner(t, Options{
-		Store:     store,
+	runner := newTestRunner(t, store, Options{
 		HubConfig: &rest.Config{Host: "https://hub.example.com"},
 	})
 
@@ -789,8 +742,7 @@ func TestInformerDoesNotDiscoverClusterProfilesFromDiscoveredClusters(t *testing
 
 func TestInitialSyncPrunesMissingDirectProfiles(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	runner := newTestRunner(t, Options{
-		Store:     store,
+	runner := newTestRunner(t, store, Options{
 		HubConfig: &rest.Config{Host: "https://hub.example.com"},
 	})
 
@@ -819,7 +771,7 @@ func TestInitialSyncPrunesMissingDirectProfiles(t *testing.T) {
 	requireProfileContextEventually(t, store, "in-cluster/default/spoke-b")
 }
 
-func TestStoreSeedsSkipClusterInventoryAndAllowSameServerPerRoot(t *testing.T) {
+func TestStoreSeedsSkipInternalContextsAndAllowSameServerPerRoot(t *testing.T) {
 	store := kubeconfig.NewContextStore()
 	require.NoError(t, store.AddContext(testStoreContext(
 		"seed-a", kubeconfig.KubeConfig, "https://shared.example.com", "token-a", false)))
@@ -828,12 +780,9 @@ func TestStoreSeedsSkipClusterInventoryAndAllowSameServerPerRoot(t *testing.T) {
 	require.NoError(t, store.AddContext(testStoreContext(
 		"internal-seed", kubeconfig.DynamicCluster, "https://internal.example.com", "token-internal", true)))
 	require.NoError(t, store.AddContext(testStoreContext(
-		"discovered", kubeconfig.ClusterInventory, "https://ignored.example.com", "", false)))
+		"discovered", kubeconfig.ClusterInventory, "https://ignored.example.com", "", true)))
 
-	runner := newTestRunner(t, Options{
-		Store:             store,
-		DiscoverFromStore: true,
-	})
+	runner := newTestRunner(t, store, Options{SeedStore: store})
 
 	requestedTokens := map[string]int{}
 	requestedHosts := map[string]int{}
@@ -874,10 +823,7 @@ func TestRemovedStoreSeedStopsWatcherAndPrunesDiscoveredContexts(t *testing.T) {
 	require.NoError(t, store.AddContext(testStoreContext(
 		"seed-a", kubeconfig.KubeConfig, "https://seed-a.example.com", "token-a", false)))
 
-	runner := newTestRunner(t, Options{
-		Store:             store,
-		DiscoverFromStore: true,
-	})
+	runner := newTestRunner(t, store, Options{SeedStore: store})
 
 	requestedHosts := map[string]int{}
 	runner.clientForConfig = func(config *rest.Config) (ciaclient.Interface, error) {
@@ -919,10 +865,7 @@ func TestStoreSeedConfigChangeRestartsWatcher(t *testing.T) {
 	require.NoError(t, store.AddContext(testStoreContext(
 		"seed-a", kubeconfig.KubeConfig, "https://seed.example.com", "token-a", false)))
 
-	runner := newTestRunner(t, Options{
-		Store:             store,
-		DiscoverFromStore: true,
-	})
+	runner := newTestRunner(t, store, Options{SeedStore: store})
 
 	requestedTokens := map[string]int{}
 	runner.clientForConfig = func(config *rest.Config) (ciaclient.Interface, error) {
@@ -965,10 +908,7 @@ func TestStoreSeedNamespaceChangeRestartsWatcher(t *testing.T) {
 	seed.KubeContext.Namespace = "team-a"
 	require.NoError(t, store.AddContext(seed))
 
-	runner := newTestRunner(t, Options{
-		Store:             store,
-		DiscoverFromStore: true,
-	})
+	runner := newTestRunner(t, store, Options{SeedStore: store})
 
 	client := namespacedProfileClient()
 	runner.clientForConfig = func(*rest.Config) (ciaclient.Interface, error) {
@@ -1030,8 +970,7 @@ func TestRootFingerprintIncludesNamespaces(t *testing.T) {
 
 func TestSelfReferencingProfileDoesNotTriggerChildWatcher(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	runner := newTestRunner(t, Options{
-		Store:     store,
+	runner := newTestRunner(t, store, Options{
 		HubConfig: &rest.Config{Host: "https://hub.example.com"},
 	})
 
@@ -1053,8 +992,7 @@ func TestSelfReferencingProfileDoesNotTriggerChildWatcher(t *testing.T) {
 
 func TestWatchAddUpdateDeleteSyncsContext(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	runner := newTestRunner(t, Options{
-		Store:     store,
+	runner := newTestRunner(t, store, Options{
 		HubConfig: &rest.Config{Host: "https://hub.example.com"},
 	})
 
@@ -1098,8 +1036,7 @@ func TestWatchAddUpdateDeleteSyncsContext(t *testing.T) {
 
 func TestWatchUpdateSyncsClusterInventoryConditions(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	runner := newTestRunner(t, Options{
-		Store:     store,
+	runner := newTestRunner(t, store, Options{
 		HubConfig: &rest.Config{Host: "https://hub.example.com"},
 	})
 
@@ -1154,8 +1091,7 @@ func TestWatchUpdateSyncsClusterInventoryConditions(t *testing.T) {
 
 func TestClusterProfileUpdateToIgnoredLabelPrunesContext(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	runner := newTestRunner(t, Options{
-		Store:         store,
+	runner := newTestRunner(t, store, Options{
 		HubConfig:     &rest.Config{Host: "https://hub.example.com"},
 		LabelSelector: "!headlamp.dev/ignore",
 	})
@@ -1188,8 +1124,7 @@ func TestClusterProfileUpdateToIgnoredLabelPrunesContext(t *testing.T) {
 
 func TestNoCRDPrunesAndSuppressesRootUntilTTL(t *testing.T) {
 	store := kubeconfig.NewContextStore()
-	runner := newTestRunner(t, Options{
-		Store:         store,
+	runner := newTestRunner(t, store, Options{
 		HubConfig:     &rest.Config{Host: "https://hub.example.com"},
 		NoCRDCacheTTL: time.Minute,
 	})
@@ -1247,8 +1182,7 @@ func TestClusterProfileInformerUsesWatchListOptions(t *testing.T) {
 	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, true)
 
 	store := kubeconfig.NewContextStore()
-	runner := newTestRunner(t, Options{
-		Store:         store,
+	runner := newTestRunner(t, store, Options{
 		HubConfig:     &rest.Config{Host: "https://hub.example.com"},
 		LabelSelector: "!headlamp.dev/ignore",
 	})
@@ -1350,14 +1284,17 @@ func TestNoCRDErrorClassification(t *testing.T) {
 }
 
 func TestNoCRDCacheTTL(t *testing.T) {
-	runner := newTestRunner(t, Options{
+	runner := newTestRunner(t, kubeconfig.NewContextStore(), Options{
 		NoCRDCacheTTL: time.Minute,
 	})
 
 	now := time.Date(2026, time.May, 8, 0, 0, 0, 0, time.UTC)
 	runner.now = func() time.Time { return now }
 
-	runner.markNoCRD("https://no-crd.example.com")
+	state := &rootState{rootID: "root", serverURL: "https://no-crd.example.com", cancel: func() {}}
+	runner.roots[state.rootID] = state
+
+	runner.markRootNoCRD(state)
 	assert.True(t, runner.hasNoCRD("https://no-crd.example.com"))
 
 	now = now.Add(2 * time.Minute)

--- a/backend/pkg/clusterregistration/http.go
+++ b/backend/pkg/clusterregistration/http.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterregistration
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
+)
+
+// Registration events carry no payload, so clients re-read the snapshot.
+const (
+	registrationFrame = "event: registration\ndata: {}\n\n"
+	keepaliveFrame    = ": keepalive\n\n"
+
+	// keepaliveInterval is the interval between keepalive comments on an idle stream.
+	keepaliveInterval = 20 * time.Second
+)
+
+// ServeSnapshot writes the current registration snapshot.
+func (r *Registry) ServeSnapshot(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if err := json.NewEncoder(w).Encode(r.Snapshot()); err != nil {
+		logger.Log(logger.LevelError, nil, err, "encoding cluster registrations")
+	}
+}
+
+// ServeEvents streams registration changes as server-sent events.
+func (r *Registry) ServeEvents(w http.ResponseWriter, request *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming is not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	changes, unsubscribe := r.subscribe()
+	defer unsubscribe()
+
+	heartbeat := time.NewTicker(keepaliveInterval)
+	defer heartbeat.Stop()
+
+	write := func(frame string) {
+		_, _ = fmt.Fprint(w, frame)
+
+		flusher.Flush()
+	}
+
+	// A client that (re)connects may have missed changes.
+	write(registrationFrame)
+
+	for {
+		select {
+		case <-request.Context().Done():
+			return
+		case <-changes:
+			write(registrationFrame)
+		case <-heartbeat.C:
+			write(keepaliveFrame)
+		}
+	}
+}

--- a/backend/pkg/clusterregistration/informer.go
+++ b/backend/pkg/clusterregistration/informer.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterregistration
+
+import "k8s.io/client-go/tools/cache"
+
+// ObjectFromEvent extracts the discovered resource from an informer event, unwrapping
+// tombstones.
+func ObjectFromEvent[T any](obj interface{}) (T, bool) {
+	if tombstone, isTombstone := obj.(cache.DeletedFinalStateUnknown); isTombstone {
+		obj = tombstone.Obj
+	}
+
+	typed, ok := obj.(T)
+
+	return typed, ok
+}

--- a/backend/pkg/clusterregistration/metadata.go
+++ b/backend/pkg/clusterregistration/metadata.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterregistration
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Resource identifies the Kubernetes object that produced a registration.
+type Resource struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Namespace  string `json:"namespace,omitempty"`
+	Name       string `json:"name"`
+	UID        string `json:"uid"`
+}
+
+// Origin identifies the management cluster and resource that produced a registration.
+type Origin struct {
+	Cluster  string   `json:"cluster"`
+	Resource Resource `json:"resource"`
+}
+
+// OriginFor builds the origin of a registration discovered from obj on cluster.
+func OriginFor(cluster string, gvk schema.GroupVersionKind, obj metav1.Object) Origin {
+	return Origin{
+		Cluster: cluster,
+		Resource: Resource{
+			APIVersion: gvk.GroupVersion().String(),
+			Kind:       gvk.Kind,
+			Namespace:  obj.GetNamespace(),
+			Name:       obj.GetName(),
+			UID:        string(obj.GetUID()),
+		},
+	}
+}
+
+// Metadata is the public, non-sensitive description of a registered cluster.
+type Metadata struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"displayName"`
+	Source      string `json:"source"`
+	Origin      Origin `json:"origin"`
+}

--- a/backend/pkg/clusterregistration/registry.go
+++ b/backend/pkg/clusterregistration/registry.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package clusterregistration stores source-independent cluster registrations and serves
+// them to clients.
+package clusterregistration
+
+import (
+	"cmp"
+	"crypto/sha256"
+	"encoding/base32"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+)
+
+const (
+	registrationIDPrefix = "hr-v1-"
+	clusterIDPrefix      = "registration/"
+)
+
+// Snapshot is the list of registrations published to clients.
+type Snapshot struct {
+	Items []Metadata `json:"items"`
+}
+
+// Candidate is a discovered cluster and the metadata published for it.
+type Candidate struct {
+	DisplayName string
+	Source      string
+	Origin      Origin
+	Context     *kubeconfig.Context
+}
+
+// Registry adds discovered cluster registrations to Headlamp's context store.
+type Registry struct {
+	store kubeconfig.ContextStore
+
+	mu            sync.RWMutex
+	registrations map[string]Metadata
+	subscribers   map[chan struct{}]struct{}
+}
+
+// New returns an empty registry backed by store.
+func New(store kubeconfig.ContextStore) *Registry {
+	return &Registry{
+		store:         store,
+		registrations: map[string]Metadata{},
+		subscribers:   map[chan struct{}]struct{}{},
+	}
+}
+
+// idFor returns the stable, opaque ID for a discovered resource.
+func idFor(source string, origin Origin) string {
+	resource := origin.Resource
+
+	// The version is left out so an apiVersion bump keeps the same ID.
+	groupVersion, _ := schema.ParseGroupVersion(resource.APIVersion)
+
+	values := []string{
+		source, origin.Cluster, groupVersion.Group,
+		resource.Kind, resource.Namespace, resource.Name, resource.UID,
+	}
+	hash := sha256.Sum256([]byte(strings.Join(values, "\x00")))
+	encoded := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(hash[:20])
+
+	return registrationIDPrefix + strings.ToLower(encoded)
+}
+
+// Upsert adds or updates a registration and returns its opaque ID.
+func (r *Registry) Upsert(candidate Candidate) (string, error) {
+	id := idFor(candidate.Source, candidate.Origin)
+
+	routable := candidate.Context.Copy()
+	if routable.KubeContext == nil {
+		routable.KubeContext = &clientcmdapi.Context{}
+	}
+
+	if routable.AuthInfo == nil {
+		routable.AuthInfo = &clientcmdapi.AuthInfo{}
+	}
+
+	routable.Name = id
+	routable.ClusterID = clusterIDPrefix + id
+	routable.KubeContext.Cluster = id
+	routable.KubeContext.AuthInfo = id
+
+	// Internal keeps registrations out of /config and out of discovery's seed roots, so
+	// discovery never recurses into what it registered.
+	routable.Internal = true
+
+	if err := routable.SetupProxy(); err != nil {
+		return "", fmt.Errorf("setup registration proxy: %w", err)
+	}
+
+	metadata := Metadata{
+		ID:          id,
+		DisplayName: candidate.DisplayName,
+		Source:      candidate.Source,
+		Origin:      candidate.Origin,
+	}
+
+	if err := r.store.AddContext(routable); err != nil {
+		return "", fmt.Errorf("store registration context: %w", err)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Only metadata is published, so a connection-only change needs no notification.
+	if r.registrations[id] != metadata {
+		r.registrations[id] = metadata
+		r.notifyLocked()
+	}
+
+	return id, nil
+}
+
+// Remove deletes a registration and its context. Unknown IDs are ignored.
+func (r *Registry) Remove(id string) error {
+	if _, found := r.Get(id); !found {
+		return nil
+	}
+
+	if err := r.store.RemoveContext(id); err != nil {
+		return fmt.Errorf("remove registration context: %w", err)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.registrations, id)
+	r.notifyLocked()
+
+	return nil
+}
+
+// RemoveOrigin deletes the registration discovered from the given resource.
+func (r *Registry) RemoveOrigin(source string, origin Origin) error {
+	return r.Remove(idFor(source, origin))
+}
+
+// Get returns the published metadata for a registration.
+func (r *Registry) Get(id string) (Metadata, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	metadata, found := r.registrations[id]
+
+	return metadata, found
+}
+
+// Snapshot returns the current registrations, sorted by display name and ID.
+func (r *Registry) Snapshot() Snapshot {
+	r.mu.RLock()
+	registrations := slices.Collect(maps.Values(r.registrations))
+	r.mu.RUnlock()
+
+	slices.SortFunc(registrations, func(a, b Metadata) int {
+		return cmp.Or(cmp.Compare(a.DisplayName, b.DisplayName), cmp.Compare(a.ID, b.ID))
+	})
+
+	return Snapshot{Items: registrations}
+}
+
+func (r *Registry) subscribe() (<-chan struct{}, func()) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	changes := make(chan struct{}, 1)
+	r.subscribers[changes] = struct{}{}
+
+	return changes, func() {
+		r.mu.Lock()
+		delete(r.subscribers, changes)
+		r.mu.Unlock()
+	}
+}
+
+func (r *Registry) notifyLocked() {
+	for subscriber := range r.subscribers {
+		select {
+		case subscriber <- struct{}{}:
+		default:
+		}
+	}
+}

--- a/backend/pkg/clusterregistration/registry_internal_test.go
+++ b/backend/pkg/clusterregistration/registry_internal_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterregistration
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+func testCandidate(uid, server string) Candidate {
+	return Candidate{
+		DisplayName: "spoke-a",
+		Source:      "cluster-inventory",
+		Origin: Origin{
+			Cluster: "hub",
+			Resource: Resource{
+				APIVersion: "multicluster.x-k8s.io/v1alpha1",
+				Kind:       "ClusterProfile",
+				Namespace:  "headlamp",
+				Name:       "spoke-a",
+				UID:        uid,
+			},
+		},
+		Context: &kubeconfig.Context{
+			Name:        "temporary",
+			KubeContext: &api.Context{Cluster: "temporary", AuthInfo: "temporary"},
+			Cluster:     &api.Cluster{Server: server},
+			AuthInfo:    &api.AuthInfo{},
+		},
+	}
+}
+
+func TestIDForIsStableAndSourceSpecific(t *testing.T) {
+	candidate := testCandidate("uid-a", "https://spoke.example")
+
+	first := idFor(candidate.Source, candidate.Origin)
+	assert.Equal(t, first, idFor(candidate.Source, candidate.Origin))
+	assert.NotEqual(t, first, idFor("cluster-api", candidate.Origin))
+
+	candidate.Origin.Resource.UID = "uid-b"
+	recreated := idFor(candidate.Source, candidate.Origin)
+	assert.NotEqual(t, first, recreated)
+
+	candidate.Origin.Resource.Namespace = ""
+	assert.NotEqual(t, recreated, idFor(candidate.Source, candidate.Origin),
+		"cluster-scoped origin resources must get their own ID")
+}
+
+func TestRegistryNotifiesOnMetadataChange(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+	registry := New(store)
+
+	changes, unsubscribe := registry.subscribe()
+	t.Cleanup(unsubscribe)
+
+	candidate := testCandidate("uid-a", "https://spoke.example")
+	id, err := registry.Upsert(candidate)
+	require.NoError(t, err)
+	require.Len(t, changes, 1)
+	<-changes
+
+	candidate.DisplayName = "renamed-spoke"
+	_, err = registry.Upsert(candidate)
+	require.NoError(t, err)
+	require.Len(t, changes, 1)
+	<-changes
+
+	require.NoError(t, registry.Remove(id))
+	assert.Len(t, changes, 1)
+
+	_, err = store.GetContext(id)
+	assert.Error(t, err)
+}
+
+func TestRegistryDoesNotNotifyOnConnectionOnlyChange(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+	registry := New(store)
+
+	candidate := testCandidate("uid-a", "https://spoke.example")
+	id, err := registry.Upsert(candidate)
+	require.NoError(t, err)
+
+	changes, unsubscribe := registry.subscribe()
+	t.Cleanup(unsubscribe)
+
+	_, err = registry.Upsert(candidate)
+	require.NoError(t, err)
+	assert.Empty(t, changes)
+
+	candidate.Context.Cluster.Server = "https://new-spoke.example"
+	_, err = registry.Upsert(candidate)
+	require.NoError(t, err)
+	assert.Empty(t, changes)
+
+	routed, err := store.GetContext(id)
+	require.NoError(t, err)
+	assert.Equal(t, "https://new-spoke.example", routed.Cluster.Server,
+		"a connection-only change must still be routed")
+}
+
+func TestRegistryListUsesDisplayNameThenID(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+	registry := New(store)
+
+	second := testCandidate("uid-b", "https://b.example")
+	second.DisplayName = "zeta"
+	_, err := registry.Upsert(second)
+	require.NoError(t, err)
+
+	first := testCandidate("uid-a", "https://a.example")
+	first.DisplayName = "alpha"
+	first.Origin.Resource.Name = "alpha"
+	_, err = registry.Upsert(first)
+	require.NoError(t, err)
+
+	registrations := registry.Snapshot().Items
+	require.Len(t, registrations, 2)
+	assert.Equal(t, "alpha", registrations[0].DisplayName)
+	assert.Equal(t, "zeta", registrations[1].DisplayName)
+}
+
+func TestHTTPHandlersExposeSnapshotAndStreamChanges(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+	registry := New(store)
+
+	id, err := registry.Upsert(testCandidate("uid-a", "https://spoke.example"))
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	registry.ServeSnapshot(recorder, httptest.NewRequestWithContext(
+		context.Background(), http.MethodGet, "/cluster-registrations", nil))
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	var snapshot Snapshot
+	require.NoError(t, json.NewDecoder(recorder.Body).Decode(&snapshot))
+	require.Len(t, snapshot.Items, 1)
+	assert.Equal(t, id, snapshot.Items[0].ID)
+
+	// A cancelled context returns from the stream right after the initial event.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	recorder = httptest.NewRecorder()
+	registry.ServeEvents(recorder, httptest.NewRequestWithContext(
+		ctx, http.MethodGet, "/cluster-registrations/events", nil))
+	assert.Equal(t, "text/event-stream", recorder.Header().Get("Content-Type"))
+	assert.Equal(t, registrationFrame, recorder.Body.String())
+}
+
+// lockDetectingStore records whether the registry held its lock while calling the store.
+type lockDetectingStore struct {
+	kubeconfig.ContextStore
+	registry          *Registry
+	calledWhileLocked atomic.Bool
+}
+
+func (s *lockDetectingStore) record() {
+	if s.registry.mu.TryLock() {
+		s.registry.mu.Unlock()
+	} else {
+		s.calledWhileLocked.Store(true)
+	}
+}
+
+func (s *lockDetectingStore) AddContext(headlampContext *kubeconfig.Context) error {
+	s.record()
+
+	return s.ContextStore.AddContext(headlampContext)
+}
+
+func (s *lockDetectingStore) RemoveContext(name string) error {
+	s.record()
+
+	return s.ContextStore.RemoveContext(name)
+}
+
+func TestRegistryCallsStoreOutsideItsLock(t *testing.T) {
+	store := &lockDetectingStore{ContextStore: kubeconfig.NewContextStore()}
+	registry := New(store)
+	store.registry = registry
+
+	id, err := registry.Upsert(testCandidate("uid-a", "https://spoke.example"))
+	require.NoError(t, err)
+	require.NoError(t, registry.Remove(id))
+
+	assert.False(t, store.calledWhileLocked.Load(),
+		"context store listeners run synchronously, so the registry lock must not be held")
+}

--- a/backend/pkg/clusterregistration/selectors.go
+++ b/backend/pkg/clusterregistration/selectors.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterregistration
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// ParseSelectors parses the label selector and namespace list that limit one discovery
+// source.
+func ParseSelectors(labelSelector, namespaces string) (labels.Selector, []string, error) {
+	selector, err := labels.Parse(labelSelector)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse label selector: %w", err)
+	}
+
+	parsed, err := ParseNamespaces(namespaces)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse namespaces: %w", err)
+	}
+
+	return selector, parsed, nil
+}
+
+// ParseNamespaces parses a comma-separated namespace list. "*" selects all namespaces
+// and must be used on its own.
+func ParseNamespaces(value string) ([]string, error) {
+	if strings.TrimSpace(value) == "" {
+		return nil, nil
+	}
+
+	var (
+		namespaces    = make([]string, 0, strings.Count(value, ",")+1)
+		allNamespaces bool
+	)
+
+	for _, namespace := range strings.Split(value, ",") {
+		namespace = strings.TrimSpace(namespace)
+
+		switch namespace {
+		case "":
+			return nil, errors.New("namespace must not be empty")
+		case "*":
+			if allNamespaces {
+				return nil, errors.New(`"*" must be used on its own`)
+			}
+
+			allNamespaces = true
+		default:
+			if errs := validation.IsDNS1123Label(namespace); len(errs) > 0 {
+				return nil, fmt.Errorf("%q: %s", namespace, strings.Join(errs, "; "))
+			}
+
+			namespaces = append(namespaces, namespace)
+		}
+	}
+
+	if allNamespaces {
+		if len(namespaces) > 0 {
+			return nil, errors.New(`"*" must be used on its own`)
+		}
+
+		return []string{metav1.NamespaceAll}, nil
+	}
+
+	slices.Sort(namespaces)
+
+	return slices.Compact(namespaces), nil
+}
+
+// NamespacesOrDefault returns the parsed namespaces, or defaultNamespace when none
+// were configured.
+func NamespacesOrDefault(namespaces []string, defaultNamespace string) []string {
+	if len(namespaces) > 0 {
+		return namespaces
+	}
+
+	return []string{cmp.Or(defaultNamespace, metav1.NamespaceDefault)}
+}

--- a/backend/pkg/clusterregistration/selectors_test.go
+++ b/backend/pkg/clusterregistration/selectors_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterregistration_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/clusterregistration"
+)
+
+func TestParseNamespaces(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    []string
+		wantErr string
+	}{
+		{name: "unset"},
+		{
+			name:  "trimmed, sorted and deduplicated",
+			value: " team-b,team-a, team-b ",
+			want:  []string{"team-a", "team-b"},
+		},
+		{
+			name:  "all namespaces",
+			value: "*",
+			want:  []string{metav1.NamespaceAll},
+		},
+		{name: "invalid namespace", value: "Team-A", wantErr: `"Team-A"`},
+		{name: `"*" cannot be combined`, value: "team-a,*", wantErr: `"*" must be used on its own`},
+		{name: "empty entries are rejected", value: "team-a,,team-b", wantErr: "namespace must not be empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespaces, err := clusterregistration.ParseNamespaces(tt.value)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, namespaces)
+		})
+	}
+}

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -16,6 +16,8 @@ import (
 	"github.com/knadh/koanf/providers/basicflag"
 	"github.com/knadh/koanf/providers/env"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/clusterinventory"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/clusterregistration"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/spa"
 	"k8s.io/apimachinery/pkg/labels"
@@ -51,6 +53,7 @@ type Config struct {
 	EnableHelm             bool   `koanf:"enable-helm"`
 	EnableDynamicClusters  bool   `koanf:"enable-dynamic-clusters"`
 	EnableClusterInventory bool   `koanf:"enable-cluster-inventory"`
+	EnableClusterAPI       bool   `koanf:"enable-cluster-api"`
 	AllowKubeconfigChanges bool   `koanf:"allow-kubeconfig-changes"`
 	ListenAddr             string `koanf:"listen-addr"`
 	WatchPluginsChanges    bool   `koanf:"watch-plugins-changes"`
@@ -69,10 +72,14 @@ type Config struct {
 	ProxyURLs              string `koanf:"proxy-urls"`
 
 	ClusterInventoryProviderFile          string        `koanf:"cluster-inventory-provider-file"`
+	ClusterInventoryAuthType              string        `koanf:"cluster-inventory-auth-type"`
+	ClusterInventoryAccessProviders       string        `koanf:"cluster-inventory-access-providers"`
 	ClusterInventoryLabelSelector         string        `koanf:"cluster-inventory-label-selector"`
 	ClusterInventoryNamespaces            string        `koanf:"cluster-inventory-namespaces"`
 	ClusterInventoryRootReconcileInterval time.Duration `koanf:"cluster-inventory-root-reconcile-interval"`
 	ClusterInventoryNoCRDCacheTTL         time.Duration `koanf:"cluster-inventory-no-crd-cache-ttl"`
+	ClusterAPILabelSelector               string        `koanf:"cluster-api-label-selector"`
+	ClusterAPINamespaces                  string        `koanf:"cluster-api-namespaces"`
 
 	OidcClientID                 string `koanf:"oidc-client-id"`
 	OidcValidatorClientID        string `koanf:"oidc-validator-client-id"`
@@ -186,7 +193,7 @@ func (c *Config) Validate() error {
 		return err
 	}
 
-	return nil
+	return c.validateClusterAPI()
 }
 
 // validateAppName ensures the application name is safe for use in Kubernetes User-Agent headers.
@@ -224,8 +231,46 @@ func (c *Config) validateClusterInventory() error {
 		return nil
 	}
 
+	if c.ClusterInventoryAuthType != kubeconfig.AuthTypeOIDC &&
+		c.ClusterInventoryAuthType != clusterinventory.AuthTypeAccessProvider {
+		return fmt.Errorf("invalid cluster-inventory-auth-type %q", c.ClusterInventoryAuthType)
+	}
+
+	if strings.TrimSpace(c.ClusterInventoryAccessProviders) == "" {
+		return errors.New("cluster-inventory-access-providers is required when cluster inventory is enabled")
+	}
+
+	if err := validateDiscoverySelectors("cluster-inventory",
+		c.ClusterInventoryLabelSelector, c.ClusterInventoryNamespaces); err != nil {
+		return err
+	}
+
+	if c.ClusterInventoryAuthType == clusterinventory.AuthTypeAccessProvider {
+		return c.validateClusterInventoryProviderFile()
+	}
+
+	return nil
+}
+
+// validateDiscoverySelectors validates the label selector and namespace list of one
+// discovery source. flagPrefix names the source's flags, such as "cluster-inventory".
+func validateDiscoverySelectors(flagPrefix, labelSelector, namespaces string) error {
+	if _, err := labels.Parse(labelSelector); err != nil {
+		return fmt.Errorf("invalid %s-label-selector: %w", flagPrefix, err)
+	}
+
+	if _, err := clusterregistration.ParseNamespaces(namespaces); err != nil {
+		return fmt.Errorf("invalid %s-namespaces: %w", flagPrefix, err)
+	}
+
+	return nil
+}
+
+// validateClusterInventoryProviderFile ensures the access provider configuration file
+// exists and can be parsed.
+func (c *Config) validateClusterInventoryProviderFile() error {
 	if c.ClusterInventoryProviderFile == "" {
-		return errors.New("cluster-inventory-provider-file is required when cluster inventory is enabled")
+		return errors.New("cluster-inventory-provider-file is required for access-provider authentication")
 	}
 
 	info, err := os.Stat(c.ClusterInventoryProviderFile)
@@ -241,20 +286,19 @@ func (c *Config) validateClusterInventory() error {
 		return fmt.Errorf("invalid cluster-inventory-provider-file: %w", err)
 	}
 
-	labelSelector := strings.TrimSpace(c.ClusterInventoryLabelSelector)
-	if labelSelector != "" {
-		if _, err := labels.Parse(labelSelector); err != nil {
-			return fmt.Errorf("invalid cluster-inventory-label-selector: %w", err)
-		}
-	}
-
-	c.ClusterInventoryLabelSelector = labelSelector
-
-	if err := clusterinventory.ValidateNamespaces(c.ClusterInventoryNamespaces); err != nil {
-		return err
-	}
-
 	return nil
+}
+
+func (c *Config) validateClusterAPI() error {
+	if !c.EnableClusterAPI {
+		return nil
+	}
+
+	if !c.InCluster {
+		return errors.New("enable-cluster-api requires in-cluster mode")
+	}
+
+	return validateDiscoverySelectors("cluster-api", c.ClusterAPILabelSelector, c.ClusterAPINamespaces)
 }
 
 func (c *Config) validateServiceAccountTokenFlags() error {
@@ -630,18 +674,7 @@ func addGeneralFlags(f *flag.FlagSet, appName string) {
 	f.Uint("port", defaultPort, "Port to listen from")
 	f.String("proxy-urls", "", "Allow proxy requests to specified URLs")
 	f.Bool("enable-helm", false, "Enable Helm operations")
-	f.Bool("enable-cluster-inventory", false,
-		"Enable experimental/alpha automatic discovery of clusters from ClusterProfile resources")
-	f.String("cluster-inventory-provider-file", "",
-		"Path to the JSON configuration file for experimental/alpha Cluster Inventory access providers")
-	f.String("cluster-inventory-label-selector", "",
-		"Label selector used to filter ClusterProfile resources for experimental/alpha Cluster Inventory")
-	f.String("cluster-inventory-namespaces", "",
-		"Comma-separated namespaces watched for experimental/alpha ClusterProfile resources; \"*\" watches all")
-	f.Duration("cluster-inventory-root-reconcile-interval", clusterinventory.DefaultRootReconcileInterval,
-		"Interval for reconciling experimental/alpha Cluster Inventory roots")
-	f.Duration("cluster-inventory-no-crd-cache-ttl", clusterinventory.DefaultNoCRDCacheTTL,
-		"How long to cache that an API server has no experimental/alpha ClusterProfile CRD")
+	addClusterDiscoveryFlags(f)
 	f.String("default-light-theme", "", "Default theme to use when user prefers light mode")
 	f.String("default-dark-theme", "", "Default theme to use when user prefers dark mode")
 	f.String("force-theme", "", "Force a specific theme, overriding user preferences")
@@ -651,6 +684,31 @@ func addGeneralFlags(f *flag.FlagSet, appName string) {
 	f.String("service-account-token-path", "",
 		"Path to the service account token. "+
 			"Only used when --unsafe-use-service-account-token is set and in-cluster")
+}
+
+func addClusterDiscoveryFlags(f *flag.FlagSet) {
+	f.Bool("enable-cluster-inventory", false,
+		"Enable experimental/alpha automatic discovery of clusters from ClusterProfile resources")
+	f.Bool("enable-cluster-api", false,
+		"Enable experimental/alpha automatic discovery of clusters from Cluster API resources")
+	f.String("cluster-inventory-provider-file", "",
+		"Path to the JSON configuration file for experimental/alpha Cluster Inventory access providers")
+	f.String("cluster-inventory-auth-type", kubeconfig.AuthTypeOIDC,
+		"Authentication for Cluster Inventory registrations: oidc or access-provider")
+	f.String("cluster-inventory-access-providers", "",
+		"Ordered, comma-separated allowlist of ClusterProfile access provider names")
+	f.String("cluster-inventory-label-selector", "",
+		"Label selector used to filter ClusterProfile resources for experimental/alpha Cluster Inventory")
+	f.String("cluster-inventory-namespaces", "",
+		"Comma-separated namespaces watched for experimental/alpha ClusterProfile resources; \"*\" watches all")
+	f.Duration("cluster-inventory-root-reconcile-interval", clusterinventory.DefaultRootReconcileInterval,
+		"Interval for reconciling experimental/alpha Cluster Inventory roots")
+	f.Duration("cluster-inventory-no-crd-cache-ttl", clusterinventory.DefaultNoCRDCacheTTL,
+		"How long to cache that an API server has no experimental/alpha ClusterProfile CRD")
+	f.String("cluster-api-label-selector", "",
+		"Label selector used to filter experimental/alpha Cluster API Cluster resources")
+	f.String("cluster-api-namespaces", "",
+		"Comma-separated namespaces watched for experimental/alpha Cluster API resources; \"*\" watches all")
 }
 
 func addOIDCFlags(f *flag.FlagSet) {

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/clusterinventory"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -586,6 +587,7 @@ func TestParseClusterInventoryFlags(t *testing.T) {
 		"go run ./cmd",
 		"--enable-cluster-inventory",
 		"--cluster-inventory-provider-file=" + providerFile,
+		"--cluster-inventory-access-providers=static-token,oidc",
 		"--cluster-inventory-label-selector=environment=prod,!headlamp.dev/ignore",
 		"--cluster-inventory-namespaces=team-a,team-b",
 		"--cluster-inventory-root-reconcile-interval=15s",
@@ -594,6 +596,8 @@ func TestParseClusterInventoryFlags(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.True(t, conf.EnableClusterInventory)
+	assert.Equal(t, kubeconfig.AuthTypeOIDC, conf.ClusterInventoryAuthType)
+	assert.Equal(t, "static-token,oidc", conf.ClusterInventoryAccessProviders)
 	assert.Equal(t, providerFile, conf.ClusterInventoryProviderFile)
 	assert.Equal(t, "environment=prod,!headlamp.dev/ignore", conf.ClusterInventoryLabelSelector)
 	assert.Equal(t, "team-a,team-b", conf.ClusterInventoryNamespaces)
@@ -605,6 +609,7 @@ func TestParseClusterInventoryEnv(t *testing.T) {
 	providerFile := writeClusterInventoryProviderFile(t)
 	t.Setenv("HEADLAMP_CONFIG_ENABLE_CLUSTER_INVENTORY", "true")
 	t.Setenv("HEADLAMP_CONFIG_CLUSTER_INVENTORY_PROVIDER_FILE", providerFile)
+	t.Setenv("HEADLAMP_CONFIG_CLUSTER_INVENTORY_ACCESS_PROVIDERS", "static-token")
 	t.Setenv("HEADLAMP_CONFIG_CLUSTER_INVENTORY_LABEL_SELECTOR", "!headlamp.dev/ignore")
 	t.Setenv("HEADLAMP_CONFIG_CLUSTER_INVENTORY_NAMESPACES", "*")
 
@@ -612,6 +617,7 @@ func TestParseClusterInventoryEnv(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.True(t, conf.EnableClusterInventory)
+	assert.Equal(t, kubeconfig.AuthTypeOIDC, conf.ClusterInventoryAuthType)
 	assert.Equal(t, providerFile, conf.ClusterInventoryProviderFile)
 	assert.Equal(t, "!headlamp.dev/ignore", conf.ClusterInventoryLabelSelector)
 	assert.Equal(t, "*", conf.ClusterInventoryNamespaces)
@@ -624,6 +630,7 @@ func TestParseClusterInventoryDefaultIntervals(t *testing.T) {
 		"go run ./cmd",
 		"--enable-cluster-inventory",
 		"--cluster-inventory-provider-file=" + providerFile,
+		"--cluster-inventory-access-providers=static-token",
 	})
 	require.NoError(t, err)
 
@@ -641,88 +648,142 @@ func TestClusterInventoryValidation(t *testing.T) {
 		assert.False(t, conf.EnableClusterInventory)
 	})
 
-	t.Run("enabled requires provider file", func(t *testing.T) {
+	t.Run("oidc is the default and does not require a provider file", func(t *testing.T) {
+		conf, err := config.Parse([]string{
+			"go run ./cmd",
+			"--enable-cluster-inventory",
+			"--cluster-inventory-access-providers=oidc",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, conf)
+		assert.Equal(t, kubeconfig.AuthTypeOIDC, conf.ClusterInventoryAuthType)
+	})
+
+	t.Run("enabled rejects an unknown auth type", func(t *testing.T) {
+		conf, err := config.Parse([]string{
+			"go run ./cmd",
+			"--enable-cluster-inventory",
+			"--cluster-inventory-auth-type=basic",
+			"--cluster-inventory-access-providers=oidc",
+		})
+		require.Error(t, err)
+		require.Nil(t, conf)
+		assert.Contains(t, err.Error(), "invalid cluster-inventory-auth-type")
+	})
+
+	t.Run("enabled requires access providers", func(t *testing.T) {
 		conf, err := config.Parse([]string{"go run ./cmd", "--enable-cluster-inventory"})
 		require.Error(t, err)
 		require.Nil(t, conf)
-		assert.Contains(t, err.Error(), "cluster-inventory-provider-file is required")
-	})
-
-	t.Run("enabled rejects missing provider file", func(t *testing.T) {
-		conf, err := config.Parse([]string{
-			"go run ./cmd",
-			"--enable-cluster-inventory",
-			"--cluster-inventory-provider-file=/does/not/exist",
-		})
-		require.Error(t, err)
-		require.Nil(t, conf)
-		assert.Contains(t, err.Error(), "error reading cluster-inventory-provider-file")
-	})
-
-	t.Run("enabled rejects directory provider file", func(t *testing.T) {
-		conf, err := config.Parse([]string{
-			"go run ./cmd",
-			"--enable-cluster-inventory",
-			"--cluster-inventory-provider-file=" + t.TempDir(),
-		})
-		require.Error(t, err)
-		require.Nil(t, conf)
-		assert.Contains(t, err.Error(), "cluster-inventory-provider-file must be a regular file")
-	})
-
-	t.Run("enabled rejects invalid provider file", func(t *testing.T) {
-		providerFile := filepath.Join(t.TempDir(), "providers.json")
-		require.NoError(t, os.WriteFile(providerFile, []byte(`{`), 0o600))
-
-		conf, err := config.Parse([]string{
-			"go run ./cmd",
-			"--enable-cluster-inventory",
-			"--cluster-inventory-provider-file=" + providerFile,
-		})
-		require.Error(t, err)
-		require.Nil(t, conf)
-		assert.Contains(t, err.Error(), "invalid cluster-inventory-provider-file")
+		assert.Contains(t, err.Error(), "cluster-inventory-access-providers is required")
 	})
 }
 
-func TestClusterInventoryRejectsInvalidNamespaces(t *testing.T) {
-	invalidNamespaces := []struct {
-		name       string
-		namespaces string
+func TestClusterInventoryProviderFileValidation(t *testing.T) {
+	unparsableProviderFile := filepath.Join(t.TempDir(), "providers.json")
+	require.NoError(t, os.WriteFile(unparsableProviderFile, []byte(`{`), 0o600))
+
+	providerFiles := []struct {
+		name          string
+		providerFile  string
+		errorContains string
 	}{
-		{name: "invalid DNS label", namespaces: "Team_A"},
-		{name: "empty list entry", namespaces: "team-a,,team-b"},
-		{name: "repeated wildcard", namespaces: "*,*"},
+		{name: "unset", providerFile: "", errorContains: "cluster-inventory-provider-file is required"},
+		{
+			name:          "missing",
+			providerFile:  "/does/not/exist",
+			errorContains: "error reading cluster-inventory-provider-file",
+		},
+		{
+			name:          "directory",
+			providerFile:  t.TempDir(),
+			errorContains: "cluster-inventory-provider-file must be a regular file",
+		},
+		{
+			name:          "unparsable",
+			providerFile:  unparsableProviderFile,
+			errorContains: "invalid cluster-inventory-provider-file",
+		},
 	}
 
-	for _, tt := range invalidNamespaces {
-		t.Run("enabled rejects "+tt.name, func(t *testing.T) {
-			providerFile := writeClusterInventoryProviderFile(t)
+	for _, tt := range providerFiles {
+		t.Run("access-provider rejects a "+tt.name+" provider file", func(t *testing.T) {
 			conf, err := config.Parse([]string{
 				"go run ./cmd",
 				"--enable-cluster-inventory",
-				"--cluster-inventory-provider-file=" + providerFile,
-				"--cluster-inventory-namespaces=" + tt.namespaces,
+				"--cluster-inventory-auth-type=access-provider",
+				"--cluster-inventory-access-providers=static-token",
+				"--cluster-inventory-provider-file=" + tt.providerFile,
 			})
 			require.Error(t, err)
 			require.Nil(t, conf)
-			assert.Contains(t, err.Error(), "invalid cluster-inventory-namespaces")
+			assert.Contains(t, err.Error(), tt.errorContains)
 		})
 	}
 }
 
-func TestClusterInventoryRejectsInvalidLabelSelector(t *testing.T) {
-	providerFile := writeClusterInventoryProviderFile(t)
+func TestDiscoverySelectorValidation(t *testing.T) {
+	clusterInventory := []string{
+		"--enable-cluster-inventory",
+		"--cluster-inventory-access-providers=static-token",
+	}
+	clusterAPI := []string{"--in-cluster", "--enable-cluster-api"}
 
+	selectors := []struct {
+		name          string
+		args          []string
+		errorContains string
+	}{
+		{
+			name:          "cluster inventory rejects an invalid namespace",
+			args:          append(clusterInventory, "--cluster-inventory-namespaces=Team_A"),
+			errorContains: "invalid cluster-inventory-namespaces",
+		},
+		{
+			name:          "cluster inventory rejects an invalid label selector",
+			args:          append(clusterInventory, "--cluster-inventory-label-selector=headlamp.dev/ignore in ("),
+			errorContains: "invalid cluster-inventory-label-selector",
+		},
+		{
+			name:          "cluster api rejects an invalid namespace",
+			args:          append(clusterAPI, "--cluster-api-namespaces=Team_A"),
+			errorContains: "invalid cluster-api-namespaces",
+		},
+		{
+			name:          "cluster api rejects an invalid label selector",
+			args:          append(clusterAPI, "--cluster-api-label-selector=headlamp.dev/ignore in ("),
+			errorContains: "invalid cluster-api-label-selector",
+		},
+	}
+
+	for _, tt := range selectors {
+		t.Run(tt.name, func(t *testing.T) {
+			conf, err := config.Parse(append([]string{"go run ./cmd"}, tt.args...))
+			require.Error(t, err)
+			require.Nil(t, conf)
+			assert.Contains(t, err.Error(), tt.errorContains)
+		})
+	}
+}
+
+func TestParseClusterAPIFlags(t *testing.T) {
 	conf, err := config.Parse([]string{
 		"go run ./cmd",
-		"--enable-cluster-inventory",
-		"--cluster-inventory-provider-file=" + providerFile,
-		"--cluster-inventory-label-selector=headlamp.dev/ignore in (",
+		"--in-cluster",
+		"--enable-cluster-api",
+		"--cluster-api-label-selector=environment=prod",
+		"--cluster-api-namespaces=team-a,team-b",
 	})
-	require.Error(t, err)
-	require.Nil(t, conf)
-	assert.Contains(t, err.Error(), "invalid cluster-inventory-label-selector")
+	require.NoError(t, err)
+	assert.True(t, conf.EnableClusterAPI)
+	assert.Equal(t, "environment=prod", conf.ClusterAPILabelSelector)
+	assert.Equal(t, "team-a,team-b", conf.ClusterAPINamespaces)
+}
+
+func TestClusterAPIRequiresInClusterMode(t *testing.T) {
+	conf, err := config.Parse([]string{"go run ./cmd", "--enable-cluster-api"})
+	require.ErrorContains(t, err, "enable-cluster-api requires in-cluster mode")
+	assert.Nil(t, conf)
 }
 
 func TestOIDCTLSValidation(t *testing.T) {

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/clusterregistration"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/telemetry"
@@ -44,6 +45,7 @@ type HeadlampConfig struct {
 	ProxyAuthEmailHeader      string
 	ProxyAuthTokenHeader      string
 	ServerCtx                 context.Context
+	ClusterRegistrationStore  *clusterregistration.Registry
 }
 
 type HeadlampCFG struct {
@@ -87,8 +89,14 @@ type HeadlampCFG struct {
 
 	EnableClusterInventory                bool
 	ClusterInventoryProviderFile          string
+	ClusterInventoryAuthType              string
+	ClusterInventoryAccessProviders       string
 	ClusterInventoryLabelSelector         string
 	ClusterInventoryNamespaces            string
 	ClusterInventoryRootReconcileInterval time.Duration
 	ClusterInventoryNoCRDCacheTTL         time.Duration
+
+	EnableClusterAPI        bool
+	ClusterAPILabelSelector string
+	ClusterAPINamespaces    string
 }

--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -57,11 +57,15 @@ func buildUserAgent() string {
 // DefaultInClusterContextName is the default name used for the in-cluster context.
 const DefaultInClusterContextName = "main"
 
+// AuthTypeOIDC is the AuthType of contexts that authenticate the end user with an OIDC token.
+const AuthTypeOIDC = "oidc"
+
 const (
 	KubeConfig = 1 << iota
 	DynamicCluster
 	InCluster
 	ClusterInventory
+	ClusterAPI
 )
 
 // Context contains all information related to a kubernetes context.
@@ -426,6 +430,8 @@ func (c *Context) SourceStr() string {
 		return "incluster"
 	case ClusterInventory:
 		return "cluster_inventory"
+	case ClusterAPI:
+		return "cluster_api"
 	default:
 		return "unknown"
 	}
@@ -442,7 +448,7 @@ func (c *Context) SetupProxy() error {
 
 	// For OIDC clusters, log a hint upon receiving a 401 from the API server (StatusUnauthorized),
 	// as it can indicate the API server does not trust the same OIDC provider as Headlamp.
-	if c.AuthType() == "oidc" {
+	if c.AuthType() == AuthTypeOIDC {
 		// Log at most once per proxy to avoid flooding the logs on repeated 401s.
 		var warnOnce sync.Once
 
@@ -488,7 +494,7 @@ func (c *Context) SetupProxy() error {
 // AuthType returns the authentication type for the context.
 func (c *Context) AuthType() string {
 	if (c.OidcConf != nil) || (c.AuthInfo != nil && c.AuthInfo.AuthProvider != nil) {
-		return "oidc"
+		return AuthTypeOIDC
 	}
 
 	return ""

--- a/docs/development/cluster-inventory.md
+++ b/docs/development/cluster-inventory.md
@@ -17,6 +17,41 @@ Headlamp can discover additional clusters from Cluster Inventory API
 backend uses `sigs.k8s.io/cluster-inventory-api v0.1.3`, the `pkg/access`
 provider configuration package, and `ClusterProfile.status.accessProviders`.
 
+Discovery uses Kubernetes LIST/WATCH with the Headlamp pod's service account.
+Added, changed, and deleted registrations are streamed to open browsers, so a
+page reload is not required. Headlamp publishes only a stable opaque ID,
+display name, source, and origin resource for each currently routable cluster;
+API endpoints and credentials remain backend-only.
+
+## Authentication and provider selection
+
+`--cluster-inventory-auth-type` accepts `oidc` or `access-provider` and defaults
+to `oidc`. In OIDC mode, Headlamp uses the token from the registration's origin
+cluster when proxying to the discovered cluster. This does not start a separate
+OIDC flow or open one browser tab per spoke. Every target API server must accept
+the origin token's issuer and audience; otherwise that target returns an
+authentication error.
+
+`--cluster-inventory-access-providers` is required in both modes. It is an
+ordered, comma-separated allowlist. Names are matched exactly and
+case-sensitively against `status.accessProviders` (or the deprecated
+`status.credentialProviders`), and the first match wins. No provider name is
+special-cased.
+
+For example, an in-cluster OIDC setup can use:
+
+```bash
+./backend/headlamp-server -in-cluster \
+  --enable-cluster-inventory \
+  --cluster-inventory-auth-type=oidc \
+  --cluster-inventory-access-providers=shared-oidc,secondary-oidc \
+  --cluster-inventory-namespaces=headlamp
+```
+
+`--cluster-inventory-provider-file` is read only in `access-provider` mode. A
+provider file is required in that mode, and Headlamp limits it to the selected
+provider before constructing the target connection.
+
 For a local end-to-end environment, follow the setup in
 [`e2e-tests/README.md`](https://github.com/kubernetes-sigs/headlamp/blob/main/e2e-tests/README.md).
 It uses the regular E2E `test` and `test2` kind clusters and deploys Cluster
@@ -56,11 +91,19 @@ HEADLAMP_BACKEND_TOKEN=headlamp \
 HEADLAMP_CONFIG_ENABLE_DYNAMIC_CLUSTERS=true \
 ./backend/headlamp-server -dev -listen-addr=localhost \
   --enable-cluster-inventory \
+  --cluster-inventory-auth-type=access-provider \
+  --cluster-inventory-access-providers=static-token-spoke-a \
   --cluster-inventory-provider-file "$WORK/provider-config.json" \
   --cluster-inventory-label-selector='!headlamp.dev/ignore' \
   --cluster-inventory-namespaces=inventory-e2e \
   --cluster-inventory-root-reconcile-interval=10s \
   --cluster-inventory-no-crd-cache-ttl=30s
+```
+
+In another terminal:
+
+```bash
+npm run frontend:start
 ```
 
 Without `--cluster-inventory-namespaces`, each root is watched in its own
@@ -69,11 +112,36 @@ kubecontext namespace (or `default`) for roots seeded from the kubeconfig.
 Pass a comma-separated list to watch more than one namespace. Use `*` on its
 own to watch all namespaces.
 
-In another terminal:
+A ClusterProfile is registered only when one of the allowed providers supplies
+a non-empty API server endpoint and Headlamp can construct its connection.
+Removing the endpoint or allowed provider removes the registration. The
+ClusterProfile object itself remains available to plugins through ordinary
+Kubernetes resource hooks on the origin cluster.
+
+## Cluster API discovery
+
+`--enable-cluster-api` enables the same registration flow for Cluster API
+Cluster resources. Headlamp prefers `cluster.x-k8s.io/v1beta2` when the API
+server serves it and falls back to `cluster.x-k8s.io/v1beta1`. Headlamp reads
+only `spec.controlPlaneEndpoint` and never reads the CAPI kubeconfig Secret. A
+Cluster without an endpoint is not registered; it is added automatically if an
+endpoint appears later.
 
 ```bash
-npm run frontend:start
+./backend/headlamp-server -in-cluster \
+  --enable-cluster-api \
+  --cluster-api-namespaces=headlamp \
+  --cluster-api-label-selector='!headlamp.dev/ignore'
 ```
+
+The pod service account needs `list` and `watch` permission for each enabled
+source in every selected namespace. All-namespace discovery requires the
+equivalent cluster-wide permissions.
+
+A cluster discovered by both sources is registered twice, once per source.
+
+Plugins consume registrations with the `useRegisteredClusters` hook, documented in
+[Plugins: Registered Clusters](https://headlamp.dev/docs/latest/development/plugins/functionality/#registered-clusters).
 
 Install the `v0.1.3` CRD on clusters that publish inventory:
 

--- a/docs/development/plugins/functionality/index.md
+++ b/docs/development/plugins/functionality/index.md
@@ -186,6 +186,31 @@ be shared with workloads or other cluster users.
 
 - Example plugin: [How To Use Plugin Secure Storage](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/secure-storage)
 
+### Registered Clusters
+
+Subscribe to routable clusters discovered by backend adapters with
+`useRegisteredClusters`. The returned opaque IDs can be passed unchanged to
+existing Kubernetes hooks, including multi-cluster list calls:
+
+```tsx
+import { K8s, useRegisteredClusters } from '@kinvolk/headlamp-plugin/lib';
+
+const registrations = useRegisteredClusters({ source: 'cluster-inventory' });
+const result = K8s.ResourceClasses.ConfigMap.useList({
+  clusters: registrations.map(registration => registration.id),
+  namespace: 'knative-serving',
+});
+```
+
+The optional `source`, `originCluster`, and `originNamespace` filters select the
+source adapter, the Headlamp ID of the origin cluster, and the namespace holding
+the origin resource. Each result carries `id`, `displayName`, `source`, and
+`origin`. Endpoints and credentials stay in the backend. The hook updates when
+registrations are added, changed, or removed, and HTTP and WebSocket routing
+resolves transparently through the origin cluster.
+
+- Backend setup: [Cluster Inventory](../../cluster-inventory.md)
+
 ### Route
 
 Show a component in the main area at a given URL with

--- a/docs/installation/in-cluster/index.md
+++ b/docs/installation/in-cluster/index.md
@@ -40,6 +40,9 @@ Create `cluster-inventory-values.yaml`:
 
 ```yaml
 config:
+  extraArgs:
+    - "-cluster-inventory-auth-type=access-provider"
+    - "-cluster-inventory-access-providers=secretreader,kubeconfig-secretreader"
   clusterInventory:
     enabled: true
     accessProvidersConfig:
@@ -95,6 +98,26 @@ Each selected namespace requires permission to get, list, and watch
 ClusterProfiles. Set `namespaces` to `["*"]` to watch all namespaces. `*`
 cannot be combined with named namespaces, and all-namespace discovery requires
 equivalent cluster-wide access.
+
+Cluster Inventory authentication defaults to OIDC. In OIDC mode, the token used
+to sign in to the origin Headlamp cluster is forwarded to discovered targets;
+the targets must accept the same issuer and audience. No per-spoke login window
+is opened. The current chart's Cluster Inventory helper still renders the
+provider ConfigMap, so an OIDC values file can use an empty provider list while
+passing the trusted status provider names explicitly:
+
+```yaml
+config:
+  extraArgs:
+    - "-cluster-inventory-access-providers=shared-oidc"
+  clusterInventory:
+    enabled: true
+    accessProvidersConfig:
+      providers: []
+```
+
+Headlamp watches the selected ClusterProfiles with its pod service account, so
+open UIs receive registration additions and removals without a page reload.
 
 ## Using simple yaml
 

--- a/e2e-tests/kubernetes-headlamp-ci.yaml
+++ b/e2e-tests/kubernetes-headlamp-ci.yaml
@@ -188,6 +188,8 @@ spec:
         - "-in-cluster"
         - "-in-cluster-context-name=main"
         - "-enable-cluster-inventory"
+        - "-cluster-inventory-auth-type=access-provider"
+        - "-cluster-inventory-access-providers=headlamp-e2e-token"
         - "-cluster-inventory-provider-file=/etc/cluster-inventory/config.json"
         - "-cluster-inventory-label-selector=!headlamp.dev/ignore"
         - "-cluster-inventory-root-reconcile-interval=2s"

--- a/e2e-tests/scripts/setup-multicluster.sh
+++ b/e2e-tests/scripts/setup-multicluster.sh
@@ -120,14 +120,15 @@ trap 'exit 130' INT TERM
 # expected is asserted by tests/clusterInventory.spec.ts, not here.
 wait_for_inventory() {
   local service_url="$1"
-  local config=""
+  local registrations=""
   local attempt
 
   for ((attempt = 0; attempt < 120; attempt++)); do
-    config="$(curl -fsS --connect-timeout 2 --max-time 5 "${service_url}/config" 2>/dev/null || true)"
+    registrations="$(curl -fsS --connect-timeout 2 --max-time 5 \
+      "${service_url}/cluster-registrations" 2>/dev/null || true)"
     if jq -e '
-      [.clusters[] | select(.meta_data.source == "cluster_inventory")] | length == 1
-    ' <<<"${config}" >/dev/null 2>&1; then
+      [.items[]? | select(.source == "cluster-inventory")] | length == 1
+    ' <<<"${registrations}" >/dev/null 2>&1; then
       return
     fi
 
@@ -135,8 +136,8 @@ wait_for_inventory() {
   done
 
   printf 'error: timed out waiting for a discovered ClusterProfile\n' >&2
-  jq -c '[.clusters[] | select(.meta_data.source == "cluster_inventory")]' \
-    <<<"${config}" >&2 || printf '%s\n' "${config}" >&2
+  jq -c '[.items[]? | select(.source == "cluster-inventory")]' \
+    <<<"${registrations}" >&2 || printf '%s\n' "${registrations}" >&2
   return 1
 }
 

--- a/e2e-tests/tests/clusterInventory.spec.ts
+++ b/e2e-tests/tests/clusterInventory.spec.ts
@@ -28,28 +28,39 @@ test.describe('Cluster Inventory', () => {
   test.skip(!shouldRun, 'Set HEADLAMP_CLUSTER_INVENTORY_E2E=true to run Cluster Inventory E2E');
 
   test('discovers clusters and proxies to them', async ({ request }) => {
-    const configResponse = await request.get('/config', requestOptions);
-    expect(configResponse.status()).toBe(200);
+    const registrationsResponse = await request.get('/cluster-registrations', requestOptions);
+    expect(registrationsResponse.status()).toBe(200);
 
-    const config = await configResponse.json();
-    const inventoryClusters = config.clusters.filter(
-      (cluster: any) => cluster.meta_data?.source === 'cluster_inventory'
+    const snapshot = await registrationsResponse.json();
+    const inventoryRegistrations = snapshot.items.filter(
+      (registration: any) => registration.source === 'cluster-inventory'
     );
-    expect(inventoryClusters).toHaveLength(1);
+    expect(inventoryRegistrations).toHaveLength(1);
 
-    const cluster = inventoryClusters[0];
-    expect(cluster.meta_data.clusterInventory.profile).toMatchObject({
-      namespace: 'kube-system',
-      name: 'inventory-test2',
+    const registration = inventoryRegistrations[0];
+    expect(registration).toMatchObject({
+      displayName: 'inventory-test2',
+      origin: {
+        cluster: 'main',
+        resource: {
+          apiVersion: 'multicluster.x-k8s.io/v1alpha1',
+          kind: 'ClusterProfile',
+          namespace: 'kube-system',
+          name: 'inventory-test2',
+        },
+      },
     });
 
-    const clusterName = encodeURIComponent(cluster.name);
+    const originCluster = encodeURIComponent(registration.origin.cluster);
+    const targetCluster = encodeURIComponent(registration.id);
     const response = await request.get(
-      `/clusters/${clusterName}/api/v1/namespaces/inventory-demo/pods`,
+      `/clusters/${originCluster}/federated/${targetCluster}/api/v1/namespaces/inventory-demo/pods`,
       requestOptions
     );
 
-    expect(response.status(), `expected pod proxy to work for ${cluster.name}`).toBe(200);
+    expect(response.status(), `expected pod proxy to work for ${registration.displayName}`).toBe(
+      200
+    );
 
     const body = await response.json();
     expect(body.items).toHaveLength(1);

--- a/frontend/src/components/App/Layout.tsx
+++ b/frontend/src/components/App/Layout.tsx
@@ -29,6 +29,7 @@ import { useDispatch } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import { getCluster } from '../../lib/cluster';
 import { getSelectedClusters } from '../../lib/cluster';
+import { startClusterRegistrationStream } from '../../lib/clusterRegistrationStream';
 import { useCluster, useClustersConf, useSelectedClusters } from '../../lib/k8s';
 import { request } from '../../lib/k8s/api/v1/clusterRequests';
 import { Cluster } from '../../lib/k8s/cluster';
@@ -228,6 +229,13 @@ export default function Layout({}: LayoutProps) {
   useEffect(() => {
     document.body.removeAttribute('style');
   }, []);
+
+  const registrationsEnabled = useTypedSelector(state => state.config.clusterRegistrationsEnabled);
+  useEffect(() => {
+    if (!registrationsEnabled) return;
+
+    return startClusterRegistrationStream();
+  }, [registrationsEnabled]);
 
   const cluster = useCluster();
   useEffect(() => {

--- a/frontend/src/components/project/NewProjectPopup.stories.tsx
+++ b/frontend/src/components/project/NewProjectPopup.stories.tsx
@@ -18,6 +18,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import { useState } from 'react';
+import { initialState as configInitialState } from '../../redux/configSlice';
 import { DefaultCreateProject } from '../../redux/projectsSlice';
 import reducers from '../../redux/reducers/reducers';
 import { API_BASE, TestContext } from '../../test';
@@ -36,8 +37,7 @@ const makeStore = (customCreateProject = {}) => {
     reducer: reducers,
     preloadedState: {
       config: {
-        clusters: null,
-        statelessClusters: null,
+        ...configInitialState,
         allClusters: {
           'cluster-a': { name: 'cluster-a' },
           'cluster-b': { name: 'cluster-b' },
@@ -49,11 +49,6 @@ const makeStore = (customCreateProject = {}) => {
           useEvict: true,
           expandLargeGraph: false,
         },
-        isDynamicClusterEnabled: false,
-        allowKubeconfigChanges: false,
-        defaultPodDebugImage: '',
-        defaultNodeShellImage: '',
-        defaultNodeShellNamespace: '',
       },
       projects: {
         headerActions: {},

--- a/frontend/src/components/project/ProjectCreateFromYaml.stories.tsx
+++ b/frontend/src/components/project/ProjectCreateFromYaml.stories.tsx
@@ -17,6 +17,7 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
+import { initialState as configInitialState } from '../../redux/configSlice';
 import reducers from '../../redux/reducers/reducers';
 import { API_BASE, TestContext } from '../../test';
 import { CreateNew } from './ProjectCreateFromYaml';
@@ -34,17 +35,12 @@ const makeStore = () => {
     reducer: reducers,
     preloadedState: {
       config: {
-        clusters: null,
-        statelessClusters: null,
+        ...configInitialState,
         allClusters: {
           'cluster-a': { name: 'cluster-a' },
           'cluster-b': { name: 'cluster-b' },
         } as any,
         isDynamicClusterEnabled: true,
-        allowKubeconfigChanges: false,
-        defaultPodDebugImage: '',
-        defaultNodeShellImage: '',
-        defaultNodeShellNamespace: '',
         settings: {
           tableRowsPerPageOptions: [15, 25, 50],
           timezone: 'UTC',

--- a/frontend/src/lib/clusterRegistration.test.ts
+++ b/frontend/src/lib/clusterRegistration.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { TestContext } from '../test';
+import { makeRegisteredCluster } from '../test/clusterRegistration';
+import {
+  getClusterRoute,
+  setRegisteredClusterSnapshot,
+  useRegisteredClusters,
+} from './clusterRegistration';
+
+const renderRegistrations = (options?: Parameters<typeof useRegisteredClusters>[0]) =>
+  renderHook(() => useRegisteredClusters(options), { wrapper: TestContext });
+
+const registrations = [
+  makeRegisteredCluster({ id: 'hr-v1-inventory', displayName: 'inventory spoke' }),
+  makeRegisteredCluster({
+    id: 'hr-v1-capi',
+    displayName: 'capi spoke',
+    source: 'cluster-api',
+    origin: {
+      cluster: 'hub',
+      resource: {
+        apiVersion: 'cluster.x-k8s.io/v1beta1',
+        kind: 'Cluster',
+        namespace: 'clusters',
+        name: 'capi-spoke',
+        uid: 'uid-capi',
+      },
+    },
+  }),
+];
+
+describe('cluster registrations', () => {
+  afterEach(() => {
+    act(() => setRegisteredClusterSnapshot(undefined));
+  });
+
+  it('filters registrations and resolves opaque IDs through their origin cluster', () => {
+    act(() => setRegisteredClusterSnapshot({ items: registrations }));
+
+    const { result } = renderRegistrations({
+      source: 'cluster-inventory',
+      originNamespace: 'headlamp',
+    });
+    expect(result.current.map(item => item.id)).toEqual(['hr-v1-inventory']);
+    expect(getClusterRoute('hr-v1-inventory')).toBe('hub/federated/hr-v1-inventory');
+    expect(getClusterRoute('hub')).toBe('hub');
+  });
+
+  it('does not re-render subscribers when a re-fetch publishes the same items', () => {
+    act(() => setRegisteredClusterSnapshot({ items: registrations }));
+
+    const { result } = renderRegistrations();
+    const first = result.current;
+
+    act(() => setRegisteredClusterSnapshot({ items: [...registrations] }));
+    expect(result.current).toBe(first);
+
+    act(() => setRegisteredClusterSnapshot({ items: [registrations[0]] }));
+    expect(result.current).toHaveLength(1);
+  });
+
+  it('stops routing a cluster through its origin once it is unregistered', () => {
+    act(() => setRegisteredClusterSnapshot({ items: registrations }));
+    expect(getClusterRoute('hr-v1-capi')).toBe('hub/federated/hr-v1-capi');
+
+    act(() => setRegisteredClusterSnapshot({ items: [registrations[0]] }));
+    expect(getClusterRoute('hr-v1-capi')).toBe('hr-v1-capi');
+  });
+
+  it('clears registrations when the backend disables the feature', () => {
+    act(() => setRegisteredClusterSnapshot({ items: registrations }));
+
+    act(() => setRegisteredClusterSnapshot(undefined));
+
+    expect(getClusterRoute('hr-v1-inventory')).toBe('hr-v1-inventory');
+    expect(renderRegistrations().result.current).toEqual([]);
+  });
+});

--- a/frontend/src/lib/clusterRegistration.ts
+++ b/frontend/src/lib/clusterRegistration.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isEqual, keyBy } from 'lodash';
+import { useMemo } from 'react';
+import { setClusterRegistrations } from '../redux/configSlice';
+import { useTypedSelector } from '../redux/hooks';
+import store from '../redux/stores/store';
+
+export interface RegisteredCluster {
+  id: string;
+  displayName: string;
+  source: string;
+  origin: {
+    cluster: string;
+    resource: {
+      apiVersion: string;
+      kind: string;
+      namespace?: string;
+      name: string;
+      uid: string;
+    };
+  };
+}
+
+export interface RegisteredClusterSnapshot {
+  items: readonly RegisteredCluster[];
+}
+
+export interface UseRegisteredClustersOptions {
+  source?: string;
+  originCluster?: string;
+  originNamespace?: string;
+}
+
+/**
+ * Publishes a registration snapshot to the redux store, keeping the previous value when
+ * nothing changed so that a re-fetch does not re-render subscribers.
+ *
+ * @param next - Snapshot as published by the backend, or undefined when registrations
+ * are disabled.
+ */
+export function setRegisteredClusterSnapshot(next: RegisteredClusterSnapshot | undefined): void {
+  const registrations = next ? keyBy(next.items, 'id') : null;
+  if (isEqual(store.getState().config.clusterRegistrations, registrations)) {
+    return;
+  }
+
+  store.dispatch(setClusterRegistrations(registrations));
+}
+
+/**
+ * Hook for getting the dynamically discovered, currently routable clusters.
+ *
+ * The IDs can be passed directly to Kubernetes resource hooks, for example:
+ * `ConfigMap.useList({ clusters: registrations.map(item => item.id) })`.
+ *
+ * @param options - Optional filters on the discovery source and the origin of the
+ * resource a registration was discovered from.
+ *
+ * @returns the registrations matching the given filters.
+ */
+export function useRegisteredClusters(
+  options: UseRegisteredClustersOptions = {}
+): readonly RegisteredCluster[] {
+  const registrations = useTypedSelector(state => state.config.clusterRegistrations);
+  const { source, originCluster, originNamespace } = options;
+
+  return useMemo(
+    () =>
+      Object.values(registrations ?? {}).filter(
+        item =>
+          (source === undefined || item.source === source) &&
+          (originCluster === undefined || item.origin.cluster === originCluster) &&
+          (originNamespace === undefined || item.origin.resource.namespace === originNamespace)
+      ),
+    [registrations, source, originCluster, originNamespace]
+  );
+}
+
+/** Returns the registration a cluster name refers to, if it is a discovered cluster. */
+export function getClusterRegistration(cluster: string): RegisteredCluster | undefined {
+  return store.getState().config.clusterRegistrations?.[cluster];
+}
+
+/**
+ * Returns the backend path that addresses a cluster. A registration routes through the
+ * cluster it was discovered from.
+ */
+export function getClusterRoute(cluster: string): string {
+  const registration = getClusterRegistration(cluster);
+  if (!registration) {
+    return cluster;
+  }
+
+  return `${registration.origin.cluster}/federated/${registration.id}`;
+}

--- a/frontend/src/lib/clusterRegistrationStream.test.ts
+++ b/frontend/src/lib/clusterRegistrationStream.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { afterEach, describe, expect, it } from 'vitest';
+import { setBackendToken } from '../helpers/getHeadlampAPIHeaders';
+import { makeRegisteredCluster } from '../test/clusterRegistration';
+import { getClusterRoute, setRegisteredClusterSnapshot } from './clusterRegistration';
+import { startClusterRegistrationStream } from './clusterRegistrationStream';
+import { BASE_HTTP_URL } from './k8s/api/v2/fetch';
+
+describe('startClusterRegistrationStream', () => {
+  afterEach(() => {
+    setBackendToken(null);
+    setRegisteredClusterSnapshot(undefined);
+    nock.cleanAll();
+  });
+
+  it('refreshes registrations from SSE using the backend token', async () => {
+    const registration = makeRegisteredCluster({ id: 'hr-v1-streamed' });
+
+    nock(BASE_HTTP_URL)
+      .get('/cluster-registrations/events')
+      .matchHeader('X-HEADLAMP_BACKEND-TOKEN', 'desktop-token')
+      .reply(200, 'event: registration\ndata: {}\n\n')
+      .get('/cluster-registrations')
+      .matchHeader('X-HEADLAMP_BACKEND-TOKEN', 'desktop-token')
+      .reply(200, { items: [registration] });
+
+    setBackendToken('desktop-token');
+    setRegisteredClusterSnapshot({
+      items: [makeRegisteredCluster({ id: 'hr-v1-before-restart' })],
+    });
+
+    const stop = startClusterRegistrationStream();
+
+    await waitFor(() =>
+      expect(getClusterRoute(registration.id)).toBe(`hub/federated/${registration.id}`)
+    );
+    expect(getClusterRoute('hr-v1-before-restart')).toBe('hr-v1-before-restart');
+
+    stop();
+  });
+});

--- a/frontend/src/lib/clusterRegistrationStream.ts
+++ b/frontend/src/lib/clusterRegistrationStream.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getHeadlampAPIHeaders } from '../helpers/getHeadlampAPIHeaders';
+import { RegisteredClusterSnapshot, setRegisteredClusterSnapshot } from './clusterRegistration';
+import { backendFetch } from './k8s/api/v2/fetch';
+
+function registrationFetch(path: string, signal: AbortSignal): Promise<Response> {
+  return backendFetch(path, { headers: getHeadlampAPIHeaders(), signal });
+}
+
+async function refresh(signal: AbortSignal): Promise<void> {
+  const response = await registrationFetch('/cluster-registrations', signal);
+  setRegisteredClusterSnapshot((await response.json()) as RegisteredClusterSnapshot);
+}
+
+async function consumeEvents(signal: AbortSignal): Promise<void> {
+  const response = await registrationFetch('/cluster-registrations/events', signal);
+  const reader = response.body?.getReader();
+  if (!reader) return;
+
+  const decoder = new TextDecoder();
+  let buffer = '';
+  while (!signal.aborted) {
+    const { value, done } = await reader.read();
+    if (done) return;
+    buffer += decoder.decode(value, { stream: true });
+
+    // Take every complete event at once, so a chunk carrying several needs one refresh.
+    const lastBoundary = buffer.lastIndexOf('\n\n');
+    if (lastBoundary === -1) continue;
+
+    const events = buffer.slice(0, lastBoundary);
+    buffer = buffer.slice(lastBoundary + 2);
+
+    // Keepalives are comments, so only registration events carry a data field.
+    if (events.includes('data:')) {
+      await refresh(signal);
+    }
+  }
+}
+
+function delay(milliseconds: number, signal: AbortSignal): Promise<void> {
+  return new Promise(resolve => {
+    const done = () => {
+      clearTimeout(timeout);
+      signal.removeEventListener('abort', done);
+      resolve();
+    };
+
+    const timeout = setTimeout(done, milliseconds);
+    signal.addEventListener('abort', done);
+  });
+}
+
+const MIN_RETRY_DELAY = 1000;
+const MAX_RETRY_DELAY = 30_000;
+
+/** A stream that stays open past the server's keepalive interval proved it is healthy. */
+const HEALTHY_STREAM_DURATION = 30_000;
+
+/** Starts the registration SSE loop and returns a cleanup function. */
+export function startClusterRegistrationStream(): () => void {
+  const controller = new AbortController();
+
+  void (async () => {
+    let retryDelay = MIN_RETRY_DELAY;
+    while (!controller.signal.aborted) {
+      const startedAt = Date.now();
+
+      try {
+        await consumeEvents(controller.signal);
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        console.error('Cluster registration stream failed:', error);
+      }
+
+      if (Date.now() - startedAt >= HEALTHY_STREAM_DURATION) {
+        retryDelay = MIN_RETRY_DELAY;
+      }
+
+      await delay(retryDelay, controller.signal);
+      retryDelay = Math.min(retryDelay * 2, MAX_RETRY_DELAY);
+    }
+  })();
+
+  return () => controller.abort();
+}

--- a/frontend/src/lib/k8s/api/v1/clusterRequests.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterRequests.ts
@@ -27,6 +27,7 @@ import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfi
 import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
 import { logout } from '../../../auth';
 import { getCluster } from '../../../cluster';
+import { getClusterRoute } from '../../../clusterRegistration';
 import type { KubeObjectInterface } from '../../KubeObject';
 import type { ApiError } from '../v2/ApiError';
 import { CLUSTERS_PREFIX, DEFAULT_TIMEOUT, JSON_HEADERS } from './constants';
@@ -160,7 +161,7 @@ export async function clusterRequest(
       opts.headers['X-HEADLAMP-USER-ID'] = userID;
     }
 
-    fullPath = combinePath(`/${CLUSTERS_PREFIX}/${cluster}`, path);
+    fullPath = combinePath(`/${CLUSTERS_PREFIX}/${getClusterRoute(cluster)}`, path);
   }
 
   const controller = new AbortController();

--- a/frontend/src/lib/k8s/api/v1/streamingApi.ts
+++ b/frontend/src/lib/k8s/api/v1/streamingApi.ts
@@ -20,6 +20,7 @@ import { getHeadlampWebSocketProtocol } from '../../../../helpers/getHeadlampAPI
 import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
 import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
 import { getCluster } from '../../../cluster';
+import { getClusterRoute } from '../../../clusterRegistration';
 import type { KubeObjectInterface } from '../../KubeObject';
 import type { ApiError } from '../v2/ApiError';
 import { clusterRequest } from './clusterRequests';
@@ -450,7 +451,7 @@ export async function connectStreamWithParams<T>(
   let fullPath = path;
   let url = '';
   if (cluster) {
-    fullPath = combinePath(`/${CLUSTERS_PREFIX}/${cluster}`, path);
+    fullPath = combinePath(`/${CLUSTERS_PREFIX}/${getClusterRoute(cluster)}`, path);
     try {
       const kubeconfig = await findKubeconfigByClusterName(cluster);
 

--- a/frontend/src/lib/k8s/api/v2/fetch.test.ts
+++ b/frontend/src/lib/k8s/api/v2/fetch.test.ts
@@ -19,6 +19,8 @@ import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { setBackendToken } from '../../../../helpers/getHeadlampAPIHeaders';
 import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
 import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
+import { makeRegisteredCluster } from '../../../../test/clusterRegistration';
+import { setRegisteredClusterSnapshot } from '../../../clusterRegistration';
 import { getClusterAuthType } from '../v1/clusterRequests';
 import { BASE_HTTP_URL, clusterFetch } from './fetch';
 
@@ -60,6 +62,7 @@ describe('clusterFetch', () => {
 
   afterEach(() => {
     setBackendToken(null);
+    setRegisteredClusterSnapshot(undefined);
     nock.cleanAll();
   });
 
@@ -70,6 +73,16 @@ describe('clusterFetch', () => {
     const responseBody = await response.json();
 
     expect(responseBody).toEqual(mockResponse);
+  });
+
+  it('routes a registration through its origin cluster without changing the caller API', async () => {
+    setRegisteredClusterSnapshot({ items: [makeRegisteredCluster()] });
+    nock(BASE_HTTP_URL)
+      .get(`/clusters/hub/federated/hr-v1-spoke${testUrl}`)
+      .reply(200, mockResponse);
+
+    const response = await clusterFetch(testUrl, { cluster: 'hr-v1-spoke' });
+    expect(await response.json()).toEqual(mockResponse);
   });
 
   it('does not add backend credentials to non-cluster requests', async () => {

--- a/frontend/src/lib/k8s/api/v2/fetch.ts
+++ b/frontend/src/lib/k8s/api/v2/fetch.ts
@@ -19,6 +19,7 @@ import { getAppUrl } from '../../../../helpers/getAppUrl';
 import { getHeadlampAPIHeaders } from '../../../../helpers/getHeadlampAPIHeaders';
 import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
 import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
+import { getClusterRoute } from '../../../clusterRegistration';
 import { ApiError } from './ApiError';
 import { makeUrl } from './makeUrl';
 
@@ -94,7 +95,7 @@ export async function clusterFetch(url: string | URL, init: RequestInit & { clus
     init.headers.set('X-HEADLAMP-USER-ID', userID);
   }
 
-  const urlParts = init.cluster ? ['clusters', init.cluster, url] : [url];
+  const urlParts = init.cluster ? ['clusters', getClusterRoute(init.cluster), url] : [url];
 
   try {
     const response = await backendFetch(makeUrl(urlParts), init);

--- a/frontend/src/lib/k8s/api/v2/hooks.ts
+++ b/frontend/src/lib/k8s/api/v2/hooks.ts
@@ -26,7 +26,7 @@ import { KubeObjectEndpoint } from './KubeObjectEndpoint';
 import { makeUrl } from './makeUrl';
 import { useWebSocket } from './multiplexer';
 import { kubeRequestRetry } from './retry';
-import { getWebsocketMultiplexerEnabled } from './useKubeObjectList';
+import { shouldMultiplexCluster } from './useKubeObjectList';
 import { useWebSockets } from './webSocket';
 
 export type QueryStatus = 'pending' | 'success' | 'error';
@@ -203,7 +203,7 @@ export function useKubeObject<K extends KubeObject>({
     ];
   }, [endpoint, namespace, name, cleanedUpQueryParams, cluster, handleMessage]);
 
-  const multiplexerEnabled = getWebsocketMultiplexerEnabled();
+  const multiplexed = shouldMultiplexCluster(cluster);
 
   useWebSocket<KubeListUpdateEvent<K>>({
     url: useCallback(
@@ -215,13 +215,13 @@ export function useKubeObject<K extends KubeObject>({
         }),
       [endpoint, namespace, cleanedUpQueryParams, name]
     ),
-    enabled: multiplexerEnabled && !!endpoint && !!data,
+    enabled: multiplexed && !!endpoint && !!data,
     cluster,
     onMessage: handleMessage,
   });
 
   useWebSockets({
-    enabled: !multiplexerEnabled && !!endpoint && !!data,
+    enabled: !multiplexed && !!endpoint && !!data,
     connections: connectionsRequests,
   });
 

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -16,11 +16,13 @@
 
 import type { QueryObserverOptions } from '@tanstack/react-query';
 import { useQueries, useQueryClient } from '@tanstack/react-query';
+import { partition } from 'lodash';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   hasAllowedNamespacesRestriction,
   loadClusterSettings,
 } from '../../../../helpers/clusterSettings';
+import { getClusterRegistration } from '../../../clusterRegistration';
 import type { KubeObject, KubeObjectClass } from '../../KubeObject';
 import type { QueryParameters } from '../v1/queryParameters';
 import { ApiError } from './ApiError';
@@ -39,12 +41,27 @@ import { BASE_WS_URL, useWebSockets } from './webSocket';
  * @returns true if the websocket multiplexer is enabled.
  * defaults to true. This is a feature flag to enable the websocket multiplexer.
  */
-export function getWebsocketMultiplexerEnabled(): boolean {
+function getWebsocketMultiplexerEnabled(): boolean {
   return import.meta.env.REACT_APP_ENABLE_WEBSOCKET_MULTIPLEXER === 'true';
+}
+
+/**
+ * Registrations use a path-scoped cookie the multiplexer endpoint never receives.
+ *
+ * @param cluster - Name of the cluster the watch is for.
+ * @returns true if watches for the given cluster go over the multiplexed connection.
+ */
+export function shouldMultiplexCluster(cluster: string): boolean {
+  return getWebsocketMultiplexerEnabled() && !getClusterRegistration(cluster);
 }
 
 /** Default page size for list consumers that opt in to pagination. */
 export const DEFAULT_LIST_LIMIT = 1000;
+
+/** A cluster and namespace to watch, at the resource version its list was fetched at. */
+type WatchList = { cluster: string; namespace?: string; resourceVersion: string };
+
+const emptyLists: WatchList[] = [];
 
 function toPaginationApiError(error: unknown, cluster: string, namespace?: string): ApiError {
   const apiError =
@@ -285,26 +302,27 @@ export function useWatchKubeObjectLists<K extends KubeObject>({
   /** Kube resource API endpoint information */
   endpoint?: KubeObjectEndpoint | null;
   /** Which clusters and namespaces to watch */
-  lists: Array<{ cluster: string; namespace?: string; resourceVersion: string }>;
+  lists: WatchList[];
 }) {
-  const multiplexerEnabled = getWebsocketMultiplexerEnabled();
+  const [multiplexedLists, legacyLists] = useMemo(
+    () => partition(lists, list => shouldMultiplexCluster(list.cluster)),
+    [lists]
+  );
 
   useWatchKubeObjectListsMultiplexed({
     kubeObjectClass,
     endpoint,
-    lists: multiplexerEnabled ? lists : [],
-    queryParams: multiplexerEnabled ? queryParams : undefined,
-    watchQueryParams: multiplexerEnabled ? watchQueryParams : undefined,
-    enabled: multiplexerEnabled,
+    lists: multiplexedLists,
+    queryParams,
+    watchQueryParams,
   });
 
   useWatchKubeObjectListsLegacy({
     kubeObjectClass,
     endpoint,
-    lists: !multiplexerEnabled ? lists : [],
-    queryParams: !multiplexerEnabled ? queryParams : undefined,
-    watchQueryParams: !multiplexerEnabled ? watchQueryParams : undefined,
-    enabled: !multiplexerEnabled,
+    lists: legacyLists,
+    queryParams,
+    watchQueryParams,
   });
 }
 
@@ -325,16 +343,15 @@ function useWatchKubeObjectListsMultiplexed<K extends KubeObject>({
   lists,
   queryParams,
   watchQueryParams,
-  enabled = true,
 }: {
   kubeObjectClass: (new (...args: any) => K) & typeof KubeObject<any>;
   endpoint?: KubeObjectEndpoint | null;
-  lists: Array<{ cluster: string; namespace?: string; resourceVersion: string }>;
+  lists: WatchList[];
   queryParams?: QueryParameters;
   watchQueryParams?: QueryParameters;
-  enabled?: boolean;
 }): void {
   const client = useQueryClient();
+  const enabled = lists.length > 0;
 
   // Track the latest resource versions to prevent duplicate updates
   const latestResourceVersions = useRef<Record<string, string>>({});
@@ -476,7 +493,6 @@ function useWatchKubeObjectListsLegacy<K extends KubeObject>({
   lists,
   queryParams,
   watchQueryParams,
-  enabled = true,
 }: {
   /** KubeObject class of the watched resource list */
   kubeObjectClass: (new (...args: any) => K) & typeof KubeObject<any>;
@@ -487,10 +503,10 @@ function useWatchKubeObjectListsLegacy<K extends KubeObject>({
   /** Kube resource API endpoint information */
   endpoint?: KubeObjectEndpoint | null;
   /** Which clusters and namespaces to watch */
-  lists: Array<{ cluster: string; namespace?: string; resourceVersion: string }>;
-  enabled?: boolean;
+  lists: WatchList[];
 }) {
   const client = useQueryClient();
+  const enabled = lists.length > 0;
 
   const stableQueryParamsKey = enabled ? JSON.stringify(queryParams) : '__disabled__';
   const stableWatchQueryParamsKey = enabled
@@ -783,9 +799,7 @@ export function useKubeObjectList<K extends KubeObject>({
   // for resources outside our fetched page, causing the list to grow unboundedly.
   const shouldWatch = watch && !refetchInterval && !query.isLoading && !query.hasMore;
 
-  const [listsToWatch, setListsToWatch] = useState<
-    { cluster: string; namespace?: string; resourceVersion: string }[]
-  >([]);
+  const [listsToWatch, setListsToWatch] = useState<WatchList[]>([]);
 
   useEffect(() => {
     setListsToWatch(currentListsToWatch => {
@@ -832,7 +846,7 @@ export function useKubeObjectList<K extends KubeObject>({
   }, [query.data, requests, shouldWatch]);
 
   useWatchKubeObjectLists({
-    lists: shouldWatch ? listsToWatch : [],
+    lists: shouldWatch ? listsToWatch : emptyLists,
     endpoint,
     kubeObjectClass,
     queryParams: perRequestQueryParams,

--- a/frontend/src/lib/k8s/api/v2/webSocket.test.ts
+++ b/frontend/src/lib/k8s/api/v2/webSocket.test.ts
@@ -20,6 +20,8 @@ import WS from 'vitest-websocket-mock';
 import { setBackendToken } from '../../../../helpers/getHeadlampAPIHeaders';
 import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
 import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
+import { makeRegisteredCluster } from '../../../../test/clusterRegistration';
+import { setRegisteredClusterSnapshot } from '../../../clusterRegistration';
 import { openWebSocket, useWebSockets } from './webSocket';
 import { BASE_WS_URL } from './webSocket';
 
@@ -110,10 +112,33 @@ describe('useWebSockets', () => {
       ]);
       expect(onMessage).toHaveBeenCalledWith('binary-data');
     });
+
+    it('routes a registered cluster websocket through its origin cluster', async () => {
+      setRegisteredClusterSnapshot({ items: [makeRegisteredCluster()] });
+      (findKubeconfigByClusterName as Mock).mockResolvedValue(null);
+
+      const socket = { addEventListener: vi.fn(), binaryType: '' };
+      const WebSocketMock = vi.fn(function () {
+        return socket;
+      });
+      vi.stubGlobal('WebSocket', WebSocketMock);
+
+      await openWebSocket('/api/v1/pods', {
+        cluster: 'hr-v1-spoke',
+        type: 'binary',
+        onMessage: vi.fn(),
+      });
+
+      expect(WebSocketMock).toHaveBeenCalledWith(
+        expect.stringContaining('/clusters/hub/federated/hr-v1-spoke/api/v1/pods'),
+        ['base64.binary.k8s.io']
+      );
+    });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    setRegisteredClusterSnapshot(undefined);
     WS.clean();
   });
 

--- a/frontend/src/lib/k8s/api/v2/webSocket.ts
+++ b/frontend/src/lib/k8s/api/v2/webSocket.ts
@@ -20,6 +20,7 @@ import { getHeadlampWebSocketProtocol } from '../../../../helpers/getHeadlampAPI
 import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
 import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
 import { getCluster } from '../../../cluster';
+import { getClusterRoute } from '../../../clusterRegistration';
 import { makeUrl } from './makeUrl';
 
 /**
@@ -110,7 +111,7 @@ export async function openWebSocket<T>(
   }
 
   if (cluster) {
-    path.unshift('clusters', cluster);
+    path.unshift('clusters', getClusterRoute(cluster));
 
     try {
       const kubeconfig = await findKubeconfigByClusterName(cluster);

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -835,5 +835,6 @@
     "storeStatelessClusterKubeconfig": [Function],
     "toStatelessConfigState": [Function],
   },
+  "useRegisteredClusters": [Function],
   "useTranslation": [Function],
 }

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -44,6 +44,7 @@ import { addBackstageAuthHeaders } from '../helpers/addBackstageAuthHeaders';
 import { getAppUrl } from '../helpers/getAppUrl';
 import { isElectron } from '../helpers/isElectron';
 import i18next from '../i18n/config';
+import { useRegisteredClusters } from '../lib/clusterRegistration';
 import * as K8s from '../lib/k8s';
 import * as ApiProxy from '../lib/k8s/apiProxy';
 import * as Crd from '../lib/k8s/crd';
@@ -104,6 +105,7 @@ window.pluginLib = {
   Headlamp,
   Plugin,
   useTranslation,
+  useRegisteredClusters,
   ...registryToExport,
   Activity,
   stateless,

--- a/frontend/src/redux/configSlice.test.ts
+++ b/frontend/src/redux/configSlice.test.ts
@@ -15,11 +15,13 @@
  */
 
 import { Cluster } from '../lib/k8s/cluster';
+import { makeRegisteredCluster } from '../test/clusterRegistration';
 import configReducer, {
   ConfigState,
   defaultTableRowsPerPageOptions,
   initialState,
   setAppSettings,
+  setClusterRegistrations,
   setConfig,
   setStatelessConfig,
 } from './configSlice';
@@ -131,6 +133,19 @@ describe('configSlice', () => {
     expect(nextState.defaultNodeShellNamespace).toBe('');
   });
 
+  it('should preserve clusterRegistrationsEnabled when setConfig is called without it', () => {
+    let state = configReducer(
+      initialState,
+      setConfig({ clusters: {}, clusterRegistrationsEnabled: true })
+    );
+
+    expect(state.clusterRegistrationsEnabled).toBe(true);
+
+    state = configReducer(state, setConfig({ clusters: {} }));
+
+    expect(state.clusterRegistrationsEnabled).toBe(true);
+  });
+
   it('should preserve isDynamicClusterEnabled when setConfig is called without it', () => {
     let state = configReducer(
       initialState,
@@ -156,6 +171,17 @@ describe('configSlice', () => {
     };
     const nextState = configReducer(initialState, setStatelessConfig({ statelessClusters }));
     expect(nextState.statelessClusters).toEqual(statelessClusters);
+  });
+
+  it('should handle setClusterRegistrations', () => {
+    const registration = makeRegisteredCluster();
+    const registrations: ConfigState['clusterRegistrations'] = { [registration.id]: registration };
+
+    let nextState = configReducer(initialState, setClusterRegistrations(registrations));
+    expect(nextState.clusterRegistrations).toEqual(registrations);
+
+    nextState = configReducer(nextState, setClusterRegistrations(null));
+    expect(nextState.clusterRegistrations).toBeNull();
   });
 
   describe('setAppSettings', () => {

--- a/frontend/src/redux/configSlice.ts
+++ b/frontend/src/redux/configSlice.ts
@@ -16,6 +16,7 @@
 
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
+import type { RegisteredCluster } from '../lib/clusterRegistration';
 import type { Cluster } from '../lib/k8s/cluster';
 
 export interface ConfigState {
@@ -42,6 +43,18 @@ export interface ConfigState {
   allClusters: {
     [clusterName: string]: Cluster;
   } | null;
+  /**
+   * Cluster Registrations is a map of opaque registration IDs to the clusters
+   * discovered by backend adapters, such as Cluster Inventory or Cluster API.
+   * Null indicates that the registrations have not been loaded yet.
+   */
+  clusterRegistrations: {
+    [registrationID: string]: RegisteredCluster;
+  } | null;
+  /**
+   * Whether the backend discovers and serves cluster registrations.
+   */
+  clusterRegistrationsEnabled: boolean;
   /**
    * Whether dynamic clusters are enabled.
    * When true, users can add and delete clusters dynamically.
@@ -168,6 +181,8 @@ export const initialState: ConfigState = {
   clusters: null,
   statelessClusters: null,
   allClusters: null,
+  clusterRegistrations: null,
+  clusterRegistrationsEnabled: false,
   isDynamicClusterEnabled: false,
   allowKubeconfigChanges: false,
   defaultPodDebugImage: '',
@@ -196,6 +211,7 @@ const configSlice = createSlice({
       state,
       action: PayloadAction<{
         clusters: ConfigState['clusters'];
+        clusterRegistrationsEnabled?: boolean;
         isDynamicClusterEnabled?: boolean;
         allowKubeconfigChanges?: boolean;
         defaultPodDebugImage?: string;
@@ -207,6 +223,9 @@ const configSlice = createSlice({
       }>
     ) {
       state.clusters = action.payload.clusters;
+      if (action.payload.clusterRegistrationsEnabled !== undefined) {
+        state.clusterRegistrationsEnabled = action.payload.clusterRegistrationsEnabled;
+      }
       if (action.payload.isDynamicClusterEnabled !== undefined) {
         state.isDynamicClusterEnabled = action.payload.isDynamicClusterEnabled;
       }
@@ -238,6 +257,14 @@ const configSlice = createSlice({
       state.statelessClusters = action.payload.statelessClusters;
     },
     /**
+     * Save the clusters discovered by backend adapters.
+     * @param state - The current state.
+     * @param action - The payload action containing the registrations.
+     */
+    setClusterRegistrations(state, action: PayloadAction<ConfigState['clusterRegistrations']>) {
+      state.clusterRegistrations = action.payload;
+    },
+    /**
      * Save the settings. To both the store, and localStorage.
      * @param state - The current state.
      * @param action - The payload action containing the settings.
@@ -251,6 +278,7 @@ const configSlice = createSlice({
   },
 });
 
-export const { setConfig, setAppSettings, setStatelessConfig } = configSlice.actions;
+export const { setConfig, setAppSettings, setStatelessConfig, setClusterRegistrations } =
+  configSlice.actions;
 
 export default configSlice.reducer;

--- a/frontend/src/test/clusterRegistration.ts
+++ b/frontend/src/test/clusterRegistration.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { RegisteredCluster } from '../lib/clusterRegistration';
+
+/** Builds a Cluster Inventory registration, overriding the fields a test cares about. */
+export const makeRegisteredCluster = (
+  partial: Partial<RegisteredCluster> = {}
+): RegisteredCluster => ({
+  id: 'hr-v1-spoke',
+  displayName: 'spoke',
+  source: 'cluster-inventory',
+  origin: {
+    cluster: 'hub',
+    resource: {
+      apiVersion: 'multicluster.x-k8s.io/v1alpha1',
+      kind: 'ClusterProfile',
+      namespace: 'headlamp',
+      name: 'spoke',
+      uid: 'uid-spoke',
+    },
+  },
+  ...partial,
+});

--- a/plugins/headlamp-plugin/src/index.ts
+++ b/plugins/headlamp-plugin/src/index.ts
@@ -24,6 +24,8 @@ import { Activity } from './components/activity/Activity';
 import * as CommonComponents from './components/common';
 import * as ResourceMap from './components/resourceMap';
 import type { AppTheme } from './lib/AppTheme';
+import type { RegisteredCluster, UseRegisteredClustersOptions } from './lib/clusterRegistration';
+import { useRegisteredClusters } from './lib/clusterRegistration';
 import * as K8s from './lib/k8s';
 import * as ApiProxy from './lib/k8s/apiProxy';
 import * as Notification from './lib/notification';
@@ -85,6 +87,7 @@ import Registry, {
 } from './plugin/registry';
 import type { ClusterEmptyStateProps } from './redux/clusterProviderSlice';
 export type { ApiResource } from './plugin/registry';
+export type { RegisteredCluster, UseRegisteredClustersOptions };
 
 // We export k8s (lowercase) since someone may use it as we do in the Headlamp source code.
 export {
@@ -99,6 +102,7 @@ export {
   Registry,
   Headlamp,
   Notification,
+  useRegisteredClusters,
   DefaultAppBarAction,
   DefaultCreateProject,
   DefaultDetailsViewSection,


### PR DESCRIPTION
## Summary

This PR adds a source-independent live cluster registration layer for Cluster Inventory and Cluster API discoveries. It lets plugins pass discovered opaque cluster IDs directly to existing Kubernetes resource hooks while Headlamp transparently routes HTTP and WebSocket requests through the origin cluster.

The change addresses OIDC-backed hub/spoke environments by reusing the signed-in user's origin-cluster OIDC token at request time. Users do not need to complete one OIDC flow per spoke, and newly routable clusters appear without reloading the UI.

## Related Issue

N/A

## Changes

- Added a shared backend registry with stable opaque IDs and non-sensitive public metadata.
- Added SSE snapshots/events so registrations are added, updated, and removed in open browsers without reloads.
- Added transparent federated HTTP and WebSocket routing for existing Kubernetes resource hooks.
- Changed Cluster Inventory authentication to support `oidc` and `access-provider`, with `oidc` as the alpha default.
- Added an ordered, exact, case-sensitive access-provider allowlist without special-casing provider names.
- Added Cluster API discovery from `spec.controlPlaneEndpoint`; endpoint-less Clusters are not registered and no kubeconfig Secrets are read.
- Exported `useRegisteredClusters({ source?, originCluster?, originNamespace? })` from the frontend plugin API.
- Updated the multicluster E2E fixture to opt into its existing access provider and validate the registration snapshot plus federated route.
- Documented authentication, source separation, CAPI behavior, installation arguments, and plugin usage.

## Steps to Test

1. Run `npm run backend:test`.
2. Run `npm run frontend:test`.
3. Run `npm run lint`, `npm run frontend:tsc`, and `npm run build`.
4. Run `./e2e-tests/scripts/setup-multicluster.sh`, load `e2e-tests/.env`, then run `npx playwright test tests/clusterInventory.spec.ts` from `e2e-tests/`.
5. Optionally run `go test -race ./pkg/clusterregistration ./pkg/clusterinventory ./pkg/clusterapi` from `backend/`.
6. Start an in-cluster Headlamp instance with Cluster Inventory enabled, OIDC configured, and an allowed provider name.
7. Create or update a routable ClusterProfile and verify `useRegisteredClusters()` updates without reloading.
8. Pass the returned ID to a resource hook such as `ConfigMap.useList({ clusters: [id] })` and verify HTTP and watch traffic reaches the target cluster using the origin login.

Local validation completed successfully:

- `npm run backend:test`
- `npm run frontend:test` (236 files, 3109 tests)
- `npm run lint`
- `npm run frontend:tsc`
- `npm run build`
- `go test -race ./pkg/clusterregistration ./pkg/clusterinventory ./pkg/clusterapi`
- focused registration/fetch/WebSocket tests (4 files, 16 tests)
- Headlamp plugin package build
- backend startup and `/config` plus `/cluster-registrations` smoke checks
- frontend startup at `localhost:3000`
- kind multicluster setup, registration snapshot convergence, and Cluster Inventory Playwright E2E (1 passed)

## Screenshots (if applicable)

N/A. This change adds data and routing APIs without changing visual components.

## Notes for the Reviewer

- This remains an experimental alpha feature and is disabled by default.
- Registration snapshots expose only `id`, `displayName`, `source`, and `origin`; endpoints and credentials remain backend-only.
- OIDC mode forwards the origin token only to OIDC-backed registrations. Access-provider registrations keep their configured credentials.
- Cluster Inventory and Cluster API representations are intentionally not merged.
- Production Kubernetes manifests, Helm charts, Dockerfiles, and CI workflows are unchanged; the E2E-only deployment fixture is updated.
