### PR TITLE
frontend: streamingApi: Cancel pending watch reconnect timer

### DIFF
--- a/frontend/src/lib/k8s/api/v1/streamingApi.test.ts
+++ b/frontend/src/lib/k8s/api/v1/streamingApi.test.ts
@@ -19,7 +19,11 @@ import { isDebugVerbose } from '../../../../helpers/debugVerbose';
 import { setBackendToken } from '../../../../helpers/getHeadlampAPIHeaders';
 import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
 import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
-import { connectStreamWithParams } from './streamingApi';
+import { connectStreamWithParams, stream } from './streamingApi';
+
+vi.mock('../../../cluster', () => ({
+  getCluster: vi.fn(() => ''),
+}));
 
 vi.mock('../../../../stateless/findKubeconfigByClusterName', () => ({
   findKubeconfigByClusterName: vi.fn(),
@@ -145,5 +149,74 @@ describe('connectStreamWithParams protocols', () => {
     listeners.message(new MessageEvent('message', { data: 'binary-data' }));
 
     expect(onMessage).toHaveBeenCalledWith('binary-data');
+  });
+
+  describe('stream reconnect cancellation', () => {
+    // Builds a fake WebSocket that drops the connection as soon as it is
+    // constructed, so stream()'s retry logic kicks in.
+    function stubDroppingWebSocket() {
+      const sockets: { close: ReturnType<typeof vi.fn>; triggerClose: () => void }[] = [];
+      const WebSocketMock = vi.fn(function () {
+        const listeners: Record<string, (() => void)[]> = {};
+        const socketInstance = {
+          binaryType: '',
+          close: vi.fn(),
+          addEventListener: (type: string, listener: (arg?: unknown) => void) => {
+            (listeners[type] = listeners[type] ?? []).push(listener);
+          },
+          removeEventListener: (type: string, listener: (arg?: unknown) => void) => {
+            listeners[type] = (listeners[type] ?? []).filter(it => it !== listener);
+          },
+          triggerClose: () => {
+            (listeners.close ?? []).forEach(listener => listener());
+          },
+        };
+        sockets.push(socketInstance);
+        setTimeout(() => socketInstance.triggerClose(), 0);
+        return socketInstance;
+      });
+      vi.stubGlobal('WebSocket', WebSocketMock);
+
+      return { sockets, WebSocketMock };
+    }
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('does not open a new socket after cancel() during the retry window', async () => {
+      vi.useFakeTimers();
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { WebSocketMock } = stubDroppingWebSocket();
+
+      const connection = stream('/api/v1/pods', vi.fn(), {});
+
+      // Let the initial connection fail.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(WebSocketMock).toHaveBeenCalledTimes(1);
+
+      // Cancel while the 3s reconnect is pending...
+      connection.cancel();
+
+      // ...and confirm no ghost connection is opened afterwards.
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(WebSocketMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('reconnects when the stream is not cancelled', async () => {
+      vi.useFakeTimers();
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { WebSocketMock } = stubDroppingWebSocket();
+
+      stream('/api/v1/pods', vi.fn(), {});
+
+      // Let the initial connection fail.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(WebSocketMock).toHaveBeenCalledTimes(1);
+
+      // The retry fires after ~3s when nothing cancels the stream.
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(WebSocketMock).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/frontend/src/lib/k8s/api/v1/streamingApi.ts
+++ b/frontend/src/lib/k8s/api/v1/streamingApi.ts
@@ -319,6 +319,7 @@ export interface StreamArgs {
  */
 export function stream<T>(url: string, cb: StreamResultsCb<T>, args: StreamArgs) {
   let connection: StreamConnection | null = null;
+  let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
   let isCancelled = false;
   const { failCb, cluster = '' } = args;
   // We only set reconnectOnFailure as true by default if the failCb has not been provided.
@@ -337,14 +338,28 @@ export function stream<T>(url: string, cb: StreamResultsCb<T>, args: StreamArgs)
   }
 
   function cancel() {
+    // Stop a pending reconnect, otherwise it fires after cancellation and
+    // opens a WebSocket nothing will ever close.
+    if (reconnectTimer !== undefined) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = undefined;
+    }
     if (connection) connection.close();
     isCancelled = true;
   }
 
   async function connect() {
+    if (isCancelled) return;
     if (connectCb) connectCb();
     try {
       connection = await connectStream(url, cb, onFail, isJson, additionalProtocols, cluster);
+      // The stream may have been cancelled while connecting.
+      if (isCancelled) {
+        connection.close();
+        connection = null;
+
+        return;
+      }
     } catch (error) {
       console.error('Error connecting stream:', error);
       onFail();
@@ -359,7 +374,7 @@ export function stream<T>(url: string, cb: StreamResultsCb<T>, args: StreamArgs)
         console.debug('k8s/apiProxy@stream retryOnFail', 'Reconnecting in 3 seconds', { url });
       }
 
-      setTimeout(connect, 3000);
+      reconnectTimer = setTimeout(connect, 3000);
     }
   }
 


### PR DESCRIPTION
## Summary

This PR stops cancelled v1 watch streams from leaving an orphaned WebSocket behind: the scheduled reconnect timer is now cleared on cancel, and a reconnect that was already scheduled can no longer open a new connection for a cancelled stream.

## Related Issue

Fixes #7445

## Changes

- Fixed `stream()` in `frontend/src/lib/k8s/api/v1/streamingApi.ts`:
  - the `setTimeout(connect, 3000)` handle returned by `retryOnFail()` is stored and cleared in `cancel()`;
  - `connect()` bails out early if the stream was already cancelled, and closes the socket if cancellation happens during the connect handshake.
- `frontend/src/lib/k8s/api/v1/streamingApi.test.ts`: regression tests for both paths — `cancel()` during the retry window opens no further socket, and an uncancelled stream still reconnects after ~3 s.
- Previously, cancelling during the 3 s retry window left `connect()` to run anyway, opening a WebSocket whose messages kept flowing into the unmounted component's callbacks, and which nothing would ever close.

## Steps to Test

1. Open any list/detail view backed by the v1 stream API.
2. Drop the watch connection so the 3 s retry is scheduled, then navigate away within that window.
3. Before: DevTools → Network → WS shows a new watch connection opened ~3 s later that is never closed; after: no connection is opened.
4. `cd frontend && npx vitest run src/lib/k8s/api/v1/streamingApi.test.ts`

## Notes for the Reviewer

- Minimal change confined to `stream()`; other helpers (`streamResultsForCluster`, `streamResult`) are untouched.
- The post-handshake guard also covers the narrower race where `cancel()` lands while `connectStream` is awaiting the handshake.

