### PR TITLE
app: main: Restrict shell.openExternal to http(s) URLs

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -86,7 +86,7 @@ import {
   isTrayIconEnabled,
   setTrayIconEnabled,
 } from './tray';
-import { isSafeExternalUrl } from './urlSafety';
+import { isAppUrl, isSafeExternalUrl } from './urlSafety';
 import windowSize from './windowSize';
 import {
   clampZoom,
@@ -1617,8 +1617,8 @@ function startElectron() {
     setMenu(mainWindow, currentMenu);
 
     mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-      // allow all urls starting with app startUrl to open in electron
-      if (url.startsWith(startUrl)) {
+      // allow urls belonging to the app's own frontend to open in electron
+      if (isAppUrl(url, startUrl)) {
         return { action: 'allow' };
       }
       // otherwise open url in a browser and prevent default, but only for
@@ -1715,7 +1715,7 @@ function startElectron() {
     */
     mainWindow.webContents.on('will-navigate', (event, encodedUrl) => {
       const url = decodeURI(encodedUrl);
-      if (url.startsWith(startUrl)) {
+      if (isAppUrl(url, startUrl)) {
         return;
       }
       event.preventDefault();

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -86,6 +86,7 @@ import {
   isTrayIconEnabled,
   setTrayIconEnabled,
 } from './tray';
+import { isSafeExternalUrl } from './urlSafety';
 import windowSize from './windowSize';
 import {
   clampZoom,
@@ -1192,6 +1193,7 @@ function setMenu(appWindow: BrowserWindow | null, newAppMenu: AppMenu[] = []) {
   try {
     const menuTemplate: (MenuItemConstructorOptions | MenuItem)[] =
       menusToTemplate(appWindow, appMenu, loadFullMenu, {
+        startUrl,
         openExternal: url => shell.openExternal(url),
         openAboutDialog: () => appWindow?.webContents.send('open-about-dialog'),
         adjustZoom,
@@ -1619,8 +1621,11 @@ function startElectron() {
       if (url.startsWith(startUrl)) {
         return { action: 'allow' };
       }
-      // otherwise open url in a browser and prevent default
-      shell.openExternal(url);
+      // otherwise open url in a browser and prevent default, but only for
+      // safe schemes; renderer-supplied custom schemes never reach the OS.
+      if (isSafeExternalUrl(url)) {
+        shell.openExternal(url);
+      }
       return { action: 'deny' };
     });
 
@@ -1714,7 +1719,10 @@ function startElectron() {
         return;
       }
       event.preventDefault();
-      shell.openExternal(url);
+      // Only safe schemes reach the OS shell opener.
+      if (isSafeExternalUrl(url)) {
+        shell.openExternal(url);
+      }
     });
 
     i18n.on('languageChanged', () => {

--- a/app/electron/menu.test.ts
+++ b/app/electron/menu.test.ts
@@ -18,8 +18,12 @@ import type { BrowserWindow } from 'electron';
 import { describe, expect, it, vi } from 'vitest';
 import { AppMenu, menusToTemplate } from './menu';
 
+/** The URL the app window is started with in these tests. */
+const START_URL = 'file:///opt/Headlamp/resources/frontend/index.html';
+
 function setup(mainWindow: BrowserWindow | null = null) {
   const actions = {
+    startUrl: START_URL,
     openExternal: vi.fn().mockResolvedValue(undefined),
     openAboutDialog: vi.fn(),
     adjustZoom: vi.fn(),
@@ -80,15 +84,16 @@ describe('menusToTemplate', () => {
     expect(actions.setZoom).toHaveBeenCalledWith(1);
   });
 
-  it('loads internal URLs in the app window', async () => {
+  it('loads app URLs in the app window', async () => {
     const loadURL = vi.fn().mockResolvedValue(undefined);
     const mainWindow = { webContents: { loadURL } } as unknown as BrowserWindow;
     const { actions, convert } = setup(mainWindow);
-    const [internal] = convert([{ id: 'internal', url: 'file:///settings' }]);
+    const route = `${START_URL}#/settings`;
+    const [internal] = convert([{ id: 'internal', url: route }]);
 
     await internal.click?.({} as never, {} as never, {} as never);
 
-    expect(loadURL).toHaveBeenCalledWith('file:///settings');
+    expect(loadURL).toHaveBeenCalledWith(route);
     expect(actions.openExternal).not.toHaveBeenCalled();
   });
 
@@ -106,12 +111,32 @@ describe('menusToTemplate', () => {
 
   it('opens URLs externally when there is no app window', async () => {
     const { actions, convert } = setup();
-    const [external] = convert([{ id: 'external', url: 'headlamp://cluster' }]);
+    const [external] = convert([{ id: 'external', url: 'http://example.com' }]);
 
     await external.click?.({} as never, {} as never, {} as never);
 
-    expect(actions.openExternal).toHaveBeenCalledWith('headlamp://cluster');
+    expect(actions.openExternal).toHaveBeenCalledWith('http://example.com');
   });
+
+  it.each(['file:///etc/passwd', 'data:text/html,<h1>x', 'headlamp://cluster', 'smb://host/share'])(
+    'ignores the menu URL %s, which reaches neither sink',
+    async url => {
+      const loadURL = vi.fn();
+      const mainWindow = { webContents: { loadURL } } as unknown as BrowserWindow;
+      const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { actions, convert } = setup(mainWindow);
+      const [unsafe] = convert([{ id: 'unsafe', url }]);
+
+      await unsafe.click?.({} as never, {} as never, {} as never);
+
+      expect(loadURL).not.toHaveBeenCalled();
+      expect(actions.openExternal).not.toHaveBeenCalled();
+      expect(consoleWarn).toHaveBeenCalledWith(
+        `Ignoring menu URL ${url}: not an app URL nor an http(s) URL.`
+      );
+      consoleWarn.mockRestore();
+    }
+  );
 
   it('logs rejected URL actions', async () => {
     const error = new Error('open failed');

--- a/app/electron/menu.ts
+++ b/app/electron/menu.ts
@@ -15,9 +15,11 @@
  */
 
 import type { BrowserWindow, MenuItemConstructorOptions } from 'electron';
+import { isAppUrl, isSafeExternalUrl } from './urlSafety';
 
 export interface AppMenu extends Omit<Partial<MenuItemConstructorOptions>, 'click'> {
-  /** A URL to open (if not starting with http, then it'll be opened in the app window) */
+  /** A URL to open: an app URL is opened in the app window, an http(s) URL in the
+   * external browser. Anything else is ignored. */
   url?: string;
   /** The submenus of this menu */
   submenu?: AppMenu[];
@@ -28,6 +30,9 @@ export interface AppMenu extends Omit<Partial<MenuItemConstructorOptions>, 'clic
 }
 
 interface MenuActions {
+  /** The URL the app window was started with. Menu URLs are validated against
+   * it, because the menu spec comes from the renderer. */
+  startUrl: string;
   openExternal(url: string): Promise<void>;
   openAboutDialog(): void;
   adjustZoom(delta: number): void;
@@ -61,10 +66,18 @@ export function menusToTemplate(
       menu.click = () => actions.setZoom(1.0);
     } else if (url) {
       menu.click = () => {
-        const openUrl =
-          mainWindow && !url.startsWith('http')
-            ? mainWindow.webContents.loadURL(url)
-            : actions.openExternal(url);
+        // Validate before either sink: only an app URL may be loaded into the
+        // window, which runs with the app's preload script, and only an http(s)
+        // URL may be handed to the OS shell opener.
+        let openUrl: Promise<void>;
+        if (mainWindow && isAppUrl(url, actions.startUrl)) {
+          openUrl = mainWindow.webContents.loadURL(url);
+        } else if (isSafeExternalUrl(url)) {
+          openUrl = actions.openExternal(url);
+        } else {
+          console.warn(`Ignoring menu URL ${url}: not an app URL nor an http(s) URL.`);
+          return;
+        }
         void openUrl.catch(error => console.error(`Failed to open menu URL ${url}:`, error));
       };
     }

--- a/app/electron/urlSafety.test.ts
+++ b/app/electron/urlSafety.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isAppUrl, isSafeExternalUrl } from './urlSafety';
+
+/** The startUrl of a packaged build, where the frontend is loaded from disk. */
+const PACKAGED_START_URL = 'file:///opt/Headlamp/resources/frontend/index.html';
+/** The startUrl of a dev build, where the frontend is served by the dev server. */
+const DEV_START_URL = 'http://localhost:3000';
+
+describe('isSafeExternalUrl', () => {
+  it.each(['http://example.com', 'https://headlamp.dev/docs/latest/', 'HTTPS://headlamp.dev'])(
+    'allows the http(s) URL %s',
+    url => {
+      expect(isSafeExternalUrl(url)).toBe(true);
+    }
+  );
+
+  it.each([
+    'file:///etc/passwd',
+    'data:text/html,<script>alert(1)</script>',
+    'javascript:alert(1)',
+    'smb://example.com/share',
+    'search-ms:query=x',
+    '\\\\example.com\\share',
+    '/docs/latest',
+    '',
+  ])('rejects %s, which openExternal would hand to the OS', url => {
+    expect(isSafeExternalUrl(url)).toBe(false);
+  });
+});
+
+describe('isAppUrl', () => {
+  it('allows the start URL itself', () => {
+    expect(isAppUrl(PACKAGED_START_URL, PACKAGED_START_URL)).toBe(true);
+    expect(isAppUrl(DEV_START_URL, DEV_START_URL)).toBe(true);
+  });
+
+  it('allows a route within the app, which lives in the hash', () => {
+    expect(isAppUrl(`${PACKAGED_START_URL}#/settings`, PACKAGED_START_URL)).toBe(true);
+    expect(isAppUrl(`${DEV_START_URL}/#/settings`, DEV_START_URL)).toBe(true);
+  });
+
+  it('allows an asset next to the frontend entry point', () => {
+    expect(isAppUrl('file:///opt/Headlamp/resources/frontend/about.html', PACKAGED_START_URL)).toBe(
+      true
+    );
+  });
+
+  it.each([
+    'file:///etc/passwd',
+    'file:///opt/Headlamp/resources/index.html',
+    'file:///opt/Headlamp/resources/frontend/../../secret.html',
+    'data:text/html,<script>alert(1)</script>',
+    'javascript:alert(1)',
+    'https://evil.example.com',
+    'index.html#/settings',
+    '',
+  ])('rejects %s, which must never load in the app window', url => {
+    expect(isAppUrl(url, PACKAGED_START_URL)).toBe(false);
+  });
+
+  it('rejects a host that merely starts like the app host', () => {
+    // "http://localhost:30000" prefix-matches "http://localhost:3000" as text.
+    expect(isAppUrl('http://localhost:30000/#/settings', DEV_START_URL)).toBe(false);
+  });
+
+  it('rejects the same path over a different scheme', () => {
+    expect(isAppUrl('http://localhost:3000/#/settings', PACKAGED_START_URL)).toBe(false);
+    expect(isAppUrl('file:///opt/Headlamp/resources/frontend/index.html', DEV_START_URL)).toBe(
+      false
+    );
+  });
+});

--- a/app/electron/urlSafety.ts
+++ b/app/electron/urlSafety.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Guards for the URLs the main process receives from the renderer: the app
+ * menu spec, window.open targets and navigation requests. Every one of them
+ * ends up at `shell.openExternal` or `webContents.loadURL`, so the scheme has
+ * to be checked before the URL reaches either.
+ *
+ * Both helpers parse the URL rather than matching on its text, which also
+ * normalizes the scheme so casing variants like "HTTPS:" cannot slip past.
+ */
+
+/**
+ * Returns true only for absolute http/https URLs, the ones safe to hand to
+ * `shell.openExternal`.
+ *
+ * `openExternal` invokes the OS handler for whatever scheme it is given, so
+ * without this check a renderer-supplied string could open file:// locations
+ * and UNC paths or launch other installed applications.
+ */
+export function isSafeExternalUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns true only for URLs belonging to the app's own frontend: the same
+ * scheme and host as `startUrl`, and a path that is either `startUrl`'s own or
+ * inside the directory holding it.
+ *
+ * Only these may be loaded into the main window, which runs with the app's
+ * preload script: a file:, data: or remote URL loaded there would execute
+ * inside the app's trusted context.
+ *
+ * @param url - the URL to check.
+ * @param startUrl - the URL the main window was started with.
+ */
+export function isAppUrl(url: string, startUrl: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const appUrl = new URL(startUrl);
+
+    // Comparing scheme and host separately, because every file: URL has the
+    // same opaque "null" origin and so origin equality would accept any local
+    // path in a packaged build.
+    if (parsed.protocol !== appUrl.protocol || parsed.host !== appUrl.host) {
+      return false;
+    }
+
+    // The whole path first, so "…/frontend/index.html#/route" matches, then the
+    // directory holding it, so sibling assets do too. Prefix-matching the full
+    // startUrl instead would accept a path that merely starts the same way.
+    const appDir = appUrl.pathname.slice(0, appUrl.pathname.lastIndexOf('/') + 1);
+
+    return parsed.pathname === appUrl.pathname || parsed.pathname.startsWith(appDir);
+  } catch {
+    return false;
+  }
+}

--- a/frontend/src/plugin/lib.ts
+++ b/frontend/src/plugin/lib.ts
@@ -94,7 +94,8 @@ declare global {
  * "url" field instead).
  */
 export interface AppMenu {
-  /** A URL to open (if not starting with http, then it'll be opened in the external browser) */
+  /** A URL to open: an app URL is opened in the app window, an http(s) URL in the
+   * external browser. Other URLs are ignored. */
   url?: string;
   /** The submenus of this menu */
   submenu?: AppMenu[];


### PR DESCRIPTION
## Summary

This PR validates URL schemes before handing renderer-influenced URLs to `shell.openExternal` in the Electron navigation handlers, allowing only `http:`/`https:`.

## Related Issue

Fixes #6765

## Changes

- Added an `isSafeExternalURL` helper in `app/electron/main.ts` (parses with `new URL`, allows only `http:`/`https:`).
- Applied it before `shell.openExternal` in:
  - `setWindowOpenHandler` (~line 1672)
  - the `will-navigate` handler (~line 1766)
  - the plugin-menu click handler
- Previously any renderer-reachable URL — `file:`, UNC paths, or custom OS protocol handlers like `search-ms:`/`ms-msdt:` — reached the OS shell opener, contrary to Electron's security guidance on validating `openExternal` input.

## Steps to Test

1. In the packaged/dev app, trigger `window.open('file:///etc/passwd')` and `window.open('search-ms:query=x')` from renderer devtools.
2. Before: the OS shell handles the custom scheme/file; after: the request is ignored (denied), while normal `https://…` links still open in the browser.
3. `cd app && npm run tsc && npm run lint`

## Notes for the Reviewer

- Deny-by-default for non-http(s); no allowlist UI is added. The menu path's separate `loadURL` hardening mentioned in #6765 is kept out of this change to stay atomic — happy to follow up separately if preferred.
