### PR TITLE
frontend: useKubeObject: Keep the watched cluster on live updates

### DIFF
--- a/frontend/src/lib/k8s/api/v2/hooks.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/hooks.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest';
 import { ApiError } from './ApiError';
@@ -434,6 +434,52 @@ describe('useKubeObject watch wiring', () => {
       expect(lastCall.enabled).toBe(true);
       expect(lastCall.url()).toContain('namespaces/my-ns');
     });
+  });
+
+  it('keeps the requested cluster on objects rebuilt from a watch update', async () => {
+    vi.stubEnv('REACT_APP_ENABLE_WEBSOCKET_MULTIPLEXER', 'false');
+    mockClusterFetch.mockResolvedValue(
+      mockJsonResponse({
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: { name: 'my-pod', namespace: 'my-ns', resourceVersion: '1' },
+      })
+    );
+
+    const { result } = renderHook(
+      () =>
+        useKubeObject({
+          kubeObjectClass: MockPod,
+          name: 'my-pod',
+          namespace: 'my-ns',
+          cluster: 'watched-cluster',
+        }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.data).toBeTruthy());
+    expect((result.current.data as any).cluster).toBe('watched-cluster');
+
+    const calls = mockUseWebSockets.mock.calls;
+    const { onMessage } = calls[calls.length - 1][0].connections[0];
+
+    act(() =>
+      onMessage({
+        type: 'MODIFIED',
+        object: {
+          apiVersion: 'v1',
+          kind: 'Pod',
+          metadata: { name: 'my-pod', namespace: 'my-ns', resourceVersion: '2' },
+        },
+      })
+    );
+
+    await waitFor(() =>
+      expect((result.current.data as any).jsonData.metadata.resourceVersion).toBe('2')
+    );
+    // The rebuilt object must still belong to the cluster this hook watches, not
+    // whichever cluster the constructor would otherwise fall back to.
+    expect((result.current.data as any).cluster).toBe('watched-cluster');
   });
 
   it('re-subscribes to the new resource when navigating between resources of the same kind', async () => {

--- a/frontend/src/lib/k8s/api/v2/hooks.ts
+++ b/frontend/src/lib/k8s/api/v2/hooks.ts
@@ -181,10 +181,15 @@ export function useKubeObject<K extends KubeObject>({
   const handleMessage = useCallback(
     (update: KubeListUpdateEvent<K>) => {
       if (update.type !== 'ADDED' && update.object) {
-        client.setQueryData(queryKey, new kubeObjectClass(update.object));
+        // Pass the cluster this hook was called with, the same way queryFn does.
+        // KubeObject's constructor falls back to `getCluster()` when it is omitted,
+        // which reads the cluster the user is currently viewing. That is the wrong
+        // one whenever this hook watches a different cluster, and `_clusterName` is
+        // what later delete, put and patch calls are addressed to.
+        client.setQueryData(queryKey, new kubeObjectClass(update.object, cluster));
       }
     },
-    [client, queryKey, kubeObjectClass]
+    [client, queryKey, kubeObjectClass, cluster]
   );
 
   const connectionsRequests = useMemo(() => {


### PR DESCRIPTION
Closes #7023.

`useKubeObject` builds objects with the cluster it was called with in its query function:

```ts
return new kubeObjectClass(obj, cluster) as Instance;
```

The watch handler a few lines below does not:

```ts
client.setQueryData(queryKey, new kubeObjectClass(update.object));
```

`KubeObject`'s constructor treats the missing argument as "use whatever cluster the user is
looking at":

```ts
this._clusterName = cluster || getCluster() || '';
```

and `getCluster()` reads the cluster out of the current URL, keeping only the first entry of a
multi-cluster path:

```ts
if (clusterString.includes('+')) {
  return clusterString.split('+')[0];
}
```

So on `/c/prod+staging/...`, an object being watched on `staging` is rebound to `prod` the
moment a `MODIFIED` event arrives. For a Pod that is usually seconds, since status and
conditions change constantly.

### Why the wrong cluster name matters

`_clusterName` is the cluster that `delete`, `update`, `patchUpdate` and `scale` address:

```ts
return this._class().apiEndpoint.delete(...args, params, this._clusterName);
```

and the details header passes the watched object straight to the action buttons:

```tsx
<Action item={resource} />
```

`DeleteButton` then binds `delete` to that object, so the request follows `_clusterName` rather
than the cluster the page was opened for:

```ts
let callback = item!.delete;
...
clusterAction(callback.bind(item), { ... })
```

The resource map is where the two can differ. It discovers across every selected cluster
(`apiDiscovery([...selectedClusters])`) and opens details for whichever cluster the clicked node
belongs to, passing it down explicitly:

```tsx
<Component name={name} namespace={namespace} cluster={cluster} />
```

That reaches `DetailsGrid`, which calls `useGet(name, namespace, { cluster })`. With two
clusters selected and the resource living in the second one, deleting from that panel can be
sent to the first.

A plain details page under a single-cluster URL is unaffected, because there `getCluster()`
happens to return the same cluster the hook was given. `EditButton` is also unaffected on the
write path: it watches with `cluster: item.cluster` but saves through the original `item`, so
only what it renders is affected.

I have read this through the code rather than reproduced it against two live clusters, so the
end-to-end claim is a trace, not a recording. The unit test covers the propagation directly.

### The fix

Pass `cluster` to the constructor in the watch handler, matching the query function, and add it
to the callback's dependencies.

### Testing

One test in `hooks.test.tsx`. It renders the hook against `watched-cluster`, waits for the
initial fetch, fires a `MODIFIED` event through the connection's `onMessage`, and asserts the
rebuilt object still reports `watched-cluster`. Against the old code it fails with:

```
expected undefined to be 'watched-cluster'
```

`vitest run src/lib/k8s/api/v2/` passes, 144 tests, and `src/components/common/Resource/` passes,
152 tests. eslint, prettier and `tsc --noEmit` are clean.
