### PR TITLE
frontend: clusterRequests: Redact credentials from error logging

### DIFF
--- a/frontend/src/lib/k8s/api/v1/clusterRequests.test.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterRequests.test.ts
@@ -156,4 +156,48 @@ describe('clusterRequest transports', () => {
 
     await expectation;
   });
+
+  it('does not log the kubeconfig header when the error body fails to parse', async () => {
+    vi.mocked(findKubeconfigByClusterName).mockResolvedValue('secret-encoded-kubeconfig');
+    // A fetch rejection becomes a synthetic body-less 502 response, whose
+    // .json() always rejects — the exact path that used to log requestData
+    // including credential-bearing headers.
+    (fetch as Mock).mockRejectedValue(new TypeError('Failed to fetch'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      clusterRequest('/api/v1/pods', { cluster: 'desktop-cluster' })
+    ).rejects.toMatchObject({ status: 502 });
+
+    expect(errorSpy).toHaveBeenCalled();
+    for (const call of errorSpy.mock.calls) {
+      expect(JSON.stringify(call)).not.toContain('secret-encoded-kubeconfig');
+      expect(JSON.stringify(call)).not.toContain('"KUBECONFIG"');
+    }
+  });
+
+  it('does not log the response body through the JSON parse error', async () => {
+    // A parse failure reports a fragment of the offending body in its message
+    // ("secret-token-abc"... is not valid JSON), so the error itself must not
+    // be logged either -- only its type.
+    (fetch as Mock).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      headers: new Headers(),
+      json: () => Promise.reject(new SyntaxError('"secret-token-abc" is not valid JSON')),
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(clusterRequest('/api/v1/pods')).rejects.toMatchObject({ status: 500 });
+
+    expect(errorSpy).toHaveBeenCalled();
+    for (const call of errorSpy.mock.calls) {
+      expect(JSON.stringify(call)).not.toContain('secret-token-abc');
+    }
+    expect(errorSpy.mock.calls.at(-1)?.[2]).toMatchObject({
+      errorType: 'SyntaxError',
+      status: 500,
+    });
+  });
 });

--- a/frontend/src/lib/k8s/api/v1/clusterRequests.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterRequests.ts
@@ -221,13 +221,16 @@ export async function clusterRequest(
         }
       }
     } catch (err) {
-      console.error(
-        'Unable to parse error json at url:',
-        url,
-        { err },
-        'with request data:',
-        requestData
-      );
+      // Log only non-sensitive metadata. requestData can carry the full
+      // kubeconfig header (client keys/tokens), and a JSON parse failure
+      // reports a fragment of the response body in its message, so neither
+      // the request data nor the error itself may reach the console.
+      console.error('Unable to parse error json at url:', url, {
+        errorType: err instanceof Error ? err.name : typeof err,
+        method: requestData.method,
+        status: response.status,
+        statusText: response.statusText,
+      });
     } finally {
       clearTimeout(id);
     }


### PR DESCRIPTION
## Summary

This PR stops the request layer from dumping the full kubeconfig — including client certificate data, private keys and bearer tokens — into the browser console whenever an error response body fails to parse as JSON.

## Related Issue

Fixes #7449

## Changes

- Fixed `clusterRequest` in `frontend/src/lib/k8s/api/v1/clusterRequests.ts`: the `console.error` in the JSON-parse failure path now logs only non-sensitive request metadata (method, url, status, statusText) instead of the whole `requestData` object.
- The old log fired routinely: any fetch rejection is converted into a synthetic body-less `Response` (502 "Unreachable" / 408 timeout), whose `.json()` always rejects, so every offline request or backend timeout printed the complete `KUBECONFIG` header.

## Steps to Test

1. Add a dynamic cluster (stateless kubeconfig flow).
2. Stop the backend / go offline and trigger any API request.
3. Before: console shows "Unable to parse error json…" with the full `KUBECONFIG` header; after: the same message logs method/url/status only.
4. `cd frontend && npx vitest run src/lib/k8s/api/v1/clusterRequests.test.ts`

## Notes for the Reviewer

- Deliberately keeps the existing log line and error surface; only the payload is redacted. Header keys considered credential-bearing: `kubeconfig`, `authorization`, `x-headlamp-user-id`.
