### PR TITLE
frontend: activity: Keep activities above sticky page content

### DIFF
--- a/frontend/src/components/activity/Activity.test.tsx
+++ b/frontend/src/components/activity/Activity.test.tsx
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import { Activity } from './Activity';
+import { act, render, screen } from '@testing-library/react';
+import { TestContext } from '../../test';
+import { ActivitiesRenderer, Activity, ACTIVITY_BASE_Z_INDEX } from './Activity';
 import { activitySlice, ActivityState } from './activitySlice';
 
 const { reducer, actions } = activitySlice;
@@ -146,5 +148,88 @@ describe('activitySlice', () => {
       const nextState = reducer(stateWithActivity, update(updatedActivity));
       expect(nextState.history).toEqual([]);
     });
+  });
+});
+
+describe('ActivitiesRenderer stacking order', () => {
+  /**
+   * z-index of the sticky resource details header, see the header Box in
+   * components/common/Resource/Resource.tsx. It is the highest stacking level used by
+   * page content inside `#main`, and `#main` is not a stacking context, so the activity
+   * layer has to stay above it.
+   */
+  const PAGE_CONTENT_STICKY_HEADER_Z_INDEX = 10;
+
+  /** Renders the activity layer in the same DOM shape the app layout uses. */
+  function renderActivityLayer(activities: Activity[]) {
+    const result = render(
+      <TestContext>
+        <div style={{ display: 'grid', position: 'relative' }}>
+          <div id="main" style={{ position: 'relative' }}>
+            <div
+              data-testid="sticky-details-header"
+              style={{ position: 'sticky', top: 0, zIndex: PAGE_CONTENT_STICKY_HEADER_Z_INDEX }}
+            >
+              Pod: some-pod
+            </div>
+          </div>
+          <ActivitiesRenderer />
+        </div>
+      </TestContext>
+    );
+
+    // Launching an activity also schedules a resize event so its content can adjust.
+    act(() => {
+      activities.forEach(activity => Activity.launch(activity));
+      vi.advanceTimersByTime(500);
+    });
+
+    return result;
+  }
+
+  /** z-index of the styled container of a named activity. */
+  const zIndexOf = (name: string) =>
+    Number(
+      getComputedStyle(screen.getByRole('complementary', { name }).firstElementChild as Element)
+        .zIndex
+    );
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1600 });
+  });
+
+  afterEach(() => {
+    act(() => {
+      Activity.reset();
+    });
+    vi.useRealTimers();
+  });
+
+  it('keeps the base stacking level above the sticky details header', () => {
+    expect(ACTIVITY_BASE_Z_INDEX).toBeGreaterThan(PAGE_CONTENT_STICKY_HEADER_Z_INDEX);
+  });
+
+  it('renders a fullscreen activity above the sticky details header', () => {
+    renderActivityLayer([
+      { id: 'logs-1', title: 'Logs', location: 'full', content: 'Log content' },
+    ]);
+
+    const headerZIndex = Number(
+      getComputedStyle(screen.getByTestId('sticky-details-header')).zIndex
+    );
+
+    expect(headerZIndex).toBe(PAGE_CONTENT_STICKY_HEADER_Z_INDEX);
+    expect(zIndexOf('Logs')).toBeGreaterThan(headerZIndex);
+  });
+
+  it('stacks later activities above earlier ones, all above page content', () => {
+    renderActivityLayer([
+      { id: 'logs-1', title: 'First', location: 'full', content: 'First' },
+      { id: 'logs-2', title: 'Second', location: 'full', content: 'Second' },
+    ]);
+
+    expect(zIndexOf('First')).toBeGreaterThan(PAGE_CONTENT_STICKY_HEADER_Z_INDEX);
+    expect(zIndexOf('Second')).toBeGreaterThan(zIndexOf('First'));
   });
 });

--- a/frontend/src/components/activity/Activity.tsx
+++ b/frontend/src/components/activity/Activity.tsx
@@ -90,6 +90,20 @@ export interface Activity {
   cluster?: string;
 }
 
+/**
+ * Base stacking level of the activity layer.
+ *
+ * Activities are rendered as siblings of the `#main` element, and `#main` is not a
+ * stacking context, so activities share a stacking context with the positioned page
+ * content inside it. The base therefore has to stay above that page content — most
+ * notably the sticky resource details header, which uses a z-index of 10 — otherwise
+ * the header paints over the activity and swallows clicks meant for its toolbar.
+ *
+ * It also has to stay well below the sidebar (1300) and the top bar (1400) so that
+ * navigation is never covered by an activity.
+ */
+export const ACTIVITY_BASE_Z_INDEX = 20;
+
 export const Activity = {
   /** Launches new Activity */
   launch(activity: Activity) {
@@ -381,7 +395,7 @@ export function SingleActivityRenderer({
             borderTop: 'none',
             borderBottom: 'none',
             willChange: 'top, left, width, height',
-            zIndex: zIndex ?? 3,
+            zIndex: zIndex ?? ACTIVITY_BASE_Z_INDEX,
             boxShadow:
               theme.palette.mode === 'light'
                 ? '0px 0px 15px rgba(0,0,0,0.15)'
@@ -1122,7 +1136,7 @@ export const ActivitiesRenderer = React.memo(function ActivitiesRenderer() {
         <SingleActivityRenderer
           key={it.id}
           activity={it}
-          zIndex={4 + history.indexOf(it.id)}
+          zIndex={ACTIVITY_BASE_Z_INDEX + history.indexOf(it.id)}
           index={i}
           isOverview={isOverview}
           onClick={() => {

--- a/frontend/src/components/activity/__snapshots__/Activity.Basic.stories.storyshot
+++ b/frontend/src/components/activity/__snapshots__/Activity.Basic.stories.storyshot
@@ -16,7 +16,7 @@
         role="complementary"
       >
         <div
-          class="MuiBox-root css-eyh8nb"
+          class="MuiBox-root css-18sl0ya"
         >
           <div
             class="MuiBox-root css-ha4r1w"
@@ -79,7 +79,7 @@
         role="complementary"
       >
         <div
-          class="MuiBox-root css-1u6as83"
+          class="MuiBox-root css-1pdmtyx"
         >
           <div
             class="MuiBox-root css-ha4r1w"

--- a/frontend/src/components/activity/__snapshots__/Activity.ResponsiveContent.stories.storyshot
+++ b/frontend/src/components/activity/__snapshots__/Activity.ResponsiveContent.stories.storyshot
@@ -16,7 +16,7 @@
         role="complementary"
       >
         <div
-          class="MuiBox-root css-eyh8nb"
+          class="MuiBox-root css-18sl0ya"
         >
           <div
             class="MuiBox-root css-ha4r1w"
@@ -89,7 +89,7 @@
         role="complementary"
       >
         <div
-          class="MuiBox-root css-1u6as83"
+          class="MuiBox-root css-1pdmtyx"
         >
           <div
             class="MuiBox-root css-ha4r1w"
@@ -162,7 +162,7 @@
         role="complementary"
       >
         <div
-          class="MuiBox-root css-1j4p9ms"
+          class="MuiBox-root css-lc6eec"
         >
           <div
             class="MuiBox-root css-ha4r1w"


### PR DESCRIPTION
## Summary

Fixes the Logs and Terminal toolbars being unclickable on resource details pages,
by moving the activity layer above the page content it shares a stacking context
with.

## Related Issue

Fixes #7410

## How to Reproduce (before this change)

1. Check out `main` and open a cluster in a browser window at least ~600px wide.
2. Go to Workloads > Pods and open any pod's details page.
3. Click "Show Logs" in the details header toolbar.
4. The pod's details header is still drawn over the top edge of the activity.
5. Click the container dropdown, or any switch next to it — nothing happens, the
   clicks land on the page header behind it. Scrolling the page first does not
   help.
6. Same with "Terminal" and its container selector.

## Root Cause

- Activities render as siblings of `#main`, which has `position: relative` and no
  `z-index` — so it is not a stacking context and activities compete directly
  with the positioned content inside it.
- The activity container used `z-index: 4`; the sticky resource details header
  uses `z-index: 10`. The header therefore painted over the activity and
  swallowed clicks meant for its toolbar.
- The header is only `position: sticky` from the `sm` breakpoint up, which is why
  this shows at viewport widths of about 600px and above, and only on details
  pages that render header sections.

## Changes

- `Activity.tsx`: added `ACTIVITY_BASE_Z_INDEX = 20` and used it for both the
  activity container default and the per-activity stacking level in
  `ActivitiesRenderer`, replacing the hardcoded 3/4.
- 20 sits above every stacking level used by page content inside `#main`, and
  still far below the sidebar (1300) and top bar (1400), so navigation is never
  covered by an activity.
- `Activity.test.tsx`: stacking-order tests that render the activity layer in the
  same DOM shape the app layout uses — a `#main` with a sticky `z-index: 10`
  header, plus the activity renderer as its sibling — and assert the activity
  ends up above it, and that later activities stack above earlier ones.
- Regenerated the two activity storyshots; the only change is the emotion class
  hash the new z-index value produces.

## Steps to Test

1. Follow the reproduction steps above on this branch.
2. The activity is now drawn above the details header. Open the container
   dropdown and toggle "Previous", "Timestamps", "Follow" and "Wrap lines" — all
   respond, before and after scrolling the page.
3. Repeat with "Terminal" and check its container selector.
4. Check nothing else moved: sidebar links, top bar (settings, account menu) and
   the activity taskbar still take clicks with an activity open, and overview
   mode (Ctrl+Down) looks unchanged.

## Testing Done

- New tests fail with `expected 4 to be greater than 10` if the constant is put
  back to its old value, so they do guard the fix.
- Checked the steps above against a kind cluster on a crash-looping pod. Before:
  every log toolbar control was covered by the details header and ignored clicks,
  both at the top of the page and after scrolling. After: all reachable, the
  container dropdown opens, and "Previous" loads the previous container's logs.
  Terminal's container selector behaves the same.
- Below the `sm` breakpoint behaviour is unchanged, since the header is not
  sticky there.
- Sidebar, top bar, taskbar and overview mode all unaffected with a fullscreen
  activity open.
- `npx vitest run` (234 files, 3108 tests), `tsc --noEmit`, ESLint and Prettier
  all pass.

## Notes for the Reviewer

- The z-index literal is what the two storyshot diffs are about — hash-only
  changes.
- I picked 20 rather than something larger to leave the existing ordering against
  the sidebar and top bar untouched.
- I considered `isolation: isolate` on `#main` instead, but `AlertNotification`
  (1099), `Chart` (1500) and `PerformanceStats` (1300) render inside `#main`, and
  isolating it would change how those paint relative to the sidebar and top bar.
