### PR TITLE
i18n: enable MUI locale for Czech and Swedish

### DIFF
--- a/frontend/src/i18n/ThemeProviderNexti18n.test.tsx
+++ b/frontend/src/i18n/ThemeProviderNexti18n.test.tsx
@@ -15,6 +15,7 @@
  */
 
 import { createTheme } from '@mui/material/styles';
+import TablePagination from '@mui/material/TablePagination';
 import { act, render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 import ThemeProviderNexti18n from './ThemeProviderNexti18n';
@@ -89,5 +90,41 @@ describe('ThemeProviderNexti18n', () => {
 
     unmount();
     expect(mockI18n.off).toHaveBeenCalledWith('languageChanged', languageChanged);
+  });
+
+  it('applies Czech (cs) MUI localization', () => {
+    mockI18n.language = 'cs';
+
+    render(
+      <ThemeProviderNexti18n theme={createTheme()}>
+        <TablePagination
+          component="div"
+          count={100}
+          page={0}
+          rowsPerPage={10}
+          onPageChange={() => {}}
+        />
+      </ThemeProviderNexti18n>
+    );
+
+    expect(screen.getByText('Řádků na stránce:')).toBeInTheDocument();
+  });
+
+  it('applies Swedish (sv) MUI localization', () => {
+    mockI18n.language = 'sv';
+
+    render(
+      <ThemeProviderNexti18n theme={createTheme()}>
+        <TablePagination
+          component="div"
+          count={100}
+          page={0}
+          rowsPerPage={10}
+          onPageChange={() => {}}
+        />
+      </ThemeProviderNexti18n>
+    );
+
+    expect(screen.getByText('Rader per sida:')).toBeInTheDocument();
   });
 });

--- a/frontend/src/i18n/ThemeProviderNexti18n.tsx
+++ b/frontend/src/i18n/ThemeProviderNexti18n.tsx
@@ -16,6 +16,7 @@
 
 import {
   arSA,
+  csCZ,
   deDE,
   enUS,
   esES,
@@ -32,6 +33,7 @@ import {
   ptBR,
   ptPT,
   ruRU,
+  svSE,
   trTR,
   urPK,
   zhCN,
@@ -53,7 +55,7 @@ function getLocale(locale: string | undefined): typeof enUS {
 
   const LOCALES = {
     en: enUS,
-    cs: enUS, // @todo: material ui needs a translation for this.
+    cs: csCZ,
     hu: huHU,
     id: idID,
     nl: nlNL,
@@ -62,7 +64,7 @@ function getLocale(locale: string | undefined): typeof enUS {
     'pt-br': ptBR,
     ru: ruRU,
     es: esES,
-    sv: enUS, // @todo: material ui needs a translation for this.
+    sv: svSE,
     tr: trTR,
     de: deDE,
     ta: enUS, // @todo: material ui needs a translation for this.


### PR DESCRIPTION
cs and sv were falling back to enUS in Material-UI components because no locale mapping existed, even though @mui/material/locale already ships csCZ and svSE.

## Summary
This PR fixes a bug where Czech and Swedish users saw English text in standard Material-UI components (table pagination, date pickers, etc.) because no locale mapping existed for `cs` and `sv`, even though `@mui/material/locale` already ships `csCZ` and `svSE`.

## Related Issue
Fixes #7400

## Changes
- Imported `csCZ` and `svSE` from `@mui/material/locale` in `ThemeProviderNexti18n.tsx`
- Updated the `LOCALES` map: `cs: csCZ` and `sv: svSE`, replacing the previous `enUS` fallback for these two languages

## Steps to Test
1. Switch application language to Czech or Swedish.
2. Open a view with standard MUI components (e.g. a table with pagination, a date picker).
3. Confirm those components now render in Czech/Swedish instead of falling back to English.

## Screenshots (if applicable)
N/A — text-only locale change, no visual layout change.

## Notes for the Reviewer
- This touches the i18n layer but only affects MUI's built-in component translations (pagination labels, date picker text, etc.) — it does not touch Headlamp's own translation files under `frontend/src/i18n/locales/`.
- No new dependencies added; `csCZ`/`svSE` are already part of the installed `@mui/material` package.
