### PR TITLE
frontend: ingress: Order ports by number

### DIFF
--- a/frontend/src/components/ingress/Details.test.tsx
+++ b/frontend/src/components/ingress/Details.test.tsx
@@ -98,6 +98,39 @@ const resourceIngress: any = {
   ],
 };
 
+const multiPortIngress: any = {
+  cluster: 'cluster-1',
+  spec: { tls: [{ hosts: ['example.com'], secretName: 'tls-secret' }] },
+  getAddresses: () => '',
+  getRules: () => [
+    {
+      http: {
+        paths: [
+          { backend: { service: { name: 'service1', port: { number: 8080 } } } },
+          { backend: { service: { name: 'service2', port: { number: 80 } } } },
+        ],
+      },
+    },
+  ],
+};
+
+const mixedPortIngress: any = {
+  cluster: 'cluster-1',
+  spec: { tls: [{ hosts: ['example.com'], secretName: 'tls-secret' }] },
+  getAddresses: () => '',
+  getRules: () => [
+    {
+      http: {
+        paths: [
+          { backend: { service: { name: 'service1', port: { number: 80 } } } },
+          { backend: { service: { name: 'service2', port: { name: 'someport' } } } },
+          { backend: { resource: { kind: 'Service', name: 'service1' } } },
+        ],
+      },
+    },
+  ],
+};
+
 describe('IngressDetails', () => {
   beforeEach(() => {
     mockDetailsGrid.mockReset();
@@ -135,6 +168,35 @@ describe('IngressDetails', () => {
     const classNameField = extraInfo.find((f: any) => String(f.name).includes('Class Name'));
     expect(classNameField).toBeDefined();
     expect((classNameField?.value as any)?.props?.children).toBe('nginx');
+  });
+
+  it('orders ports by number rather than by digit', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'test-ingress' }}>
+        <IngressDetails />
+      </TestContext>
+    );
+
+    const props = mockDetailsGrid.mock.calls[0][0];
+    const extraInfo = props.extraInfo(multiPortIngress);
+
+    const portsField = extraInfo.find((f: any) => String(f.name).includes('Ports'));
+    // A plain string sort puts 443 first, because '4' precedes '8'.
+    expect(portsField?.value).toBe('80, 443, 8080');
+  });
+
+  it('keeps named ports and resource backends alongside numbered ports', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'test-ingress' }}>
+        <IngressDetails />
+      </TestContext>
+    );
+
+    const props = mockDetailsGrid.mock.calls[0][0];
+    const extraInfo = props.extraInfo(mixedPortIngress);
+
+    const portsField = extraInfo.find((f: any) => String(f.name).includes('Ports'));
+    expect(portsField?.value).toBe('80, 443, Service:service1, someport');
   });
 
   it('includes TLS configuration in extraInfo when TLS is configured', () => {

--- a/frontend/src/components/ingress/Details.tsx
+++ b/frontend/src/components/ingress/Details.tsx
@@ -198,7 +198,11 @@ export default function IngressDetails(props: {
       ports.push('443');
     }
 
-    return ports.sort((a, b) => a.localeCompare(b));
+    // Most of these are port numbers held as strings, so a plain string compare
+    // orders 443 before 80. Numeric collation compares the digit runs as numbers
+    // and still handles the entries that are not numbers at all: a named service
+    // port such as "someport", or a "Kind:name" resource backend.
+    return ports.sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
   }
 
   function getDefaultBackend(item: Ingress) {

--- a/frontend/src/components/ingress/__snapshots__/Details.WithTLS.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.WithTLS.stories.storyshot
@@ -196,7 +196,7 @@
                     <span
                       class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
                     >
-                      443, 80, someport
+                      80, 443, someport
                     </span>
                   </dd>
                   <dt


### PR DESCRIPTION
The Ports row on an ingress details page is ordered by digit rather than by value. `getPorts`
turns each service port number into a string:

```ts
const portNumber = path.backend.service.port.number ?? path.backend.service.port.name ?? '';
ports.push(portNumber.toString());
```

and then sorts the strings:

```ts
return ports.sort((a, b) => a.localeCompare(b));
```

So an ingress serving 80, 443 and 8080 shows `443, 80, 8080`. The committed
`Details.WithTLS.stories.storyshot` records the same thing for the story fixture, which has a
path on port 80, a named port, and TLS:

```
443, 80, someport
```

Numeric collation fixes the ordering without giving up the non-numeric entries. `getPorts` also
pushes a named service port when `port.number` is absent, and `Kind:name` for a resource
backend, so a plain numeric comparator would produce `NaN` for those. `localeCompare` with
`{ numeric: true }` compares runs of digits as numbers and falls back to normal collation for
everything else, which gives `80, 443, someport`.

### Testing

Two tests in `Details.test.tsx`, using the existing `extraInfo` harness. Against the old
comparator they fail with:

```
expected '443, 80, 8080' to be '80, 443, 8080'
expected '443, 80, Service:service1, someport' to be '80, 443, Service:service1, someport'
```

The second one covers the mixed case, so a later change to a numeric-only comparator would fail
here rather than render `NaN`.

The `WithTLS` storyshot changes on one line, from `443, 80, someport` to `80, 443, someport`,
and is updated in this commit. `vitest run src/components/ingress/` passes, eslint and prettier
are clean, and `tsc --noEmit` reports nothing for these files.
