### PR TITLE
0006: app: build-manifest: Configure package targets

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -41,6 +41,41 @@ Note, it runs the development servers for the backend and the frontend as well. 
 - `npm run verify-build-mac`: Verifies the macOS build artifacts and binaries (requires built app in dist/).
 - `npm run verify-build-windows`: Verifies the Windows build artifacts and binaries (requires built app in dist/).
 
+## Build manifest
+
+Desktop packages use `app-build-manifest.json` to configure product-specific
+build behavior. Set `HEADLAMP_BUILD_MANIFEST` to select another manifest; relative
+paths are resolved from the current working directory. The selected file is also
+copied into the packaged app as `app-build-manifest.json` for runtime features.
+
+When a manifest omits `targets`, Electron Builder uses the targets from
+`app/package.json`. A manifest can replace the target list for one or more
+platforms while preserving the other platform settings:
+
+```json
+{
+  "targets": {
+    "linux": ["AppImage"],
+    "mac": [{ "target": "dmg", "arch": ["arm64"] }],
+    "win": [{ "target": "nsis", "arch": ["x64"] }]
+  }
+}
+```
+
+Only `linux`, `mac`, and `win` platform keys are supported. Each configured
+platform must have a non-empty array whose entries are either a non-blank target
+name or an object containing a non-blank `target` and a non-empty `arch` array.
+Supported architectures depend on the platform: Linux supports `arm64`, `armv7l`,
+and `x64`; macOS supports `arm64`, `universal`, and `x64`; and Windows supports
+`arm64`, `ia32`, and `x64`. Invalid target configuration stops the build before
+Electron Builder packaging.
+
+For example, from the repository root:
+
+```bash
+HEADLAMP_BUILD_MANIFEST=../product/app-build-manifest.json npm --prefix app run package
+```
+
 ## Verifying Builds
 
 After building the desktop app with `npm run package`, you can verify that the built binaries work correctly:

--- a/app/e2e-tests/playwright.electron.config.ts
+++ b/app/e2e-tests/playwright.electron.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
   testDir: './tests',
   testMatch: [
     'backendToken.spec.ts',
+    'buildManifest.spec.ts',
     'clusterRename.spec.ts',
     'namespaces.spec.ts',
     'clusterAutoConnect.spec.ts',

--- a/app/e2e-tests/tests/buildManifest.spec.ts
+++ b/app/e2e-tests/tests/buildManifest.spec.ts
@@ -32,7 +32,7 @@ test('keeps the MCP adapter out of the Electron startup bundle', () => {
   expect(fs.statSync(adapterBundlePath).size).toBeGreaterThan(100_000);
 });
 
-test('custom platform metadata reaches the Electron Builder configuration', () => {
+test('custom platform settings reach the Electron Builder configuration', () => {
   const manifestDir = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-build-manifest-'));
   const manifestFile = path.join(manifestDir, 'app-build-manifest.json');
   fs.writeFileSync(
@@ -42,6 +42,11 @@ test('custom platform metadata reaches the Electron Builder configuration', () =
         linux: { executableName: 'branded-headlamp' },
         mac: { appId: 'io.example.branded-headlamp' },
         win: { artifactName: 'branded-${version}.${ext}' },
+      },
+      targets: {
+        linux: [{ target: 'AppImage', arch: ['x64'] }],
+        mac: [{ target: 'dmg', arch: ['arm64'] }],
+        win: [{ target: 'nsis', arch: ['x64'] }],
       },
     })
   );
@@ -63,10 +68,12 @@ test('custom platform metadata reaches the Electron Builder configuration', () =
 
     expect(config.linux.executableName).toBe('branded-headlamp');
     expect(config.linux.category).toBe('Network');
+    expect(config.linux.target).toEqual([{ target: 'AppImage', arch: ['x64'] }]);
     expect(config.mac.appId).toBe('io.example.branded-headlamp');
     expect(config.mac.hardenedRuntime).toBe(true);
+    expect(config.mac.target).toEqual([{ target: 'dmg', arch: ['arm64'] }]);
     expect(config.win.artifactName).toBe('branded-${version}.${ext}');
-    expect(config.win.target).toEqual(['nsis']);
+    expect(config.win.target).toEqual([{ target: 'nsis', arch: ['x64'] }]);
   } finally {
     fs.rmSync(manifestDir, { recursive: true, force: true });
   }

--- a/app/electron-builder.config.ts
+++ b/app/electron-builder.config.ts
@@ -28,6 +28,7 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
+  applyBuildTargets,
   applyPlatformMetadata,
   applyProductMetadata,
   DEFAULT_MANIFEST_FILE,
@@ -56,21 +57,24 @@ const manifest = loadBuildManifest(manifestFile);
 const defaultManifest = path.resolve(DEFAULT_MANIFEST_FILE);
 const packageBuild = packageJson.build as ElectronBuilderConfiguration;
 
-const config: Configuration = applyPlatformMetadata(
-  applyProductMetadata(
-    {
-      ...packageBuild,
-      extraResources: packageBuild.extraResources.map(resource => {
-        // Preserve every resource except the default manifest entry.
-        if (
-          typeof resource === 'string' ||
-          path.resolve(configDirectory, resource.from) !== defaultManifest
-        ) {
-          return resource;
-        }
-        return { ...resource, from: manifestFile, to: 'app-build-manifest.json' };
-      }),
-    },
+const config: Configuration = applyBuildTargets(
+  applyPlatformMetadata(
+    applyProductMetadata(
+      {
+        ...packageBuild,
+        extraResources: packageBuild.extraResources.map(resource => {
+          // Preserve every resource except the default manifest entry.
+          if (
+            typeof resource === 'string' ||
+            path.resolve(configDirectory, resource.from) !== defaultManifest
+          ) {
+            return resource;
+          }
+          return { ...resource, from: manifestFile, to: 'app-build-manifest.json' };
+        }),
+      },
+      manifest
+    ),
     manifest
   ),
   manifest

--- a/app/electron/build-backend.test.ts
+++ b/app/electron/build-backend.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { mapElectronArchToGoArch } = require('../scripts/build-backend');
+
+describe('Electron architecture mapping', () => {
+  it.each([
+    ['x64', 'amd64'],
+    ['armv7l', 'arm'],
+    ['ia32', '386'],
+    ['arm64', 'arm64'],
+  ])('maps %s to Go architecture %s', (electronArch, goArch) => {
+    expect(mapElectronArchToGoArch(electronArch)).toBe(goArch);
+  });
+});

--- a/app/electron/build-manifest.test.ts
+++ b/app/electron/build-manifest.test.ts
@@ -23,6 +23,7 @@ import path from 'node:path';
 import * as tar from 'tar';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  applyBuildTargets,
   applyPlatformMetadata,
   applyProductMetadata,
   DEFAULT_MANIFEST_FILE,
@@ -44,6 +45,123 @@ import {
 const require = createRequire(import.meta.url);
 const { getConfig } = require('app-builder-lib/out/util/config/config');
 const appPath = path.resolve(__dirname, '..');
+
+describe('build target validation', () => {
+  it('replaces platform targets without changing other platform settings', () => {
+    expect(
+      applyBuildTargets(
+        { mac: { hardenedRuntime: true, target: ['zip'] } },
+        { targets: { mac: [{ target: 'dmg', arch: ['arm64'] }] } }
+      )
+    ).toEqual({
+      mac: { hardenedRuntime: true, target: [{ target: 'dmg', arch: ['arm64'] }] },
+    });
+  });
+
+  it('rejects unknown architectures and empty target sets', () => {
+    expect(() => applyBuildTargets({}, { targets: { mac: [] } })).toThrow('non-empty array');
+    expect(() =>
+      applyBuildTargets({}, { targets: { mac: [{ target: 'dmg', arch: ['mips'] }] } })
+    ).toThrow('Invalid build manifest architecture for mac');
+  });
+
+  it('preserves the configuration when build targets are absent', () => {
+    const defaults = { mac: { target: ['zip'] } };
+
+    expect(applyBuildTargets(defaults, {})).toBe(defaults);
+  });
+
+  it.each([null, [], 'mac'])('rejects an invalid targets value: %j', targets => {
+    expect(() => applyBuildTargets({}, { targets })).toThrow(
+      'Build manifest targets must be an object'
+    );
+  });
+
+  it('rejects unsupported target platforms', () => {
+    expect(() => applyBuildTargets({}, { targets: { windows: ['nsis'] } })).toThrow(
+      'Unsupported build manifest target platform: windows'
+    );
+  });
+
+  it.each([null, {}, 'dmg', []])('rejects invalid mac targets: %j', mac => {
+    expect(() => applyBuildTargets({}, { targets: { mac } })).toThrow(
+      'Build manifest targets.mac must be a non-empty array'
+    );
+  });
+
+  it('accepts string targets for every supported platform', () => {
+    expect(
+      applyBuildTargets(
+        {
+          linux: { category: 'Network' },
+          mac: { hardenedRuntime: true },
+          win: { artifactName: 'headlamp-${version}.${ext}' },
+        },
+        { targets: { linux: ['AppImage'], mac: ['dmg'], win: ['nsis'] } }
+      )
+    ).toEqual({
+      linux: { category: 'Network', target: ['AppImage'] },
+      mac: { hardenedRuntime: true, target: ['dmg'] },
+      win: { artifactName: 'headlamp-${version}.${ext}', target: ['nsis'] },
+    });
+  });
+
+  it.each([
+    { platform: 'linux', architectures: ['arm64', 'armv7l', 'x64'] },
+    { platform: 'mac', architectures: ['arm64', 'universal', 'x64'] },
+    { platform: 'win', architectures: ['arm64', 'ia32', 'x64'] },
+  ])('accepts supported $platform architectures', ({ platform, architectures }) => {
+    expect(
+      applyBuildTargets(
+        {},
+        { targets: { [platform]: [{ target: 'package', arch: architectures }] } }
+      )
+    ).toEqual({
+      [platform]: { target: [{ target: 'package', arch: architectures }] },
+    });
+  });
+
+  it.each([
+    { platform: 'linux', architecture: 'ia32' },
+    { platform: 'linux', architecture: 'universal' },
+    { platform: 'mac', architecture: 'armv7l' },
+    { platform: 'mac', architecture: 'ia32' },
+    { platform: 'win', architecture: 'armv7l' },
+    { platform: 'win', architecture: 'universal' },
+  ])('rejects $architecture for $platform', ({ platform, architecture }) => {
+    expect(() =>
+      applyBuildTargets(
+        {},
+        { targets: { [platform]: [{ target: 'package', arch: [architecture] }] } }
+      )
+    ).toThrow(`Invalid build manifest architecture for ${platform}`);
+  });
+
+  it.each([null, {}, { target: 1, arch: [] }, { target: 'dmg', arch: 'arm64' }])(
+    'rejects an invalid mac target descriptor: %j',
+    target => {
+      expect(() => applyBuildTargets({}, { targets: { mac: [target] } })).toThrow(
+        'Invalid build manifest target for mac'
+      );
+    }
+  );
+
+  it.each(['', '  ', { target: '', arch: ['arm64'] }, { target: '  ', arch: ['arm64'] }])(
+    'rejects a blank mac target name: %j',
+    target => {
+      expect(() => applyBuildTargets({}, { targets: { mac: [target] } })).toThrow(
+        'Invalid build manifest target for mac'
+      );
+    }
+  );
+
+  it('rejects an empty architecture list', () => {
+    expect(() =>
+      applyBuildTargets({}, { targets: { linux: [{ target: 'AppImage', arch: [] }] } })
+    ).toThrow('Invalid build manifest architecture for linux');
+  });
+});
+
 describe('platform metadata', () => {
   afterEach(() => {
     delete process.env.HEADLAMP_BUILD_MANIFEST;

--- a/app/scripts/build-backend.js
+++ b/app/scripts/build-backend.js
@@ -13,6 +13,7 @@ const { execSync } = require('child_process');
  * Known mappings:
  * - x64 -> amd64
  * - armv7l -> arm
+ * - ia32 -> 386
  * - arm64 -> (passthrough; already valid for GOARCH)
  *
  * Unknown values are passed through unchanged so existing/custom workflows do not
@@ -25,10 +26,13 @@ function mapElectronArchToGoArch(electronArch) {
   const archMap = {
     x64: 'amd64',
     armv7l: 'arm',
+    ia32: '386',
   };
 
   return archMap[electronArch] || electronArch;
 }
+
+exports.mapElectronArchToGoArch = mapElectronArchToGoArch;
 
 exports.default = async context => {
   const arch = mapElectronArchToGoArch(context.arch);

--- a/app/scripts/build-manifest.ts
+++ b/app/scripts/build-manifest.ts
@@ -33,8 +33,23 @@ export type BuildManifest = {
   /** Product identity fields consumed by Electron Builder. */
   product?: Record<string, unknown>;
 
+  /** Per-platform package targets consumed by Electron Builder. */
+  targets?: Record<string, unknown>;
+
   [key: string]: unknown;
 };
+
+/** An Electron Builder target with an explicit architecture selection. */
+type BuildTargetDescriptor = {
+  /** Electron Builder package target name. */
+  target: string;
+
+  /** Architectures to build for this package target. */
+  arch: string[];
+};
+
+/** A supported package target declaration from a build manifest. */
+type BuildTarget = string | BuildTargetDescriptor;
 
 type ProductMetadata = {
   name?: string;
@@ -201,6 +216,86 @@ export function applyProductMetadata<T extends object>(config: T, manifest: unkn
       ...(metadata.version && { version: metadata.version }),
     },
   } as T;
+}
+
+/**
+ * Applies manifest-declared package targets to supported Electron Builder platforms.
+ *
+ * @param config Electron Builder configuration to extend.
+ * @param manifest Parsed application build manifest.
+ * @returns The original configuration when targets are absent, or a copy with targets applied.
+ * @throws When target declarations or architecture names are malformed.
+ */
+export function applyBuildTargets<T extends object>(config: T, manifest: unknown): T {
+  if (typeof manifest !== 'object' || manifest === null || Array.isArray(manifest)) {
+    throw new Error('Build manifest must be an object');
+  }
+
+  const targets = (manifest as BuildManifest).targets;
+  if (targets === undefined) {
+    return config;
+  }
+  if (typeof targets !== 'object' || targets === null || Array.isArray(targets)) {
+    throw new Error('Build manifest targets must be an object');
+  }
+
+  const architecturesByPlatform: Record<string, ReadonlySet<string>> = {
+    linux: new Set(['arm64', 'armv7l', 'x64']),
+    mac: new Set(['arm64', 'universal', 'x64']),
+    win: new Set(['arm64', 'ia32', 'x64']),
+  };
+  const supportedPlatforms = new Set(Object.keys(architecturesByPlatform));
+  for (const platform of Object.keys(targets)) {
+    if (!supportedPlatforms.has(platform)) {
+      throw new Error(`Unsupported build manifest target platform: ${platform}`);
+    }
+  }
+
+  const configRecord = config as Record<string, unknown>;
+  const result: Record<string, unknown> = { ...configRecord };
+  for (const platform of supportedPlatforms) {
+    const platformTargets = targets[platform];
+    if (platformTargets === undefined) {
+      continue;
+    }
+    if (!Array.isArray(platformTargets) || platformTargets.length === 0) {
+      throw new Error(`Build manifest targets.${platform} must be a non-empty array`);
+    }
+    for (const target of platformTargets) {
+      if (typeof target === 'string') {
+        if (target.trim() === '') {
+          throw new Error(`Invalid build manifest target for ${platform}`);
+        }
+        continue;
+      }
+      if (
+        typeof target !== 'object' ||
+        target === null ||
+        typeof (target as Record<string, unknown>).target !== 'string' ||
+        ((target as Record<string, unknown>).target as string).trim() === '' ||
+        !Array.isArray((target as Record<string, unknown>).arch)
+      ) {
+        throw new Error(`Invalid build manifest target for ${platform}`);
+      }
+      const targetDescriptor = target as BuildTargetDescriptor;
+      if (
+        targetDescriptor.arch.length === 0 ||
+        targetDescriptor.arch.some(arch => !architecturesByPlatform[platform].has(arch))
+      ) {
+        throw new Error(`Invalid build manifest architecture for ${platform}`);
+      }
+    }
+    const defaults = configRecord[platform];
+    const platformDefaults =
+      typeof defaults === 'object' && defaults !== null
+        ? (defaults as Record<string, unknown>)
+        : {};
+    result[platform] = {
+      ...platformDefaults,
+      target: platformTargets as BuildTarget[],
+    };
+  }
+  return result as T;
 }
 
 /**


### PR DESCRIPTION
## Summary

- let build manifests replace Linux, macOS, and Windows Electron Builder package targets
- accept target names or target/architecture descriptors while rejecting malformed target sets, unsupported platforms, blank target names, and architectures unsupported by the selected platform
- preserve unrelated platform settings when applying manifest targets
- cover target validation and effective Electron Builder configuration with unit and process-level e2e tests
- document manifest selection, target replacement semantics, platform-specific constraints, and packaging usage

## Depends on

- https://github.com/kubernetes-sigs/headlamp/pull/6830

## Provenance

This upstreams `patches/0006-headlamp-upstream-build-manifest-targets.patch` from [Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823).

- Original AKS Desktop change: [645f38d2e810fc3ff0442899fe388c5ffde45ad6](https://github.com/Azure/aks-desktop/commit/645f38d2e810fc3ff0442899fe388c5ffde45ad6) (`Only build for arm64 for now`)
- Original Azure PR carrying that downstream change into `main`: [Azure/aks-desktop#741](https://github.com/Azure/aks-desktop/pull/741)
- Original patch commit recorded by the patch header: `f5108e7b0cc3801fac03878981760ffe78dbb2da`, authored by ashu8912 on 2026-08-01 (the generated SHA is not present on a published Azure ref)
- Published Azure commit retaining the numbered patch: [387eb27e3f586211610dda61949255e7264a9c95](https://github.com/Azure/aks-desktop/commit/387eb27e3f586211610dda61949255e7264a9c95)
- Published Azure commit consuming the retained patch series: [4404d719e98f04c51c9504671a7ba2f169d97005](https://github.com/Azure/aks-desktop/commit/4404d719e98f04c51c9504671a7ba2f169d97005)
- Related Azure PR: [Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823)

The commit preserves ashu8912 as author and the original author date, with René Dudfield added as co-author.

## Improvements over the existing changes

- port the original JavaScript helper to the current typed build-manifest module and document the new manifest fields and API with TSDoc, because Headlamp's build-manifest implementation moved to TypeScript after the downstream patch was generated
- expand unit coverage across pass-through behavior, all supported platforms, string and descriptor targets, malformed target collections, unsupported platform keys, malformed descriptors, invalid target names, unsupported cross-platform architecture combinations, and valid architecture sets for each platform
- register the existing build-manifest process spec in the current Playwright configuration and assert target propagation for every platform, because the spec was present but excluded by the suite's `testMatch`
- map Electron Builder's Windows `ia32` architecture to Go's `386` architecture in the backend build hook, with direct unit coverage, so every accepted target architecture can complete packaging
- document the desktop build-manifest contract in `app/README.md`, including `HEADLAMP_BUILD_MANIFEST`, fallback behavior, supported platforms and platform-specific architectures, validation rules, and a packaging example whose relative path accounts for npm's `app/` working directory
- keep the implementation, documentation, and all associated tests in one buildable commit so the PR remains coherent and bisectable

## Testing

- `npm --prefix app test` (24 files, 417 tests)
- `npm --prefix app test -- electron/build-backend.test.ts electron/build-manifest.test.ts` (114 tests)
- `npm --prefix app test -- electron/build-manifest.test.ts` (110 tests)
- focused Istanbul coverage for `app/scripts/build-manifest.ts` (97.31% branches, 96.29% statements, 100% functions, 96.26% lines)
- `npm --prefix app run tsc`
- `npm --prefix app/e2e-tests run test-app -- buildManifest.spec.ts` (2 passed)
- Prettier checks for all changed TypeScript and Markdown files
- `git diff --check upstream/main...HEAD`

Assisted by copilot

