### PR TITLE
backend: helm: Mark install failed when VerifyUser rejects

### DIFF
--- a/backend/pkg/helm/handler_test.go
+++ b/backend/pkg/helm/handler_test.go
@@ -230,3 +230,37 @@ func TestGetReleaseStatusUnmarshalError(t *testing.T) {
 	_, err = h.getReleaseStatus("install", "badrelease")
 	assert.Error(t, err)
 }
+
+// installRelease must mark the action as failed when VerifyUser rejects the
+// request; otherwise the status stays "processing" until the cache TTL
+// expires and the frontend polls forever.
+func TestInstallReleaseVerifyUserFailureSetsFailedStatus(t *testing.T) {
+	h, err := NewHandler(newTestCache())
+	require.NoError(t, err)
+
+	// An empty kubeconfig makes ToRESTConfig fail, so VerifyUser rejects the
+	// request deterministically without any network I/O. Pointing at a fixed
+	// local port instead would depend on nothing listening there.
+	emptyCC := clientcmd.NewDefaultClientConfig(clientcmdapi.Config{}, &clientcmd.ConfigOverrides{})
+	actionConfig, err := NewActionConfig(emptyCC, "default")
+	require.NoError(t, err)
+
+	req := InstallRequest{
+		CommonInstallUpdateRequest: CommonInstallUpdateRequest{
+			Name:      "verify-user-failure",
+			Chart:     "test-chart",
+			Namespace: "default",
+		},
+	}
+
+	// InstallRelease sets "processing" before spawning the async install;
+	// reproduce that state here.
+	require.NoError(t, h.setReleaseStatus("install", req.Name, processing, nil))
+
+	h.installRelease(req, actionConfig)
+
+	stat, err := h.getReleaseStatus("install", req.Name)
+	require.NoError(t, err)
+	assert.Equal(t, failed, stat.Status)
+	assert.NotNil(t, stat.Err)
+}

--- a/backend/pkg/helm/release.go
+++ b/backend/pkg/helm/release.go
@@ -732,6 +732,10 @@ func (h *Handler) installRelease(req InstallRequest, actionConfig *action.Config
 	installClient.Version = req.Version
 
 	if !VerifyUser(actionConfig, req) {
+		// Mirror the other failure paths so the status doesn't stay at
+		// "processing" until the cache TTL expires.
+		h.setReleaseStatusSilent("install", req.Name, failed, errors.New("insufficient privileges or auth check failed"))
+
 		return
 	}
 


### PR DESCRIPTION
## Summary

This PR fixes Helm install operations reporting `processing` forever when the user fails the auth check, by marking the action as failed (with an error message) instead of silently returning.

## Related Issue

Fixes #7452

## Changes

- Fixed `installRelease` in `backend/pkg/helm/release.go`: the `VerifyUser` failure path now calls `setReleaseStatusSilent(..., failed, err)` like every other failure path, instead of returning while the cached status stays at `processing` until the TTL expires.
- Added a regression test (`TestInstallReleaseVerifyUserFailureSetsFailedStatus`) that reproduces the stuck-`processing` state and asserts the terminal `failed` status with a non-nil error. Verified it fails without the fix and passes with it.

## Steps to Test

1. Use credentials whose SelfSubjectReview creation fails (e.g. RBAC denial) against a cluster.
2. Install any chart through Headlamp.
3. Before: action status polls as `processing` indefinitely with no error; after: status becomes `failed` with "insufficient privileges or auth check failed".
4. `go test ./pkg/helm/... -count=1` from `backend/`.

## Notes for the Reviewer

- The failure branch intentionally mirrors the existing pattern used by the decode/unmarshal/`Run` error paths, so no new plumbing is introduced.
- `VerifyUser` returns false for *any* `SelfSubjectReviews.Create` failure (including plain RBAC denial), which is why exactly permission-restricted users hit this hang.
