### PR TITLE
frontend: EditorDialog: Confirm before closing with unsaved changes

### DIFF
--- a/frontend/src/components/activity/Activity.test.tsx
+++ b/frontend/src/components/activity/Activity.test.tsx
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { Activity } from './Activity';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import store from '../../redux/stores/store';
+import { TestContext } from '../../test';
+import { ActivitiesRenderer, Activity } from './Activity';
 import { activitySlice, ActivityState } from './activitySlice';
 
 const { reducer, actions } = activitySlice;
@@ -153,5 +157,122 @@ describe('activitySlice', () => {
       expect(nextState.activities['ghost']).toBeUndefined();
       expect(nextState.history).toEqual([]);
     });
+  });
+});
+
+describe('Activity.requestClose', () => {
+  afterEach(() => {
+    Activity.reset();
+  });
+
+  it('calls onCloseRequest instead of closing when the activity has one', () => {
+    const onCloseRequest = vi.fn();
+    Activity.launch({
+      id: 'guarded',
+      content: 'Guarded content',
+      location: 'full',
+      onCloseRequest,
+    });
+
+    Activity.requestClose('guarded');
+
+    expect(onCloseRequest).toHaveBeenCalledTimes(1);
+    expect(store.getState().activity.activities['guarded']).toBeDefined();
+  });
+
+  it('closes directly when the activity has no onCloseRequest', () => {
+    Activity.launch({ id: 'plain', content: 'Plain content', location: 'full' });
+
+    Activity.requestClose('plain');
+
+    expect(store.getState().activity.activities['plain']).toBeUndefined();
+  });
+
+  it('does nothing harmful when the activity does not exist', () => {
+    expect(() => Activity.requestClose('missing')).not.toThrow();
+  });
+});
+
+describe('Activity close buttons', () => {
+  afterEach(() => {
+    Activity.reset();
+  });
+
+  function launchAndRender(activity: Partial<Activity> & { id: string }) {
+    Activity.launch({
+      content: 'Some content',
+      location: 'full',
+      title: 'Some activity',
+      ...activity,
+    });
+    return render(
+      <TestContext>
+        <ActivitiesRenderer />
+      </TestContext>
+    );
+  }
+
+  it('routes the title-bar X through the close guard', () => {
+    const onCloseRequest = vi.fn();
+    launchAndRender({ id: 'guarded', onCloseRequest });
+
+    fireEvent.click(screen.getByTitle('Close'));
+
+    expect(onCloseRequest).toHaveBeenCalledTimes(1);
+    expect(store.getState().activity.activities['guarded']).toBeDefined();
+  });
+
+  it('closes from the title-bar X when there is no guard', () => {
+    launchAndRender({ id: 'plain' });
+
+    fireEvent.click(screen.getByTitle('Close'));
+
+    expect(store.getState().activity.activities['plain']).toBeUndefined();
+  });
+
+  it('routes the taskbar close button through the close guard', () => {
+    const onCloseRequest = vi.fn();
+    launchAndRender({ id: 'guarded', onCloseRequest });
+
+    fireEvent.click(screen.getByLabelText('Close'));
+
+    expect(onCloseRequest).toHaveBeenCalledTimes(1);
+    expect(store.getState().activity.activities['guarded']).toBeDefined();
+  });
+
+  it('routes a middle-click on the taskbar button through the close guard', () => {
+    const onCloseRequest = vi.fn();
+    launchAndRender({ id: 'guarded', onCloseRequest });
+
+    fireEvent.mouseDown(screen.getByRole('button', { name: /Some activity/ }), { button: 1 });
+
+    expect(onCloseRequest).toHaveBeenCalledTimes(1);
+    expect(store.getState().activity.activities['guarded']).toBeDefined();
+  });
+
+  it('closes from a middle-click on the taskbar button when there is no guard', () => {
+    launchAndRender({ id: 'plain' });
+
+    fireEvent.mouseDown(screen.getByRole('button', { name: /Some activity/ }), { button: 1 });
+
+    expect(store.getState().activity.activities['plain']).toBeUndefined();
+  });
+
+  it('routes Close All through each activity close guard', () => {
+    const onCloseRequest = vi.fn();
+    launchAndRender({ id: 'guarded', onCloseRequest });
+    Activity.launch({
+      id: 'plain',
+      content: 'Plain content',
+      location: 'full',
+      title: 'Plain activity',
+    });
+
+    fireEvent.click(screen.getByLabelText('Overview'));
+    fireEvent.click(screen.getByRole('button', { name: /Close All/ }));
+
+    expect(onCloseRequest).toHaveBeenCalledTimes(1);
+    expect(store.getState().activity.activities['guarded']).toBeDefined();
+    expect(store.getState().activity.activities['plain']).toBeUndefined();
   });
 });

--- a/frontend/src/components/activity/Activity.test.tsx
+++ b/frontend/src/components/activity/Activity.test.tsx
@@ -146,5 +146,12 @@ describe('activitySlice', () => {
       const nextState = reducer(stateWithActivity, update(updatedActivity));
       expect(nextState.history).toEqual([]);
     });
+
+    it('should ignore updates for activities that do not exist', () => {
+      const emptyState: ActivityState = { history: [], activities: {} };
+      const nextState = reducer(emptyState, update({ id: 'ghost', title: 'Ghost' }));
+      expect(nextState.activities['ghost']).toBeUndefined();
+      expect(nextState.history).toEqual([]);
+    });
   });
 });

--- a/frontend/src/components/activity/Activity.tsx
+++ b/frontend/src/components/activity/Activity.tsx
@@ -88,6 +88,15 @@ export interface Activity {
   temporary?: boolean;
   /** Cluster of the launched activity */
   cluster?: string;
+  /**
+   * Optional close interceptor. When set, user-initiated close actions
+   * (the title-bar X, the taskbar close buttons and Close All) call this
+   * instead of closing the activity directly, so the content can e.g. ask
+   * for confirmation about unsaved changes. The handler is then responsible
+   * for eventually calling Activity.close(id) itself. Programmatic
+   * Activity.close() calls are unaffected.
+   */
+  onCloseRequest?: () => void;
 }
 
 export const Activity = {
@@ -98,6 +107,18 @@ export const Activity = {
   /** Closes activity */
   close(id: string) {
     store.dispatch(activitySlice.actions.close(id));
+  },
+  /**
+   * Closes the activity unless it has an onCloseRequest handler, in which
+   * case the handler is called and decides whether/when to close.
+   */
+  requestClose(id: string) {
+    const activity = store.getState().activity.activities[id];
+    if (activity?.onCloseRequest) {
+      activity.onCloseRequest();
+    } else {
+      Activity.close(id);
+    }
   },
   /** Update existing activity with a partial changes */
   update(id: string, diff: Partial<Activity>) {
@@ -733,7 +754,11 @@ export function SingleActivityRenderer({
                   >
                     <Icon icon="mdi:minimize" />
                   </IconButton>
-                  <IconButton onClick={() => Activity.close(id)} size="small" title={t('Close')}>
+                  <IconButton
+                    onClick={() => Activity.requestClose(id)}
+                    size="small"
+                    title={t('Close')}
+                  >
                     <Icon icon="mdi:close" />
                   </IconButton>
                 </>
@@ -1149,7 +1174,9 @@ export const ActivitiesRenderer = React.memo(function ActivitiesRenderer() {
             variant="contained"
             startIcon={<Icon icon="mdi:close-box-multiple-outline" />}
             onClick={() => {
-              Activity.reset();
+              // Not Activity.reset(): each activity's close guard must get a
+              // chance to intercept, e.g. to confirm discarding unsaved edits.
+              activities.forEach(it => Activity.requestClose(it.id));
               setIsOverview(false);
             }}
             sx={{
@@ -1233,7 +1260,7 @@ export const ActivityBar = React.memo(function ({
             }}
             onMouseDown={e => {
               if (e.button === 1) {
-                Activity.close(it.id);
+                Activity.requestClose(it.id);
               }
             }}
           >
@@ -1299,7 +1326,7 @@ export const ActivityBar = React.memo(function ({
             onClick={e => {
               e.preventDefault();
               e.stopPropagation();
-              Activity.close(it.id);
+              Activity.requestClose(it.id);
             }}
             sx={{ width: '42px', height: '100%', borderRadius: 1, flexShrink: 0 }}
             aria-label={t('Close')}

--- a/frontend/src/components/activity/activitySlice.tsx
+++ b/frontend/src/components/activity/activitySlice.tsx
@@ -80,6 +80,14 @@ export const activitySlice = createSlice({
       delete state.activities[action.payload];
     },
     update(state, action: PayloadAction<Partial<Activity> & { id: string }>) {
+      // Ignore updates for activities that no longer exist — e.g. a content
+      // component clearing state on unmount after its activity was already
+      // closed. Spreading onto a missing entry would recreate a ghost
+      // activity with no content or location.
+      if (!state.activities[action.payload.id]) {
+        return;
+      }
+
       // Bump this activity in history
       if (!action.payload.minimized) {
         state.history = state.history.filter(it => it !== action.payload.id);

--- a/frontend/src/components/common/Resource/EditorDialog.test.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.test.tsx
@@ -18,6 +18,7 @@ import Button from '@mui/material/Button';
 import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';
 import { TestContext } from '../../../test';
+import { ActivitiesRenderer, Activity } from '../../activity/Activity';
 import EditorDialog, { EditorDialogProps, ViewDialog } from './EditorDialog';
 
 const {
@@ -999,6 +1000,64 @@ describe('EditorDialog', () => {
       fireEvent.click(screen.getByRole('button', { name: /undo/i }));
 
       fireEvent.click(getFooterCloseButton());
+
+      expect(screen.queryByText(confirmText)).not.toBeInTheDocument();
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('activity close guard', () => {
+    const confirmText =
+      'You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?';
+
+    afterEach(() => {
+      Activity.reset();
+    });
+
+    function launchEditorActivity(onClose: () => void) {
+      Activity.launch({
+        id: 'edit-activity',
+        title: 'Edit: node-1',
+        location: 'full',
+        content: (
+          <EditorDialog
+            open
+            noDialog
+            item={{ apiVersion: 'v1', kind: 'Node', metadata: { name: 'node-1' } }}
+            onClose={onClose}
+          />
+        ),
+      });
+
+      return render(
+        <TestContext>
+          <ActivitiesRenderer />
+        </TestContext>
+      );
+    }
+
+    it('guards the activity title-bar X when there are unsaved changes', () => {
+      const onClose = vi.fn();
+      launchEditorActivity(onClose);
+
+      fireEvent.change(screen.getByRole('textbox', { name: /code$/i }), {
+        target: { value: 'user-edited-content' },
+      });
+
+      fireEvent.click(screen.getByTitle('Close'));
+
+      expect(screen.getByText(confirmText)).toBeInTheDocument();
+      expect(onClose).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByTestId('confirm-button'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('closes the activity immediately from the X when there are no unsaved changes', () => {
+      const onClose = vi.fn();
+      launchEditorActivity(onClose);
+
+      fireEvent.click(screen.getByTitle('Close'));
 
       expect(screen.queryByText(confirmText)).not.toBeInTheDocument();
       expect(onClose).toHaveBeenCalledTimes(1);

--- a/frontend/src/components/common/Resource/EditorDialog.test.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import Button from '@mui/material/Button';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';
 import { TestContext } from '../../../test';
 import EditorDialog, { EditorDialogProps, ViewDialog } from './EditorDialog';
@@ -150,17 +150,20 @@ vi.mock('../ConfirmButton', () => ({
     disabled,
     'aria-label': ariaLabel,
     'aria-controls': ariaControls,
+    confirmDescription,
   }: {
     children: React.ReactNode;
     onConfirm: () => void;
     disabled?: boolean;
     'aria-label'?: string;
     'aria-controls'?: string;
+    confirmDescription?: string;
   }) => (
     <Button
       aria-label={ariaLabel}
       disabled={disabled}
       aria-controls={ariaControls}
+      data-confirm-description={confirmDescription}
       onClick={() => {
         if (!disabled) {
           onConfirm();
@@ -569,6 +572,9 @@ describe('EditorDialog', () => {
 
     const saveApplyButton = screen.getByRole('button', { name: /save & apply/i });
     expect(saveApplyButton).toHaveAttribute('aria-controls', textareaId);
+
+    const closeButton = screen.getByRole('button', { name: /^close$/i });
+    expect(closeButton).toHaveAttribute('aria-controls', textareaId);
   });
 
   it('configures the dialog content to scroll with a minimum height', () => {
@@ -598,6 +604,11 @@ describe('EditorDialog', () => {
     );
 
     expect(screen.getByRole('button', { name: /save & apply/i })).toHaveAttribute(
+      'aria-controls',
+      textareaId
+    );
+
+    expect(screen.getByRole('button', { name: /^close$/i })).toHaveAttribute(
       'aria-controls',
       textareaId
     );
@@ -878,6 +889,120 @@ describe('EditorDialog', () => {
       );
     });
     expect(screen.getByText('Failed to create Node node-1 in v1.')).toBeInTheDocument();
+  });
+
+  describe('close confirmation', () => {
+    const confirmText =
+      'You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?';
+
+    function makeEdit() {
+      fireEvent.change(screen.getByRole('textbox', { name: /code$/i }), {
+        target: { value: 'user-edited-content' },
+      });
+    }
+
+    // The title-bar X is also an accessible "Close" button, so scope footer
+    // queries to the action bar.
+    function getFooterCloseButton() {
+      const actionBar = document.querySelector('.MuiDialogActions-root') as HTMLElement;
+      return within(actionBar).getByRole('button', { name: /^close$/i });
+    }
+
+    it('closes immediately from the Close button when there are no unsaved changes', () => {
+      const onClose = vi.fn();
+      renderEditorDialog({ noDialog: false, onClose });
+
+      fireEvent.click(getFooterCloseButton());
+
+      expect(screen.queryByText(confirmText)).not.toBeInTheDocument();
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('asks for confirmation from the Close button and closes on confirm', () => {
+      const onClose = vi.fn();
+      renderEditorDialog({ noDialog: false, onClose });
+      makeEdit();
+
+      fireEvent.click(getFooterCloseButton());
+
+      expect(screen.getByText(confirmText)).toBeInTheDocument();
+      expect(onClose).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByTestId('confirm-button'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the editor open with its edits when the confirmation is cancelled', () => {
+      const onClose = vi.fn();
+      renderEditorDialog({ noDialog: false, onClose });
+      makeEdit();
+
+      fireEvent.click(getFooterCloseButton());
+      fireEvent.click(screen.getByTestId('cancel-button'));
+
+      act(() => {
+        vi.advanceTimersByTime(1000); // let the confirm dialog's exit transition finish
+      });
+
+      expect(onClose).not.toHaveBeenCalled();
+      expect(screen.queryByText(confirmText)).not.toBeInTheDocument();
+      expect(screen.getByRole('textbox', { name: /code$/i })).toHaveValue('user-edited-content');
+    });
+
+    it('guards the Escape key when there are unsaved changes', () => {
+      const onClose = vi.fn();
+      renderEditorDialog({ noDialog: false, onClose });
+      makeEdit();
+
+      fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+
+      expect(screen.getByText(confirmText)).toBeInTheDocument();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('closes on Escape without confirmation when there are no unsaved changes', () => {
+      const onClose = vi.fn();
+      renderEditorDialog({ noDialog: false, onClose });
+
+      fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('guards backdrop clicks when there are unsaved changes', () => {
+      const onClose = vi.fn();
+      renderEditorDialog({ noDialog: false, onClose });
+      makeEdit();
+
+      fireEvent.click(document.querySelector('.MuiBackdrop-root') as HTMLElement);
+
+      expect(screen.getByText(confirmText)).toBeInTheDocument();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('guards the title-bar close button when there are unsaved changes', () => {
+      const onClose = vi.fn();
+      renderEditorDialog({ noDialog: false, onClose });
+      makeEdit();
+
+      const titleBar = document.querySelector('.MuiDialogTitle-root') as HTMLElement;
+      fireEvent.click(within(titleBar).getByRole('button', { name: /^close$/i }));
+
+      expect(screen.getByText(confirmText)).toBeInTheDocument();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('closes without confirmation again after Undo restores the original content', () => {
+      const onClose = vi.fn();
+      renderEditorDialog({ noDialog: false, onClose });
+      makeEdit();
+      fireEvent.click(screen.getByRole('button', { name: /undo/i }));
+
+      fireEvent.click(getFooterCloseButton());
+
+      expect(screen.queryByText(confirmText)).not.toBeInTheDocument();
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('disables form actions when validation fails and opens the upload dialog', () => {

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -46,7 +46,7 @@ import { AppDispatch } from '../../../redux/stores/store';
 import { useCurrentAppTheme } from '../../App/themeSlice';
 import { useLocalStorageState } from '../../globalSearch/useLocalStorageState';
 import ConfirmButton from '../ConfirmButton';
-import { Dialog, DialogProps } from '../Dialog';
+import { ConfirmDialog, Dialog, DialogProps } from '../Dialog';
 import Loader from '../Loader';
 import Tabs from '../Tabs';
 import DocsViewer from './DocsViewer';
@@ -116,6 +116,7 @@ export default function EditorDialog(props: EditorDialogProps) {
     cluster,
     formInvalid,
     onBaselineAccepted,
+    noDialog,
     ...other
   } = props;
   const editorOptions = {
@@ -156,6 +157,7 @@ export default function EditorDialog(props: EditorDialogProps) {
   const [uploadFiles, setUploadFiles] = React.useState(false);
   const [hasOpenedDiffEditor, setHasOpenedDiffEditor] = React.useState(false);
   const [activeTabIndex, setActiveTabIndex] = React.useState(0);
+  const [showCloseConfirm, setShowCloseConfirm] = React.useState(false);
 
   const dispatchCreateEvent = useEventCallback(HeadlampEventType.CREATE_RESOURCE);
   const dispatch: AppDispatch = useDispatch();
@@ -679,6 +681,18 @@ export default function EditorDialog(props: EditorDialogProps) {
   }
 
   const errorLabel = error || errorMessage;
+  const hasUnsavedChanges = !isReadOnly() && originalCodeRef.current.code !== code.code;
+
+  // Every dismissal route (footer Close, Escape, backdrop click, title-bar X)
+  // must go through here so unsaved edits always get a confirmation prompt.
+  function handleCloseRequest() {
+    if (hasUnsavedChanges) {
+      setShowCloseConfirm(true);
+    } else {
+      onClose();
+    }
+  }
+
   let dialogTitle = title;
   if (!dialogTitle && item) {
     const itemName = (isKubeObjectIsh(item) && item.metadata?.name) || t('New Object');
@@ -826,7 +840,12 @@ export default function EditorDialog(props: EditorDialogProps) {
         <div style={{ flex: '1 0 0' }} />
         {errorLabel && <Typography color="error">{errorLabel}</Typography>}
         <div style={{ flex: '1 0 0' }} />
-        <Button onClick={onClose} color="secondary" variant="contained">
+        <Button
+          onClick={handleCloseRequest}
+          color="secondary"
+          variant="contained"
+          aria-controls={editorId}
+        >
           {t('translation|Close')}
         </Button>
         {!isReadOnly() && (
@@ -862,6 +881,15 @@ export default function EditorDialog(props: EditorDialogProps) {
           </Button>
         )}
       </DialogActions>
+      <ConfirmDialog
+        open={showCloseConfirm}
+        title={t('translation|Are you sure?')}
+        description={t(
+          'You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?'
+        )}
+        handleClose={() => setShowCloseConfirm(false)}
+        onConfirm={onClose}
+      />
     </React.Fragment>
   );
 
@@ -869,7 +897,7 @@ export default function EditorDialog(props: EditorDialogProps) {
     return null;
   }
 
-  if (other.noDialog) {
+  if (noDialog) {
     return content;
   }
 
@@ -881,7 +909,7 @@ export default function EditorDialog(props: EditorDialogProps) {
       scroll="paper"
       fullWidth
       withFullScreen
-      onClose={onClose}
+      onClose={handleCloseRequest}
       {...other}
       aria-labelledby={dialogTitleId}
       titleProps={{

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -43,6 +43,7 @@ import {
   useEventCallback,
 } from '../../../redux/headlampEventSlice';
 import { AppDispatch } from '../../../redux/stores/store';
+import { Activity, useActivity } from '../../activity/Activity';
 import { useCurrentAppTheme } from '../../App/themeSlice';
 import { useLocalStorageState } from '../../globalSearch/useLocalStorageState';
 import ConfirmButton from '../ConfirmButton';
@@ -692,6 +693,27 @@ export default function EditorDialog(props: EditorDialogProps) {
       onClose();
     }
   }
+
+  // In noDialog mode the editor is hosted inside an Activity, whose own
+  // title-bar/taskbar close buttons never reach this component. Register
+  // handleCloseRequest as the Activity's close guard so those routes get the
+  // same unsaved-changes confirmation. Registered once via a ref so the
+  // handler the Activity stores always sees the current editor state.
+  const [hostActivity] = useActivity();
+  const closeGuardActivityId = noDialog ? hostActivity?.id : undefined;
+  const handleCloseRequestRef = React.useRef(handleCloseRequest);
+  handleCloseRequestRef.current = handleCloseRequest;
+  React.useEffect(() => {
+    if (!closeGuardActivityId) {
+      return;
+    }
+    Activity.update(closeGuardActivityId, {
+      onCloseRequest: () => handleCloseRequestRef.current(),
+    });
+    return () => {
+      Activity.update(closeGuardActivityId, { onCloseRequest: undefined });
+    };
+  }, [closeGuardActivityId]);
 
   let dialogTitle = title;
   if (!dialogTitle && item) {

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
@@ -273,6 +273,7 @@
             style="flex: 1 0 0px;"
           />
           <button
+            aria-controls="editor-textarea-id"
             class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation css-14f6w6s-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
@@ -301,6 +302,7 @@
             Save & Apply
           </button>
         </div>
+        <div />
       </div>
     </div>
     <div

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
@@ -309,6 +309,7 @@
             style="flex: 1 0 0px;"
           />
           <button
+            aria-controls="editor-textarea-id"
             class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation css-14f6w6s-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
@@ -337,6 +338,7 @@
             Save & Apply
           </button>
         </div>
+        <div />
       </div>
     </div>
     <div

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -431,6 +431,7 @@
   "Are you sure?": "هل أنت متأكد؟",
   "This will discard your changes in the editor. Do you want to proceed?": "سيؤدي هذا إلى تجاهل التغييرات في المحرر، هل تريد المتابعة؟",
   "Undo Changes": "التراجع عن التغييرات",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "تجربة جافة",
   "Invalid Secret Reference": "مرجع Secret غير صالح",
   "Invalid Config Map Reference": "مرجع Config Map غير صالح",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -423,6 +423,7 @@
   "Are you sure?": "তুমি কি নিশ্চিত?",
   "This will discard your changes in the editor. Do you want to proceed?": "এটি Editorটিতে আপনার পরিবর্তনগুলি বাতিল করবে। ",
   "Undo Changes": "পরিবর্তনগুলি পূর্বাবস্থায় ফিরিয়ে দেয়",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "ড্রাই রান",
   "Invalid Secret Reference": "অবৈধ Secret রেফারেন্স",
   "Invalid Config Map Reference": "অবৈধ Config Map রেফারেন্স",

--- a/frontend/src/i18n/locales/cs/translation.json
+++ b/frontend/src/i18n/locales/cs/translation.json
@@ -427,6 +427,7 @@
   "Are you sure?": "Jste si jistí?",
   "This will discard your changes in the editor. Do you want to proceed?": "Tím se zahodí vaše změny v editoru. Chcete pokračovat?",
   "Undo Changes": "Vrátit změny",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "",
   "Invalid Secret Reference": "Neplatný odkaz na tajný kód",
   "Invalid Config Map Reference": "Neplatný odkaz na konfigurační mapu",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -423,6 +423,7 @@
   "Are you sure?": "Sind Sie sicher?",
   "This will discard your changes in the editor. Do you want to proceed?": "Dadurch werden Ihre Änderungen im Editor verworfen. Möchten Sie fortfahren?",
   "Undo Changes": "Änderungen rückgängig machen",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "",
   "Invalid Secret Reference": "",
   "Invalid Config Map Reference": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -423,6 +423,7 @@
   "Are you sure?": "Are you sure?",
   "This will discard your changes in the editor. Do you want to proceed?": "This will discard your changes in the editor. Do you want to proceed?",
   "Undo Changes": "Undo Changes",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?",
   "Dry Run": "Dry Run",
   "Invalid Secret Reference": "Invalid Secret Reference",
   "Invalid Config Map Reference": "Invalid Config Map Reference",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -425,6 +425,7 @@
   "Are you sure?": "¿Está seguro?",
   "This will discard your changes in the editor. Do you want to proceed?": "Esto descartará sus cambios en el editor. ¿Desea avanzar?",
   "Undo Changes": "Deshacer cambios",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "",
   "Invalid Secret Reference": "",
   "Invalid Config Map Reference": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -425,6 +425,7 @@
   "Are you sure?": "Êtes-vous sûr ?",
   "This will discard your changes in the editor. Do you want to proceed?": "Vos modifications seront perdues. Voulez-vous continuer ?",
   "Undo Changes": "Annuler les modifications",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "",
   "Invalid Secret Reference": "",
   "Invalid Config Map Reference": "",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -425,6 +425,7 @@
   "Are you sure?": "Are you sure?",
   "This will discard your changes in the editor. Do you want to proceed?": "This will discard your changes in the editor. Do you want to proceed?",
   "Undo Changes": "Undo Changes",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "Dry Run",
   "Invalid Secret Reference": "Invalid Secret Reference",
   "Invalid Config Map Reference": "Invalid Config Map Reference",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -423,6 +423,7 @@
   "Are you sure?": "",
   "This will discard your changes in the editor. Do you want to proceed?": "",
   "Undo Changes": "",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "",
   "Invalid Secret Reference": "",
   "Invalid Config Map Reference": "",

--- a/frontend/src/i18n/locales/hu/translation.json
+++ b/frontend/src/i18n/locales/hu/translation.json
@@ -423,6 +423,7 @@
   "Are you sure?": "Biztos benne?",
   "This will discard your changes in the editor. Do you want to proceed?": "Ezzel elveti a módosításokat a szerkesztőben. Folytatja?",
   "Undo Changes": "Módosítások visszavonása",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "",
   "Invalid Secret Reference": "Érvénytelen titkos kód hivatkozás",
   "Invalid Config Map Reference": "Érvénytelen konfigurációs térkép hivatkozás",

--- a/frontend/src/i18n/locales/id/translation.json
+++ b/frontend/src/i18n/locales/id/translation.json
@@ -421,6 +421,7 @@
   "Are you sure?": "Yakin?",
   "This will discard your changes in the editor. Do you want to proceed?": "Tindakan ini akan membuang perubahan Anda di editor. Ingin melanjutkan?",
   "Undo Changes": "Batalkan Perubahan",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "",
   "Invalid Secret Reference": "Referensi Rahasia Tidak Valid",
   "Invalid Config Map Reference": "Referensi Peta Konfigurasi Tidak Valid",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -425,6 +425,7 @@
   "Are you sure?": "Sei sicuro?",
   "This will discard your changes in the editor. Do you want to proceed?": "Questo annullerà le modifiche apportate nell'editor. Vuoi procedere?",
   "Undo Changes": "Annulla Modifiche",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "",
   "Invalid Secret Reference": "",
   "Invalid Config Map Reference": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -421,6 +421,7 @@
   "Are you sure?": "よろしいですか？",
   "This will discard your changes in the editor. Do you want to proceed?": "エディターでの変更が破棄されます。続行しますか？",
   "Undo Changes": "変更を元に戻す",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "",
   "Invalid Secret Reference": "",
   "Invalid Config Map Reference": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -421,6 +421,7 @@
   "Are you sure?": "확실합니까?",
   "This will discard your changes in the editor. Do you want to proceed?": "편집기의 변경 사항이 삭제됩니다. 계속하시겠습니까?",
   "Undo Changes": "변경 사항 취소",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "",
   "Invalid Secret Reference": "",
   "Invalid Config Map Reference": "",

--- a/frontend/src/i18n/locales/nl/translation.json
+++ b/frontend/src/i18n/locales/nl/translation.json
@@ -423,6 +423,7 @@
   "Are you sure?": "Weet je het zeker?",
   "This will discard your changes in the editor. Do you want to proceed?": "Hiermee worden uw wijzigingen in de editor verwijderd. Wilt u doorgaan?",
   "Undo Changes": "Wijzigingen ongedaan maken",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "",
   "Invalid Secret Reference": "Ongeldige geheime verwijzing",
   "Invalid Config Map Reference": "Ongeldige verwijzing naar configuratietoewijzing",

--- a/frontend/src/i18n/locales/pl/translation.json
+++ b/frontend/src/i18n/locales/pl/translation.json
@@ -427,6 +427,7 @@
   "Are you sure?": "Czy na pewno chcesz to zrobić?",
   "This will discard your changes in the editor. Do you want to proceed?": "Spowoduje to odrzucenie zmian w edytorze. Czy chcesz kontynuować?",
   "Undo Changes": "Cofnij zmiany",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "",
   "Invalid Secret Reference": "Nieprawidłowe odwołanie do wpisu tajnego",
   "Invalid Config Map Reference": "Nieprawidłowe odwołanie do mapy konfiguracji",

--- a/frontend/src/i18n/locales/pt-br/translation.json
+++ b/frontend/src/i18n/locales/pt-br/translation.json
@@ -425,6 +425,7 @@
   "Are you sure?": "Tem a certeza?",
   "This will discard your changes in the editor. Do you want to proceed?": "Irá descartar as suas modificações no editor. Deseja prosseguir?",
   "Undo Changes": "Desfazer modificações",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "",
   "Invalid Secret Reference": "Referência de Segredo Inválida",
   "Invalid Config Map Reference": "Referência de Mapa de Configuração Inválida",

--- a/frontend/src/i18n/locales/pt-pt/translation.json
+++ b/frontend/src/i18n/locales/pt-pt/translation.json
@@ -425,6 +425,7 @@
   "Are you sure?": "",
   "This will discard your changes in the editor. Do you want to proceed?": "",
   "Undo Changes": "",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "",
   "Invalid Secret Reference": "",
   "Invalid Config Map Reference": "",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -427,6 +427,7 @@
   "Are you sure?": "Вы уверены?",
   "This will discard your changes in the editor. Do you want to proceed?": "Это приведёт к отмене ваших изменений в редакторе. Хотите продолжить?",
   "Undo Changes": "Отменить изменения",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "Пробный запуск",
   "Invalid Secret Reference": "Неверная секретная ссылка",
   "Invalid Config Map Reference": "Неверная ссылка на карту конфигурации",

--- a/frontend/src/i18n/locales/sv/translation.json
+++ b/frontend/src/i18n/locales/sv/translation.json
@@ -423,6 +423,7 @@
   "Are you sure?": "Är du säker?",
   "This will discard your changes in the editor. Do you want to proceed?": "Det här raderar dina ändringar i redigeraren. Vill du fortsätta?",
   "Undo Changes": "Ångra ändringar",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "",
   "Invalid Secret Reference": "Ogiltig lösenordsreferens",
   "Invalid Config Map Reference": "Ogiltig referens till konfigurationsöversikt",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -423,6 +423,7 @@
   "Are you sure?": "உறுதியாகவா?",
   "This will discard your changes in the editor. Do you want to proceed?": "இது எடிட்டரில் உங்கள் மாற்றங்களை நிராகரிக்கும். தொடர விரும்புகிறீர்களா?",
   "Undo Changes": "மாற்றங்களை செயல்தவிர்",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "",
   "Invalid Secret Reference": "",
   "Invalid Config Map Reference": "",

--- a/frontend/src/i18n/locales/tr/translation.json
+++ b/frontend/src/i18n/locales/tr/translation.json
@@ -423,6 +423,7 @@
   "Are you sure?": "Emin misiniz?",
   "This will discard your changes in the editor. Do you want to proceed?": "Bu işlem düzenleyicideki değişikliklerinizi atar. Devam etmek istiyor musunuz?",
   "Undo Changes": "Değişiklikleri Geri Al",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "",
   "Invalid Secret Reference": "Geçersiz Gizli Dizi Başvurusu",
   "Invalid Config Map Reference": "Geçersiz Yapılandırma Eşlemesi Başvurusu",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -423,6 +423,7 @@
   "Are you sure?": "کیا آپ کو یقین ہے؟",
   "This will discard your changes in the editor. Do you want to proceed?": "اس سے ایڈیٹر میں کی گئی تبدیلیاں ختم ہو جائیں گی، کیا آپ آگے بڑھنا چاہتے ہیں؟",
   "Undo Changes": "تبدیلیاں واپس کریں",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "ڈرائی رن",
   "Invalid Secret Reference": "غلط سیکرٹ ریفرنس",
   "Invalid Config Map Reference": "غلط کنفیگ میپ ریفرنس",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -421,6 +421,7 @@
   "Are you sure?": "您確定嗎？",
   "This will discard your changes in the editor. Do you want to proceed?": "這將放棄您在編輯器中的更改。您要繼續嗎？",
   "Undo Changes": "撤銷更改",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "",
   "Invalid Secret Reference": "",
   "Invalid Config Map Reference": "",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -421,6 +421,7 @@
   "Are you sure?": "您确定吗？",
   "This will discard your changes in the editor. Do you want to proceed?": "这将放弃您在编辑器中的更改。您要继续吗？",
   "Undo Changes": "撤销更改",
+  "You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?": "",
   "Dry Run": "",
   "Invalid Secret Reference": "",
   "Invalid Config Map Reference": "",

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -2,6 +2,7 @@
   "Activity": {
     "close": [Function],
     "launch": [Function],
+    "requestClose": [Function],
     "reset": [Function],
     "update": [Function],
   },


### PR DESCRIPTION
Fixes #7444

## What this PR does

The editor dialog discarded unsaved changes instantly on any dismissal route — the footer **Close** button, the Escape key, a backdrop click, or the title-bar X — so a single misclick lost all edits. Now every dismissal goes through a close guard: with unsaved edits it shows an "Are you sure?" `ConfirmDialog` ("You have unsaved changes in the editor. Closing will discard them. Do you want to proceed?"). A pristine editor still closes immediately, and the programmatic close after a successful apply is unaffected.

When the editor runs inside an Activity (`noDialog`), the Activity's own close buttons never reach the editor, so this PR also adds a small public Activity API to cover those routes:

- An optional `onCloseRequest` field on `Activity` plus `Activity.requestClose(id)`: user-initiated close actions (title-bar X, taskbar close button, taskbar middle-click, and the overview's **Close All**) now call `requestClose`, which invokes the guard when set and closes directly otherwise. `Activity.close()` and guard-less activities behave exactly as before. `EditorDialog` registers its confirmation as the host activity's guard in `noDialog` mode.
- The activity `update` reducer now ignores updates for already-closed activities, so a content component clearing its guard on unmount can't recreate a ghost activity.

<img width="1622" height="831" alt="image" src="https://github.com/user-attachments/assets/4efa1ec4-380f-49d1-ab10-6b72bd14294a" />

## Testing

- `EditorDialog.test.tsx`: the guard on the Close button, Escape, backdrop click, and title-bar X; confirm closes and cancel keeps the edits; a pristine editor closes immediately, including again after Undo; the Activity title-bar X is guarded in `noDialog` mode.
- `Activity.test.tsx`: `Activity.requestClose` semantics, the reducer ignoring updates for closed activities, and regression tests routing the title-bar X, taskbar close button, taskbar middle-click, and Close All through the guard.
- Updated `pluginLib.snapshot` for `Activity.requestClose` and the EditorDialog storyshots for the Close button's `aria-controls`.

