### PR TITLE
frontend: streamingApi: Relist after watch 410 Gone errors

### DIFF
--- a/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
+++ b/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
@@ -505,7 +505,7 @@ describe('apiProxy', () => {
     });
 
     it('Successfully handles error messages', async () => {
-      expect.assertions(2);
+      expect.assertions(3);
 
       apiProxy.streamResult(streamResultsUrl, mockConfigMap.metadata.name, cb, errCb, {
         watch: '1',
@@ -515,7 +515,17 @@ describe('apiProxy', () => {
       expect(cb).toHaveBeenNthCalledWith(1, mockConfigMap);
 
       mockServer.send(JSON.stringify(errorMessage));
-      expect(cb).toHaveBeenNthCalledWith(2, errorMessage.object);
+
+      // An ERROR event carries a Status object, not the watched resource, so it
+      // must reach errCb rather than being handed to cb as an update.
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(errCb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: errorMessage.object.reason,
+          message: errorMessage.object.message,
+        }),
+        expect.any(Function)
+      );
     });
 
     it('Successfully handles stream cancellation', () =>

--- a/frontend/src/lib/k8s/api/v1/streamingApi.test.ts
+++ b/frontend/src/lib/k8s/api/v1/streamingApi.test.ts
@@ -19,7 +19,12 @@ import { isDebugVerbose } from '../../../../helpers/debugVerbose';
 import { setBackendToken } from '../../../../helpers/getHeadlampAPIHeaders';
 import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
 import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
-import { connectStreamWithParams } from './streamingApi';
+import { clusterRequest } from './clusterRequests';
+import { connectStreamWithParams, streamResult, streamResultsForCluster } from './streamingApi';
+
+vi.mock('./clusterRequests', () => ({
+  clusterRequest: vi.fn(),
+}));
 
 vi.mock('../../../../stateless/findKubeconfigByClusterName', () => ({
   findKubeconfigByClusterName: vi.fn(),
@@ -145,5 +150,156 @@ describe('connectStreamWithParams protocols', () => {
     listeners.message(new MessageEvent('message', { data: 'binary-data' }));
 
     expect(onMessage).toHaveBeenCalledWith('binary-data');
+  });
+
+  describe('streamResultsForCluster ERROR handling', () => {
+    afterEach(() => {
+      setBackendToken(null);
+      vi.unstubAllGlobals();
+      vi.restoreAllMocks();
+    });
+
+    function stubWebSocketCollector() {
+      const sockets: {
+        url: string;
+        listeners: Record<string, ((ev: any) => void)[]>;
+        close: ReturnType<typeof vi.fn>;
+        emit: (type: string, event: any) => void;
+        addEventListener: (type: string, listener: (ev: any) => void) => void;
+        removeEventListener: (type: string, listener: (ev: any) => void) => void;
+      }[] = [];
+      const WebSocketMock = vi.fn(function (url: string) {
+        const instance = {
+          url,
+          binaryType: '',
+          listeners: {} as Record<string, ((ev: any) => void)[]>,
+          close: vi.fn(),
+          addEventListener: (type: string, listener: (ev: any) => void) => {
+            instance.listeners[type] = instance.listeners[type] ?? [];
+            instance.listeners[type].push(listener);
+          },
+          removeEventListener: (type: string, listener: (ev: any) => void) => {
+            instance.listeners[type] = (instance.listeners[type] ?? []).filter(
+              it => it !== listener
+            );
+          },
+          emit: (type: string, event: any) => {
+            (instance.listeners[type] ?? []).forEach(listener => listener(event));
+          },
+        };
+        sockets.push(instance);
+
+        return instance;
+      });
+      vi.stubGlobal('WebSocket', WebSocketMock);
+
+      return { sockets };
+    }
+
+    it('relists and restarts the watch on 410 Gone', async () => {
+      const { sockets } = stubWebSocketCollector();
+      const listResponse = (resourceVersion: string) => ({
+        kind: 'PodList',
+        items: [],
+        metadata: { resourceVersion },
+      });
+      vi.mocked(clusterRequest)
+        .mockResolvedValueOnce(listResponse('1') as any)
+        .mockResolvedValueOnce(listResponse('2') as any);
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      streamResultsForCluster('/api/v1/pods', {
+        cb: vi.fn(),
+        errCb: vi.fn(),
+        cluster: 'test-cluster',
+      });
+
+      // Initial LIST pins resourceVersion=1 into the watch URL.
+      await vi.waitFor(() => expect(sockets.length).toBe(1));
+      expect(sockets[0].url).toContain('resourceVersion=1');
+
+      // Server reports 410 Gone for the pinned resourceVersion.
+      sockets[0].emit(
+        'message',
+        new MessageEvent('message', {
+          data: JSON.stringify({ type: 'ERROR', object: { code: 410, message: 'too old' } }),
+        })
+      );
+
+      // The client relists and starts a new watch from a fresh
+      // resourceVersion instead of reconnecting to the expired one.
+      await vi.waitFor(() => expect(sockets.length).toBe(2));
+      expect(clusterRequest).toHaveBeenCalledTimes(2);
+      expect(sockets[1].url).toContain('resourceVersion=2');
+      expect(sockets[1].url).not.toContain('resourceVersion=1');
+    });
+
+    it('refetches a single object and restarts its watch on 410 Gone', async () => {
+      const { sockets } = stubWebSocketCollector();
+      const pod = (resourceVersion: string) => ({
+        kind: 'Pod',
+        metadata: { name: 'pod-1', uid: 'pod-1-uid', resourceVersion },
+      });
+      vi.mocked(clusterRequest)
+        .mockResolvedValueOnce(pod('1') as any)
+        .mockResolvedValueOnce(pod('2') as any);
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      const cb = vi.fn();
+      const errCb = vi.fn();
+
+      streamResult('/api/v1/pods', 'pod-1', cb, errCb, {}, 'test-cluster');
+
+      await vi.waitFor(() => expect(sockets.length).toBe(1));
+      expect(cb).toHaveBeenCalledTimes(1);
+
+      sockets[0].emit(
+        'message',
+        new MessageEvent('message', {
+          data: JSON.stringify({ type: 'ERROR', object: { code: 410, message: 'too old' } }),
+        })
+      );
+
+      // The Status object must not be delivered as the watched resource; the
+      // object is re-fetched and a new watch replaces the dead one.
+      await vi.waitFor(() => expect(sockets.length).toBe(2));
+      expect(clusterRequest).toHaveBeenCalledTimes(2);
+      expect(cb).toHaveBeenCalledTimes(2);
+      expect(cb).toHaveBeenLastCalledWith(pod('2'));
+      expect(errCb).not.toHaveBeenCalled();
+    });
+
+    it('reports a non-410 single-object watch error through errCb', async () => {
+      const { sockets } = stubWebSocketCollector();
+      vi.mocked(clusterRequest).mockResolvedValueOnce({
+        kind: 'Pod',
+        metadata: { name: 'pod-1', uid: 'pod-1-uid', resourceVersion: '1' },
+      } as any);
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      const cb = vi.fn();
+      const errCb = vi.fn();
+
+      streamResult('/api/v1/pods', 'pod-1', cb, errCb, {}, 'test-cluster');
+
+      await vi.waitFor(() => expect(sockets.length).toBe(1));
+
+      sockets[0].emit(
+        'message',
+        new MessageEvent('message', {
+          data: JSON.stringify({
+            type: 'ERROR',
+            object: { code: 500, reason: 'InternalError', message: 'boom' },
+          }),
+        })
+      );
+
+      await vi.waitFor(() => expect(errCb).toHaveBeenCalled());
+      expect(errCb).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'InternalError' }),
+        expect.any(Function)
+      );
+      // Only the initial GET reached cb; the Status object did not.
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(clusterRequest).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/frontend/src/lib/k8s/api/v1/streamingApi.ts
+++ b/frontend/src/lib/k8s/api/v1/streamingApi.ts
@@ -92,13 +92,44 @@ export function streamResult<T extends KubeObjectInterface>(
         url +
         asQuery({ ...queryParams, ...{ watch: '1', fieldSelector: `metadata.name=${name}` } });
 
-      socket = stream(watchUrl, (x: any) => cb(x.object), { isJson: true, cluster: clusterName });
+      socket = stream(watchUrl, update, { isJson: true, cluster: clusterName });
     } catch (err) {
       console.error('Error in api request', { err, url });
       // @todo: sometimes errCb is {}, the typing for apiProxy needs improving.
       //        See https://github.com/kinvolk/headlamp/pull/833
       if (errCb && typeof errCb === 'function') errCb(err as ApiError, cancel);
     }
+  }
+
+  function update({ type, object }: StreamUpdate) {
+    // An ERROR event carries a Status object rather than the watched resource,
+    // so it must never reach cb as if the object itself had changed.
+    if (type === 'ERROR') {
+      const statusCode = (object as { code?: number })?.code;
+
+      // 410 Gone means the version this watch started from has expired (etcd
+      // compaction, proxy restart). Re-fetch the object and start a fresh
+      // watch rather than reconnecting to a version the server no longer has.
+      if (statusCode === 410) {
+        console.error('Watch resourceVersion expired, refetching', { url, name });
+
+        if (socket) socket.cancel();
+
+        run();
+
+        return;
+      }
+
+      console.error('Error in update', { type, object });
+
+      if (errCb && typeof errCb === 'function') {
+        errCb(object as ApiError, cancel);
+      }
+
+      return;
+    }
+
+    cb(object as T);
   }
 
   function cancel() {
@@ -243,9 +274,27 @@ export function streamResultsForCluster(
       case 'DELETED':
         delete results[object.metadata.uid];
         break;
-      case 'ERROR':
+      case 'ERROR': {
+        // 410 Gone means the resourceVersion the watch was started from has
+        // expired (etcd compaction, proxy restarts). Reconnects to the same
+        // URL would keep failing forever, so relist and restart the watch
+        // from a fresh resourceVersion instead.
+        const statusCode = (object as { code?: number })?.code;
+        if (statusCode === 410) {
+          console.error('Watch resourceVersion expired, relisting', { url });
+          socket?.cancel();
+          Object.keys(results).forEach(uid => delete results[uid]);
+          run();
+
+          return;
+        }
+
         console.error('Error in update', { type, object });
+        if (errCb && typeof errCb === 'function') {
+          errCb(object as ApiError, cancel);
+        }
         break;
+      }
       default:
         console.error('Unknown update type', type);
     }


### PR DESCRIPTION
## Summary

This PR makes the v1 stream client handle watch `ERROR` events — in particular 410 Gone — instead of swallowing them, so lists recover after etcd compaction instead of going permanently stale in an infinite reconnect loop.

## Related Issue

Fixes #7451

## Changes

- Fixed `streamResultsForCluster` in `frontend/src/lib/k8s/api/v1/streamingApi.ts`: the `'ERROR'` case now inspects the Status object's code; on 410 Gone it cancels the socket and restarts the flow with a fresh LIST (no pinned resourceVersion), and other error codes are surfaced through `errCb` instead of being silently logged. The ERROR Status object is no longer delivered into `cb` as if it were the watched resource.
- Previously the client kept its stale `results`, reconnected every 3 s to the same expired resourceVersion, got another 410 immediately, and looped forever — lists froze until manual reload, and single-object views received the raw Status object as their "updated" object.

## Steps to Test

1. Watch any resource list long enough for etcd compaction (or force it by restarting the API server / sleeping the machine).
2. Change watched resources afterwards.
3. Before: list never updates again; Network shows repeated watch requests to the expired resourceVersion failing every ~3 s. After: one fresh LIST re-establishes the watch and updates flow again.
4. `cd frontend && npx vitest run src/lib/k8s/api/v1/streamingApi.test.ts`

## Notes for the Reviewer

- Related but distinct from #7340 (v2 `KubeList.applyUpdate` corrupting its own resourceVersion on ERROR events); this is the v1 client-side behavior.
- Reuses the existing cancel/run plumbing rather than adding a new retry mechanism.
