### PR TITLE
frontend: multiplexer: Reconnect watches after connection drop

### DIFF
--- a/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
@@ -95,6 +95,11 @@ describe('WebSocket Multiplexer', () => {
     WebSocketManager.activeSubscriptions.clear();
     WebSocketManager.pendingUnsubscribes.forEach(clearTimeout);
     WebSocketManager.pendingUnsubscribes.clear();
+    if (WebSocketManager.reconnectTimer !== null) {
+      clearTimeout(WebSocketManager.reconnectTimer);
+    }
+    WebSocketManager.reconnectTimer = null;
+    WebSocketManager.reconnectAttempts = 0;
   });
 
   describe('WebSocketManager', () => {
@@ -651,6 +656,78 @@ describe('WebSocket Multiplexer', () => {
       expect(WebSocketManager.connecting).toBe(false);
       expect(WebSocketManager.completedPaths.size).toBe(0);
       expect(WebSocketManager.isReconnecting).toBe(true); // Should be true since we have active subscriptions
+
+      // Stop the scheduled reconnect from firing during this test.
+      if (WebSocketManager.reconnectTimer !== null) {
+        clearTimeout(WebSocketManager.reconnectTimer);
+        WebSocketManager.reconnectTimer = null;
+      }
+    });
+
+    it('schedules an automatic reconnect after close while subscriptions exist', async () => {
+      vi.useFakeTimers();
+
+      WebSocketManager.activeSubscriptions.set('k', {
+        clusterId: clusterName,
+        path: '/p',
+        query: '',
+      });
+      const connectSpy = vi
+        .spyOn(WebSocketManager, 'connect')
+        .mockResolvedValue({ send: vi.fn() } as unknown as WebSocket);
+
+      WebSocketManager.handleWebSocketClose();
+      expect(WebSocketManager.isReconnecting).toBe(true);
+
+      // First attempt fires after ~1s of backoff.
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+
+      vi.useRealTimers();
+    });
+
+    it('backs off between reconnect attempts', async () => {
+      vi.useFakeTimers();
+
+      WebSocketManager.activeSubscriptions.set('k', {
+        clusterId: clusterName,
+        path: '/p',
+        query: '',
+      });
+      const connectSpy = vi.spyOn(WebSocketManager, 'connect').mockRejectedValue(new Error('down'));
+
+      WebSocketManager.handleWebSocketClose();
+
+      await vi.advanceTimersByTimeAsync(999);
+      expect(connectSpy).not.toHaveBeenCalled();
+
+      // First attempt after ~1s.
+      await vi.advanceTimersByTimeAsync(1);
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+
+      // Second attempt only after the doubled delay (~2s).
+      await vi.advanceTimersByTimeAsync(1999);
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(connectSpy).toHaveBeenCalledTimes(2);
+
+      vi.useRealTimers();
+    });
+
+    it('does not schedule reconnect when no subscriptions remain', () => {
+      vi.useFakeTimers();
+
+      const connectSpy = vi
+        .spyOn(WebSocketManager, 'connect')
+        .mockResolvedValue({ send: vi.fn() } as unknown as WebSocket);
+
+      WebSocketManager.handleWebSocketClose();
+
+      expect(WebSocketManager.isReconnecting).toBe(false);
+      vi.advanceTimersByTime(60_000);
+      expect(connectSpy).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
     });
 
     it('should handle error in message callback', async () => {

--- a/frontend/src/lib/k8s/api/v2/multiplexer.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.ts
@@ -37,6 +37,12 @@ export const WebSocketManager = {
   /** Flag to track if we're reconnecting after a disconnect */
   isReconnecting: false,
 
+  /** Pending reconnect timer scheduled after a connection drop */
+  reconnectTimer: null as NodeJS.Timeout | null,
+
+  /** Number of consecutive failed reconnect attempts, for backoff */
+  reconnectAttempts: 0,
+
   /** Map of message handlers for each subscription path */
   listeners: new Map<string, Set<(data: any) => void>>(),
 
@@ -122,6 +128,7 @@ export const WebSocketManager = {
       socket.onopen = () => {
         this.socketMultiplexer = socket;
         this.connecting = false;
+        this.reconnectAttempts = 0;
 
         // Only resubscribe if we're reconnecting after a disconnect
         if (this.isReconnecting) {
@@ -298,6 +305,33 @@ export const WebSocketManager = {
   },
 
   /**
+   * Schedules a reconnect attempt after a connection drop, with exponential
+   * backoff. Existing subscriptions are replayed once the connection is
+   * re-established (see connect()'s onopen handler).
+   */
+  scheduleReconnect(): void {
+    if (this.reconnectTimer !== null) {
+      return;
+    }
+
+    const delay = Math.min(30_000, 1000 * 2 ** this.reconnectAttempts);
+    this.reconnectAttempts++;
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+
+      // Everyone unsubscribed while we were waiting; nothing to restore.
+      if (this.activeSubscriptions.size === 0) {
+        return;
+      }
+
+      this.connect().catch(() => {
+        this.scheduleReconnect();
+      });
+    }, delay);
+  },
+
+  /**
    * Handles WebSocket connection close event
    * Sets up state for potential reconnection
    */
@@ -308,6 +342,13 @@ export const WebSocketManager = {
 
     // Only log reconnecting if we have active subscriptions
     this.isReconnecting = this.activeSubscriptions.size > 0;
+
+    // Without this, mounted views would never receive updates again: the
+    // socket is gone and resubscribeAll only runs when a NEW subscriber
+    // triggers a successful connect().
+    if (this.isReconnecting) {
+      this.scheduleReconnect();
+    }
   },
 
   /**

--- a/frontend/src/lib/k8s/api/v2/webSocket.test.ts
+++ b/frontend/src/lib/k8s/api/v2/webSocket.test.ts
@@ -200,6 +200,100 @@ describe('useWebSockets', () => {
     });
   });
 
+  describe('reconnect after a drop', () => {
+    // Builds a WebSocket stub whose instances expose triggerOpen/triggerClose,
+    // so a drop can be simulated without a real server.
+    function stubWebSocket() {
+      const sockets: Array<{
+        close: ReturnType<typeof vi.fn>;
+        triggerOpen: () => void;
+        triggerClose: () => void;
+      }> = [];
+      const WebSocketMock = vi.fn(function () {
+        const listeners: Record<string, Array<(arg?: unknown) => void>> = {};
+        const instance = {
+          binaryType: '',
+          close: vi.fn(),
+          addEventListener: (type: string, listener: (arg?: unknown) => void) => {
+            (listeners[type] = listeners[type] ?? []).push(listener);
+          },
+          removeEventListener: (type: string, listener: (arg?: unknown) => void) => {
+            listeners[type] = (listeners[type] ?? []).filter(it => it !== listener);
+          },
+          triggerOpen: () => (listeners.open ?? []).forEach(listener => listener()),
+          triggerClose: () => (listeners.close ?? []).forEach(listener => listener()),
+        };
+        sockets.push(instance);
+        return instance;
+      });
+      vi.stubGlobal('WebSocket', WebSocketMock);
+
+      return { sockets, WebSocketMock };
+    }
+
+    afterEach(() => {
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    });
+
+    it('keeps reconnecting when a reconnected socket drops again', async () => {
+      vi.useFakeTimers();
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      const url = 'api/v1/pods?watch=1&resourceVersion=reconnect-twice';
+      const { sockets, WebSocketMock } = stubWebSocket();
+
+      const hook = renderHook(() =>
+        useWebSockets({
+          connections: [{ cluster: '', url, onMessage: vi.fn() }],
+        })
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(WebSocketMock).toHaveBeenCalledTimes(1);
+      sockets[0].triggerOpen();
+
+      // First drop reconnects after the initial 1s backoff.
+      sockets[0].triggerClose();
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(WebSocketMock).toHaveBeenCalledTimes(2);
+      sockets[1].triggerOpen();
+
+      // The reconnected socket must have replaced the pending marker, or its
+      // own close is ignored and the watch stays dead forever.
+      sockets[1].triggerClose();
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(WebSocketMock).toHaveBeenCalledTimes(3);
+
+      hook.unmount();
+    });
+
+    it('closes a reconnected socket when the last listener unsubscribes', async () => {
+      vi.useFakeTimers();
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      const url = 'api/v1/pods?watch=1&resourceVersion=reconnect-cleanup';
+      const { sockets } = stubWebSocket();
+
+      const hook = renderHook(() =>
+        useWebSockets({
+          connections: [{ cluster: '', url, onMessage: vi.fn() }],
+        })
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+      sockets[0].triggerOpen();
+      sockets[0].triggerClose();
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(sockets).toHaveLength(2);
+      sockets[1].triggerOpen();
+
+      // Unmounting must close the reconnected socket; while the marker was
+      // still in the map, cleanup could not reach it and the backend watch
+      // stayed open.
+      hook.unmount();
+      expect(sockets[1].close).toHaveBeenCalled();
+    });
+  });
+
   it('keeps a pending shared websocket alive when its first listener unsubscribes', async () => {
     const url = 'api/v1/pods?watch=1&resourceVersion=4';
     const server = new WS(`${BASE_WS_URL}${url}`);

--- a/frontend/src/lib/k8s/api/v2/webSocket.ts
+++ b/frontend/src/lib/k8s/api/v2/webSocket.ts
@@ -66,6 +66,89 @@ export type WebSocketConnectionRequest<T> = {
  */
 const sockets = new Map<string, WebSocket | symbol>();
 const listeners = new Map<string, Array<(update: any) => void>>();
+/** Arguments of the last open attempt per connection, used to reconnect */
+const lastOpenArgs = new Map<string, { url: string; options: OpenWebSocketOptions }>();
+/** Pending reconnect timers per connection */
+const reconnectTimers = new Map<string, NodeJS.Timeout>();
+/** Consecutive failed reconnect attempts per connection, for backoff */
+const reconnectAttempts = new Map<string, number>();
+
+type OpenWebSocketOptions = {
+  protocols?: string | string[];
+  type: 'json' | 'binary';
+  cluster?: string;
+};
+
+/**
+ * Schedules a reconnect for a dropped legacy WebSocket connection, with
+ * exponential backoff. Only reconnects while something still listens.
+ */
+function scheduleLegacyReconnect(connectionKey: string): void {
+  if (reconnectTimers.has(connectionKey)) {
+    return;
+  }
+
+  const attempts = reconnectAttempts.get(connectionKey) ?? 0;
+  reconnectAttempts.set(connectionKey, attempts + 1);
+
+  const delay = Math.min(30_000, 1000 * 2 ** attempts);
+  const timer = setTimeout(() => {
+    reconnectTimers.delete(connectionKey);
+
+    // Everyone unsubscribed while we were waiting.
+    if ((listeners.get(connectionKey)?.length ?? 0) === 0) {
+      return;
+    }
+
+    const args = lastOpenArgs.get(connectionKey);
+    if (!args || sockets.has(connectionKey)) {
+      return;
+    }
+
+    // Mark as pending so concurrent opens don't duplicate, mirroring useWebSockets.
+    const pendingSocket = Symbol('pendingWebSocket');
+    sockets.set(connectionKey, pendingSocket);
+
+    // Message dispatch fans out to the registered listeners; the per-call
+    // onMessage is only a fallback, so a no-op is safe here.
+    openWebSocket(args.url, { ...args.options, onMessage: () => {} })
+      .then(socket => {
+        // A newer connection took over this key, or everyone unsubscribed
+        // while the socket was opening. Either way this one is unwanted, and
+        // leaving the marker in place would hide the socket from the close
+        // handler and from cleanup, leaking the backend watch.
+        if (
+          sockets.get(connectionKey) !== pendingSocket ||
+          (listeners.get(connectionKey)?.length ?? 0) === 0
+        ) {
+          socket.close();
+
+          if (sockets.get(connectionKey) === pendingSocket) {
+            sockets.delete(connectionKey);
+          }
+
+          return;
+        }
+
+        // Replace the marker with the live socket so its own close handler can
+        // evict it and schedule the next reconnect.
+        sockets.set(connectionKey, socket);
+      })
+      .catch(err => {
+        if (sockets.get(connectionKey) === pendingSocket) {
+          sockets.delete(connectionKey);
+        }
+
+        console.error('WebSocket reconnect failed:', err);
+
+        if ((listeners.get(connectionKey)?.length ?? 0) > 0) {
+          scheduleLegacyReconnect(connectionKey);
+        }
+      });
+  }, delay);
+
+  reconnectTimers.set(connectionKey, timer);
+}
 
 /**
  * Create new WebSocket connection to the backend
@@ -82,19 +165,7 @@ export async function openWebSocket<T>(
     type = 'binary',
     cluster = getCluster() ?? '',
     onMessage,
-  }: {
-    /**
-     * Any additional protocols to include in WebSocket connection
-     */
-    protocols?: string | string[];
-    /**
-     *
-     */
-    type: 'json' | 'binary';
-    /**
-     * Cluster name
-     */
-    cluster?: string;
+  }: OpenWebSocketOptions & {
     /**
      * Message callback
      */
@@ -126,6 +197,31 @@ export async function openWebSocket<T>(
 
   const socket = new WebSocket(makeUrl([getBaseWsUrl(), ...path], {}), protocols);
   socket.binaryType = 'arraybuffer';
+
+  // Remember how this connection was opened so it can be re-established
+  // after a drop (see the close handler below).
+  lastOpenArgs.set(connectionKey, {
+    url,
+    options: { protocols: moreProtocols, type, cluster },
+  });
+
+  socket.addEventListener('open', () => {
+    reconnectAttempts.delete(connectionKey);
+  });
+
+  socket.addEventListener('close', () => {
+    // Evict the dead socket so it's never handed out again.
+    if (sockets.get(connectionKey) === socket) {
+      sockets.delete(connectionKey);
+    }
+
+    // Re-establish the watch while something still listens and no other
+    // connection took over for this key in the meantime.
+    if (!sockets.has(connectionKey) && (listeners.get(connectionKey)?.length ?? 0) > 0) {
+      scheduleLegacyReconnect(connectionKey);
+    }
+  });
+
   socket.addEventListener('message', (body: MessageEvent) => {
     const data = type === 'json' ? JSON.parse(body.data) : body.data;
     const callbacks = listeners.get(connectionKey) ?? [onMessage];
@@ -226,6 +322,15 @@ export function useWebSockets<T>({
             }
             sockets.delete(connectionKey);
           }
+
+          // Also cancel any pending reconnect and forget the connection.
+          const pendingReconnect = reconnectTimers.get(connectionKey);
+          if (pendingReconnect) {
+            clearTimeout(pendingReconnect);
+            reconnectTimers.delete(connectionKey);
+          }
+          reconnectAttempts.delete(connectionKey);
+          lastOpenArgs.delete(connectionKey);
         }
       };
     }


### PR DESCRIPTION
﻿## Summary

This PR re-establishes WebSocket watches after a connection drop in the v2 data layer, instead of silently freezing dashboards until an unrelated remount.

## Related Issue

Fixes #7446

## Changes

- Fixed `WebSocketManager.handleWebSocketClose` in `frontend/src/lib/k8s/api/v2/multiplexer.ts`: when subscriptions remain after a close, it now schedules a reconnect with exponential backoff that calls `connect()` and replays `resubscribeAll(activeSubscriptions)` once the socket is re-established. Backoff resets on a successful connect.
- Added an `onclose` handler for legacy (non-multiplexed) sockets in `frontend/src/lib/k8s/api/v2/webSocket.ts`, which previously kept handing out the dead cached socket with listeners still registered; closed sockets are now evicted and re-established with backoff while listeners remain.

## Steps to Test

1. Open a resource list/dashboard using the v2 watch path.
2. Force the WebSocket to close (restart backend, suspend/resume, or drop connectivity), then restore it.
3. Before: items freeze indefinitely (`staleTime: 3 * 60_000`, `refetchOnWindowFocus: false`, no refetchInterval); after: the socket reconnects with backoff and subscriptions replay.
4. `cd frontend && npx vitest run src/lib/k8s/api/v2/multiplexer.test.ts src/lib/k8s/api/v2/webSocket.test.ts`

## Notes for the Reviewer

- Reconnect state is surfaced through the existing manager API so consumers can indicate staleness later; no UI changes are included here.
