### PR TITLE
0014: Authorize package cluster providers

### DIFF
--- a/app/e2e-tests/playwright.electron.config.ts
+++ b/app/e2e-tests/playwright.electron.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
   testDir: './tests',
   testMatch: [
     'backendToken.spec.ts',
+    'clusterProviderCapabilities.spec.ts',
     'clusterRename.spec.ts',
     'namespaces.spec.ts',
     'clusterAutoConnect.spec.ts',

--- a/app/e2e-tests/tests/clusterProviderCapabilities.spec.ts
+++ b/app/e2e-tests/tests/clusterProviderCapabilities.spec.ts
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { _electron, ElectronApplication, Page } from 'playwright';
+
+/** Result recorded by the cluster provider package plugin. */
+interface ClusterProviderTestResult {
+  /** Whether the package plugin source started executing. */
+  loaded?: boolean;
+  /** Type of the cluster provider wrapper injected for the plugin. */
+  invokeType?: string;
+  /** Result returned by the declared provider. */
+  allowed?: unknown;
+  /** Unexpected error returned for the declared provider. */
+  allowedError?: string;
+  /** Error returned for an undeclared provider. */
+  denied?: string;
+}
+
+/** Renderer fields recorded by the cluster provider package plugin. */
+type ClusterProviderTestWindow = Window & {
+  /** Results from the provider authorization checks. */
+  clusterProviderTestResult?: ClusterProviderTestResult;
+};
+
+const appPath = path.resolve(__dirname, '../../');
+const electronExecutable = process.platform === 'win32' ? 'electron.cmd' : 'electron';
+const electronPath = path.resolve(__dirname, `../../node_modules/.bin/${electronExecutable}`);
+const electronDistPath = path.join(appPath, 'node_modules', 'electron', 'dist');
+const electronResourcesPath =
+  process.platform === 'darwin'
+    ? path.join(electronDistPath, 'Electron.app', 'Contents', 'Resources')
+    : path.join(electronDistPath, 'resources');
+const electronEnv = { ...process.env };
+delete electronEnv.ELECTRON_RUN_AS_NODE;
+const pluginName = 'cluster-provider-capabilities-e2e';
+const providerName = 'e2e.cluster';
+
+let electronApp: ElectronApplication;
+let electronPage: Page;
+let pluginPath: string;
+let userDataPath: string;
+
+test.describe('package cluster provider capabilities', () => {
+  test.setTimeout(2 * 60 * 1000);
+
+  test.beforeEach(() => {
+    test.skip(process.env.PLAYWRIGHT_TEST_MODE !== 'app', 'This test only runs in app mode');
+  });
+
+  test.beforeAll(async ({}, testInfo) => {
+    testInfo.setTimeout(2 * 60 * 1000);
+
+    if (process.env.PLAYWRIGHT_TEST_MODE !== 'app') {
+      return;
+    }
+
+    pluginPath = path.join(electronResourcesPath, '.plugins', pluginName);
+    fs.mkdirSync(pluginPath, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginPath, 'main.js'),
+      `window.clusterProviderTestResult = {
+        loaded: true,
+        invokeType: typeof clusterProviderInvoke,
+      };
+      const record = result => Object.assign(window.clusterProviderTestResult, result);
+      clusterProviderInvoke('${providerName}', { cluster: 'demo' }).then(
+        allowed => record({ allowed }),
+        error => record({ allowedError: error.message })
+      );
+      clusterProviderInvoke('undeclared.cluster', {}).then(
+        () => record({ denied: 'unexpected success' }),
+        error => record({ denied: error.message })
+      );`
+    );
+    fs.writeFileSync(
+      path.join(pluginPath, 'package.json'),
+      JSON.stringify({
+        name: pluginName,
+        version: '1.0.0',
+        description: 'Cluster provider capability e2e fixture',
+        homepage: 'https://example.com/cluster-provider-capabilities-e2e',
+        isManagedByHeadlampPlugin: true,
+        artifacthub: {
+          title: 'Cluster provider capability e2e fixture',
+          url: 'https://example.com/cluster-provider-capabilities-e2e',
+          repoName: 'e2e',
+          author: 'Headlamp',
+          version: '1.0.0',
+        },
+        devDependencies: {
+          '@kinvolk/headlamp-plugin': '^0.8.0',
+        },
+        headlamp: {
+          clusterProviders: [providerName],
+        },
+      })
+    );
+
+    userDataPath = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-cluster-provider-e2e-'));
+    electronApp = await _electron.launch({
+      cwd: appPath,
+      executablePath: electronPath,
+      args: ['.', `--user-data-dir=${userDataPath}`],
+      env: {
+        ...electronEnv,
+        ELECTRON_DEV: 'true',
+        NODE_ENV: 'development',
+      },
+    });
+    await electronApp.evaluate(
+      ({ app }, { mainPath, provider }) => {
+        const requireFromApp = process.getBuiltinModule('module').createRequire(app.getAppPath());
+        const main = requireFromApp(mainPath) as {
+          registerClusterProvider: (
+            providerName: string,
+            handler: (request: Record<string, unknown>) => unknown
+          ) => () => void;
+        };
+        main.registerClusterProvider(provider, request => ({ provider, request }));
+      },
+      {
+        mainPath: path.join(appPath, 'build', 'main.js'),
+        provider: providerName,
+      }
+    );
+    electronPage = await electronApp.firstWindow();
+    await electronPage.reload();
+  });
+
+  test.afterAll(async () => {
+    await electronApp?.close();
+    if (pluginPath) {
+      fs.rmSync(pluginPath, { force: true, recursive: true });
+    }
+    if (userDataPath) {
+      fs.rmSync(userDataPath, { force: true, recursive: true });
+    }
+  });
+
+  test('invokes only providers declared by the package plugin', async () => {
+    await electronPage.waitForLoadState('load');
+    const baseUrl = electronPage.url().split('#')[0];
+    await electronPage.goto(`${baseUrl}#/settings/plugins`);
+
+    const pluginRow = electronPage.getByRole('row').filter({ hasText: pluginName });
+    await expect(pluginRow.getByRole('checkbox')).toBeChecked();
+    await expect
+      .poll(() =>
+        electronPage.evaluate(
+          () => (window as unknown as ClusterProviderTestWindow).clusterProviderTestResult
+        )
+      )
+      .toEqual({
+        loaded: true,
+        invokeType: 'function',
+        allowed: {
+          provider: providerName,
+          request: { cluster: 'demo' },
+        },
+        denied: "Cluster provider is outside the plugin's declared scope: undeclared.cluster",
+      });
+  });
+});

--- a/app/electron/cluster-provider.test.ts
+++ b/app/electron/cluster-provider.test.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createClusterProviderCapabilities,
+  registerClusterProvider,
+  setupClusterProviderHandlers,
+} from './cluster-provider';
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  cleanups.splice(0).forEach(cleanup => cleanup());
+});
+
+function register(provider: string, handler = vi.fn()) {
+  cleanups.push(registerClusterProvider(provider, handler));
+  return handler;
+}
+
+describe('cluster provider registration', () => {
+  it('creates an opaque capability only for a registered provider', () => {
+    register('example.cluster');
+
+    const { capabilities, providerByCapability } = createClusterProviderCapabilities([
+      { pluginName: '@example/plugin', providers: ['example.cluster', 'missing.cluster'] },
+    ]);
+
+    expect(capabilities['@example/plugin']).toEqual([
+      { provider: 'example.cluster', capability: expect.stringMatching(/^[a-f0-9]{64}$/) },
+    ]);
+    expect(providerByCapability.get(capabilities['@example/plugin'][0].capability)).toBe(
+      'example.cluster'
+    );
+  });
+
+  it('rejects duplicate provider ownership', () => {
+    register('example.cluster');
+    expect(() => registerClusterProvider('example.cluster', vi.fn())).toThrow(
+      'Cluster provider is already registered'
+    );
+  });
+
+  it('ignores malformed registrations', () => {
+    register('example.cluster');
+    expect(
+      createClusterProviderCapabilities([
+        { pluginName: '../plugin', providers: ['example.cluster'] },
+        { pluginName: 'example', providers: ['../provider'] },
+      ]).capabilities
+    ).toEqual({ example: [] });
+  });
+});
+
+describe('cluster provider IPC', () => {
+  function setup() {
+    const handlers = new Map<string, (...args: any[]) => any>();
+    const webContents = { on: vi.fn() };
+    const removeHandler = vi.fn(channel => handlers.delete(channel));
+    setupClusterProviderHandlers(
+      { webContents } as any,
+      {
+        handle: vi.fn((channel, handler) => handlers.set(channel, handler)),
+        removeHandler,
+      } as any
+    );
+    return {
+      handlers,
+      event: { sender: webContents },
+      otherEvent: { sender: {} },
+      removeHandler,
+      webContents,
+    };
+  }
+
+  it('invokes the provider associated with the capability', async () => {
+    const handler = register('example.cluster', vi.fn().mockResolvedValue({ success: true }));
+    const { handlers, event } = setup();
+    const capabilities = await handlers.get('register-plugin-cluster-provider-capabilities')!(
+      event,
+      [{ pluginName: 'example', providers: ['example.cluster'] }]
+    );
+
+    await expect(
+      handlers.get('invoke-cluster-provider')!(event, capabilities.example[0].capability, {
+        cluster: 'demo',
+      })
+    ).resolves.toEqual({ success: true });
+    expect(handler).toHaveBeenCalledWith({ cluster: 'demo' });
+  });
+
+  it('rejects another renderer and an unknown capability', async () => {
+    register('example.cluster');
+    const { handlers, event, otherEvent } = setup();
+    const invoke = handlers.get('invoke-cluster-provider')!;
+
+    await expect(invoke(otherEvent, 'a'.repeat(64), {})).resolves.toEqual({
+      success: false,
+      message: 'Invalid cluster provider capability or request',
+    });
+    await expect(invoke(event, 'a'.repeat(64), {})).resolves.toEqual({
+      success: false,
+      message: 'Invalid cluster provider capability or request',
+    });
+  });
+
+  it('returns a generic error when the provider fails', async () => {
+    register('example.cluster', vi.fn().mockRejectedValue(new Error('sensitive detail')));
+    const { handlers, event } = setup();
+    const capabilities = await handlers.get('register-plugin-cluster-provider-capabilities')!(
+      event,
+      [{ pluginName: 'example', providers: ['example.cluster'] }]
+    );
+
+    await expect(
+      handlers.get('invoke-cluster-provider')!(event, capabilities.example[0].capability, {
+        cluster: 'demo',
+      })
+    ).resolves.toEqual({ success: false, message: 'Cluster provider failed' });
+  });
+
+  it('allows capability registration only once per page load', async () => {
+    register('example.cluster');
+    const { handlers, event, webContents } = setup();
+    const registerCapabilities = handlers.get('register-plugin-cluster-provider-capabilities')!;
+
+    expect(
+      await registerCapabilities(event, [{ pluginName: 'example', providers: ['example.cluster'] }])
+    ).toHaveProperty('example');
+    expect(await registerCapabilities(event, [])).toEqual({});
+
+    const didStartLoading = webContents.on.mock.calls.find(
+      ([eventName]) => eventName === 'did-start-loading'
+    )![1];
+    didStartLoading();
+    expect(
+      await registerCapabilities(event, [{ pluginName: 'example', providers: ['example.cluster'] }])
+    ).toHaveProperty('example');
+  });
+
+  it('replaces its own handlers when a window is recreated', () => {
+    const { removeHandler } = setup();
+
+    expect(removeHandler).toHaveBeenCalledWith('register-plugin-cluster-provider-capabilities');
+    expect(removeHandler).toHaveBeenCalledWith('invoke-cluster-provider');
+  });
+});

--- a/app/electron/cluster-provider.ts
+++ b/app/electron/cluster-provider.ts
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import crypto from 'crypto';
+import type { BrowserWindow, IpcMain, IpcMainInvokeEvent } from 'electron';
+
+const VALID_NAME = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/i;
+const MAX_NAME_LENGTH = 214;
+const MAX_PLUGINS = 256;
+const MAX_PROVIDERS_PER_PLUGIN = 16;
+const MAX_REQUEST_LENGTH = 1024 * 1024;
+
+/** Handles a request for a host-registered cluster provider. */
+export type ClusterProviderHandler = (
+  /** Request supplied by the authorized package plugin. */
+  request: Record<string, unknown>
+) => unknown | Promise<unknown>;
+
+/** Cluster providers requested by one package plugin. */
+interface ClusterProviderRegistration {
+  /** Package plugin name that requests the providers. */
+  pluginName: string;
+  /** Stable IDs of the requested cluster providers. */
+  providers: string[];
+}
+
+/** Opaque authorization for one host-registered cluster provider. */
+export interface ClusterProviderCapability {
+  /** Stable ID of the authorized provider. */
+  provider: string;
+  /** Opaque token that authorizes provider invocation. */
+  capability: string;
+}
+
+/** Capabilities generated for the package plugins in one renderer load. */
+export interface ClusterProviderCapabilities {
+  /** Authorized providers keyed by package plugin name. */
+  capabilities: Record<string, ClusterProviderCapability[]>;
+  /** Host provider ID keyed by opaque capability token. */
+  providerByCapability: Map<string, string>;
+}
+
+const providers = new Map<string, ClusterProviderHandler>();
+
+/**
+ * Checks whether a package or provider ID has a valid package-style name.
+ *
+ * @param value - Candidate name.
+ * @returns Whether the value is a valid name.
+ */
+function validName(value: unknown): value is string {
+  return typeof value === 'string' && value.length <= MAX_NAME_LENGTH && VALID_NAME.test(value);
+}
+
+/**
+ * Registers a cluster provider owned by the desktop host.
+ *
+ * @param provider - Stable provider ID exposed to package plugins.
+ * @param handler - Handler invoked for authorized requests.
+ * @returns A function that unregisters this handler if it is still current.
+ */
+export function registerClusterProvider(
+  provider: string,
+  handler: ClusterProviderHandler
+): () => void {
+  if (!validName(provider) || typeof handler !== 'function') {
+    throw new Error('Invalid cluster provider registration');
+  }
+  if (providers.has(provider)) {
+    throw new Error(`Cluster provider is already registered: ${provider}`);
+  }
+  providers.set(provider, handler);
+
+  return () => {
+    if (providers.get(provider) === handler) {
+      providers.delete(provider);
+    }
+  };
+}
+
+/**
+ * Creates opaque capabilities for valid provider declarations.
+ *
+ * @param registrations - Untrusted package plugin provider declarations.
+ * @returns Authorized capabilities and their host provider lookup.
+ */
+export function createClusterProviderCapabilities(
+  registrations: unknown
+): ClusterProviderCapabilities {
+  const capabilities: Record<string, ClusterProviderCapability[]> = Object.create(null);
+  const providerByCapability = new Map<string, string>();
+  if (!Array.isArray(registrations) || registrations.length > MAX_PLUGINS) {
+    return { capabilities, providerByCapability };
+  }
+
+  const seenPlugins = new Set<string>();
+  for (const item of registrations) {
+    if (typeof item !== 'object' || item === null) {
+      continue;
+    }
+    const { pluginName, providers: requestedProviders } =
+      item as Partial<ClusterProviderRegistration>;
+    if (
+      !validName(pluginName) ||
+      seenPlugins.has(pluginName) ||
+      !Array.isArray(requestedProviders) ||
+      requestedProviders.length > MAX_PROVIDERS_PER_PLUGIN
+    ) {
+      continue;
+    }
+    seenPlugins.add(pluginName);
+    capabilities[pluginName] = [];
+
+    for (const provider of new Set(requestedProviders)) {
+      if (!validName(provider) || !providers.has(provider)) {
+        continue;
+      }
+      const capability = crypto.randomBytes(32).toString('hex');
+      capabilities[pluginName].push({ provider, capability });
+      providerByCapability.set(capability, provider);
+    }
+  }
+  return { capabilities, providerByCapability };
+}
+
+/**
+ * Checks whether an invocation payload is a bounded JSON object.
+ *
+ * @param request - Untrusted invocation payload.
+ * @returns Whether the payload can be sent to a provider.
+ */
+function validRequest(request: unknown): request is Record<string, unknown> {
+  if (typeof request !== 'object' || request === null || Array.isArray(request)) {
+    return false;
+  }
+  try {
+    return JSON.stringify(request).length <= MAX_REQUEST_LENGTH;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Installs the renderer-scoped cluster provider IPC handlers.
+ *
+ * @param mainWindow - Window allowed to register and invoke capabilities.
+ * @param ipcMain - Electron IPC registry receiving the handlers.
+ * @returns Nothing.
+ */
+export function setupClusterProviderHandlers(mainWindow: BrowserWindow, ipcMain: IpcMain): void {
+  let registrationAllowed = true;
+  let providerByCapability = new Map<string, string>();
+  const fromMainWindow = (event: IpcMainInvokeEvent) => event.sender === mainWindow.webContents;
+
+  ipcMain.removeHandler('register-plugin-cluster-provider-capabilities');
+  ipcMain.removeHandler('invoke-cluster-provider');
+  ipcMain.handle('register-plugin-cluster-provider-capabilities', (event, registrations) => {
+    if (!fromMainWindow(event) || !registrationAllowed) {
+      return {};
+    }
+    registrationAllowed = false;
+    const registration = createClusterProviderCapabilities(registrations);
+    providerByCapability = registration.providerByCapability;
+    return registration.capabilities;
+  });
+
+  ipcMain.handle('invoke-cluster-provider', async (event, capability, request) => {
+    const provider =
+      fromMainWindow(event) && typeof capability === 'string'
+        ? providerByCapability.get(capability)
+        : undefined;
+    const handler = provider ? providers.get(provider) : undefined;
+    if (!provider || !handler || !validRequest(request)) {
+      return { success: false, message: 'Invalid cluster provider capability or request' };
+    }
+    try {
+      return await handler(request);
+    } catch (error) {
+      console.error(`Cluster provider failed: ${provider}`, error);
+      return { success: false, message: 'Cluster provider failed' };
+    }
+  });
+
+  mainWindow.webContents.on('did-start-loading', () => {
+    registrationAllowed = true;
+    providerByCapability.clear();
+  });
+}

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -38,6 +38,7 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { withBackendMemoryDefaults } from './backendMemory';
 import { createCertificateSetup } from './certificates';
+import { registerClusterProvider, setupClusterProviderHandlers } from './cluster-provider';
 import { startWindowsVMDetection, waitForWindowsVMDetection } from './hardwareAcceleration';
 import i18n from './i18next.config';
 import {
@@ -84,6 +85,8 @@ import {
   loadZoomFactor,
   saveZoomFactor,
 } from './zoom';
+
+export { registerClusterProvider };
 
 if (process.env.APPIMAGE) {
   app.commandLine.appendSwitch('disable-setuid-sandbox');
@@ -1842,6 +1845,7 @@ function startElectron() {
       applyTrayIconSetting(enabled);
     });
 
+    setupClusterProviderHandlers(mainWindow, ipcMain);
     setupRunCmdHandlers(mainWindow, ipcMain);
 
     new PluginManagerEventListeners().setupEventHandlers();

--- a/app/electron/preload.test.ts
+++ b/app/electron/preload.test.ts
@@ -93,4 +93,24 @@ describe('desktop preload API', () => {
     expect(electronMocks.removeListener).toHaveBeenNthCalledWith(1, 'currentMenu', listener);
     expect(electronMocks.removeListener).toHaveBeenNthCalledWith(2, 'locale', expect.any(Function));
   });
+
+  it('exposes cluster provider capability registration and invocation', async () => {
+    const registrations = [{ pluginName: 'example', providers: ['example.cluster'] }];
+    const request = { cluster: 'demo' };
+
+    await desktopApi.clusterProviderCapabilities.register(registrations);
+    await desktopApi.clusterProviderCapabilities.invoke('opaque-capability', request);
+
+    expect(electronMocks.invoke).toHaveBeenNthCalledWith(
+      1,
+      'register-plugin-cluster-provider-capabilities',
+      registrations
+    );
+    expect(electronMocks.invoke).toHaveBeenNthCalledWith(
+      2,
+      'invoke-cluster-provider',
+      'opaque-capability',
+      request
+    );
+  });
 });

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -115,6 +115,13 @@ contextBridge.exposeInMainWorld('desktopApi', {
       ipcRenderer.invoke('mcp-cluster-change', { cluster }),
   },
 
+  clusterProviderCapabilities: {
+    register: (registrations: Array<{ pluginName: string; providers: string[] }>) =>
+      ipcRenderer.invoke('register-plugin-cluster-provider-capabilities', registrations),
+    invoke: (capability: string, request: Record<string, unknown>) =>
+      ipcRenderer.invoke('invoke-cluster-provider', capability, request),
+  },
+
   // Notify cluster change (for MCP server restart)
   notifyClusterChange: (cluster: string | null) => {
     ipcRenderer.send('cluster-changed', cluster);

--- a/frontend/src/plugin/clusterProviderCapabilities.test.ts
+++ b/frontend/src/plugin/clusterProviderCapabilities.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  findClusterProviderCapability,
+  getDeclaredClusterProviders,
+} from './clusterProviderCapabilities';
+
+describe('getDeclaredClusterProviders', () => {
+  it('reads unique provider IDs from plugin metadata', () => {
+    expect(
+      getDeclaredClusterProviders({
+        headlamp: { clusterProviders: ['example.cluster', 'example.cluster'] },
+      })
+    ).toEqual(['example.cluster']);
+  });
+
+  it('ignores invalid provider IDs', () => {
+    expect(
+      getDeclaredClusterProviders({
+        headlamp: { clusterProviders: ['example.cluster', '../provider', 1] },
+      })
+    ).toEqual(['example.cluster']);
+  });
+});
+
+describe('findClusterProviderCapability', () => {
+  it('returns only the requested provider capability', () => {
+    const capabilities = [
+      { provider: 'example.cluster', capability: 'example-capability' },
+      { provider: 'other.cluster', capability: 'other-capability' },
+    ];
+
+    expect(findClusterProviderCapability(capabilities, 'example.cluster')).toBe(
+      'example-capability'
+    );
+    expect(findClusterProviderCapability(capabilities, 'missing.cluster')).toBeUndefined();
+  });
+});

--- a/frontend/src/plugin/clusterProviderCapabilities.ts
+++ b/frontend/src/plugin/clusterProviderCapabilities.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const VALID_PROVIDER = /^[a-z0-9][a-z0-9._-]*$/i;
+const MAX_PROVIDER_LENGTH = 214;
+const MAX_PROVIDERS = 16;
+
+/** Opaque authorization for one host-registered cluster provider. */
+export interface ClusterProviderCapability {
+  /** Stable ID of the authorized provider. */
+  provider: string;
+  /** Opaque token that authorizes provider invocation. */
+  capability: string;
+}
+
+/**
+ * Reads valid cluster provider declarations from package metadata.
+ *
+ * @param packageInfo - Untrusted package metadata.
+ * @returns Unique valid provider IDs declared by the package.
+ */
+export function getDeclaredClusterProviders(packageInfo: unknown): string[] {
+  if (typeof packageInfo !== 'object' || packageInfo === null) {
+    return [];
+  }
+  const headlamp = (packageInfo as { headlamp?: unknown }).headlamp;
+  if (typeof headlamp !== 'object' || headlamp === null) {
+    return [];
+  }
+  const providers = (headlamp as { clusterProviders?: unknown }).clusterProviders;
+  if (!Array.isArray(providers) || providers.length > MAX_PROVIDERS) {
+    return [];
+  }
+  return [
+    ...new Set(
+      providers.filter(
+        provider =>
+          typeof provider === 'string' &&
+          provider.length <= MAX_PROVIDER_LENGTH &&
+          VALID_PROVIDER.test(provider)
+      )
+    ),
+  ];
+}
+
+/**
+ * Finds the opaque capability for a declared provider.
+ *
+ * @param capabilities - Capabilities authorized for one package plugin.
+ * @param provider - Stable provider ID requested by the plugin.
+ * @returns The capability token, or undefined when the provider is unauthorized.
+ */
+export function findClusterProviderCapability(
+  capabilities: ClusterProviderCapability[],
+  provider: string
+): string | undefined {
+  return capabilities.find(item => item.provider === provider)?.capability;
+}

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -53,6 +53,11 @@ import * as Utils from '../lib/util';
 import { eventAction, HeadlampEventType } from '../redux/headlampEventSlice';
 import store from '../redux/stores/store';
 import * as stateless from '../stateless/index';
+import {
+  ClusterProviderCapability,
+  findClusterProviderCapability,
+  getDeclaredClusterProviders,
+} from './clusterProviderCapabilities';
 import { Headlamp, Plugin } from './lib';
 import { changePluginLanguage, initializePluginI18n } from './pluginI18n';
 import { useTranslation } from './pluginI18n';
@@ -572,6 +577,17 @@ export async function fetchAndExecutePlugins(
   const sourcesToExecute = indicesToExecute.map(index => sources[index]);
   const pluginPathsToExecute = indicesToExecute.map(index => pluginPaths[index]);
   const packageInfosToExecute = indicesToExecute.map(index => packageInfos[index]);
+  const clusterProviderBridge = window?.desktopApi?.clusterProviderCapabilities;
+  const invokeClusterProvider = clusterProviderBridge?.invoke;
+  const clusterProviderCapabilities: Record<string, ClusterProviderCapability[]> =
+    clusterProviderBridge
+      ? await clusterProviderBridge.register(
+          packageInfosToExecute.map(plugin => ({
+            pluginName: plugin.name,
+            providers: getDeclaredClusterProviders(plugin),
+          }))
+        )
+      : {};
 
   // Save references to the pluginRunCommand and desktopApiSend/Receive.
   // Plugins can use without worrying about modified global window.desktopApi.
@@ -634,6 +650,27 @@ export async function fetchAndExecutePlugins(
           return secretsToReturn;
         },
         getArgValues: (pluginName, pluginPath, allowedPermissions) => {
+          const declaredClusterProviders = clusterProviderCapabilities[pluginName] ?? [];
+          if (declaredClusterProviders.length > 0 && invokeClusterProvider) {
+            /** Invokes a host cluster provider authorized for this package plugin. */
+            function clusterProviderInvoke(
+              provider: string,
+              request: Record<string, unknown>
+            ): Promise<unknown> {
+              const capability = findClusterProviderCapability(declaredClusterProviders, provider);
+              if (!capability) {
+                return Promise.reject(
+                  new Error(`Cluster provider is outside the plugin's declared scope: ${provider}`)
+                );
+              }
+              return invokeClusterProvider(capability, request);
+            }
+            return [
+              ['clusterProviderInvoke', 'pluginPath'],
+              [clusterProviderInvoke, pluginPath],
+            ];
+          }
+
           // allowedPermissions is the return value of getAllowedPermissions
           const isPackage = identifyPackages(pluginPath, pluginName, isDevelopmentMode);
           if (isPackage['@headlamp-k8s/minikube']) {

--- a/frontend/src/plugin/pluginsSlice.ts
+++ b/frontend/src/plugin/pluginsSlice.ts
@@ -46,6 +46,8 @@ export type PluginSettingsComponentType =
 export interface PluginPackageHeadlampConfig {
   /** Whether a shipped plugin is enabled when first discovered. */
   enabledByDefault?: boolean;
+  /** Stable IDs of host cluster providers the package plugin may invoke. */
+  clusterProviders?: string[];
   /** Array of supported locales for i18n. */
   i18n?: string[];
 }


### PR DESCRIPTION
## Summary

This adds a broker for desktop distributions that need a packaged Headlamp plugin to request a cluster operation implemented by the Electron host.

For example, a product can keep native SDK, credential, proxy, or cluster lifecycle code in the main process, register it under a stable provider ID, and let only plugins that declare that ID invoke it through an opaque renderer-scoped capability. This avoids exposing the provider handler itself or adding a broad provider-specific IPC API to Headlamp.

The flow is:

1. The desktop host registers a handler with `registerClusterProvider('product.cluster', handler)`.
2. A packaged plugin declares `headlamp.clusterProviders: ['product.cluster']`.
3. Headlamp gives that plugin a `clusterProviderInvoke` function backed by an opaque capability.
4. Electron main validates the capability and request before dispatching to the host handler.

This PR does not add a cluster provider or visible UI by itself. It has no production effect until a downstream desktop product registers a provider and a plugin declares it.

## Provenance

- Original AKS Desktop PR where patch 0014 was introduced: https://github.com/illume/aks-desktop/pull/95
- Azure source-package follow-up: https://github.com/Azure/aks-desktop/pull/823
- Original embedded patch commit: `bc7d2152cab7cc720ef11f6356f94b1f4eaf957b` (`app: authorize package cluster providers`) by Joaquim Rocha, dated 2026-07-31
- Patch 0014 first entered AKS Desktop history in https://github.com/Azure/aks-desktop/commit/597c871866593d82d67c1fc81eb0a69bb7b816eb
- Azure PR 823 carries the retained patch series in https://github.com/Azure/aks-desktop/commit/387eb27e3f586211610dda61949255e7264a9c95

## Improvements over the existing changes

- Rebased the patch onto current Headlamp `main` and removed command-capability context from earlier patches so 0014 remains independent.
- Reset renderer authorization at the start of page loading rather than after loading finishes. The Electron e2e exposed that the previous timing could race plugin registration during reload.
- Added TSDoc for the cluster-provider contracts and package metadata so downstream hosts and plugin authors have a documented TypeScript API.
- Added preload bridge coverage and a real Electron packaged-plugin e2e so metadata scoping, IPC invocation, renderer reloads, and undeclared-provider rejection are exercised together.

## Test coverage

- Electron cluster-provider module: 89.79% branches
- Frontend cluster-provider helper: 80% branches
- `cd app && ./node_modules/.bin/vitest run electron/cluster-provider.test.ts electron/preload.test.ts`
- `cd frontend && ./node_modules/.bin/vitest run src/plugin/clusterProviderCapabilities.test.ts`
- `cd app && npm run tsc`
- `cd frontend && npm run tsc`
- `cd app/e2e-tests && PLAYWRIGHT_TEST_MODE=app npm run test-app -- clusterProviderCapabilities.spec.ts`

## Screenshots

Not applicable. This changes a non-visual authorization and IPC path.

Assisted by copilot.
