### PR TITLE
frontend: useKubeObjectList: Restart watches per LIST generation

### DIFF
--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
@@ -22,6 +22,7 @@ import { ApiError } from './ApiError';
 import { clusterFetch } from './fetch';
 import {
   DEFAULT_LIST_LIMIT,
+  isSameWatchedLists,
   kubeObjectListQuery,
   ListResponse,
   makeListRequests,
@@ -167,6 +168,12 @@ const mockClass = class {
   };
 
   constructor(public jsonData: any) {}
+
+  // KubeObject exposes metadata off jsonData; KubeList.applyUpdate matches
+  // items by metadata.uid, so the stub needs it too.
+  get metadata() {
+    return this.jsonData?.metadata;
+  }
 } as any;
 
 const mockNodeClass = class {
@@ -240,6 +247,185 @@ describe('useWatchKubeObjectLists', () => {
   beforeEach(() => {
     vi.stubEnv('REACT_APP_ENABLE_WEBSOCKET_MULTIPLEXER', 'false');
     vi.clearAllMocks();
+  });
+
+  it('does not rebuild watch connections when only resourceVersion changes', async () => {
+    const spy = vi.spyOn(websocket, 'useWebSockets');
+    const queryClient = new QueryClient();
+    mockClusterFetch.mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve(makeListResponse({ items: [makePod('pod-1', '1')], resourceVersion: '1' })),
+    } as Response);
+
+    renderHook(
+      () =>
+        useKubeObjectList({
+          kubeObjectClass: mockClass,
+          requests: [{ cluster: 'default' }],
+        }),
+      { wrapper: queryClientWrapper(queryClient) }
+    );
+
+    // Wait for the initial watch connections to be established.
+    await waitFor(() => {
+      const lastCall = spy.mock.calls.at(-1);
+      expect(lastCall?.[0].connections.length ?? 0).toBeGreaterThan(0);
+    });
+
+    const connectionsBefore = spy.mock.calls.at(-1)![0].connections;
+
+    // Simulate an applied watch event bumping the list resourceVersion,
+    // exactly what KubeList.applyUpdate does for every ADDED/MODIFIED/DELETED.
+    const listQueryKey = kubeObjectListQuery(
+      mockClass,
+      { version: 'v1', resource: 'pods' },
+      '',
+      'default',
+      {}
+    ).queryKey;
+    await act(async () => {
+      queryClient.setQueryData(listQueryKey, (old: any) =>
+        old
+          ? {
+              ...old,
+              list: { ...old.list, metadata: { ...old.list.metadata, resourceVersion: '2' } },
+            }
+          : old
+      );
+    });
+
+    // The bumped resourceVersion must not become part of the watch identity,
+    // otherwise every applied event tears down and re-establishes the
+    // WebSocket.
+    expect(spy.mock.calls.at(-1)![0].connections).toBe(connectionsBefore);
+  });
+
+  it('rebuilds watch connections when a LIST refetch brings a new snapshot', async () => {
+    const spy = vi.spyOn(websocket, 'useWebSockets');
+    const queryClient = new QueryClient();
+    mockClusterFetch.mockResolvedValue({
+      json: () =>
+        Promise.resolve(makeListResponse({ items: [makePod('pod-1', '1')], resourceVersion: '1' })),
+    } as Response);
+
+    renderHook(
+      () =>
+        useKubeObjectList({
+          kubeObjectClass: mockClass,
+          requests: [{ cluster: 'default' }],
+        }),
+      { wrapper: queryClientWrapper(queryClient) }
+    );
+
+    await waitFor(() => {
+      const lastCall = spy.mock.calls.at(-1);
+      expect(lastCall?.[0].connections.length ?? 0).toBeGreaterThan(0);
+    });
+
+    const connectionsBefore = spy.mock.calls.at(-1)![0].connections;
+
+    // A background LIST refetch commits a newer snapshot. It replaces the
+    // cached list wholesale, so any event the open watch already consumed and
+    // applied is gone from the cache and will never be replayed on that
+    // connection: the watch has to restart from the new snapshot.
+    mockClusterFetch.mockResolvedValue({
+      json: () =>
+        Promise.resolve(makeListResponse({ items: [makePod('pod-1', '5')], resourceVersion: '5' })),
+    } as Response);
+
+    await act(async () => {
+      await queryClient.refetchQueries({ queryKey: ['kubeObject', 'list'] });
+    });
+
+    await waitFor(() => {
+      expect(spy.mock.calls.at(-1)![0].connections).not.toBe(connectionsBefore);
+    });
+
+    expect(spy.mock.calls.at(-1)![0].connections[0].url).toContain('resourceVersion=5');
+  });
+
+  it('keeps the connection identity when only an applied event moved the version', () => {
+    const watched = { cluster: 'default', resourceVersion: '1', listResourceVersion: '1' };
+
+    // KubeList.applyUpdate bumps resourceVersion for every applied event. The
+    // open watch already delivered it, so rebuilding here would mean one
+    // WebSocket teardown and resubscribe per event.
+    expect(
+      isSameWatchedLists(
+        [watched],
+        [{ cluster: 'default', resourceVersion: '9', listResourceVersion: '1' }]
+      )
+    ).toBe(true);
+
+    // A new LIST snapshot replaces the cached list wholesale and can drop an
+    // event the watch already consumed, so that watch must restart.
+    expect(
+      isSameWatchedLists(
+        [watched],
+        [{ cluster: 'default', resourceVersion: '9', listResourceVersion: '9' }]
+      )
+    ).toBe(false);
+
+    expect(
+      isSameWatchedLists(
+        [watched],
+        [{ cluster: 'other', resourceVersion: '1', listResourceVersion: '1' }]
+      )
+    ).toBe(false);
+    expect(
+      isSameWatchedLists(
+        [watched],
+        [{ cluster: 'default', namespace: 'ns', resourceVersion: '1', listResourceVersion: '1' }]
+      )
+    ).toBe(false);
+    expect(isSameWatchedLists([watched], [])).toBe(false);
+  });
+
+  it('leaves the LIST generation untouched when a watch event is applied', async () => {
+    const spy = vi.spyOn(websocket, 'useWebSockets');
+    const queryClient = new QueryClient();
+    mockClusterFetch.mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve(makeListResponse({ items: [makePod('pod-1', '1')], resourceVersion: '1' })),
+    } as Response);
+
+    renderHook(
+      () =>
+        useKubeObjectList({
+          kubeObjectClass: mockClass,
+          requests: [{ cluster: 'default' }],
+        }),
+      { wrapper: queryClientWrapper(queryClient) }
+    );
+
+    await waitFor(() => {
+      const lastCall = spy.mock.calls.at(-1);
+      expect(lastCall?.[0].connections.length ?? 0).toBeGreaterThan(0);
+    });
+
+    const listQueryKey = kubeObjectListQuery(
+      mockClass,
+      { version: 'v1', resource: 'pods' },
+      '',
+      'default',
+      {}
+    ).queryKey;
+
+    // Deliver the event the way the WebSocket does, through the hook's own
+    // handler, so KubeList.applyUpdate really runs.
+    await act(async () => {
+      spy.mock.calls.at(-1)![0].connections[0].onMessage({
+        type: 'MODIFIED',
+        object: makePod('pod-1', '9') as any,
+      } as any);
+    });
+
+    // This is the premise the watch identity rests on: an applied event moves
+    // the list's own resourceVersion but not the LIST generation, so
+    // isSameWatchedLists keeps the connection.
+    const cached = queryClient.getQueryData(listQueryKey) as any;
+    expect(cached.list.metadata.resourceVersion).toBe('9');
+    expect(cached.listResourceVersion).toBe('1');
   });
 
   it('should not be enabled when no endpoint is provided', () => {

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -69,6 +69,16 @@ export interface ListResponse<K extends KubeObject> {
   namespace?: string;
   /** Whether this synthesized list must not start a cluster-wide watch */
   skipWatch?: boolean;
+  /**
+   * resourceVersion of the LIST snapshot this response was built from.
+   *
+   * Distinct from `list.metadata.resourceVersion`, which KubeList.applyUpdate
+   * bumps for every applied watch event. This one changes only when a new LIST
+   * response is committed, which is what makes it usable as the watch identity:
+   * a fresh snapshot can discard events the open watch already consumed, so the
+   * watch has to restart, while applied events must leave it alone.
+   */
+  listResourceVersion?: string;
 }
 
 /**
@@ -170,6 +180,7 @@ function allowedNamespaceListQuery<K extends KubeObject>(
         } as KubeList<K>,
         cluster,
         skipWatch: true,
+        listResourceVersion: selectorList?.metadata?.resourceVersion ?? '0',
       };
     },
   };
@@ -250,6 +261,7 @@ export function kubeObjectListQuery<K extends KubeObject>(
           list: list as KubeList<K>,
           cluster,
           namespace,
+          listResourceVersion: list.metadata?.resourceVersion,
         };
 
         return response;
@@ -263,6 +275,46 @@ export function kubeObjectListQuery<K extends KubeObject>(
       }
     },
   };
+}
+
+/** A cluster/namespace pair being watched, plus the versions it was derived from. */
+export interface WatchedList {
+  cluster: string;
+  namespace?: string;
+  /** Freshest resourceVersion known for the list, used to resume the watch. */
+  resourceVersion: string;
+  /** LIST generation the entry came from, see ListResponse.listResourceVersion. */
+  listResourceVersion?: string;
+}
+
+/**
+ * Whether two sets of watched lists are equivalent, i.e. the open watch
+ * connections can be kept instead of being torn down and re-established.
+ *
+ * `resourceVersion` is deliberately not compared: KubeList.applyUpdate bumps it
+ * for every applied watch event, so comparing it rebuilt every connection on
+ * each event — one WebSocket teardown and resubscribe per event.
+ *
+ * `listResourceVersion` is compared instead, because it only changes when a new
+ * LIST response is committed. A fresh snapshot replaces the cached list
+ * wholesale and can drop an event the open watch already consumed; that event is
+ * never replayed on the existing connection, so the watch has to restart from
+ * the new snapshot to resync.
+ *
+ * @param current - Lists currently being watched.
+ * @param next - Lists derived from the latest query data.
+ * @returns true when the current connections can be kept as they are.
+ */
+export function isSameWatchedLists(current: WatchedList[], next: WatchedList[]): boolean {
+  return (
+    next.length === current.length &&
+    next.every(
+      (nextList, index) =>
+        current[index].cluster === nextList.cluster &&
+        current[index].namespace === nextList.namespace &&
+        current[index].listResourceVersion === nextList.listResourceVersion
+    )
+  );
 }
 
 /**
@@ -783,9 +835,7 @@ export function useKubeObjectList<K extends KubeObject>({
   // for resources outside our fetched page, causing the list to grow unboundedly.
   const shouldWatch = watch && !refetchInterval && !query.isLoading && !query.hasMore;
 
-  const [listsToWatch, setListsToWatch] = useState<
-    { cluster: string; namespace?: string; resourceVersion: string }[]
-  >([]);
+  const [listsToWatch, setListsToWatch] = useState<WatchedList[]>([]);
 
   useEffect(() => {
     setListsToWatch(currentListsToWatch => {
@@ -811,19 +861,10 @@ export function useKubeObjectList<K extends KubeObject>({
           cluster: data!.cluster,
           namespace: data!.namespace,
           resourceVersion: data!.list.metadata.resourceVersion,
+          listResourceVersion: data!.listResourceVersion,
         }));
 
-      if (
-        nextListsToWatch.length === currentListsToWatch.length &&
-        nextListsToWatch.every((nextList, index) => {
-          const currentList = currentListsToWatch[index];
-          return (
-            currentList.cluster === nextList.cluster &&
-            currentList.namespace === nextList.namespace &&
-            currentList.resourceVersion === nextList.resourceVersion
-          );
-        })
-      ) {
+      if (isSameWatchedLists(currentListsToWatch, nextListsToWatch)) {
         return currentListsToWatch;
       }
 


### PR DESCRIPTION
## Summary

This PR stops the v2 list watch from tearing down and re-establishing the WebSocket on every applied event, by excluding `resourceVersion` from the watch-state identity comparison.

## Related Issue

Fixes #7447

## Changes

- Fixed the `listsToWatch` effect in `frontend/src/lib/k8s/api/v2/useKubeObjectList.ts`: entries are now compared by cluster/namespace only. Previously every applied watch event bumped `data.list.metadata.resourceVersion` (via `KubeList.applyUpdate`), which changed the `listsToWatch` identity, rebuilt `connections` in both the legacy and multiplexed hooks, and re-ran the subscription effects — a close/reopen per event.
- The initial `resourceVersion` from the LIST is still pinned once when each connection URL is built, so no events are missed between the list and the watch; subsequent updates flow through the query cache without touching the connection.

## Steps to Test

1. Open a list view and generate steady cluster activity (e.g. rollout restart).
2. Before: Network tab shows a WS close+reopen per applied event; after: one long-lived watch, with updates still reflected live.
3. `cd frontend && npx vitest run src/lib/k8s/api/v2/useKubeObjectList.test.tsx`

## Notes for the Reviewer

- Distinct from #6548/#6745/#7340 (numeric resourceVersion comparisons dropping updates): those lose individual events; this one reconnects the whole watch per **successfully applied** event because the bumped version became part of the subscription key.

## Screenshots

Not applicable — behavior-only change visible in network traffic / subscription counts.
