### PR TITLE
frontend: node: Show the node pool for Karpenter nodes

### DIFF
--- a/frontend/src/lib/k8s/node.test.ts
+++ b/frontend/src/lib/k8s/node.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import App from '../../App';
+import Node from './node';
+import { NODE_POOL_LABEL_KEYS } from './nodeConstants';
+
+// cyclic imports fix
+// eslint-disable-next-line no-unused-vars
+const _dont_delete_me = App;
+
+function makeNode(labels?: Record<string, string>) {
+  return new Node({
+    apiVersion: 'v1',
+    kind: 'Node',
+    metadata: {
+      name: 'test-node',
+      resourceVersion: '1',
+      ...(labels ? { labels } : {}),
+    },
+    spec: {},
+    status: {},
+  } as any);
+}
+
+describe('Node.getNodePool', () => {
+  const poolNames: Record<(typeof NODE_POOL_LABEL_KEYS)[number], string> = {
+    'cloud.google.com/gke-nodepool': 'gke-pool',
+    'kubernetes.azure.com/agentpool': 'aks-pool',
+    'eks.amazonaws.com/nodegroup': 'eks-managed-group',
+    'kops.k8s.io/instancegroup': 'kops-group',
+    'cluster.x-k8s.io/deployment-name': 'capi-deployment',
+    'karpenter.sh/nodepool': 'karpenter-pool',
+  };
+
+  it.each(NODE_POOL_LABEL_KEYS)('reads the pool name from %s', key => {
+    expect(makeNode({ [key]: poolNames[key] }).getNodePool()).toBe(poolNames[key]);
+  });
+
+  it('returns the karpenter pool for an EKS auto mode node', () => {
+    const node = makeNode({
+      'karpenter.sh/nodepool': 'general-purpose',
+      'node.kubernetes.io/instance-type': 'c6g.large',
+    });
+
+    expect(node.getNodePool()).toBe('general-purpose');
+  });
+
+  it('returns an empty string when no pool label is present', () => {
+    expect(makeNode({ 'node.kubernetes.io/instance-type': 'm5.large' }).getNodePool()).toBe('');
+  });
+
+  it('returns an empty string when the node has no labels', () => {
+    expect(makeNode().getNodePool()).toBe('');
+  });
+
+  it('prefers the provider label when a node also carries a karpenter label', () => {
+    const node = makeNode({
+      'eks.amazonaws.com/nodegroup': 'managed-group',
+      'karpenter.sh/nodepool': 'karpenter-pool',
+    });
+
+    expect(node.getNodePool()).toBe('managed-group');
+  });
+});

--- a/frontend/src/lib/k8s/node.ts
+++ b/frontend/src/lib/k8s/node.ts
@@ -146,7 +146,7 @@ class Node extends KubeObject<KubeNode> {
 
   /**
    * Returns the node pool name from well-known cloud provider labels.
-   * Supports GKE, AKS, EKS, kOps, and Cluster API.
+   * Supports GKE, AKS, EKS, kOps, Cluster API, and Karpenter.
    */
   getNodePool(): string {
     const labels = this.metadata.labels ?? {};

--- a/frontend/src/lib/k8s/nodeConstants.ts
+++ b/frontend/src/lib/k8s/nodeConstants.ts
@@ -26,4 +26,5 @@ export const NODE_POOL_LABEL_KEYS = [
   'eks.amazonaws.com/nodegroup',
   'kops.k8s.io/instancegroup',
   'cluster.x-k8s.io/deployment-name',
+  'karpenter.sh/nodepool',
 ] as const;

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -567,6 +567,7 @@
         "eks.amazonaws.com/nodegroup",
         "kops.k8s.io/instancegroup",
         "cluster.x-k8s.io/deployment-name",
+        "karpenter.sh/nodepool",
       ],
       "default": [Function],
     },


### PR DESCRIPTION
## Summary

This PR fixes the missing "Node Pool" column for EKS auto mode clusters by adding the `karpenter.sh/nodepool` label to the list of well-known node pool labels.

The column was not merely blank — it was omitted entirely. `Nodes` list view only adds the column when at least one node reports a pool (`hasNodePools` in `List.tsx`), and the node details row hides itself the same way (`hide: !nodePool` in `Details.tsx`). Both read `Node.getNodePool()`, which matched a known set of provider labels that did not include Karpenter's. On EKS auto mode every node returned an empty string, so neither view showed a pool.

## Related Issue

Fixes #7302

## Changes

- Added `karpenter.sh/nodepool` to `NODE_POOL_LABEL_KEYS` in `frontend/src/lib/k8s/nodeConstants.ts`
- Updated the `pluginLib` snapshot, which pins the exported constant
- Updated the `getNodePool()` doc comment to mention Karpenter
- Added `frontend/src/lib/k8s/node.test.ts`, the first test coverage for `getNodePool()`

The new key is appended **last** deliberately: `getNodePool()` returns the first matching label, so appending guarantees no precedence change for any existing provider. It also reads correctly, since Karpenter is not tied to a single cloud provider.

## Steps to Test

With an EKS auto mode cluster:

1. Connect to the cluster
2. Go to the Nodes list — the "Node Pool" column is now present and shows the Karpenter node pool (e.g. `general-purpose`)
3. Open a node's details page — the "Node Pool" row is now shown

Without such a cluster, the behaviour can be verified directly:

1. `cd frontend && npm test -- src/lib/k8s/node.test.ts` — 10 tests covering every label key, both empty cases, and label precedence
2. Or label any node with `karpenter.sh/nodepool=general-purpose` and confirm the column appears

## Notes for the Reviewer

- `nodeConstants.ts` is the single source of truth here; I searched the repo and there is no other hardcoded pool-label list. `NODE_DUMMY_DATA_NO_POOLS` in `storyHelper.ts` derives from the constant, so story fixtures needed no changes.
- `getNodePool()` previously had **no tests**, which is how a missing label key went unnoticed. The new expectations are keyed by `NODE_POOL_LABEL_KEYS` via a typed `Record`, so adding a future label key fails to compile until it is covered. (Verified: adding an unlisted key produces `TS2741`.)
- One test asserts that a node carrying both `eks.amazonaws.com/nodegroup` and `karpenter.sh/nodepool` resolves to the managed group. This combination does not occur in practice — auto mode nodes carry `eks.amazonaws.com/compute-type: auto`, not the nodegroup label — so it is there to document the "first match wins" precedence and guard against a silent reorder. Happy to drop it if you consider it noise.
- Karpenter's legacy `karpenter.sh/provisioner-name` (v1alpha5, deprecated 2023) is intentionally **not** included. Let me know if you would like it covered as well.
