### PR TITLE
0023: frontend: storybook: Expand apps workload mock coverage

### DIFF
--- a/e2e-tests/tests/workloads.spec.ts
+++ b/e2e-tests/tests/workloads.spec.ts
@@ -39,6 +39,7 @@ const appsWorkloads = [
       numberAvailable: 1,
       numberReady: 1,
     },
+    expectedText: 'kubernetes.io/os: linux',
   },
   {
     resource: 'deployments',
@@ -55,10 +56,12 @@ const appsWorkloads = [
     },
     status: {
       availableReplicas: 1,
+      conditions: [{ type: 'Available', status: 'True', message: 'Deployment is available' }],
       readyReplicas: 1,
       replicas: 1,
       updatedReplicas: 1,
     },
+    expectedText: 'Available',
   },
   {
     resource: 'replicasets',
@@ -79,6 +82,7 @@ const appsWorkloads = [
       readyReplicas: 1,
       replicas: 1,
     },
+    expectedText: 'replica-server',
   },
   {
     resource: 'statefulsets',
@@ -102,6 +106,7 @@ const appsWorkloads = [
       updateRevision: 'database-1',
       updatedReplicas: 1,
     },
+    expectedText: '1/1',
   },
 ];
 
@@ -156,13 +161,19 @@ const batchWorkloads = [
   },
 ];
 
-test('loads apps workload list pages', async ({ page }) => {
-  const requestedResources = new Set<string>();
-
-  for (const workload of appsWorkloads) {
-    const collectionUrl = new RegExp(`/clusters/test/apis/apps/v1/${workload.resource}(?:\\?.*)?$`);
+for (const workload of appsWorkloads) {
+  test(`loads the ${workload.kind} list page`, async ({ page }) => {
+    let requestSeen = false;
+    const collectionUrl = new RegExp(
+      `/clusters/test/apis/apps/v1/(?:namespaces/[^/]+/)?${workload.resource}(?:\\?.*)?$`
+    );
     await page.route(collectionUrl, async route => {
-      requestedResources.add(workload.resource);
+      requestSeen = true;
+      const namespaceMatch = new URL(route.request().url()).pathname.match(
+        /\/namespaces\/([^/]+)\//
+      );
+      const namespace = namespaceMatch ? decodeURIComponent(namespaceMatch[1]) : 'default';
+
       await route.fulfill({
         json: {
           apiVersion: 'apps/v1',
@@ -174,7 +185,7 @@ test('loads apps workload list pages', async ({ page }) => {
               kind: workload.kind,
               metadata: {
                 name: workload.name,
-                namespace: 'default',
+                namespace,
                 resourceVersion: '1',
                 creationTimestamp: '2026-01-01T00:00:00Z',
                 uid: `${workload.resource}-uid`,
@@ -186,19 +197,19 @@ test('loads apps workload list pages', async ({ page }) => {
         },
       });
     });
-  }
 
-  const headlampPage = new HeadlampPage(page);
-  await headlampPage.navigateToCluster('test', process.env.HEADLAMP_TEST_TOKEN);
-
-  for (const workload of appsWorkloads) {
+    const headlampPage = new HeadlampPage(page);
+    await headlampPage.navigateToCluster('test', process.env.HEADLAMP_TEST_TOKEN);
     await headlampPage.navigateTopage(`/c/test/${workload.resource}`, workload.title);
-    await expect.poll(() => requestedResources.has(workload.resource)).toBe(true);
-    const workloadLink = page.getByRole('link', { name: workload.name, exact: true });
 
-    await expect(workloadLink).toBeVisible();
-  }
-});
+    await expect.poll(() => requestSeen).toBe(true);
+    const workloadRow = page
+      .getByRole('row')
+      .filter({ has: page.getByRole('link', { name: workload.name, exact: true }) });
+    await expect(workloadRow).toBeVisible();
+    await expect(workloadRow.getByText(workload.expectedText, { exact: true })).toBeVisible();
+  });
+}
 
 test('loads batch workload list pages', async ({ page }) => {
   const requestedResources = new Set<string>();

--- a/frontend/.storybook/baseMocks.ts
+++ b/frontend/.storybook/baseMocks.ts
@@ -257,6 +257,26 @@ export const baseMocks = [
   ),
 ];
 
+const appsWorkloadMocks = [
+  { resource: 'deployments', kind: 'Deployment' },
+  { resource: 'statefulsets', kind: 'StatefulSet' },
+  { resource: 'daemonsets', kind: 'DaemonSet' },
+  { resource: 'replicasets', kind: 'ReplicaSet' },
+].map(({ resource, kind }) =>
+  http.get(
+    new RegExp(
+      `^http://localhost:4466/(?:clusters/[^/]+/)?apis/apps/v1/(?:namespaces/[^/]+/)?${resource}(?:\\?.*)?$`
+    ),
+    () =>
+      HttpResponse.json({
+        kind: `${kind}List`,
+        apiVersion: 'apps/v1',
+        metadata: {},
+        items: [],
+      })
+  )
+);
+
 export const fallbackMocks = [
   http.get('http://localhost:4466/api/v1/pods', () =>
     HttpResponse.json({
@@ -282,36 +302,5 @@ export const fallbackMocks = [
       items: [],
     })
   ),
-  http.get('http://localhost:4466/apis/apps/v1/deployments', () =>
-    HttpResponse.json({
-      kind: 'DeploymentList',
-      apiVersion: 'apps/v1',
-      metadata: {},
-      items: [],
-    })
-  ),
-  http.get('http://localhost:4466/apis/apps/v1/statefulsets', () =>
-    HttpResponse.json({
-      kind: 'StatefulSetList',
-      apiVersion: 'apps/v1',
-      metadata: {},
-      items: [],
-    })
-  ),
-  http.get('http://localhost:4466/apis/apps/v1/daemonsets', () =>
-    HttpResponse.json({
-      kind: 'DaemonSetList',
-      apiVersion: 'apps/v1',
-      metadata: {},
-      items: [],
-    })
-  ),
-  http.get('http://localhost:4466/apis/apps/v1/replicasets', () =>
-    HttpResponse.json({
-      kind: 'ReplicaSetList',
-      apiVersion: 'apps/v1',
-      metadata: {},
-      items: [],
-    })
-  ),
+  ...appsWorkloadMocks,
 ];

--- a/frontend/src/test/storybookBaseMocks.test.ts
+++ b/frontend/src/test/storybookBaseMocks.test.ts
@@ -18,7 +18,8 @@ import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, expect, test } from 'vitest';
 import * as storybookMocks from '../../.storybook/baseMocks';
 import {
-  APPS_WORKLOAD_COLLECTION_URLS,
+  APPS_WORKLOAD_COLLECTIONS,
+  appsWorkloadCollectionUrl,
   BATCH_WORKLOAD_COLLECTION_URLS,
   CLUSTER_WIDE_PODS_URL,
   NAMESPACED_PODS_URL,
@@ -27,12 +28,6 @@ import {
 } from './storybookBaseMocks.testHelper';
 
 const server = setupServer();
-const appsWorkloadKinds: Record<string, string> = {
-  daemonsets: 'DaemonSet',
-  deployments: 'Deployment',
-  replicasets: 'ReplicaSet',
-  statefulsets: 'StatefulSet',
-};
 const batchWorkloadKinds: Record<string, string> = {
   cronjobs: 'CronJob',
   jobs: 'Job',
@@ -101,7 +96,31 @@ async function expectWorkloadFallbacks(
 }
 
 test('returns apps workload lists from the frontend fallbacks', async () => {
-  await expectWorkloadFallbacks('apps', APPS_WORKLOAD_COLLECTION_URLS, appsWorkloadKinds);
+  server.use(...storybookMocks.fallbackMocks);
+  const requestOptions = [
+    {},
+    { namespace: 'default' },
+    { cluster: 'cluster0' },
+    { cluster: 'cluster0', namespace: 'default' },
+  ];
+
+  for (const { resource, kind } of APPS_WORKLOAD_COLLECTIONS) {
+    for (const options of requestOptions) {
+      const collectionUrl = appsWorkloadCollectionUrl(resource, options);
+
+      for (const url of [collectionUrl, `${collectionUrl}?limit=500`]) {
+        const response = await fetch(url);
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toEqual({
+          kind: `${kind}List`,
+          apiVersion: 'apps/v1',
+          metadata: {},
+          items: [],
+        });
+      }
+    }
+  }
 });
 
 test('returns batch workload lists from the frontend fallbacks', async () => {

--- a/frontend/src/test/storybookBaseMocks.testHelper.ts
+++ b/frontend/src/test/storybookBaseMocks.testHelper.ts
@@ -18,13 +18,13 @@ import type { http } from 'msw';
 
 export const CLUSTER_WIDE_PODS_URL = 'http://localhost:4466/api/v1/pods';
 export const NAMESPACED_PODS_URL = 'http://localhost:4466/api/v1/namespaces/default/pods';
-/** The apps/v1 workload collection fallbacks maintained by Storybook. */
-export const APPS_WORKLOAD_COLLECTION_URLS = [
-  'http://localhost:4466/apis/apps/v1/daemonsets',
-  'http://localhost:4466/apis/apps/v1/deployments',
-  'http://localhost:4466/apis/apps/v1/replicasets',
-  'http://localhost:4466/apis/apps/v1/statefulsets',
-];
+/** The apps/v1 workload collections expected in Storybook fallbacks. */
+export const APPS_WORKLOAD_COLLECTIONS = [
+  { resource: 'daemonsets', kind: 'DaemonSet' },
+  { resource: 'deployments', kind: 'Deployment' },
+  { resource: 'replicasets', kind: 'ReplicaSet' },
+  { resource: 'statefulsets', kind: 'StatefulSet' },
+] as const;
 /** The batch/v1 workload collection fallbacks maintained by Storybook. */
 export const BATCH_WORKLOAD_COLLECTION_URLS = [
   'http://localhost:4466/apis/batch/v1/cronjobs',
@@ -63,14 +63,31 @@ export function workloadCollectionUrls(handlers: HttpHandler[], apiGroup: string
 
   return handlers
     .filter(handler => {
-      if (handler.info.method !== 'GET') {
+      if (handler.info.method !== 'GET' || typeof handler.info.path !== 'string') {
         return false;
       }
 
-      const pathname = new URL(String(handler.info.path)).pathname;
+      const pathname = new URL(handler.info.path).pathname;
       const resourcePath = pathname.slice(collectionPathPrefix.length);
       return pathname.startsWith(collectionPathPrefix) && !resourcePath.includes('/');
     })
     .map(handler => String(handler.info.path))
     .sort();
+}
+
+/**
+ * Builds a Storybook backend URL for an apps/v1 workload collection.
+ *
+ * @param resource - Kubernetes collection resource name.
+ * @param options - Optional cluster and namespace path segments.
+ * @returns The absolute Storybook backend URL.
+ */
+export function appsWorkloadCollectionUrl(
+  resource: (typeof APPS_WORKLOAD_COLLECTIONS)[number]['resource'],
+  options: { cluster?: string; namespace?: string } = {}
+): string {
+  const clusterPath = options.cluster ? `/clusters/${options.cluster}` : '';
+  const namespacePath = options.namespace ? `/namespaces/${options.namespace}` : '';
+
+  return `http://localhost:4466${clusterPath}/apis/apps/v1${namespacePath}/${resource}`;
 }

--- a/plugins/headlamp-plugin/config/.storybook/baseMocks.ts
+++ b/plugins/headlamp-plugin/config/.storybook/baseMocks.ts
@@ -330,6 +330,26 @@ export const baseMocks = [
   ),
 ];
 
+const appsWorkloadMocks = [
+  { resource: 'deployments', kind: 'Deployment' },
+  { resource: 'statefulsets', kind: 'StatefulSet' },
+  { resource: 'daemonsets', kind: 'DaemonSet' },
+  { resource: 'replicasets', kind: 'ReplicaSet' },
+].map(({ resource, kind }) =>
+  http.get(
+    new RegExp(
+      `^http://localhost:4466/(?:clusters/[^/]+/)?apis/apps/v1/(?:namespaces/[^/]+/)?${resource}(?:\\?.*)?$`
+    ),
+    () =>
+      HttpResponse.json({
+        kind: `${kind}List`,
+        apiVersion: 'apps/v1',
+        metadata: {},
+        items: [],
+      })
+  )
+);
+
 export const fallbackMocks = [
   http.get('http://localhost:4466/api/v1/pods', () =>
     HttpResponse.json({
@@ -355,36 +375,5 @@ export const fallbackMocks = [
       items: [],
     })
   ),
-  http.get('http://localhost:4466/apis/apps/v1/deployments', () =>
-    HttpResponse.json({
-      kind: 'DeploymentList',
-      apiVersion: 'apps/v1',
-      metadata: {},
-      items: [],
-    })
-  ),
-  http.get('http://localhost:4466/apis/apps/v1/statefulsets', () =>
-    HttpResponse.json({
-      kind: 'StatefulSetList',
-      apiVersion: 'apps/v1',
-      metadata: {},
-      items: [],
-    })
-  ),
-  http.get('http://localhost:4466/apis/apps/v1/daemonsets', () =>
-    HttpResponse.json({
-      kind: 'DaemonSetList',
-      apiVersion: 'apps/v1',
-      metadata: {},
-      items: [],
-    })
-  ),
-  http.get('http://localhost:4466/apis/apps/v1/replicasets', () =>
-    HttpResponse.json({
-      kind: 'ReplicaSetList',
-      apiVersion: 'apps/v1',
-      metadata: {},
-      items: [],
-    })
-  ),
+  ...appsWorkloadMocks,
 ];

--- a/plugins/headlamp-plugin/storybookBaseMocks.test.ts
+++ b/plugins/headlamp-plugin/storybookBaseMocks.test.ts
@@ -20,10 +20,10 @@ import { baseMocks, fallbackMocks } from './config/.storybook/baseMocks';
 
 const server = setupServer();
 const appsWorkloads = [
-  { url: 'http://localhost:4466/apis/apps/v1/daemonsets', kind: 'DaemonSetList' },
-  { url: 'http://localhost:4466/apis/apps/v1/deployments', kind: 'DeploymentList' },
-  { url: 'http://localhost:4466/apis/apps/v1/replicasets', kind: 'ReplicaSetList' },
-  { url: 'http://localhost:4466/apis/apps/v1/statefulsets', kind: 'StatefulSetList' },
+  { resource: 'daemonsets', kind: 'DaemonSet' },
+  { resource: 'deployments', kind: 'Deployment' },
+  { resource: 'replicasets', kind: 'ReplicaSet' },
+  { resource: 'statefulsets', kind: 'StatefulSet' },
 ];
 const batchWorkloads = [
   { url: 'http://localhost:4466/apis/batch/v1/cronjobs', kind: 'CronJobList' },
@@ -34,18 +34,41 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
+test.each(appsWorkloads)('returns $kind lists for every apps request form', async workload => {
+  const requestPaths = [
+    `/apis/apps/v1/${workload.resource}`,
+    `/apis/apps/v1/namespaces/default/${workload.resource}`,
+    `/clusters/cluster0/apis/apps/v1/${workload.resource}`,
+    `/clusters/cluster0/apis/apps/v1/namespaces/default/${workload.resource}`,
+  ];
+  server.use(...fallbackMocks);
+
+  for (const requestPath of requestPaths) {
+    const collectionUrl = `http://localhost:4466${requestPath}`;
+
+    for (const url of [collectionUrl, `${collectionUrl}?limit=500`]) {
+      const response = await fetch(url);
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        kind: `${workload.kind}List`,
+        apiVersion: 'apps/v1',
+        metadata: {},
+        items: [],
+      });
+    }
+  }
+});
+
 // Keep this executable contract in the plugin package, where its MSW and Vite
 // dependencies are installed. It catches fallback handlers accidentally moving
 // into baseMocks and verifies that each URL returns its matching Kubernetes kind.
-test.each([
-  ['apps', appsWorkloads],
-  ['batch', batchWorkloads],
-])('returns %s workload lists from plugin-template fallbacks', async (apiGroup, workloads) => {
+test('returns batch workload lists from plugin-template fallbacks', async () => {
   const basePaths = baseMocks.map(handler => String(handler.info.path));
   const fallbackPaths = fallbackMocks.map(handler => String(handler.info.path));
   server.use(...fallbackMocks);
 
-  for (const workload of workloads) {
+  for (const workload of batchWorkloads) {
     expect(basePaths).not.toContain(workload.url);
     expect(fallbackPaths).toContain(workload.url);
 
@@ -54,7 +77,7 @@ test.each([
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
       kind: workload.kind,
-      apiVersion: `${apiGroup}/v1`,
+      apiVersion: 'batch/v1',
       metadata: {},
       items: [],
     });


### PR DESCRIPTION
## Summary

- expand apps/v1 workload fallbacks to namespaced and cluster-prefixed requests
- execute both packages' handlers through MSW in their own dependency environments
- add independent end-to-end regressions for all four apps workload list pages

## Source

The original implementation was reviewed in:

- https://github.com/Azure/aks-desktop/pull/255
- https://github.com/Azure/aks-desktop/commit/c5f671f98c93b9aced0c872ffc846593e7e16471

The same stacked diff also appeared in:

- https://github.com/Azure/aks-desktop/pull/256

AKS Desktop later retained the apps workload subset as patch 0023 in:

- https://github.com/Azure/aks-desktop/pull/823
- https://github.com/Azure/aks-desktop/commit/387eb27e3f586211610dda61949255e7264a9c95

The retained patch is
[`0023-headlamp-upstream-storybook-apps-workload-mocks.patch`](https://github.com/Azure/aks-desktop/blob/112577ea8241e9a0da575f293858cee22bf066c1/patches/0023-headlamp-upstream-storybook-apps-workload-mocks.patch).
The patch export records synthetic commit
`bb54958414d234f5e58ed1bdf895c6f8359a4799`. The reachable original PR commit is
`c5f671f98c93b9aced0c872ffc846593e7e16471`, authored by Evangelos Skopelitis on
February 16, 2026. The upstream commit preserves that author and author date.

PR https://github.com/kubernetes-sigs/headlamp/pull/7473 merged the original
0023 commits as part of its stacked history. This PR is rebased onto that merge
and now contains only the additional coverage and request-form improvements.

## Improvements over the existing changes

- retain the workload handlers in `fallbackMocks` so story-specific handlers
  keep precedence while the defaults cover more request forms
- match unrestricted, namespace-restricted, selected-cluster, and combined
  cluster/namespace requests, with and without query parameters
- execute the frontend and plugin-template handlers in their own packages so
  malformed responses and initialization failures are caught without crossing
  package dependency boundaries
- cover each Deployment, StatefulSet, DaemonSet, and ReplicaSet list page in its
  own Playwright test with valid selectors, pod templates, containers, images,
  and kind-specific status; assert visible ready, condition, or selector columns

These changes make the downstream behavior safer to maintain upstream: defaults
remain available without silently replacing richer per-story fixtures, and both
the mock contract and user-facing list routes have regression coverage.

## Testing

- `npm test -- --run src/test/storybookBaseMocks.test.ts` (3 passed)
- `npm run test:storybook-mocks` from `plugins/headlamp-plugin` (5 passed)
- `make frontend-test` (full suite and coverage passed)
- focused Istanbul coverage for the frontend mock handlers and helper
  (92.3% branches overall, 100% for `baseMocks.ts`; 80% required)
- `npm test -- --run src/storybook.test.tsx -t 'workload/Overview'`
  (1 passed, 711 skipped, no snapshot changes)
- `npm test -- --run src/storybook.test.tsx -t 'Job/List'`
  (1 passed, 711 skipped, no snapshot changes)
- `npm run tsc`
- `npm run build-typedoc` (0 errors)
- `npx playwright test --list tests/workloads.spec.ts` (5 tests discovered)

The full Playwright cases were not run locally because Docker was not running and
the required two-cluster in-cluster Headlamp environment was unavailable. CI can
run the committed browser test in the repository's standard e2e environment.

Assisted by copilot.
