### PR TITLE
fix(frontend): prevent unrestricted useApiList when namespace restriction is empty

### DIFF
--- a/frontend/src/lib/k8s/KubeObject.test.ts
+++ b/frontend/src/lib/k8s/KubeObject.test.ts
@@ -15,14 +15,26 @@
  */
 
 import { renderHook } from '@testing-library/react';
-import { vi } from 'vitest';
+import { type MockInstance, vi } from 'vitest';
+import {
+  getCombinedAllowedNamespaces,
+  hasAllowedNamespacesRestriction,
+} from '../../helpers/clusterSettings';
+import { getCluster } from '../cluster';
+import { useConnectApi, useSelectedClusters } from './api/v1/hooks';
+import { makeListRequests, useKubeObjectList } from './api/v2/useKubeObjectList';
+import { KubeObject } from './KubeObject';
 
 vi.mock('../cluster', () => ({
   formatClusterPathParam: vi.fn(),
   getCluster: vi.fn(),
   getSelectedClusters: vi.fn(),
 }));
-vi.mock('../../helpers/clusterSettings', () => ({ loadClusterSettings: vi.fn() }));
+vi.mock('../../helpers/clusterSettings', () => ({
+  loadClusterSettings: vi.fn(),
+  getCombinedAllowedNamespaces: vi.fn(() => []),
+  hasAllowedNamespacesRestriction: vi.fn(() => false),
+}));
 vi.mock('../router/createRouteURL', () => ({ createRouteURL: vi.fn() }));
 vi.mock('../util', () => ({ timeAgo: vi.fn() }));
 vi.mock('./api/v1/clusterRequests', () => ({ post: vi.fn() }));
@@ -43,10 +55,6 @@ vi.mock('./patchUtils', () => ({
   computePatchOperations: vi.fn(),
   computeRawPatchCount: vi.fn(),
 }));
-
-import { useSelectedClusters } from './api/v1/hooks';
-import { makeListRequests, useKubeObjectList } from './api/v2/useKubeObjectList';
-import { KubeObject } from './KubeObject';
 
 describe('KubeObject', () => {
   beforeEach(() => {
@@ -118,5 +126,205 @@ describe('KubeObject', () => {
         requests: [{ cluster: 'cluster-a', namespaces: undefined }],
       })
     );
+  });
+});
+
+describe('KubeObject.useApiList namespace restriction', () => {
+  class NamespacedResource extends KubeObject {
+    static apiVersion = 'v1';
+    static apiName = 'pods';
+    static kind = 'Pod';
+    static isNamespaced = true;
+  }
+
+  class ClusterScopedResource extends KubeObject {
+    static apiVersion = 'v1';
+    static apiName = 'nodes';
+    static kind = 'Node';
+    static isNamespaced = false;
+  }
+
+  // Stub apiList so the tests never touch the (mocked) apiEndpoint and can count the
+  // list requests that useApiList decides to make.
+  let apiListSpy: MockInstance;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getCluster).mockReturnValue('my-cluster');
+    vi.mocked(getCombinedAllowedNamespaces).mockReturnValue([]);
+    vi.mocked(hasAllowedNamespacesRestriction).mockReturnValue(false);
+    apiListSpy = vi
+      .spyOn(KubeObject, 'apiList')
+      .mockImplementation(() => () => Promise.resolve(() => {}));
+  });
+
+  afterEach(() => {
+    apiListSpy.mockRestore();
+  });
+
+  /** The namespace passed to each apiList call, in order (undefined for a cluster-wide list). */
+  function requestedNamespaces(): Array<string | undefined> {
+    return apiListSpy.mock.calls.map(
+      call => (call[2] as { namespace?: string } | undefined)?.namespace
+    );
+  }
+
+  /** How many list-call thunks were handed to useConnectApi on the single render. */
+  function connectedCallCount(): number {
+    const mockUseConnectApi = vi.mocked(useConnectApi);
+    expect(mockUseConnectApi).toHaveBeenCalledTimes(1);
+    return mockUseConnectApi.mock.calls[0].length;
+  }
+
+  it('performs a single cluster-wide list when there is no namespace restriction', () => {
+    renderHook(() => NamespacedResource.useApiList(() => {}));
+
+    expect(apiListSpy).toHaveBeenCalledTimes(1);
+    expect(requestedNamespaces()).toEqual([undefined]);
+    expect(connectedCallCount()).toBe(1);
+  });
+
+  it('lists each explicitly requested namespace', () => {
+    renderHook(() =>
+      NamespacedResource.useApiList(() => {}, undefined, { namespace: ['ns-a', 'ns-b'] })
+    );
+
+    expect(apiListSpy).toHaveBeenCalledTimes(2);
+    expect(requestedNamespaces()).toEqual(['ns-a', 'ns-b']);
+    expect(connectedCallCount()).toBe(2);
+  });
+
+  it('lists each allowed namespace when a restriction resolves to namespaces', () => {
+    vi.mocked(hasAllowedNamespacesRestriction).mockReturnValue(true);
+    vi.mocked(getCombinedAllowedNamespaces).mockReturnValue(['allowed-a', 'allowed-b']);
+
+    renderHook(() => NamespacedResource.useApiList(() => {}));
+
+    expect(apiListSpy).toHaveBeenCalledTimes(2);
+    expect(requestedNamespaces()).toEqual(['allowed-a', 'allowed-b']);
+    expect(connectedCallCount()).toBe(2);
+  });
+
+  it('calls onList([]) and issues no request when an allowed-namespaces restriction resolves empty (fail closed)', () => {
+    vi.mocked(hasAllowedNamespacesRestriction).mockReturnValue(true);
+    vi.mocked(getCombinedAllowedNamespaces).mockReturnValue([]);
+    const onList = vi.fn();
+
+    renderHook(() => NamespacedResource.useApiList(onList));
+
+    // No unrestricted cluster-wide fallback: no list thunks are ever connected.
+    expect(apiListSpy).not.toHaveBeenCalled();
+    const mockUseConnectApi = vi.mocked(useConnectApi);
+    expect(mockUseConnectApi.mock.calls.every(call => call.length === 0)).toBe(true);
+    // Consumer is explicitly notified with an empty list so stale objects are cleared.
+    expect(onList).toHaveBeenCalledWith([]);
+  });
+
+  it('clears stale objects when the restriction transitions from non-empty to empty (regression)', () => {
+    // Start with a non-empty restriction so the first render produces results.
+    vi.mocked(hasAllowedNamespacesRestriction).mockReturnValue(true);
+    vi.mocked(getCombinedAllowedNamespaces).mockReturnValue(['ns-a']);
+    const onList = vi.fn();
+
+    const { rerender } = renderHook(() => NamespacedResource.useApiList(onList));
+
+    // First render: one request for 'ns-a'.
+    expect(apiListSpy).toHaveBeenCalledTimes(1);
+    expect(requestedNamespaces()).toEqual(['ns-a']);
+
+    // Now the restriction resolves to zero namespaces (e.g. RBAC changed).
+    vi.mocked(getCombinedAllowedNamespaces).mockReturnValue([]);
+
+    vi.clearAllMocks();
+    // Reset spy so connectedCallCount reflects only the second render.
+    apiListSpy = vi
+      .spyOn(KubeObject, 'apiList')
+      .mockImplementation(() => () => Promise.resolve(() => {}));
+
+    rerender();
+
+    // No unrestricted fallback request must be made.
+    expect(apiListSpy).not.toHaveBeenCalled();
+    // No list thunks are connected in any render after the transition.
+    const mockUseConnectApi = vi.mocked(useConnectApi);
+    expect(mockUseConnectApi.mock.calls.every(call => call.length === 0)).toBe(true);
+    // The consumer must be notified with [] so stale objects are not retained.
+    expect(onList).toHaveBeenCalledWith([]);
+  });
+
+  it('performs a single cluster-wide list for cluster-scoped resources even under a restriction', () => {
+    vi.mocked(hasAllowedNamespacesRestriction).mockReturnValue(true);
+    vi.mocked(getCombinedAllowedNamespaces).mockReturnValue([]);
+
+    renderHook(() => ClusterScopedResource.useApiList(() => {}));
+
+    expect(apiListSpy).toHaveBeenCalledTimes(1);
+    expect(requestedNamespaces()).toEqual([undefined]);
+    expect(connectedCallCount()).toBe(1);
+  });
+
+  // Multi-cluster regression tests (opts.cluster vs getCluster)
+
+  it('applies restriction from the current cluster when no opts.cluster is given', () => {
+    // Current cluster ("my-cluster") is restricted.
+    vi.mocked(getCombinedAllowedNamespaces).mockImplementation(cluster =>
+      cluster === 'my-cluster' ? ['ns-current'] : []
+    );
+    vi.mocked(hasAllowedNamespacesRestriction).mockImplementation(
+      cluster => cluster === 'my-cluster'
+    );
+
+    renderHook(() => NamespacedResource.useApiList(() => {}));
+
+    expect(apiListSpy).toHaveBeenCalledTimes(1);
+    expect(requestedNamespaces()).toEqual(['ns-current']);
+    expect(connectedCallCount()).toBe(1);
+  });
+
+  it('applies restriction from opts.cluster when current cluster is unrestricted', () => {
+    // Current cluster is unrestricted, but opts.cluster ("remote") is restricted.
+    vi.mocked(getCombinedAllowedNamespaces).mockImplementation(cluster =>
+      cluster === 'remote' ? ['ns-remote'] : []
+    );
+    vi.mocked(hasAllowedNamespacesRestriction).mockImplementation(cluster => cluster === 'remote');
+
+    renderHook(() => NamespacedResource.useApiList(() => {}, undefined, { cluster: 'remote' }));
+
+    expect(apiListSpy).toHaveBeenCalledTimes(1);
+    expect(requestedNamespaces()).toEqual(['ns-remote']);
+    expect(connectedCallCount()).toBe(1);
+  });
+
+  it('does unrestricted list on opts.cluster when only the current cluster is restricted', () => {
+    // Current cluster is restricted, but opts.cluster ("remote") is unrestricted.
+    vi.mocked(getCombinedAllowedNamespaces).mockImplementation(cluster =>
+      cluster === 'my-cluster' ? ['ns-current'] : []
+    );
+    vi.mocked(hasAllowedNamespacesRestriction).mockImplementation(
+      cluster => cluster === 'my-cluster'
+    );
+
+    renderHook(() => NamespacedResource.useApiList(() => {}, undefined, { cluster: 'remote' }));
+
+    // "remote" has no restriction, so a single cluster-wide list is expected.
+    expect(apiListSpy).toHaveBeenCalledTimes(1);
+    expect(requestedNamespaces()).toEqual([undefined]);
+    expect(connectedCallCount()).toBe(1);
+  });
+
+  it('fails closed on opts.cluster when its restriction resolves empty', () => {
+    // Current cluster is unrestricted, opts.cluster ("remote") has a restriction
+    // that resolves to zero namespaces.
+    vi.mocked(getCombinedAllowedNamespaces).mockReturnValue([]);
+    vi.mocked(hasAllowedNamespacesRestriction).mockImplementation(cluster => cluster === 'remote');
+    const onList = vi.fn();
+
+    renderHook(() => NamespacedResource.useApiList(onList, undefined, { cluster: 'remote' }));
+
+    // Fail closed: no requests, but consumer is notified with [] to clear stale objects.
+    expect(apiListSpy).not.toHaveBeenCalled();
+    const mockUseConnectApi = vi.mocked(useConnectApi);
+    expect(mockUseConnectApi.mock.calls.every(call => call.length === 0)).toBe(true);
+    expect(onList).toHaveBeenCalledWith([]);
   });
 });

--- a/frontend/src/lib/k8s/KubeObject.ts
+++ b/frontend/src/lib/k8s/KubeObject.ts
@@ -350,9 +350,30 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
 
     // If the request itself has no namespaces set, we check whether to apply the
     // allowed namespaces.
+    let restrictedToNoNamespaces = false;
     if (namespaces.length === 0 && this.isNamespaced) {
-      namespaces = getAllowedNamespaces();
+      const restrictionCluster = cluster ?? getCluster();
+      namespaces = getAllowedNamespaces(restrictionCluster);
+
+      // An active allowed-namespaces restriction that currently resolves to no
+      // namespaces must fail closed: issue no request rather than falling back to an
+      // unrestricted cluster-wide list. This mirrors makeListRequests (see #7361, #7382).
+      // The restriction is checked against the same cluster used for the list request.
+      restrictedToNoNamespaces =
+        namespaces.length === 0 && hasAllowedNamespacesRestriction(restrictionCluster ?? '');
     }
+
+    // When restricted to zero namespaces, clear any accumulated state and notify
+    // the consumer with an empty list so stale objects are not left visible.
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    React.useEffect(() => {
+      if (restrictedToNoNamespaces) {
+        setObjs({});
+        listCallback([]);
+      }
+      // listCallback intentionally omitted: it's a new function reference every render.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [restrictedToNoNamespaces]);
 
     if (namespaces.length > 0) {
       // If we have a namespace set, then we have to make an API call for each
@@ -366,7 +387,7 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
           })
         );
       }
-    } else {
+    } else if (!restrictedToNoNamespaces) {
       // If we don't have a namespace set, then we only have one API call
       // response to set and we return it right away.
       listCalls.push(this.apiList(listCallback, onError, { queryParams, cluster }));


### PR DESCRIPTION
## Summary

Fixes #7382.

`KubeObject.useApiList` could fall back to an unrestricted cluster-wide
LIST request when an active allowed-namespaces restriction resolved to
zero namespaces.

This caused the namespace restriction to fail open for callers using
the public `useApiList` API.

## Changes

- Detect when an allowed-namespaces restriction is active but resolves
  to zero namespaces.
- Skip the unrestricted cluster-wide fallback in that case.
- Preserve existing behavior for:
  - unrestricted namespaced resources
  - explicitly requested namespaces
  - non-empty namespace restrictions
  - cluster-scoped resources
- Add regression tests covering the namespace restriction cases.

The behavior mirrors the fail-closed handling introduced by #7361.

## Testing

- `npx vitest run src/lib/k8s/KubeObject.test.ts`
- `npx vitest run src/lib/k8s/allowedNamespaces.test.ts src/lib/k8s/api/v2/useKubeObjectList.test.tsx`
- `npx vitest run src/lib/k8s`
- `npx eslint -c package.json` on changed files
- `npm run tsc`

All tests and checks pass.