### PR TITLE
frontend: NamespacesAutocomplete: Fix tooltip listing already-visible namespaces as hidden

### DIFF
--- a/frontend/src/components/common/NamespacesAutocomplete.tsx
+++ b/frontend/src/components/common/NamespacesAutocomplete.tsx
@@ -140,12 +140,14 @@ export function PureNamespacesAutocomplete({
         const joiner = ', ';
         const joinerLength = joiner.length;
         let joinnedNamespaces = 1;
-        const remainingTags = tags.slice(1);
+        const hiddenTags: string[] = [];
 
         tags.slice(1).forEach(tag => {
           if (namespacesToShow.length + tag.length + joinerLength <= maxNamespacesChars) {
             namespacesToShow += joiner + tag;
             joinnedNamespaces++;
+          } else {
+            hiddenTags.push(tag);
           }
         });
 
@@ -160,8 +162,8 @@ export function PureNamespacesAutocomplete({
                 <Tooltip
                   title={
                     <ul style={{ margin: 0, padding: 10, listStyle: 'none' }}>
-                      {remainingTags.map((tag, key) => (
-                        <li key={key}>{tag}</li>
+                      {hiddenTags.map(tag => (
+                        <li key={tag}>{tag}</li>
                       ))}
                     </ul>
                   }


### PR DESCRIPTION
## Summary
This PR fixes a bug in the namespace filter tooltip where the "+N more" list repeats namespaces that are already visible in the collapsed label, instead of only showing the ones that got hidden.

## Related Issue
Fixes #7393 

## Changes
- Replaced `remainingTags`, which was a static slice of every selected namespace after the first one, with `hiddenTags`, which is built inside the same loop that decides which namespaces get packed into the visible label
- A namespace now only gets added to `hiddenTags` when it fails the length check and does not make it into the label, so the tooltip content matches what is actually not shown
- Left the "+N" count logic untouched since that part was already correct

## Steps to Test
1. Run headlamp locally and open any page that has the namespace filter in the top bar
2. Open the namespace dropdown and select 4 to 5 namespaces with short names, for example dev, qa, staging, production, monitoring
3. Look at the collapsed label next to the dropdown, it will show something like "dev, qa" with a "+3" badge
4. Hover over the "+3" badge and check the tooltip, before this fix it repeats "qa" even though it is already shown in the label, after this fix it only lists staging, production, monitoring

## Screenshots (if applicable)
Before (bug, "staging" repeated in tooltip even though already visible in the label):
<img width="276" height="163" alt="Screenshot from 2026-08-22 09-51-21" src="https://github.com/user-attachments/assets/9f6a905f-edeb-4d2b-8da3-9ad1c4c6c06f" />

After (fix, tooltip only lists namespaces that are actually hidden):
<img width="275" height="150" alt="Screenshot from 2026-08-22 09-49-43" src="https://github.com/user-attachments/assets/39472699-6cd5-4049-a07e-85600c4bee69" />



## Notes for the Reviewer
This only touches rendering logic inside `renderTags`, no props, state shape, or external behavior changed. Also considered adding a Storybook story that selects multiple namespaces since the existing story only covers an empty selection, which is likely why this went unnoticed for a while, happy to add that in this PR or a follow up if you'd prefer.