### PR TITLE
app: main: Handle headless startServer failure

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -2009,14 +2009,25 @@ function attachServerEventHandlers(serverProcess: ChildProcessWithoutNullStreams
 }
 
 if (isHeadlessMode) {
-  startServer(['-html-static-dir', path.join(process.resourcesPath, './frontend')]).then(
-    serverProcess => {
+  startServer(['-html-static-dir', path.join(process.resourcesPath, './frontend')])
+    .then(serverProcess => {
       attachServerEventHandlers(serverProcess);
 
       // Give 1s for backend to start
       setTimeout(() => shell.openExternal(`http://localhost:${actualPort}`), 1000);
-    }
-  );
+    })
+    .catch((error: Error) => {
+      // Without this, a port-exhaustion rejection becomes an unhandled
+      // promise rejection: the user gets no browser window and no diagnostic.
+      console.error('Failed to start the backend server:', error);
+      dialog.showErrorBox(
+        i18n.t('Headlamp failed to start'),
+        i18n.t('The backend server could not be started:\n\n{{ error }}', {
+          error: error.message,
+        })
+      );
+      app.quit();
+    });
 } else {
   if (!isRunningScript) {
     startElectron();

--- a/frontend/src/i18n/locales/ar/app.json
+++ b/frontend/src/i18n/locales/ar/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "فشل التشغيل",
   "Could not start the server even after terminating existing processes.": "تعذر تشغيل الخادم حتى بعد إنهاء العمليات الحالية.",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "تعذر العثور على منفذ متاح في النطاق {{startPort}}-{{endPort}}. يرجى تحرير منفذ والمحاولة مرة أخرى.",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "رابط غير صالح",
   "Application opened with an invalid URL: {{ url }}": "تم فتح التطبيق برابط غير صالح: {{ url }}",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/bn/app.json
+++ b/frontend/src/i18n/locales/bn/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "শুরু করতে ব্যর্থ",
   "Could not start the server even after terminating existing processes.": "বিদ্যমান process বন্ধ করার পরও সার্ভারটি শুরু করা যায়নি।",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "{{startPort}}-{{endPort}} রেঞ্জের মধ্যে কোনো উপলব্ধ পোর্ট খুঁজে পাওয়া যায়নি। অনুগ্রহ করে একটি পোর্ট খালি করুন এবং আবার চেষ্টা করুন।",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "অবৈধ URL",
   "Application opened with an invalid URL: {{ url }}": "অ্যাপটি একটি অবৈধ URL দিয়ে খোলা হয়েছে: {{ url }}",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/cs/app.json
+++ b/frontend/src/i18n/locales/cs/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "Spuštění selhalo.",
   "Could not start the server even after terminating existing processes.": "Server nelze spustit ani po ukončení existujících procesů.",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "Nelze najít dostupný port v rozsahu {{startPort}}–{{endPort}}. Uvolněte prosím port a zkuste to znovu.",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "Neplatná adresa URL",
   "Application opened with an invalid URL: {{ url }}": "Aplikace se otevřela s neplatnou adresou URL: {{ url }}.",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/de/app.json
+++ b/frontend/src/i18n/locales/de/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "",
   "Could not start the server even after terminating existing processes.": "",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "Ungültige URL",
   "Application opened with an invalid URL: {{ url }}": "Anwendung mit einer ungültigen URL geöffnet: {{ url }}",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/en/app.json
+++ b/frontend/src/i18n/locales/en/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "Failed to start",
   "Could not start the server even after terminating existing processes.": "Could not start the server even after terminating existing processes.",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.",
+  "Headlamp failed to start": "Headlamp failed to start",
+  "The backend server could not be started:\n\n{{ error }}": "The backend server could not be started:\n\n{{ error }}",
   "Invalid URL": "Invalid URL",
   "Application opened with an invalid URL: {{ url }}": "Application opened with an invalid URL: {{ url }}",
   "OAuth callback failed": "OAuth callback failed",

--- a/frontend/src/i18n/locales/es/app.json
+++ b/frontend/src/i18n/locales/es/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "",
   "Could not start the server even after terminating existing processes.": "",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "URL inválida",
   "Application opened with an invalid URL: {{ url }}": "Aplicación abierta con una URL inválida: {{ url }}",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/fr/app.json
+++ b/frontend/src/i18n/locales/fr/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "Échec du démarrage",
   "Could not start the server even after terminating existing processes.": "Impossible de démarrer le serveur même après avoir terminé les processus existants.",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "Impossible de trouver un port disponible dans la plage {{startPort}}-{{endPort}}. Veuillez libérer un port et réessayer.",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "URL invalide",
   "Application opened with an invalid URL: {{ url }}": "Application ouverte avec une URL invalide : {{ url }}",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/he/app.json
+++ b/frontend/src/i18n/locales/he/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "Failed to start",
   "Could not start the server even after terminating existing processes.": "Could not start the server even after terminating existing processes.",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "Invalid URL",
   "Application opened with an invalid URL: {{ url }}": "Application opened with an invalid URL: {{ url }}",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/hi/app.json
+++ b/frontend/src/i18n/locales/hi/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "",
   "Could not start the server even after terminating existing processes.": "",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "अमान्य URL",
   "Application opened with an invalid URL: {{ url }}": "अनुप्रयोग एक अमान्य URL के साथ खोला गया: {{ url }}",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/hu/app.json
+++ b/frontend/src/i18n/locales/hu/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "Nem sikerült elindítani",
   "Could not start the server even after terminating existing processes.": "A kiszolgálót a meglévő folyamatok leállítása után sem sikerült elindítani.",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "Nem található elérhető port a(z) {{startPort}}-{{endPort}}tartományban. Szabadítson fel egy portot, majd próbálkozzon újra.",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "Érvénytelen URL-cím",
   "Application opened with an invalid URL: {{ url }}": "Érvénytelen URL-címmel megnyitott alkalmazás: {{ url }}",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/id/app.json
+++ b/frontend/src/i18n/locales/id/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "Gagal memulai",
   "Could not start the server even after terminating existing processes.": "Tidak dapat memulai server bahkan setelah menghentikan proses yang ada.",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "Tidak dapat menemukan port yang tersedia dalam rentang {{startPort}}-{{endPort}}. Kosongkan port dan coba lagi.",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "URL tidak valid",
   "Application opened with an invalid URL: {{ url }}": "Aplikasi dibuka dengan URL yang tidak valid: {{ url }}",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/it/app.json
+++ b/frontend/src/i18n/locales/it/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "",
   "Could not start the server even after terminating existing processes.": "",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "URL Non Valido",
   "Application opened with an invalid URL: {{ url }}": "Applicazione avviata con un URL non valido: {{ url }}",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/ja/app.json
+++ b/frontend/src/i18n/locales/ja/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "",
   "Could not start the server even after terminating existing processes.": "",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "無効な URL",
   "Application opened with an invalid URL: {{ url }}": "無効な URL でアプリケーションが開かれました: {{ url }}",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/ko/app.json
+++ b/frontend/src/i18n/locales/ko/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "",
   "Could not start the server even after terminating existing processes.": "",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "잘못된 URL",
   "Application opened with an invalid URL: {{ url }}": "잘못된 URL로 애플리케이션이 열렸습니다: {{ url }}",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/nl/app.json
+++ b/frontend/src/i18n/locales/nl/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "Starten is mislukt",
   "Could not start the server even after terminating existing processes.": "Kan de server niet starten, zelfs niet nadat bestaande processen zijn beëindigd.",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "Kan geen beschikbare poort vinden in het bereik {{startPort}}-{{endPort}}. Maak een poort vrij en probeer het opnieuw.",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "Ongeldige URL",
   "Application opened with an invalid URL: {{ url }}": "Toepassing geopend met een ongeldige URL: {{ url }}",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/pl/app.json
+++ b/frontend/src/i18n/locales/pl/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "Nie można uruchomić",
   "Could not start the server even after terminating existing processes.": "Nie można uruchomić serwera nawet po zakończeniu istniejących procesów.",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "Nie można odnaleźć dostępnego portu w zakresie {{startPort}}-{{endPort}}. Zwolnij port i spróbuj ponownie.",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "Nieprawidłowy adres URL",
   "Application opened with an invalid URL: {{ url }}": "Aplikacja została otwarta z nieprawidłowym adresem URL: {{ url }}",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/pt-br/app.json
+++ b/frontend/src/i18n/locales/pt-br/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "Falha ao iniciar",
   "Could not start the server even after terminating existing processes.": "Não\u00a0foi possível iniciar o servidor mesmo após terminar os processos existentes.",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "Não foi possível encontrar uma porta disponível no intervalo {{startPort}}-{{endPort}}. Libere uma porta e tente novamente.",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "URL inválido",
   "Application opened with an invalid URL: {{ url }}": "Aplicação aberta com um URL inválido: {{ url }}",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/pt-pt/app.json
+++ b/frontend/src/i18n/locales/pt-pt/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "",
   "Could not start the server even after terminating existing processes.": "",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "URL inválido",
   "Application opened with an invalid URL: {{ url }}": "Aplicação aberta com um URL inválido: {{ url }}",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/ru/app.json
+++ b/frontend/src/i18n/locales/ru/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "Не удалось запустить",
   "Could not start the server even after terminating existing processes.": "Не удалось запустить сервер даже после завершения существующих процессов.",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "Не удалось найти свободный порт в диапазоне {{startPort}}-{{endPort}}. Освободите порт и повторите попытку.",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "Некорректный URL",
   "Application opened with an invalid URL: {{ url }}": "Приложение было открыто с некорректным URL: {{ url }}",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/sv/app.json
+++ b/frontend/src/i18n/locales/sv/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "Det gick inte att starta",
   "Could not start the server even after terminating existing processes.": "Det gick inte att starta servern även efter att befintliga processer avslutats.",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "Det gick inte att hitta en tillgänglig port inom intervallet {{startPort}} till {{endPort}}. Frigör en port och försök igen.",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "Ogiltig webbadress",
   "Application opened with an invalid URL: {{ url }}": "Programmet har öppnats med en ogiltig webbadress: {{ url }}",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/ta/app.json
+++ b/frontend/src/i18n/locales/ta/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "",
   "Could not start the server even after terminating existing processes.": "",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "தவறான URL",
   "Application opened with an invalid URL: {{ url }}": "பயன்பாடு தவறான URL உடன் திறக்கப்பட்டது: {{ url }}",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/tr/app.json
+++ b/frontend/src/i18n/locales/tr/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "Başlatılamadı",
   "Could not start the server even after terminating existing processes.": "Mevcut işlemler sonlandırıldıktan sonra bile sunucu başlatılamadı.",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "{{startPort}}-{{endPort}} aralığında kullanılabilir bir bağlantı noktası bulunamadı. Lütfen bir bağlantı noktası serbest bırakın ve yeniden deneyin.",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "Geçersiz URL",
   "Application opened with an invalid URL: {{ url }}": "Uygulama geçersiz bir URL'yle açıldı: {{ url }}",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/ur/app.json
+++ b/frontend/src/i18n/locales/ur/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "شروع کرنے میں ناکامی",
   "Could not start the server even after terminating existing processes.": "موجودہ عمل بند کرنے کے باوجود سرور شروع نہیں ہو سکا۔",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "رینج {{startPort}}-{{endPort}} میں کوئی دستیاب پورٹ نہیں ملی۔ براہِ کرم ایک پورٹ خالی کریں اور دوبارہ کوشش کریں۔",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "غیر درست URL",
   "Application opened with an invalid URL: {{ url }}": "ایپلیکیشن ایک غیر درست URL کے ساتھ کھولی گئی: {{ url }}",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/zh-tw/app.json
+++ b/frontend/src/i18n/locales/zh-tw/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "啟動失敗",
   "Could not start the server even after terminating existing processes.": "即使終止現有程序後也無法啟動伺服器。",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "無法在範圍 {{startPort}}-{{endPort}} 中找到可用的連接埠。請釋放一個連接埠並重試。",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "無效的網址",
   "Application opened with an invalid URL: {{ url }}": "應用程式以無效的網址開啟：{{ url }}",
   "OAuth callback failed": "",

--- a/frontend/src/i18n/locales/zh/app.json
+++ b/frontend/src/i18n/locales/zh/app.json
@@ -52,6 +52,8 @@
   "Failed to start": "",
   "Could not start the server even after terminating existing processes.": "",
   "Could not find an available port in the range {{startPort}}-{{endPort}}. Please free up a port and try again.": "",
+  "Headlamp failed to start": "",
+  "The backend server could not be started:\n\n{{ error }}": "",
   "Invalid URL": "非法的URL",
   "Application opened with an invalid URL: {{ url }}": "应用程序打开了一个非法URL: {{ url }}",
   "OAuth callback failed": "",


### PR DESCRIPTION
## Summary

This PR handles `startServer()` rejection in headless mode, so a port-exhaustion failure produces a clear error and exit instead of an unhandled promise rejection (silent hang or process death) with no browser window.

## Related Issue

Fixes #7455

## Changes

- Fixed the headless branch in `app/electron/main.ts`: added a `.catch` on the `startServer(...)` promise that logs the error, surfaces it via stderr and `dialog.showErrorBox`, and quits the app.
- Previously that rejection became an unhandled promise rejection in the Electron main process (process death on current Node/Electron defaults, or a silent no-op), so users got neither a browser window nor any diagnostic.

## Steps to Test

1. Occupy all candidate ports (or otherwise force `findAvailablePort` failure) and run the app in headless mode.
2. Before: silent hang/crash with no diagnostics; after: an explicit error message and clean exit.
3. Normal headless start still opens the browser at the right time.
4. `cd app && npm run tsc && npm run lint`

## Notes for the Reviewer

- Mirrors the port-exhaustion handling already built for the interactive path (`startServerIfNeeded`).
