### PR TITLE
backend: k8cache: Skip cache for requests with a query string

### DIFF
--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -3131,6 +3131,93 @@ func TestCacheMiddleware_CachesResourceNamedVersion(t *testing.T) {
 	assert.Equal(t, "true", resp2.Header.Get("X-HEADLAMP-CACHE"))
 }
 
+// TestCacheMiddleware_QueryBearingRequests checks the gate that decides which requests the
+// cache may handle. Cache keys are built from the path and context only, so a GET narrowed by
+// a query must bypass the cache entirely, while a mutation carrying a query must still reach
+// invalidation. An unconditional query bypass would satisfy the first case and break the second.
+func TestCacheMiddleware_QueryBearingRequests(t *testing.T) {
+	oldCache := k8sResponseCache
+	k8sResponseCache = cache.New[string]()
+
+	t.Cleanup(func() { k8sResponseCache = oldCache })
+
+	fakeK8s := newFakeK8sServer(true)
+	defer fakeK8s.Close()
+
+	c := newHeadlampConfig(fakeK8s, t.Name())
+
+	var (
+		mu   sync.Mutex
+		seen []string
+	)
+
+	proxyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+
+		seen = append(seen, r.Method+" "+r.URL.RawQuery)
+
+		mu.Unlock()
+
+		w.WriteHeader(http.StatusOK)
+
+		_, err := w.Write([]byte(fakeK8sResourceListResponse))
+		assert.NoError(t, err)
+	})
+
+	router := mux.NewRouter()
+	router.PathPrefix("/clusters/{clusterName}/{api:.*}").Handler(
+		CacheMiddleWare(c)(proxyHandler),
+	)
+
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	resourceURL := ts.URL + "/clusters/test/api/v1/namespaces/ns/configmaps"
+
+	requireQueryGetsBypassCache(t, resourceURL)
+
+	mu.Lock()
+	afterGets := len(seen)
+	mu.Unlock()
+
+	assert.Equal(t, 2, afterGets, "both query-bearing GETs must reach the proxy")
+
+	// A mutation carrying a query must still go through invalidation, which forwards the
+	// mutation and then issues its own queryless refresh.
+	resp, err := httpRequestWithContext(
+		context.Background(), resourceURL+"?pretty=true", http.MethodDelete,
+	)
+	require.NoError(t, err)
+
+	defer func() { _ = resp.Body.Close() }()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.Len(t, seen, 4, "the mutation and its refresh must both reach the proxy")
+	assert.Equal(t, http.MethodDelete+" pretty=true", seen[2])
+	assert.Equal(t, http.MethodGet+" ", seen[3], "the refresh must be queryless")
+}
+
+// requireQueryGetsBypassCache issues the same query-narrowed GET twice and asserts neither
+// response came from the cache, so repeating it always reaches the proxy.
+func requireQueryGetsBypassCache(t *testing.T, resourceURL string) {
+	t.Helper()
+
+	for range 2 {
+		resp, err := httpRequestWithContext(
+			context.Background(), resourceURL+"?labelSelector=app%3Dweb", http.MethodGet,
+		)
+		require.NoError(t, err)
+
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Empty(t, resp.Header.Get("X-HEADLAMP-CACHE"),
+			"a query-narrowed GET must not be served from the cache")
+	}
+}
+
 // TestCacheMiddleware_CacheHitAndCacheMiss test whether the k8s is storing into the cache
 // and returns the data if the data is present in the cache.
 func TestCacheMiddleware_CacheHitAndCacheMiss(t *testing.T) {

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -295,6 +295,11 @@ func cacheMiddlewareHandler(c *HeadlampConfig, next http.Handler, w http.Respons
 		return
 	}
 
+	if r.Method == http.MethodGet && k8cache.HasQueryParameters(r.URL) {
+		next.ServeHTTP(w, r)
+		return
+	}
+
 	ctx, span, contextKey, kContext, err := GetContextKeyAndKContext(w, r, c)
 	if err != nil {
 		return

--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -78,7 +78,12 @@ func HandleNonGETCacheInvalidation(k8scache cache.Cache[string], w http.Response
 
 	DeleteKeys(key, k8scache)
 
+	// The cache key is built from the path and context only, so the refreshed body must not be
+	// narrowed by a query. A mutation carrying labelSelector would otherwise store a filtered
+	// collection under the key a queryless GET reads.
 	freshURL := *r.URL
+	freshURL.RawQuery = ""
+	freshURL.ForceQuery = false
 
 	freshReq, err := http.NewRequestWithContext(r.Context(), http.MethodGet, freshURL.String(), nil) //nolint:gosec
 	if err != nil {

--- a/backend/pkg/k8cache/cacheInvalidation_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_test.go
@@ -882,3 +882,90 @@ func TestSyncWatchers(t *testing.T) {
 	assert.True(t, canceled["ctx2"], "ctx2 should be canceled")
 	assert.False(t, canceled["ctx3"], "ctx3 should not be canceled")
 }
+
+// TestHandleNonGETCacheInvalidation_PatchWithQueryStillInvalidates verifies that a
+// mutation carrying a query string still purges the cached entry. Headlamp appends
+// pretty=true to every PATCH and JSON Patch, so a query-bearing mutation must not
+// skip invalidation and leave a stale entry for the TTL.
+func TestHandleNonGETCacheInvalidation_PatchWithQueryStillInvalidates(t *testing.T) {
+	mockCache := NewMockCache()
+	targetURL := &url.URL{
+		Path:     "/clusters/kind/api/v1/namespaces/ns/configmaps/my-config",
+		RawQuery: "pretty=true",
+	}
+
+	cacheKey, err := k8cache.GenerateKey(targetURL, "ctx")
+	require.NoError(t, err)
+	require.NoError(t, mockCache.Set(context.Background(), cacheKey, `{"body":"stale"}`))
+
+	called := 0
+
+	var seen []string
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		called++
+
+		seen = append(seen, req.URL.RawQuery)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"kind":"ConfigMap"}`))
+	})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(
+		context.Background(), http.MethodPatch, targetURL.String(), nil,
+	)
+	r.URL = targetURL
+
+	err = k8cache.HandleNonGETCacheInvalidation(mockCache, w, r, next, "ctx")
+	assert.ErrorIs(t, err, k8cache.ErrHandled)
+	assert.Equal(t, 2, called, "original PATCH and fresh GET should both be forwarded")
+	require.Len(t, seen, 2)
+	assert.Equal(t, "pretty=true", seen[0], "the mutation itself keeps its query")
+	assert.Empty(t, seen[1], "the refresh must be queryless so it matches the path-only cache key")
+
+	cached, getErr := mockCache.Get(context.Background(), cacheKey)
+	if getErr == nil {
+		assert.NotContains(t, cached, "stale", "stale entry must not survive the mutation")
+	}
+}
+
+// TestHandleNonGETCacheInvalidation_RefreshDropsNarrowingQuery verifies that a mutation
+// carrying a collection-narrowing query does not refresh the cache from a filtered body.
+// The cache key is built from the path and context only, so a labelSelector on the refresh
+// would store a filtered list where a queryless GET expects the whole collection.
+func TestHandleNonGETCacheInvalidation_RefreshDropsNarrowingQuery(t *testing.T) {
+	mockCache := NewMockCache()
+	targetURL := &url.URL{
+		Path:     "/clusters/kind/api/v1/namespaces/ns/configmaps",
+		RawQuery: "labelSelector=app%3Dweb",
+	}
+
+	cacheKey, err := k8cache.GenerateKey(targetURL, "ctx")
+	require.NoError(t, err)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		body := `{"kind":"ConfigMapList","items":["all"]}`
+		if req.URL.RawQuery != "" {
+			body = `{"kind":"ConfigMapList","items":["filtered"]}`
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(
+		context.Background(), http.MethodDelete, targetURL.String(), nil,
+	)
+	r.URL = targetURL
+
+	err = k8cache.HandleNonGETCacheInvalidation(mockCache, w, r, next, "ctx")
+	assert.ErrorIs(t, err, k8cache.ErrHandled)
+
+	cached, getErr := mockCache.Get(context.Background(), cacheKey)
+	if getErr == nil {
+		assert.NotContains(t, cached, "filtered",
+			"the refresh must not store a query-narrowed body under the path-only key")
+	}
+}

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -62,6 +62,14 @@ func IsKubernetesAPIPath(path string) bool {
 	return kubernetesAPIPathIndex(parts) != -1
 }
 
+// HasQueryParameters returns true when the request URL carries a query string.
+// Cache keys are built from the request path and context only, so a request
+// whose query narrows or pages the response must not share a cache entry with
+// one that does not.
+func HasQueryParameters(u *url.URL) bool {
+	return u.RawQuery != ""
+}
+
 // CachedResponseData stores information such as StatusCode, Headers, and Body.
 // It helps cache responses efficiently and serve them from the cache.
 type CachedResponseData struct {

--- a/backend/pkg/k8cache/cacheStore_test.go
+++ b/backend/pkg/k8cache/cacheStore_test.go
@@ -1046,3 +1046,38 @@ func TestRedactCacheKey(t *testing.T) {
 		})
 	}
 }
+
+func TestHasQueryParameters(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      url.URL
+		expected bool
+	}{
+		{
+			name:     "plain list request",
+			url:      url.URL{Path: "/api/v1/namespaces/test-kube/pods"},
+			expected: false,
+		},
+		{
+			name:     "label selector",
+			url:      url.URL{Path: "/api/v1/namespaces/test-kube/pods", RawQuery: "labelSelector=app%3Dnginx"},
+			expected: true,
+		},
+		{
+			name:     "field selector",
+			url:      url.URL{Path: "/api/v1/namespaces/test-kube/pods", RawQuery: "fieldSelector=metadata.name%3Dmy-pod"},
+			expected: true,
+		},
+		{
+			name:     "paginated page",
+			url:      url.URL{Path: "/api/v1/namespaces/test-kube/pods", RawQuery: "limit=100&continue=TOKEN"},
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, k8cache.HasQueryParameters(&tc.url))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

With `--cache-enabled`, cache keys are built from the request path and context only, and the middleware gates on the path alone. Two GETs to the same resource differing only in their query therefore share one entry, and the first to populate it is served to the other for the 10 minute TTL.

Headlamp's own frontend sends response-narrowing queries to list endpoints — `labelSelector`, `fieldSelector`, `limit`, and `continue` for pagination — so this shows up as resources missing from a list, resources appearing that do not match a filter, or paging returning page 1 repeatedly.

Authorization is unaffected: `IsAllowed` still runs a `SelfSubjectAccessReview` per request, so a user is only served data they may read, just the wrong subset of it.

## Related Issue

Fixes #7401

## Changes

- Added `HasQueryParameters`, and skip the cache for requests that carry a query string, so a narrowed or paged response can never be served in place of another.
- Added a table test covering a plain list request, a label selector, a field selector and a paginated page.

Adding the query to the key was the other option, but three places parse keys with `strings.SplitN(key, "+", 4)` and require the context at `parts[3]`, so a fifth segment corrupts context extraction; `DeleteKeys` would also need to become prefix based or every query variant would be left stale after a mutation. Skipping is the smaller change and cannot serve a wrong body. Plain list requests carry no query and are still cached.

## Steps to Test

1. `cd backend && go test -count=1 -run TestHasQueryParameters ./pkg/k8cache/`
2. `cd backend && go test -count=1 ./pkg/k8cache/ ./cmd/`
3. Manually, with `--cache-enabled`: open a list view, then reload it with a label selector applied inside the TTL, and confirm the filtered view is no longer served the unfiltered body.
