### PR TITLE
frontend: advancedSearch: Keep results at exactly the item limit

### DIFF
--- a/frontend/src/components/advancedSearch/SearchSettings.tsx
+++ b/frontend/src/components/advancedSearch/SearchSettings.tsx
@@ -109,8 +109,17 @@ export function SearchSettings({
             sx={{ alignSelf: 'flex-end' }}
             onClick={() => {
               if (maxItemsInputRef.current && refetchInputRef.current) {
-                setMaxItemsPerResource(parseInt(maxItemsInputRef.current.value));
-                setRefetchIntervalMs(parseInt(refetchInputRef.current.value));
+                const maxItems = parseInt(maxItemsInputRef.current.value, 10);
+                const refetchInterval = parseInt(refetchInputRef.current.value, 10);
+
+                if (Number.isFinite(maxItems)) {
+                  setMaxItemsPerResource(maxItems);
+                }
+
+                if (Number.isFinite(refetchInterval)) {
+                  setRefetchIntervalMs(refetchInterval);
+                }
+
                 setAnchorEl(null);
               }
             }}

--- a/frontend/src/components/advancedSearch/utils/useKubeLists.test.tsx
+++ b/frontend/src/components/advancedSearch/utils/useKubeLists.test.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useKubeLists } from './useKubeLists';
+
+const { listResult, MockKubeObject } = vi.hoisted(() => {
+  const listResult = { items: [] as any[], errors: null as any, isError: false };
+
+  class MockKubeObject {
+    static useList() {
+      return listResult;
+    }
+  }
+
+  return { listResult, MockKubeObject };
+});
+
+vi.mock('../../../lib/k8s/KubeObject', () => ({ KubeObject: MockKubeObject }));
+
+vi.mock('../../../redux/filterSlice', () => ({
+  default: () => ({}),
+  initialState: {},
+  useNamespaces: () => [],
+}));
+
+vi.mock('../../../lib/k8s', () => ({
+  ResourceClasses: { Pod: MockKubeObject },
+}));
+
+const podResource = {
+  kind: 'Pod',
+  apiVersion: 'v1',
+  pluralName: 'pods',
+  isNamespaced: true,
+} as any;
+
+function itemsOfLength(n: number) {
+  return Array.from({ length: n }, (_, i) => ({ metadata: { uid: String(i) } }));
+}
+
+describe('useKubeLists', () => {
+  beforeEach(() => {
+    listResult.items = [];
+  });
+
+  it('includes a resource holding exactly the maximum number of items', () => {
+    listResult.items = itemsOfLength(3);
+
+    const { result } = renderHook(() => useKubeLists([podResource], ['cluster'], 3));
+
+    expect(result.current.items).toHaveLength(3);
+  });
+
+  it('keeps items when the maximum is not a number', () => {
+    listResult.items = itemsOfLength(3);
+
+    const { result } = renderHook(() => useKubeLists([podResource], ['cluster'], NaN));
+
+    expect(result.current.items).toHaveLength(3);
+  });
+
+  it('excludes a resource holding more than the maximum', () => {
+    listResult.items = itemsOfLength(4);
+
+    const { result } = renderHook(() => useKubeLists([podResource], ['cluster'], 3));
+
+    expect(result.current.items).toHaveLength(0);
+  });
+});

--- a/frontend/src/components/advancedSearch/utils/useKubeLists.ts
+++ b/frontend/src/components/advancedSearch/utils/useKubeLists.ts
@@ -69,8 +69,10 @@ export const useKubeLists = (
   useEffect(() => {
     if (isLoading) return;
 
+    const limit = Number.isFinite(maxItems) ? maxItems : Infinity;
+
     const newItems = data.flatMap(it => {
-      if (it.items && it.items.length < maxItems) {
+      if (it.items && it.items.length <= limit) {
         return it.items;
       } else {
         // The amount of items exceeds the limit


### PR DESCRIPTION
## Summary

Two problems in the same filter in `useKubeLists`, both of which silently remove results from Advanced Search.

A resource holding exactly `maxItems` items was excluded by `it.items.length < maxItems`, although the settings field describes the limit as *"If a resource has more items than this amount they will be excluded from Search."* Since an over-limit resource is dropped whole rather than truncated, this removed every result for that resource, not just one item.

Separately, `SearchSettings` stored the limit with `parseInt(value)` on a clearable `type="number"` input, so clearing the field and saving stored `NaN`. Every comparison against `NaN` is false, so the search returned nothing for all resources with no indication why.

## Related Issue

Fixes #7386

## Changes

- Compare with `<=` so a resource holding exactly the limit is included.
- Treat a non-finite limit as no limit in `useKubeLists`, rather than excluding everything.
- Only store the parsed values in `SearchSettings` when they are finite, and pass the radix to `parseInt`.
- Added `useKubeLists.test.tsx` covering exactly-at-limit, over-limit and a `NaN` limit.

## Steps to Test

1. `cd frontend && npx vitest run src/components/advancedSearch/`
2. Confirm 35 tests pass. On `main`, the exactly-at-limit and `NaN` cases fail.
3. Manually: open Advanced Search settings, clear "Max items per resource", save, and confirm results still appear.
