### PR TITLE
frontend: parse lowercase k in parseRam/parseDiskSpace

### DIFF
--- a/frontend/src/lib/units.test.ts
+++ b/frontend/src/lib/units.test.ts
@@ -35,6 +35,12 @@ describe('parseRam', () => {
     expect(parseRam('1G')).toBe(1000000000);
   });
 
+  it('should parse lowercase decimal kilo (k) the same as uppercase K', () => {
+    expect(parseRam('1k')).toBe(1000);
+    expect(parseRam('500k')).toBe(500000);
+    expect(parseRam('1024k')).toBe(1024000);
+  });
+
   it('should parse milli-bytes suffix (m)', () => {
     expect(parseRam('1000m')).toBe(1);
     expect(parseRam('11973899059200m')).toBe(11973899059.2);
@@ -92,11 +98,15 @@ describe('parseRam', () => {
 
   it('should always return non-negative values', () => {
     fc.assert(
-      fc.property(fc.nat(), fc.constantFrom('', 'K', 'M', 'G', 'Ki', 'Mi', 'Gi'), (num, unit) => {
-        const input = `${num}${unit}`;
-        const result = parseRam(input);
-        expect(result).toBeGreaterThanOrEqual(0);
-      })
+      fc.property(
+        fc.nat(),
+        fc.constantFrom('', 'K', 'k', 'M', 'G', 'Ki', 'Mi', 'Gi'),
+        (num, unit) => {
+          const input = `${num}${unit}`;
+          const result = parseRam(input);
+          expect(result).toBeGreaterThanOrEqual(0);
+        }
+      )
     );
   });
 });

--- a/frontend/src/lib/units.ts
+++ b/frontend/src/lib/units.ts
@@ -44,7 +44,7 @@ function parseUnitsOfBytes(value: string): number {
     return parseFloat(value.slice(0, -1)) / 1000;
   }
 
-  const groups = value.match(/(\d+(?:\.\d+)?)([BKMGTPEe])?(i)?(\d+)?/) || [];
+  const groups = value.match(/(\d+(?:\.\d+)?)(k(?!i)|[BKMGTPEe])?(i)?(\d+)?/) || [];
   const number = parseFloat(groups[1]);
 
   // number ex. 1000
@@ -57,7 +57,10 @@ function parseUnitsOfBytes(value: string): number {
     return number * 10 ** parseInt(groups[4], 10);
   }
 
-  const unitIndex = _.indexOf(UNITS, groups[2]);
+  // Per the Kubernetes quantity spec, decimal kilo is lowercase "k" while
+  // the other decimal suffixes (M, G, T, P, E) are uppercase.
+  const unit = groups[2] === 'k' ? 'K' : groups[2];
+  const unitIndex = _.indexOf(UNITS, unit);
 
   // Unit + i ex. 1Ki
   if (groups[3] !== undefined) {


### PR DESCRIPTION
Fixes #7422.

`parseUnitsOfBytes` (behind `parseRam`/`parseDiskSpace`) only matched an uppercase `K`, so `500k` came out as `500` instead of `500000` - lowercase decimal kilo per the k8s quantity spec, everything else (M/G/T/P/E) was already correct.

Added `k` to the suffix character class and normalize it to `K` right before the `UNITS` lookup, so it scales through the exact same `1000 ** unitIndex` path as `K` does. Left the exponent branch (`1e3`) alone since that's handled earlier and doesn't touch this.

`normalizeUnit` in `util.ts` already parses `k` correctly and was the reference for what the output should be.

Added tests for `1k`/`500k`/`1024k`, and threw lowercase `k` into the existing property-based non-negative-value check. `npm run tsc`, lint, all clean on the touched files.
