### PR TITLE
frontend: Fix react-hooks/exhaustive-deps in cluster and k8s api

### DIFF
--- a/frontend/src/components/cluster/Chooser.tsx
+++ b/frontend/src/components/cluster/Chooser.tsx
@@ -398,39 +398,38 @@ function Chooser(props: ClusterDialogProps) {
   const [show, setShow] = React.useState(props.open);
   const { t } = useTranslation();
 
-  React.useEffect(
-    () => {
-      if (open !== null && open !== show) {
-        setShow(open);
-        return;
+  const handleButtonClick = React.useCallback(
+    (cluster: Cluster) => {
+      if (cluster.name !== getCluster()) {
+        setRecentCluster(cluster);
+        history.push({
+          pathname: generatePath(getClusterPrefixedPath(), {
+            cluster: cluster.name,
+          }),
+        });
       }
 
-      // If we only have one cluster configured, then we skip offering
-      // the choice to the user.
-      if (!!clusters && Object.keys(clusters).length === 1) {
-        handleButtonClick(Object.values(clusters)[0]);
+      setShow(false);
+
+      if (!!onClose) {
+        onClose();
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [open, show, clusters]
+    [history, onClose]
   );
 
-  function handleButtonClick(cluster: Cluster) {
-    if (cluster.name !== getCluster()) {
-      setRecentCluster(cluster);
-      history.push({
-        pathname: generatePath(getClusterPrefixedPath(), {
-          cluster: cluster.name,
-        }),
-      });
+  React.useEffect(() => {
+    if (open !== null && open !== show) {
+      setShow(open);
+      return;
     }
 
-    setShow(false);
-
-    if (!!onClose) {
-      onClose();
+    // If we only have one cluster configured, then we skip offering
+    // the choice to the user.
+    if (!!clusters && Object.keys(clusters).length === 1) {
+      handleButtonClick(Object.values(clusters)[0]);
     }
-  }
+  }, [open, show, clusters, handleButtonClick]);
 
   function handleClose() {
     if (open === null) {

--- a/frontend/src/lib/k8s/api/v2/hooks.ts
+++ b/frontend/src/lib/k8s/api/v2/hooks.ts
@@ -134,10 +134,10 @@ export function useKubeObject<K extends KubeObject>({
 
   const queryParamsString = JSON.stringify(queryParams);
   const cleanedUpQueryParams = useMemo(() => {
+    const params = queryParamsString ? JSON.parse(queryParamsString) : {};
     return Object.fromEntries(
-      Object.entries(queryParams ?? {}).filter(([, value]) => value !== undefined && value !== '')
+      Object.entries(params).filter(([, value]) => value !== undefined && value !== '')
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [queryParamsString]);
 
   const queryKey = useMemo(

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -722,8 +722,7 @@ export function useKubeObjectList<K extends KubeObject>({
             )
           )
         : [],
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [activeListRequests, kubeObjectClass, endpoint, perRequestQueryParams]
+    [activeListRequests, kubeObjectClass, endpoint, perRequestQueryParams, refetchInterval]
   );
 
   const query = useQueries({


### PR DESCRIPTION
**Summary:**
frontend: Fix `react-hooks/exhaustive-deps` in cluster Chooser and k8s api/v2 hooks.

**Related Issue:**
(Include the issue number if applicable)

**Changes:**
- `frontend/src/components/cluster/Chooser.tsx`: Wrapped `handleButtonClick` in `useCallback` and added it to dependencies. Removed `eslint-disable` comment.
- `frontend/src/lib/k8s/api/v2/hooks.ts`: Parsed `queryParamsString` internally instead of relying on the unstable `queryParams` reference. Removed `eslint-disable` comment.
- `frontend/src/lib/k8s/api/v2/useKubeObjectList.ts`: Added missing `refetchInterval` dependency to `useMemo`. Removed `eslint-disable` comment.

**Steps to Test:**
1. Run `npm run frontend:lint` to verify that there are no `exhaustive-deps` errors.
2. Run `npm run frontend:test` to verify that all unit tests pass.
3. Test the application UI (e.g., Cluster Chooser popup) to ensure the cluster selection continues to work properly.
