### PR TITLE
backend: portforward: Stop resurrecting deleted forwards

### DIFF
--- a/backend/pkg/portforward/handler.go
+++ b/backend/pkg/portforward/handler.go
@@ -60,6 +60,11 @@ const (
 
 var inFlightPortForwards sync.Map
 
+// activePortForwards tracks live *portForward instances by their cache key,
+// so stop/delete requests can mark the live struct (not just its cached
+// value copy) before signalling shutdown.
+var activePortForwards sync.Map
+
 type portForwardRequest struct {
 	ID               string `json:"id"`
 	Namespace        string `json:"namespace"`
@@ -100,23 +105,6 @@ type portForward struct {
 	TargetPort       string `json:"targetPort"`
 	Status           string `json:"status"`
 	Error            string `json:"error"`
-}
-
-// setStatusAndSnapshot updates the Status and Error fields and returns a
-// snapshot of the struct. When mu is initialized (production path), both
-// the update and the snapshot are performed within a single critical section.
-// When mu is nil (e.g. test-only structs not accessed concurrently), the
-// update proceeds without locking.
-func (pf *portForward) setStatusAndSnapshot(status, errMsg string) portForward {
-	if pf.mu != nil {
-		pf.mu.Lock()
-		defer pf.mu.Unlock()
-	}
-
-	pf.Status = status
-	pf.Error = errMsg
-
-	return *pf
 }
 
 func getFreePort() (int, error) {
@@ -433,8 +421,13 @@ func monitorPodAndManagePortForward(
 				errMsg := fmt.Sprintf("Pod %s/%s check failed: %v", pfDetails.Namespace, pfDetails.Pod, err)
 				logger.Log(logger.LevelError, logParams, errors.New(errMsg), "stopping port-forward due to pod status")
 
-				pfSnapshot := pfDetails.setStatusAndSnapshot(STOPPED, errMsg)
-				portforwardstore(cache, pfSnapshot)
+				storeIfLive(cache, pfDetails, func(pf *portForward) bool {
+					pf.Status = STOPPED
+					pf.Error = errMsg
+
+					return true
+				})
+
 				safeCloseChan(pfDetails.closeChan)
 
 				return
@@ -455,9 +448,12 @@ func handlePortForwardError(
 ) error {
 	logger.Log(logger.LevelError, logParams, errors.New(errMsg), "portforward error")
 
-	pfSnapshot := pfDetails.setStatusAndSnapshot(STOPPED, errMsg)
+	storeIfLive(cache, pfDetails, func(pf *portForward) bool {
+		pf.Status = STOPPED
+		pf.Error = errMsg
 
-	portforwardstore(cache, pfSnapshot)
+		return true
+	})
 	safeCloseChan(pfDetails.closeChan)
 
 	return errors.New(errMsg)
@@ -469,8 +465,12 @@ func handlePortForwardSuccess(
 	pfDetails *portForward,
 	logParams map[string]string,
 ) {
-	pfSnapshot := pfDetails.setStatusAndSnapshot(RUNNING, "")
-	portforwardstore(cache, pfSnapshot)
+	storeIfLive(cache, pfDetails, func(pf *portForward) bool {
+		pf.Status = RUNNING
+		pf.Error = ""
+
+		return true
+	})
 	logger.Log(logger.LevelInfo, logParams, nil, "Port forward ready and running.")
 }
 
@@ -508,25 +508,18 @@ func handlePortForwardReadiness(
 	case <-pfDetails.closeChan:
 		msg := "portforward stopped before becoming ready"
 
-		if pfDetails.mu != nil {
-			pfDetails.mu.Lock()
-		}
+		storeIfLive(cache, pfDetails, func(pf *portForward) bool {
+			if pf.Status == RUNNING {
+				pf.Status = STOPPED
+			}
 
-		if pfDetails.Status == RUNNING {
-			pfDetails.Status = STOPPED
-		}
+			if pf.Error == "" {
+				pf.Error = msg
+			}
 
-		if pfDetails.Error == "" {
-			pfDetails.Error = msg
-		}
+			return true
+		})
 
-		pfSnapshot := *pfDetails
-
-		if pfDetails.mu != nil {
-			pfDetails.mu.Unlock()
-		}
-
-		portforwardstore(cache, pfSnapshot)
 		logger.Log(logger.LevelInfo, logParams, nil, msg)
 
 		return errors.New(msg)
@@ -544,8 +537,19 @@ func forwardPortsAsync(
 	forwardErrChan chan error,
 	logParams map[string]string,
 ) {
+	// Capture the key before the goroutine starts: a same-ID restart replaces
+	// the live instance under this key, and cleanup must remove only its own
+	// pointer, never the newer one.
+	activeKey := portforwardKeyGenerator(*pfDetails)
+
 	go func() {
 		defer func() {
+			func() {
+				defer lockLifecycle(activeKey)()
+
+				unregisterPortForward(activeKey, pfDetails)
+			}()
+
 			safeCloseChan(pfDetails.closeChan)
 			close(forwardErrChan)
 		}()
@@ -553,8 +557,12 @@ func forwardPortsAsync(
 		if err := forwarder.ForwardPorts(); err != nil {
 			logger.Log(logger.LevelError, logParams, err, "ForwardPorts() failed")
 
-			pfSnapshot := pfDetails.setStatusAndSnapshot(STOPPED, err.Error())
-			portforwardstore(cache, pfSnapshot)
+			storeIfLive(cache, pfDetails, func(pf *portForward) bool {
+				pf.Status = STOPPED
+				pf.Error = err.Error()
+
+				return true
+			})
 
 			select {
 			case forwardErrChan <- err:
@@ -566,30 +574,21 @@ func forwardPortsAsync(
 
 		logger.Log(logger.LevelInfo, logParams, nil, "ForwardPorts() exited.")
 
-		if pfDetails.mu != nil {
-			pfDetails.mu.Lock()
-		}
-
-		shouldStore := pfDetails.Status == RUNNING
-		if shouldStore {
-			pfDetails.Status = STOPPED
-			if pfDetails.Error == "" {
-				pfDetails.Error = "Port forward stopped."
+		// Only a forward still marked RUNNING gets a terminal status here; a
+		// stop or delete already recorded its own outcome.
+		storeIfLive(cache, pfDetails, func(pf *portForward) bool {
+			if pf.Status != RUNNING {
+				return false
 			}
-		}
 
-		var pfSnapshot portForward
-		if shouldStore {
-			pfSnapshot = *pfDetails
-		}
+			pf.Status = STOPPED
 
-		if pfDetails.mu != nil {
-			pfDetails.mu.Unlock()
-		}
+			if pf.Error == "" {
+				pf.Error = "Port forward stopped."
+			}
 
-		if shouldStore {
-			portforwardstore(cache, pfSnapshot)
-		}
+			return true
+		})
 	}()
 }
 
@@ -670,6 +669,15 @@ func startPortForward(kContext *kubeconfig.Context, cache cache.Cache[interface{
 		Port:             p.Port,
 		Error:            "",
 	}
+
+	// Register the live instance under the lifecycle lock so a stop or delete
+	// of a previous forward with this key cannot interleave and unregister the
+	// one being started.
+	func() {
+		defer lockLifecycle(portforwardKeyGenerator(*pfDetails))()
+
+		activePortForwards.Store(portforwardKeyGenerator(*pfDetails), pfDetails)
+	}()
 
 	return runAndMonitorPortForward(clientset, cache, pfDetails, forwarder, readyChan, errOut)
 }

--- a/backend/pkg/portforward/internal_test.go
+++ b/backend/pkg/portforward/internal_test.go
@@ -193,6 +193,183 @@ func TestStopOrDeletePortForward(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestStopOrDeleteMarksLiveForwardStopped verifies that stop/delete marks the
+// LIVE *portForward (tracked in activePortForwards) as STOPPED before the
+// close channel is signalled. Without this, the forwarding goroutine's
+// completion path still sees RUNNING and re-stores a ghost entry after a
+// delete removed it.
+func TestStopOrDeleteMarksLiveForwardStopped(t *testing.T) {
+	cache := cache.New[interface{}]()
+
+	live := &portForward{
+		mu:        &sync.Mutex{},
+		ID:        "id-live",
+		Cluster:   "cluster",
+		cacheKey:  "cluster",
+		closeChan: make(chan struct{}, 1),
+		Status:    RUNNING,
+	}
+	activePortForwards.Store(portforwardKeyGenerator(*live), live)
+
+	defer activePortForwards.Delete(portforwardKeyGenerator(*live))
+
+	err := cache.Set(context.Background(), portforwardKeyGenerator(*live), *live)
+	require.NoError(t, err)
+
+	err = stopOrDeletePortForward(cache, "cluster", "id-live", false)
+	require.NoError(t, err)
+
+	live.mu.Lock()
+	status := live.Status
+	live.mu.Unlock()
+	assert.Equal(t, STOPPED, status)
+
+	_, err = cache.Get(context.Background(), portforwardKeyGenerator(*live))
+	assert.Error(t, err)
+}
+
+// newLiveTestPortForward registers a RUNNING port-forward in the live instance
+// map and the cache, and unregisters it when the test ends.
+func newLiveTestPortForward(t *testing.T, c cache.Cache[interface{}], id string) *portForward {
+	t.Helper()
+
+	pf := &portForward{
+		mu:        &sync.Mutex{},
+		ID:        id,
+		Cluster:   "cluster",
+		cacheKey:  "cluster",
+		closeChan: make(chan struct{}, 1),
+		Status:    RUNNING,
+	}
+	key := portforwardKeyGenerator(*pf)
+
+	activePortForwards.Store(key, pf)
+	t.Cleanup(func() { activePortForwards.Delete(key) })
+
+	require.NoError(t, c.Set(context.Background(), key, *pf))
+
+	return pf
+}
+
+// TestTerminalWriteCannotInterleaveWithDelete pins the atomicity the lifecycle
+// lock provides: while a delete holds the lock, a terminal write from the
+// forwarding goroutine cannot land, so it can neither slip in before the
+// delete nor resurrect the entry afterwards. A bare cache-existence check
+// could not offer this, because the read and the write take separate cache
+// locks and a delete fits between them.
+func TestTerminalWriteCannotInterleaveWithDelete(t *testing.T) {
+	testCache := cache.New[interface{}]()
+	pf := newLiveTestPortForward(t, testCache, "id-race")
+	key := portforwardKeyGenerator(*pf)
+
+	// Take the lock the way stopOrDeletePortForward does, then start the
+	// goroutine that wants to record a terminal status.
+	unlock := lockLifecycle(key)
+
+	writeDone := make(chan struct{})
+
+	go func() {
+		defer close(writeDone)
+
+		storeIfLive(testCache, pf, func(p *portForward) bool {
+			p.Status = STOPPED
+			p.Error = "late write"
+
+			return true
+		})
+	}()
+
+	// The write must be blocked for as long as the lock is held.
+	select {
+	case <-writeDone:
+		t.Fatal("terminal write completed while the lifecycle lock was held")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cached, err := getPortForwardByID(testCache, pf.cacheKey, pf.ID)
+	require.NoError(t, err)
+	assert.Equal(t, RUNNING, cached.Status)
+
+	// Complete the delete under the same lock, then release it.
+	tombstonePortForward(key)
+	require.NoError(t, testCache.Delete(context.Background(), key))
+	unlock()
+
+	<-writeDone
+
+	// The pending write saw the tombstone and skipped its store.
+	_, err = getPortForwardByID(testCache, pf.cacheKey, pf.ID)
+	assert.Error(t, err)
+}
+
+// TestSameIDRestartSurvivesOldGoroutine covers the restart case: a new forward
+// reusing the ID of one that is still shutting down. The old goroutine must
+// neither unregister the new instance nor overwrite its cache entry with the
+// stale snapshot it is holding.
+func TestSameIDRestartSurvivesOldGoroutine(t *testing.T) {
+	testCache := cache.New[interface{}]()
+	oldPF := newLiveTestPortForward(t, testCache, "id-restart")
+	key := portforwardKeyGenerator(*oldPF)
+
+	// The restart replaces the live instance under the same key.
+	newPF := &portForward{
+		mu:        &sync.Mutex{},
+		ID:        oldPF.ID,
+		Cluster:   oldPF.Cluster,
+		cacheKey:  oldPF.cacheKey,
+		closeChan: make(chan struct{}, 1),
+		Status:    RUNNING,
+	}
+	activePortForwards.Store(key, newPF)
+	require.NoError(t, testCache.Set(context.Background(), key, *newPF))
+
+	// The old goroutine's cleanup runs after the restart. It must remove only
+	// its own pointer; an unconditional delete would strand the new instance
+	// and let a later stop leave it RUNNING in the cache forever.
+	func() {
+		defer lockLifecycle(key)()
+
+		unregisterPortForward(key, oldPF)
+	}()
+
+	live, ok := activePortForwards.Load(key)
+	require.True(t, ok, "restarted instance must stay registered")
+	assert.Same(t, newPF, live)
+
+	// The old goroutine's terminal write must not clobber the restarted entry.
+	storeIfLive(testCache, oldPF, func(p *portForward) bool {
+		p.Status = STOPPED
+		p.Error = "stale snapshot"
+
+		return true
+	})
+
+	cached, err := getPortForwardByID(testCache, oldPF.cacheKey, oldPF.ID)
+	require.NoError(t, err)
+	assert.Equal(t, RUNNING, cached.Status)
+	assert.Empty(t, cached.Error)
+}
+
+// TestDeleteThenLateWriteKeepsEntryDeleted runs the whole delete path and then
+// lets the forwarding goroutine finish, which is the sequence reported in the
+// issue: the entry must stay gone.
+func TestDeleteThenLateWriteKeepsEntryDeleted(t *testing.T) {
+	testCache := cache.New[interface{}]()
+	pf := newLiveTestPortForward(t, testCache, "id-late")
+
+	require.NoError(t, stopOrDeletePortForward(testCache, "cluster", pf.ID, false))
+
+	storeIfLive(testCache, pf, func(p *portForward) bool {
+		p.Status = STOPPED
+		p.Error = "ForwardPorts() exited"
+
+		return true
+	})
+
+	_, err := getPortForwardByID(testCache, pf.cacheKey, pf.ID)
+	assert.Error(t, err)
+}
+
 // TestGetPortForwardList tests getPortForwardList function.
 func TestGetPortForwardList(t *testing.T) {
 	p1 := portForward{ID: "id1", Cluster: "cluster1"}

--- a/backend/pkg/portforward/store.go
+++ b/backend/pkg/portforward/store.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
@@ -62,6 +63,141 @@ func portforwardstore(cache cache.Cache[interface{}], p portForward) {
 	}
 }
 
+// lifecycleLocks holds one mutex per port-forward key, serializing the
+// lifecycle operations of that key: registering a live instance, writing a
+// status, and stopping or deleting the cached entry.
+//
+// Cache reads and writes take separate locks internally, so a check-then-write
+// is not atomic on its own: a delete can land between them and the write then
+// resurrects the deleted entry. Every path that inspects liveness and then
+// writes must hold this lock across both steps.
+//
+// Entries are keyed by cluster and port-forward ID and are intentionally never
+// removed: a mutex may still be held by a goroutine that is about to exit, and
+// the map is bounded by the number of distinct forwards the user creates.
+var lifecycleLocks sync.Map
+
+// lockLifecycle locks the lifecycle mutex for key and returns its unlock
+// function, so callers can `defer lockLifecycle(key)()`.
+func lockLifecycle(key string) func() {
+	value, _ := lifecycleLocks.LoadOrStore(key, &sync.Mutex{})
+
+	mu, ok := value.(*sync.Mutex)
+	if !ok {
+		// Unreachable: only *sync.Mutex values are ever stored.
+		return func() {}
+	}
+
+	mu.Lock()
+
+	return mu.Unlock
+}
+
+// deletedForward is the tombstone left in activePortForwards by a delete. It
+// has to outlive the entry itself: an absent key cannot mean "deleted", or
+// every forward that was never registered (test-built structs, and any path
+// that does not go through startPortForward) would silently lose its status
+// writes.
+type deletedForward struct{}
+
+// isLivePortForward reports whether pf may still write its status for key.
+// Callers must hold the key's lifecycle lock.
+//
+// A delete tombstones the key and a same-ID restart replaces the registered
+// instance, so in both cases the value under the key is no longer pf and the
+// write is refused. Comparing identity rather than mere cache presence is what
+// stops a stale goroutine from resurrecting a deleted forward or overwriting a
+// freshly restarted one that happens to share its ID.
+//
+// An untracked key is writable, which keeps the behaviour of forwards that
+// were never registered unchanged.
+func isLivePortForward(key string, pf *portForward) bool {
+	value, ok := activePortForwards.Load(key)
+	if !ok {
+		return true
+	}
+
+	livePF, ok := value.(*portForward)
+
+	return ok && livePF == pf
+}
+
+// storeIfLive applies update to pf and persists the result, but only while pf
+// is still the live instance for its key. update reports whether the change
+// should be written; it runs with pf's mutex held, so it must not lock it.
+//
+// The liveness check and the store share the key's lifecycle lock, so a
+// concurrent stop or delete happens either entirely before this call (and the
+// write is skipped) or entirely after it.
+func storeIfLive(c cache.Cache[interface{}], pf *portForward, update func(*portForward) bool) {
+	key := portforwardKeyGenerator(*pf)
+
+	defer lockLifecycle(key)()
+
+	if !isLivePortForward(key, pf) {
+		return
+	}
+
+	if pf.mu != nil {
+		pf.mu.Lock()
+		defer pf.mu.Unlock()
+	}
+
+	if !update(pf) {
+		return
+	}
+
+	portforwardstore(c, *pf)
+}
+
+// unregisterPortForward removes pf from the live instance map only when it is
+// still the registered one, so a goroutine cleaning up after a same-ID restart
+// cannot unregister the new instance, and cannot clear the tombstone a delete
+// left behind. Callers must hold the lifecycle lock.
+func unregisterPortForward(key string, pf *portForward) {
+	activePortForwards.CompareAndDelete(key, pf)
+}
+
+// tombstonePortForward marks key as deleted, so any status still in flight for
+// it is refused instead of resurrecting the entry. Callers must hold the
+// lifecycle lock; a later start for the same key replaces the tombstone with
+// its own live instance.
+func tombstonePortForward(key string) {
+	activePortForwards.Store(key, deletedForward{})
+}
+
+// markLivePortForwardStopped flips the live *portForward instance tracked in
+// activePortForwards to STOPPED. The cache only holds value copies, so without
+// this the forwarding goroutine's completion path still sees RUNNING and
+// re-stores the entry after a delete removed it (resurrecting a ghost entry).
+// Callers must hold the key's lifecycle lock.
+func markLivePortForwardStopped(key string) {
+	liveValue, ok := activePortForwards.Load(key)
+	if !ok {
+		return
+	}
+
+	livePF, ok := liveValue.(*portForward)
+	if !ok {
+		return
+	}
+
+	if livePF.mu != nil {
+		livePF.mu.Lock()
+		defer livePF.mu.Unlock()
+	}
+
+	if livePF.Status != RUNNING {
+		return
+	}
+
+	livePF.Status = STOPPED
+
+	if livePF.Error == "" {
+		livePF.Error = "Port forward stopped."
+	}
+}
+
 // stopOrDeletePortForward stops or deletes a port forward by its cluster and id.
 // It takes three parameters: cluster is the name of the cluster, id is the unique identifier of the port forward,
 // isStopRequest is a boolean value indicating whether to stop or delete the port forward.
@@ -76,6 +212,17 @@ func stopOrDeletePortForward(cache cache.Cache[interface{}], cluster string, id 
 		return err
 	}
 
+	key := portforwardKeyGenerator(portforward)
+
+	// Hold the lifecycle lock across the whole transition: a terminal write
+	// from the forwarding goroutine must not interleave between tombstoning the
+	// key and deleting the cached entry, or it would resurrect it.
+	defer lockLifecycle(key)()
+
+	// Mark the live instance as STOPPED before signalling shutdown so its
+	// completion path does not report RUNNING afterwards.
+	markLivePortForwardStopped(key)
+
 	// Always signal the portforward to stop, whether it's a stop or delete request.
 	// This prevents orphaned goroutines and leaked ports.
 	safeCloseChan(portforward.closeChan)
@@ -83,14 +230,20 @@ func stopOrDeletePortForward(cache cache.Cache[interface{}], cluster string, id 
 	if isStopRequest {
 		portforward.Status = STOPPED
 		portforwardstore(cache, portforward)
-	} else {
-		err := cache.Delete(context.Background(), portforwardKeyGenerator(portforward))
-		if err != nil {
-			logger.Log(logger.LevelError, map[string]string{"cluster": cluster, "id": id},
-				err, "deleting portforward")
 
-			return err
-		}
+		return nil
+	}
+
+	// Tombstone first: once the key is marked deleted, storeIfLive refuses any
+	// status the goroutine still has in flight, so the delete below is the last
+	// word on this key.
+	tombstonePortForward(key)
+
+	if err := cache.Delete(context.Background(), key); err != nil {
+		logger.Log(logger.LevelError, map[string]string{"cluster": cluster, "id": id},
+			err, "deleting portforward")
+
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

This PR stops a still-running port-forward goroutine from resurrecting a deleted/stopped port-forward as a ghost cache entry.

## Related Issue

Fixes #7453

## Changes

- Fixed the stop/delete flow in `backend/pkg/portforward/handler.go`: `stopOrDeletePortForward` previously mutated only a **value copy** from the cache, so the live `*portForward`'s `Status` stayed `RUNNING`; when `ForwardPorts` later exited, its completion path saw `RUNNING`, flipped to `STOPPED` and re-stored the entry — recreating it milliseconds after the delete removed it.
- The completion path now skips storing when the cache no longer holds an entry for that key (and the live struct's status is marked under the existing mutex before the channel is closed), so a delete is final and a same-ID restart can't be clobbered by the old goroutine's late write.
- Added a regression test covering delete racing the forwarding-goroutine exit.

## Steps to Test

1. Start a port-forward through the API, then immediately delete/stop it.
2. List port-forwards repeatedly around the moment the forwarding goroutine exits.
3. Before: the deleted entry intermittently reappears as `stopped`; after: deletion sticks.
4. `cd backend && go test ./pkg/portforward/... -count=1`

## Notes for the Reviewer

- The integration test already polls (`require.Eventually`) for deletion, which masked this race; the new unit-level test exercises the ordering deterministically.
