### PR TITLE
backend: multiplexer: Read Connection fields under conn.mu

### DIFF
--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -584,26 +584,31 @@ func (m *Multiplexer) reconnect(conn *Connection) (*Connection, error) {
 		return nil, fmt.Errorf("cannot reconnect closed connection")
 	}
 
-	if conn.WSConn != nil {
-		_ = conn.WSConn.Close()
+	conn.mu.RLock()
+	clusterID, userID, path, query := conn.ClusterID, conn.UserID, conn.Path, conn.Query
+	client, token, wsConn := conn.Client, conn.Token, conn.WSConn
+	conn.mu.RUnlock()
+
+	if wsConn != nil {
+		_ = wsConn.Close()
 	}
 
 	newConn, err := m.establishClusterConnection(
-		conn.ClusterID,
-		conn.UserID,
-		conn.Path,
-		conn.Query,
-		conn.Client,
-		conn.Token,
+		clusterID,
+		userID,
+		path,
+		query,
+		client,
+		token,
 	)
 	if err != nil {
-		logger.Log(logger.LevelError, map[string]string{logFieldClusterID: conn.ClusterID}, err, "reconnecting to cluster")
+		logger.Log(logger.LevelError, map[string]string{logFieldClusterID: clusterID}, err, "reconnecting to cluster")
 
 		return nil, err
 	}
 
 	m.mutex.Lock()
-	m.connections[m.createConnectionKey(conn.ClusterID, conn.Path, conn.UserID)] = newConn
+	m.connections[m.createConnectionKey(clusterID, path, userID)] = newConn
 	m.mutex.Unlock()
 
 	return newConn, nil
@@ -700,7 +705,11 @@ func (m *Multiplexer) processClientMessage(
 		return
 	}
 
-	if msg.Type == "REQUEST" && conn.Status.State == StateConnected {
+	conn.mu.RLock()
+	state := conn.Status.State
+	conn.mu.RUnlock()
+
+	if msg.Type == "REQUEST" && state == StateConnected {
 		_ = m.writeMessageToCluster(conn, []byte(msg.Data))
 	}
 }

--- a/backend/cmd/multiplexer_test.go
+++ b/backend/cmd/multiplexer_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
@@ -1933,4 +1934,87 @@ func BenchmarkCreateConnectionKey(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		benchConnectionKeySink = m.createConnectionKey(clusterID, path, userID)
 	}
+}
+
+func TestReconnectDoesNotRaceWithTokenRefresh(t *testing.T) {
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+
+	initialToken := "initial-token"
+	conn := &Connection{
+		ClusterID: "cluster-a",
+		UserID:    "user-a",
+		Path:      "/api/v1/pods",
+		Query:     "watch=1",
+		Token:     &initialToken,
+		Done:      make(chan struct{}),
+	}
+
+	refreshedToken := "refreshed-token"
+
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+
+		_, _ = m.reconnect(conn)
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		require.NoError(t, m.refreshConnectionToken(conn, &refreshedToken))
+	}()
+
+	wg.Wait()
+}
+
+func TestProcessClientMessageDoesNotRaceWithStatusUpdate(t *testing.T) {
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+
+	token := "token"
+	conn := &Connection{
+		ClusterID: "cluster-a",
+		UserID:    "user-a",
+		Path:      "/api/v1/pods",
+		Token:     &token,
+		Done:      make(chan struct{}),
+	}
+	conn.Status.State = StateClosed
+
+	m.connections[m.createConnectionKey("cluster-a", "/api/v1/pods", "user-a")] = conn
+
+	msg := Message{
+		Type:      "REQUEST",
+		ClusterID: "cluster-a",
+		Path:      "/api/v1/pods",
+		UserID:    "user-a",
+		Data:      "{}",
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+
+		m.processClientMessage(req, nil, msg)
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		conn.updateStatus(StateError, nil)
+	}()
+
+	wg.Wait()
+
+	conn.mu.RLock()
+	state := conn.Status.State
+	conn.mu.RUnlock()
+
+	require.Equal(t, StateError, state)
 }


### PR DESCRIPTION
## Summary

`Connection` carries a `sync.RWMutex` and most accesses take it, but two reads bypass it and race with writes that hold it. Both pairs run on different goroutines in normal operation, and both are reported by the race detector.

- `reconnect` reads `conn.Token` (line 597) while `refreshConnectionToken` writes it under `conn.mu.Lock()` (line 809). `reconnect` is reached from the per-connection `monitorConnection` goroutine; `refreshConnectionToken` runs on the client read loop.
- `processClientMessage` reads `conn.Status.State` (line 703) while `updateStatus` writes `Status` under `conn.mu.Lock()`, called from `monitorConnection` on heartbeat failure and on close.

`closeClientConnections` and `sendDataMessage` already lock before touching `Status`, so these two reads were the outliers.

## Related Issue

Fixes #7384

## Changes

- `reconnect` snapshots `ClusterID`, `UserID`, `Path`, `Query`, `Client`, `Token` and `WSConn` under `conn.mu.RLock()`, releases the lock, then closes the old socket and establishes the new connection from the snapshot. The lock is not held across `establishClusterConnection`.
- `processClientMessage` reads `Status.State` under `conn.mu.RLock()` before acting on it.
- Added two regression tests that drive each pair concurrently.

## Steps to Test

1. `cd backend && go test -race -count=25 -run "TestReconnectDoesNotRace|TestProcessClientMessageDoesNotRace" ./cmd/`
2. Confirm it passes. On `main` the same command reports `WARNING: DATA RACE` for both.
3. Whole package: `cd backend && go test -race -count=1 ./cmd/`
