### PR TITLE
frontend: k8s: Reject API discovery when no source answers

### DIFF
--- a/frontend/src/lib/k8s/api/v2/apiDiscovery.test.ts
+++ b/frontend/src/lib/k8s/api/v2/apiDiscovery.test.ts
@@ -24,7 +24,12 @@ import {
   MockInstance,
   vi,
 } from 'vitest';
-import { apiDiscovery, MAX_SUMMARY_KEYS, type PayloadSummary } from './apiDiscovery';
+import {
+  apiDiscovery,
+  ApiDiscoveryUnavailableError,
+  MAX_SUMMARY_KEYS,
+  type PayloadSummary,
+} from './apiDiscovery';
 import { clusterFetch } from './fetch';
 
 // Reused across tests that need a Response whose body fails to parse as JSON.
@@ -246,8 +251,10 @@ const mockLegacyBatchV1Beta1Resources = {
 
 describe('apiDiscovery', () => {
   beforeEach(() => {
-    // Reset mocks before each test
-    mockClusterFetch.mockClear();
+    // Reset rather than clear: tests below install persistent implementations with
+    // `mockRejectedValue`, and `mockClear` would leave those in place for whichever
+    // test runs next, making the suite order-dependent.
+    mockClusterFetch.mockReset();
   });
 
   it('should return an empty array if cluster list is empty', async () => {
@@ -635,6 +642,69 @@ describe('apiDiscovery', () => {
       ]
     `);
     expect(sortedResult).toHaveLength(2);
+  });
+
+  // A resolved empty array used to mean two different things: the cluster
+  // answered and listed nothing, or nothing answered at all. Consumers render
+  // the first as "no resources" and had no way to tell the second apart, so a
+  // cluster that was never reached looked like a cluster with no APIs.
+  describe('total discovery failure', () => {
+    let debugSpy: MockInstance<Console['debug']>;
+
+    beforeEach(() => {
+      debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      debugSpy.mockRestore();
+    });
+
+    it('rejects when no discovery source answers for the only cluster', async () => {
+      // Every call rejects, which is what `clusterFetch` does in production for
+      // a non-OK response or a dropped connection.
+      mockClusterFetch
+        .mockRejectedValueOnce(new Error('agg /api'))
+        .mockRejectedValueOnce(new Error('agg /apis'))
+        .mockRejectedValueOnce(new Error('legacy /api'))
+        .mockRejectedValueOnce(new Error('legacy /apis'));
+
+      await expect(apiDiscovery(['cluster1'])).rejects.toThrow(ApiDiscoveryUnavailableError);
+    });
+
+    it('names the clusters it could not reach', async () => {
+      mockClusterFetch.mockRejectedValue(new Error('unreachable'));
+
+      await expect(apiDiscovery(['cluster1', 'cluster2'])).rejects.toThrow(/cluster1, cluster2/);
+    });
+
+    it('resolves empty when the cluster answers and lists nothing', async () => {
+      // The aggregated endpoints are unavailable but legacy discovery replies,
+      // reporting no core versions and no groups. That is an answer, so it must
+      // stay a resolved empty list rather than becoming an error.
+      mockClusterFetch
+        .mockRejectedValueOnce(new Error('agg /api'))
+        .mockRejectedValueOnce(new Error('agg /apis'))
+        .mockResolvedValueOnce(mockJsonResponse({ versions: [] }))
+        .mockResolvedValueOnce(mockJsonResponse({ groups: [] }));
+
+      await expect(apiDiscovery(['cluster1'])).resolves.toEqual([]);
+    });
+
+    it('returns what it has when one cluster of several fails outright', async () => {
+      mockClusterFetch
+        // cluster1: nothing answers
+        .mockRejectedValueOnce(new Error('agg /api'))
+        .mockRejectedValueOnce(new Error('agg /apis'))
+        .mockRejectedValueOnce(new Error('legacy /api'))
+        .mockRejectedValueOnce(new Error('legacy /apis'))
+        // cluster2: aggregated discovery works
+        .mockResolvedValueOnce(mockJsonResponse(mockAggregatedApi))
+        .mockResolvedValueOnce(mockJsonResponse(mockAggregatedApis));
+
+      const result = await apiDiscovery(['cluster1', 'cluster2']);
+
+      expect(result.length).toBeGreaterThan(0);
+    });
   });
 
   // #4840: critical network and parsing failures used to be swallowed without

--- a/frontend/src/lib/k8s/api/v2/apiDiscovery.test.ts
+++ b/frontend/src/lib/k8s/api/v2/apiDiscovery.test.ts
@@ -24,6 +24,7 @@ import {
   MockInstance,
   vi,
 } from 'vitest';
+import { shouldRetryQuery } from '../../../queryClient';
 import {
   apiDiscovery,
   ApiDiscoveryUnavailableError,
@@ -671,6 +672,87 @@ describe('apiDiscovery', () => {
       await expect(apiDiscovery(['cluster1'])).rejects.toThrow(ApiDiscoveryUnavailableError);
     });
 
+    it('carries the status when every failure agreed on one', async () => {
+      // A user with no discovery access gets 403 from every endpoint. The status has to
+      // reach the thrown error, because retry policies read it to tell a permanent
+      // failure from a transient one.
+      const forbidden = Object.assign(new Error('forbidden'), { status: 403 });
+      mockClusterFetch.mockRejectedValue(forbidden);
+
+      await expect(apiDiscovery(['cluster1'])).rejects.toMatchObject({ status: 403 });
+    });
+
+    it('leaves the status unset when the failures disagreed', async () => {
+      // One endpoint refuses and another is simply unreachable. There is no single
+      // status to report, so the caller should treat the failure as retryable.
+      mockClusterFetch
+        .mockRejectedValueOnce(Object.assign(new Error('forbidden'), { status: 403 }))
+        .mockRejectedValueOnce(Object.assign(new Error('gateway'), { status: 502 }))
+        .mockRejectedValueOnce(Object.assign(new Error('forbidden'), { status: 403 }))
+        .mockRejectedValueOnce(Object.assign(new Error('gateway'), { status: 502 }));
+
+      await expect(apiDiscovery(['cluster1'])).rejects.toMatchObject({ status: undefined });
+    });
+
+    it('leaves the status unset when a failure carried none', async () => {
+      // A dropped connection rejects without a status, so nothing can be concluded
+      // about whether retrying is worthwhile.
+      mockClusterFetch.mockRejectedValue(new Error('network down'));
+
+      await expect(apiDiscovery(['cluster1'])).rejects.toMatchObject({ status: undefined });
+    });
+
+    // The four tests below pin the statuses of the sources the aggregated pair does not
+    // cover. Each one is a failure the caller should retry, and each would be reported as
+    // a terminal 403 if its source contributed nothing to the agreement check.
+    it('leaves the status unset when the legacy failures disagreed', async () => {
+      // Aggregated discovery is forbidden while legacy discovery hits a bad gateway. The
+      // 502 is worth retrying, so the 403 the aggregated pair agreed on must not stand as
+      // the status for the whole failure.
+      mockClusterFetch
+        .mockRejectedValueOnce(Object.assign(new Error('forbidden'), { status: 403 }))
+        .mockRejectedValueOnce(Object.assign(new Error('forbidden'), { status: 403 }))
+        .mockRejectedValueOnce(Object.assign(new Error('gateway'), { status: 502 }))
+        .mockRejectedValueOnce(Object.assign(new Error('gateway'), { status: 502 }));
+
+      await expect(apiDiscovery(['cluster1'])).rejects.toMatchObject({ status: undefined });
+    });
+
+    it('leaves the status unset when a legacy failure carried none', async () => {
+      // The legacy connection drops without a status. Once a statusless failure is in the
+      // mix the 403s no longer speak for every source.
+      mockClusterFetch
+        .mockRejectedValueOnce(Object.assign(new Error('forbidden'), { status: 403 }))
+        .mockRejectedValueOnce(Object.assign(new Error('forbidden'), { status: 403 }))
+        .mockRejectedValueOnce(new Error('legacy /api connection reset'))
+        .mockRejectedValueOnce(new Error('legacy /apis connection reset'));
+
+      await expect(apiDiscovery(['cluster1'])).rejects.toMatchObject({ status: undefined });
+    });
+
+    it('leaves the status unset when an aggregated source replied with something else', async () => {
+      // A 200 carrying anything but an APIGroupDiscoveryList is unusable, and it came back
+      // over a request that succeeded, so it has no status of its own to contribute.
+      mockClusterFetch
+        .mockResolvedValueOnce(mockJsonResponse({ message: 'not a discovery document' }))
+        .mockRejectedValueOnce(Object.assign(new Error('forbidden'), { status: 403 }))
+        .mockRejectedValueOnce(Object.assign(new Error('forbidden'), { status: 403 }))
+        .mockRejectedValueOnce(Object.assign(new Error('forbidden'), { status: 403 }));
+
+      await expect(apiDiscovery(['cluster1'])).rejects.toMatchObject({ status: undefined });
+    });
+
+    it('leaves the status unset when a legacy source replied with something else', async () => {
+      // Same on the legacy side: a parsed body with no `versions` list is not an answer,
+      // and the request behind it succeeded.
+      mockClusterFetch
+        .mockRejectedValueOnce(Object.assign(new Error('forbidden'), { status: 403 }))
+        .mockRejectedValueOnce(Object.assign(new Error('forbidden'), { status: 403 }))
+        .mockResolvedValueOnce(mockJsonResponse({ message: 'not a discovery document' }))
+        .mockRejectedValueOnce(Object.assign(new Error('forbidden'), { status: 403 }));
+
+      await expect(apiDiscovery(['cluster1'])).rejects.toMatchObject({ status: undefined });
+    });
     it('names the clusters it could not reach', async () => {
       mockClusterFetch.mockRejectedValue(new Error('unreachable'));
 
@@ -704,6 +786,31 @@ describe('apiDiscovery', () => {
       const result = await apiDiscovery(['cluster1', 'cluster2']);
 
       expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('keeps what one source collected when the other one throws while processing', async () => {
+      // `/apis` carries an `items` array, so the cluster answered, but a nested
+      // `resources` that is not an array makes the processor throw. The resources
+      // `/api` already contributed have to survive that, and the failed legacy
+      // fallback must not turn an answered cluster into a total failure.
+      mockClusterFetch
+        .mockResolvedValueOnce(mockJsonResponse(mockAggregatedApi))
+        .mockResolvedValueOnce(
+          mockJsonResponse({
+            items: [
+              {
+                metadata: { name: 'apps' },
+                versions: [{ version: 'v1', resources: 'not-an-array' }],
+              },
+            ],
+          })
+        )
+        .mockRejectedValueOnce(new Error('legacy /api down'))
+        .mockRejectedValueOnce(new Error('legacy /apis down'));
+
+      const result = await apiDiscovery(['cluster1']);
+
+      expect(result.map(resource => resource.pluralName)).toContain('pods');
     });
   });
 
@@ -993,5 +1100,28 @@ describe('apiDiscovery', () => {
       expect(booleanSummaries.length).toBeGreaterThan(0);
       expect(booleanSummaries[0].value).toBe(false);
     });
+  });
+});
+
+// The status exists so the shared client policy can tell a permanent discovery
+// failure from a transient one. These pin that wiring, so a change to either side
+// fails here rather than silently restoring the three pointless retries.
+describe('ApiDiscoveryUnavailableError and the shared retry policy', () => {
+  it('does not retry a failure every source reported as 403', () => {
+    expect(shouldRetryQuery(0, new ApiDiscoveryUnavailableError(['cluster1'], 403))).toBe(false);
+  });
+
+  it('retries a failure whose sources disagreed', () => {
+    expect(shouldRetryQuery(0, new ApiDiscoveryUnavailableError(['cluster1'], undefined))).toBe(
+      true
+    );
+  });
+
+  it('retries a 502, which is transient', () => {
+    expect(shouldRetryQuery(0, new ApiDiscoveryUnavailableError(['cluster1'], 502))).toBe(true);
+  });
+
+  it('gives up on a retryable failure once the attempts run out', () => {
+    expect(shouldRetryQuery(3, new ApiDiscoveryUnavailableError(['cluster1'], 502))).toBe(false);
   });
 });

--- a/frontend/src/lib/k8s/api/v2/apiDiscovery.tsx
+++ b/frontend/src/lib/k8s/api/v2/apiDiscovery.tsx
@@ -114,37 +114,48 @@ function logAggregatedUnusable(
   );
 }
 
+/** Outcome of one legacy discovery fetch. */
+type LegacyDiscoveryOutcome =
+  /** The body parsed as an object. It may still lack the list the caller wants. */
+  | { ok: true; body: Record<string, unknown> }
+  /** The fetch or the parse failed, or the body was not an object. */
+  | { ok: false; status?: number };
+
 /**
- * Fetches one side of legacy discovery and logs/swallows any failure.
+ * Fetches one side of legacy discovery, logging any failure and reporting it back.
  * `clusterFetch` is not bare `fetch`: it already throws an `ApiError` on any
  * non-ok response (see `fetch.ts`), so non-2xx HTTP responses surface as
  * rejected promises and reach this `.catch` the same way a network failure
  * does. A `res.json()` parse rejection lands here too, so the log says
  * "fetch or parse" rather than just "fetch".
+ *
+ * A total discovery failure reports an HTTP status only when every unusable source
+ * agreed on one, so the caller has to see the failure itself. A swallowed rejection
+ * would leave the sources that remain to agree among themselves.
  */
-function fetchLegacyOrLogFailure(
+function fetchLegacyDiscovery(
   path: '/api' | '/apis',
   cluster: string
-): Promise<Record<string, unknown> | null> {
+): Promise<LegacyDiscoveryOutcome> {
   return clusterFetch(path, { cluster })
     .then(res => res.json())
-    .then(parsed => {
+    .then((parsed): LegacyDiscoveryOutcome => {
       // `res.json()` can return any JSON value (object, array, string,
       // number, boolean, null). Legacy discovery callers only care about
-      // the `versions`/`groups` properties on an object body, so coerce
-      // non-object bodies to null up front. We return a plain
+      // the `versions`/`groups` properties on an object body, so treat
+      // non-object bodies as unusable up front. We return a plain
       // `Record<string, unknown>` rather than typing `versions`/`groups` as
       // `unknown[]` so the type doesn't over-promise arrayness for fields
       // the helper itself never validates; callers `Array.isArray` to
       // narrow.
       if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-        return null;
+        return { ok: false };
       }
-      return parsed as Record<string, unknown>;
+      return { ok: true, body: parsed as Record<string, unknown> };
     })
-    .catch(err => {
+    .catch((err): LegacyDiscoveryOutcome => {
       console.debug(`Legacy ${path} discovery fetch or parse failed for cluster ${cluster}:`, err);
-      return null;
+      return { ok: false, status: httpStatusOf(err) };
     });
 }
 
@@ -261,10 +272,33 @@ function processLegacyApiResourceList(
  * for a cluster they never reached.
  */
 export class ApiDiscoveryUnavailableError extends Error {
-  constructor(clusters: string[]) {
+  /**
+   * HTTP status shared by every failure that produced this error, when they agreed on one.
+   *
+   * Retry policies key off `status`, so leaving it unset makes a permanent failure look
+   * transient and earns three pointless retries. It stays unset when the failures disagreed
+   * or carried no status, since there is then no single answer to report.
+   */
+  readonly status?: number;
+
+  constructor(clusters: string[], status?: number) {
     super(`API discovery failed for every requested cluster: ${clusters.join(', ')}`);
     this.name = 'ApiDiscoveryUnavailableError';
+    this.status = status;
   }
+}
+
+/** Reads a numeric HTTP status off a rejected discovery error, when it carries one. */
+function httpStatusOf(error: unknown): number | undefined {
+  if (error !== null && typeof error === 'object' && 'status' in error) {
+    const { status } = error as { status?: unknown };
+
+    if (typeof status === 'number' && Number.isFinite(status)) {
+      return status;
+    }
+  }
+
+  return undefined;
 }
 
 /**
@@ -288,6 +322,12 @@ export async function apiDiscovery(clusters: string[]): Promise<ApiResource[]> {
   // groups: an empty answer from a reachable cluster is information, whereas a
   // failed fetch is not.
   let anyClusterAnswered = false;
+  // Statuses of the sources that could not answer, so a total failure can report one
+  // when they all agree. Every unusable source has to add an entry, `undefined`
+  // included, for a source that failed without a status or replied with a body that
+  // was not discovery. Leaving those out would let the sources that did carry a status
+  // agree by default and report a mixed failure as a single one.
+  const failureStatuses = new Set<number | undefined>();
 
   for (const cluster of clusters) {
     let useFallback = false;
@@ -314,8 +354,13 @@ export async function apiDiscovery(clusters: string[]): Promise<ApiResource[]> {
         apiAggregatedResult.value &&
         Array.isArray(apiAggregatedResult.value.items)
       ) {
-        processAggregatedDiscoveryItems(apiAggregatedResult.value.items, resultMap);
+        // The `items` array is itself the answer, so record it before processing. A
+        // payload whose nested shape is malformed can make the processor throw, and
+        // that must not retract an answer the cluster already gave, nor discard what
+        // the other source collected before it.
         apiAggregatedOk = true;
+        anyClusterAnswered = true;
+        processAggregatedDiscoveryItems(apiAggregatedResult.value.items, resultMap);
       }
 
       let apisAggregatedOk = false;
@@ -324,19 +369,26 @@ export async function apiDiscovery(clusters: string[]): Promise<ApiResource[]> {
         apisAggregatedResult.value &&
         Array.isArray(apisAggregatedResult.value.items)
       ) {
-        processAggregatedDiscoveryItems(apisAggregatedResult.value.items, resultMap);
         apisAggregatedOk = true;
-      }
-
-      if (apiAggregatedOk || apisAggregatedOk) {
         anyClusterAnswered = true;
+        processAggregatedDiscoveryItems(apisAggregatedResult.value.items, resultMap);
       }
 
       if (!apiAggregatedOk) {
         logAggregatedUnusable('/api', cluster, apiAggregatedResult);
+        failureStatuses.add(
+          apiAggregatedResult.status === 'rejected'
+            ? httpStatusOf(apiAggregatedResult.reason)
+            : undefined
+        );
       }
       if (!apisAggregatedOk) {
         logAggregatedUnusable('/apis', cluster, apisAggregatedResult);
+        failureStatuses.add(
+          apisAggregatedResult.status === 'rejected'
+            ? httpStatusOf(apisAggregatedResult.reason)
+            : undefined
+        );
       }
       if (!apiAggregatedOk || !apisAggregatedOk) {
         useFallback = true;
@@ -346,21 +398,37 @@ export async function apiDiscovery(clusters: string[]): Promise<ApiResource[]> {
         `Aggregated API discovery threw for cluster ${cluster}; falling back to legacy:`,
         error
       );
+      failureStatuses.add(httpStatusOf(error));
       useFallback = true;
     }
 
     if (useFallback) {
       try {
-        const [coreApiVersionsData, apiGroupsData] = await Promise.all([
-          fetchLegacyOrLogFailure('/api', cluster),
-          fetchLegacyOrLogFailure('/apis', cluster),
+        const [coreApiOutcome, apiGroupsOutcome] = await Promise.all([
+          fetchLegacyDiscovery('/api', cluster),
+          fetchLegacyDiscovery('/apis', cluster),
         ]);
+
+        const coreApiVersionsData = coreApiOutcome.ok ? coreApiOutcome.body : null;
+        const apiGroupsData = apiGroupsOutcome.ok ? apiGroupsOutcome.body : null;
 
         // Symmetric with the aggregated check above, which requires an `items`
         // array: a body that carries the expected list is an answer even when the
         // list is empty, whereas a failed fetch or an unrecognisable body is not.
-        if (Array.isArray(coreApiVersionsData?.versions) || Array.isArray(apiGroupsData?.groups)) {
+        const coreApiAnswered = Array.isArray(coreApiVersionsData?.versions);
+        const apiGroupsAnswered = Array.isArray(apiGroupsData?.groups);
+
+        if (coreApiAnswered || apiGroupsAnswered) {
           anyClusterAnswered = true;
+        }
+
+        // A body that parsed but carried no list came back over a successful request,
+        // so there is no status to report for it.
+        if (!coreApiAnswered) {
+          failureStatuses.add(coreApiOutcome.ok ? undefined : coreApiOutcome.status);
+        }
+        if (!apiGroupsAnswered) {
+          failureStatuses.add(apiGroupsOutcome.ok ? undefined : apiGroupsOutcome.status);
         }
 
         if (coreApiVersionsData && Array.isArray(coreApiVersionsData.versions)) {
@@ -430,6 +498,7 @@ export async function apiDiscovery(clusters: string[]): Promise<ApiResource[]> {
         }
       } catch (legacyError) {
         console.debug(`Failed to fetch legacy API resources for cluster ${cluster}:`, legacyError);
+        failureStatuses.add(httpStatusOf(legacyError));
       }
     }
   }
@@ -437,7 +506,12 @@ export async function apiDiscovery(clusters: string[]): Promise<ApiResource[]> {
   // Only the total-failure case throws. Anything that was discovered is returned,
   // so one unreachable cluster in a multi-cluster call still yields the others.
   if (clusters.length > 0 && !anyClusterAnswered) {
-    throw new ApiDiscoveryUnavailableError(clusters);
+    const [onlyStatus] = failureStatuses;
+
+    throw new ApiDiscoveryUnavailableError(
+      clusters,
+      failureStatuses.size === 1 ? onlyStatus : undefined
+    );
   }
 
   return Array.from(resultMap.values());

--- a/frontend/src/lib/k8s/api/v2/apiDiscovery.tsx
+++ b/frontend/src/lib/k8s/api/v2/apiDiscovery.tsx
@@ -254,15 +254,40 @@ function processLegacyApiResourceList(
 }
 
 /**
+ * Thrown when discovery produced nothing for any requested cluster because every
+ * source failed. Distinguishing this from an empty result matters: a resolved
+ * empty array reads as "these clusters serve no API resources", which no reachable
+ * cluster does, so callers that cannot tell the two apart render "nothing found"
+ * for a cluster they never reached.
+ */
+export class ApiDiscoveryUnavailableError extends Error {
+  constructor(clusters: string[]) {
+    super(`API discovery failed for every requested cluster: ${clusters.join(', ')}`);
+    this.name = 'ApiDiscoveryUnavailableError';
+  }
+}
+
+/**
  * Discovers available API resources from Kubernetes clusters.
  * - Only resources that support the 'list' verb are included in the results
  *
+ * Partial failures are tolerated and logged: a cluster, group or version that
+ * could not be fetched is skipped and whatever else was discovered is returned.
+ *
  * @param clusters - An array of cluster names to discover API resources from
  * @returns list of API resources
+ * @throws {ApiDiscoveryUnavailableError} if no discovery source succeeded for any
+ * of the requested clusters. An empty `clusters` array is not a failure and
+ * resolves to an empty list.
  *
  */
 export async function apiDiscovery(clusters: string[]): Promise<ApiResource[]> {
   const resultMap = new Map<string, ApiResource>();
+  // Tracks whether any discovery source answered for any cluster. A source
+  // "answered" when its fetch and parse both succeeded, even if it reported no
+  // groups: an empty answer from a reachable cluster is information, whereas a
+  // failed fetch is not.
+  let anyClusterAnswered = false;
 
   for (const cluster of clusters) {
     let useFallback = false;
@@ -303,6 +328,10 @@ export async function apiDiscovery(clusters: string[]): Promise<ApiResource[]> {
         apisAggregatedOk = true;
       }
 
+      if (apiAggregatedOk || apisAggregatedOk) {
+        anyClusterAnswered = true;
+      }
+
       if (!apiAggregatedOk) {
         logAggregatedUnusable('/api', cluster, apiAggregatedResult);
       }
@@ -326,6 +355,13 @@ export async function apiDiscovery(clusters: string[]): Promise<ApiResource[]> {
           fetchLegacyOrLogFailure('/api', cluster),
           fetchLegacyOrLogFailure('/apis', cluster),
         ]);
+
+        // Symmetric with the aggregated check above, which requires an `items`
+        // array: a body that carries the expected list is an answer even when the
+        // list is empty, whereas a failed fetch or an unrecognisable body is not.
+        if (Array.isArray(coreApiVersionsData?.versions) || Array.isArray(apiGroupsData?.groups)) {
+          anyClusterAnswered = true;
+        }
 
         if (coreApiVersionsData && Array.isArray(coreApiVersionsData.versions)) {
           const coreResourceFetchPromises = coreApiVersionsData.versions.map(async (v: any) => {
@@ -396,6 +432,12 @@ export async function apiDiscovery(clusters: string[]): Promise<ApiResource[]> {
         console.debug(`Failed to fetch legacy API resources for cluster ${cluster}:`, legacyError);
       }
     }
+  }
+
+  // Only the total-failure case throws. Anything that was discovered is returned,
+  // so one unreachable cluster in a multi-cluster call still yields the others.
+  if (clusters.length > 0 && !anyClusterAnswered) {
+    throw new ApiDiscoveryUnavailableError(clusters);
   }
 
   return Array.from(resultMap.values());


### PR DESCRIPTION
`apiDiscovery` returns whatever it managed to accumulate. Every failure path logs to
`console.debug` and carries on, and the function ends with:

```ts
return Array.from(resultMap.values());
```

So when aggregated discovery fails for both `/api` and `/apis` and the legacy fallback fails
too, the call resolves to `[]`. A caller cannot tell that apart from a cluster that genuinely
serves no API resources, and no reachable cluster serves none.

Both consumers today treat the empty list as an answer. `AdvancedSearch` selects every resource
in it, and `sources.tsx` uses it to decide whether the Gateway API group is served. A cluster
that was never reached looks like a cluster with nothing in it.

This adds `ApiDiscoveryUnavailableError` and throws it when no discovery source answered for any
requested cluster. A source counts as having answered when its fetch and parse both succeeded
and the body carried the expected list. That is the same bar the aggregated path already applies
with `Array.isArray(items)`, so an empty `versions` or `groups` array from a cluster that replied
still counts as an answer.

Partial failures behave as before. A cluster, group or version that could not be fetched is
still skipped and logged, a multi-cluster call still returns whatever the reachable clusters
reported, and `apiDiscovery([])` still resolves to an empty list.

### Testing

Four tests in `apiDiscovery.test.ts`. With the `throw` removed and everything else left in
place, the two covering total failure fail with `promise resolved "[]" instead of rejecting`.
The other two pin the boundary from the other side: a cluster that answers and lists nothing
must stay a resolved empty array, and one dead cluster among several must not lose the others.

`vitest run src/lib/k8s/api/v2/` passes, 130 tests. The consumers' own suites pass, 347 tests
across `advancedSearch` and `resourceMap`. eslint, prettier and `tsc --noEmit` are clean.

### Consumers and retries

Nothing changes in the UI yet. `AdvancedSearch.tsx` destructures `data` and `isLoading`, and
`sources.tsx` destructures `data`. Neither reads `isError`, so both still render an empty state
when discovery fails. This changes the API boundary so the difference can be observed at all;
updating the consumers to show it is separate work.

Retries now apply where they did not. `queryClient` sets `staleTime` and `refetchOnWindowFocus`
and leaves `retry` at the react-query default of 3, and this query used to resolve instead of
rejecting. A fully unreachable cluster therefore goes from four requests to as many as sixteen.
`shouldRetryKubeRequest` in `retry.ts` is the existing knob if a policy is wanted here, though
it keys on `ApiError` status and would not match this error as written.

### Context

This came out of headlamp-k8s/plugins#1083, where nine plugins each run their own install check
and most collapse every probe failure into "not installed". @sniok pointed at `apiDiscovery` as
the foundation for a shared presence check. A presence check built on the current return shape
inherits this problem one layer down, so it seemed worth fixing here first.
