### PR TITLE
frontend: ResourceTable: Ignore namespace filter when disabled

### DIFF
--- a/docs/development/api/modules/lib_util.md
+++ b/docs/development/api/modules/lib_util.md
@@ -99,7 +99,7 @@ ___
 
 ### filterResource
 
-▸ **filterResource**(`item`, `filter`, `search?`, `matchCriteria?`): `boolean`
+▸ **filterResource**(`item`, `filter`, `search?`, `matchCriteria?`, `ignoreNamespaceFilter?`): `boolean`
 
 Filters a resource based on the filter state.
 
@@ -111,6 +111,7 @@ Filters a resource based on the filter state.
 | `filter` | `FilterState` | The filter state. |
 | `search?` | `string` | - |
 | `matchCriteria?` | `string`[] | The JSONPath criteria to match. |
+| `ignoreNamespaceFilter?` | `boolean` | When true, skips matching the item's namespace against the global namespace filter. |
 
 #### Returns
 
@@ -381,7 +382,7 @@ ___
 
 ### useFilterFunc
 
-▸ **useFilterFunc**<`T`\>(`matchCriteria?`): (`item`: `T`, `search?`: `string`) => `boolean`
+▸ **useFilterFunc**<`T`\>(`matchCriteria?`, `ignoreNamespaceFilter?`): (`item`: `T`, `search?`: `string`) => `boolean`
 
 Get a function to filter kube resources based on the current global filter state.
 
@@ -396,6 +397,7 @@ Get a function to filter kube resources based on the current global filter state
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `matchCriteria?` | `string`[] | The JSONPath criteria to match. |
+| `ignoreNamespaceFilter?` | `boolean` | When true, the returned function ignores the global namespace filter; textual/search filtering still applies. |
 
 #### Returns
 

--- a/frontend/src/components/advancedSearch/ResourceSearch.tsx
+++ b/frontend/src/components/advancedSearch/ResourceSearch.tsx
@@ -296,6 +296,7 @@ export function ResourceSearch({
             ]}
             data={deferredResults.items.slice(0, maxResults) ?? []}
             hideColumns={selectedClusters.length > 1 ? undefined : ['cluster']}
+            noNamespaceFilter
           />
         )}
       </Box>

--- a/frontend/src/components/common/Resource/ResourceListView.test.tsx
+++ b/frontend/src/components/common/Resource/ResourceListView.test.tsx
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../../test';
+import ResourceListView from './ResourceListView';
+
+const { lastResourceTablePropsHolder, lastSectionFilterHeaderPropsHolder } = vi.hoisted(() => ({
+  lastResourceTablePropsHolder: { current: null as any },
+  lastSectionFilterHeaderPropsHolder: { current: null as any },
+}));
+
+vi.mock('./ResourceTable', () => ({
+  default: (props: any) => {
+    lastResourceTablePropsHolder.current = props;
+    return <div data-testid="mock-resource-table" />;
+  },
+}));
+
+// URL sync and widget rendering are out of scope here; only the noNamespaceFilter
+// value forwarded to SectionFilterHeader (to compare against ResourceTable) is under test.
+vi.mock('../SectionFilterHeader', () => ({
+  default: (props: any) => {
+    lastSectionFilterHeaderPropsHolder.current = props;
+    return null;
+  },
+}));
+
+// Avoids pulling in the full resource-class import graph (unrelated to this test).
+vi.mock('../CreateResourceButton', () => ({
+  CreateResourceButton: () => null,
+}));
+
+// Lightweight fakes standing in for a real KubeObjectClass, so these tests don't
+// need to pull in an actual resource-class import graph.
+class FakeNamespacedResource {
+  static isNamespaced = true;
+}
+
+class FakeClusterScopedResource {
+  static isNamespaced = false;
+}
+
+describe('ResourceListView effective noNamespaceFilter', () => {
+  beforeEach(() => {
+    lastResourceTablePropsHolder.current = null;
+    lastSectionFilterHeaderPropsHolder.current = null;
+  });
+
+  describe('without a resourceClass', () => {
+    it.each([
+      {
+        description: 'headerProps is not provided',
+        headerProps: undefined,
+        expected: true,
+      },
+      {
+        description: 'headerProps is {} (no noNamespaceFilter key)',
+        headerProps: {},
+        expected: true,
+      },
+      {
+        description:
+          'headerProps has a noNamespaceFilter key present but undefined (e.g. Pod/Job renderers)',
+        headerProps: { noNamespaceFilter: undefined },
+        expected: false,
+      },
+      {
+        description: 'headerProps.noNamespaceFilter is explicitly false',
+        headerProps: { noNamespaceFilter: false },
+        expected: false,
+      },
+      {
+        description: 'headerProps.noNamespaceFilter is explicitly true',
+        headerProps: { noNamespaceFilter: true },
+        expected: true,
+      },
+    ])(
+      'resolves noNamespaceFilter=$expected for both SectionFilterHeader and ResourceTable when $description',
+      ({ headerProps, expected }) => {
+        render(
+          <TestContext>
+            <ResourceListView title="Pods" columns={[]} data={[]} headerProps={headerProps} />
+          </TestContext>
+        );
+
+        expect(lastResourceTablePropsHolder.current.noNamespaceFilter).toBe(expected);
+        expect(lastSectionFilterHeaderPropsHolder.current.noNamespaceFilter).toBe(expected);
+      }
+    );
+  });
+
+  describe('with a resourceClass and no header override', () => {
+    it.each([
+      {
+        description: 'a namespaced resourceClass',
+        resourceClass: FakeNamespacedResource,
+        expected: false,
+      },
+      {
+        description: 'a cluster-scoped resourceClass',
+        resourceClass: FakeClusterScopedResource,
+        expected: true,
+      },
+    ])(
+      'resolves noNamespaceFilter=$expected for both SectionFilterHeader and ResourceTable given $description',
+      ({ resourceClass, expected }) => {
+        render(
+          <TestContext>
+            <ResourceListView title="Pods" columns={[]} resourceClass={resourceClass as any} />
+          </TestContext>
+        );
+
+        expect(lastResourceTablePropsHolder.current.noNamespaceFilter).toBe(expected);
+        expect(lastSectionFilterHeaderPropsHolder.current.noNamespaceFilter).toBe(expected);
+      }
+    );
+  });
+
+  // Regression guard for renderers like pod/List.tsx and the Jobs list, which never set
+  // resourceClass and always pass a headerProps object where the noNamespaceFilter key
+  // is present but undefined (e.g. `{ noNamespaceFilter, titleSideActions, actions }`
+  // with an undefined local `noNamespaceFilter`). This preserves their existing rendered
+  // behavior (namespace selector shown, global filter applied) unchanged.
+  it('keeps applying the namespace filter for a headerProps object with an undefined noNamespaceFilter key and other props', () => {
+    render(
+      <TestContext>
+        <ResourceListView
+          title="Pods"
+          columns={[]}
+          data={[]}
+          headerProps={{ noNamespaceFilter: undefined, titleSideActions: [] }}
+        />
+      </TestContext>
+    );
+
+    expect(lastResourceTablePropsHolder.current.noNamespaceFilter).toBe(false);
+    expect(lastSectionFilterHeaderPropsHolder.current.noNamespaceFilter).toBe(false);
+  });
+});

--- a/frontend/src/components/common/Resource/ResourceListView.tsx
+++ b/frontend/src/components/common/Resource/ResourceListView.tsx
@@ -23,7 +23,7 @@ import SectionFilterHeader, { SectionFilterHeaderProps } from '../SectionFilterH
 import ResourceTable, { ResourceTableProps } from './ResourceTable';
 
 export interface ResourceListViewProps<Item extends KubeObject>
-  extends PropsWithChildren<Omit<ResourceTableProps<Item>, 'data'>> {
+  extends PropsWithChildren<Omit<ResourceTableProps<Item>, 'data' | 'noNamespaceFilter'>> {
   title: ReactNode;
   //** The location to go back to. If provided as an empty string, the browser's history will be used. If not provided (default)), then no back button is used. */
   backLink?: BackLinkProps['to'] | boolean;
@@ -32,7 +32,9 @@ export interface ResourceListViewProps<Item extends KubeObject>
 }
 
 export interface ResourceListViewWithResourceClassProps<ItemClass extends KubeObjectClass>
-  extends PropsWithChildren<Omit<ResourceTableProps<InstanceType<ItemClass>>, 'data'>> {
+  extends PropsWithChildren<
+    Omit<ResourceTableProps<InstanceType<ItemClass>>, 'data' | 'noNamespaceFilter'>
+  > {
   title: ReactNode;
   //** The location to go back to. If provided as an empty string, the browser's history will be used. If not provided (default)), then no back button is used. */
   backLink?: BackLinkProps['to'] | boolean;
@@ -53,6 +55,17 @@ export default function ResourceListView(
   const withNamespaceFilter = 'resourceClass' in props && props.resourceClass?.isNamespaced;
   const resourceClass = (props as ResourceListViewWithResourceClassProps<any>)
     .resourceClass as KubeObjectClass;
+  // A headerProps object with the noNamespaceFilter key present (even set to undefined,
+  // as several renderers like Pod/Job do via `{ noNamespaceFilter, ...}` with an
+  // undefined local variable) is an explicit override, matching how {...headerProps}
+  // used to win over the derived header prop. Otherwise fall back to the resourceClass
+  // signal, matching the header's previous default.
+  const hasNoNamespaceFilterOverride =
+    headerProps !== undefined &&
+    Object.prototype.hasOwnProperty.call(headerProps, 'noNamespaceFilter');
+  const noNamespaceFilter = hasNoNamespaceFilterOverride
+    ? headerProps?.noNamespaceFilter === true
+    : !withNamespaceFilter;
 
   return (
     <SectionBox
@@ -61,12 +74,12 @@ export default function ResourceListView(
         typeof title === 'string' ? (
           <SectionFilterHeader
             title={title}
-            noNamespaceFilter={!withNamespaceFilter}
             titleSideActions={
               headerProps?.titleSideActions ||
               (resourceClass ? [<CreateResourceButton resourceClass={resourceClass} />] : undefined)
             }
             {...headerProps}
+            noNamespaceFilter={noNamespaceFilter}
           />
         ) : (
           title
@@ -75,6 +88,7 @@ export default function ResourceListView(
     >
       <ResourceTable
         {...tableProps}
+        noNamespaceFilter={noNamespaceFilter}
         enableRowActions={tableProps.enableRowActions ?? true}
         enableRowSelection={tableProps.enableRowSelection ?? true}
       />

--- a/frontend/src/components/common/Resource/ResourceTable.test.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.test.tsx
@@ -15,13 +15,29 @@
  */
 
 import { ThemeProvider } from '@mui/material/styles';
+import { configureStore } from '@reduxjs/toolkit';
 import { act, render } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { loadTableSettings, storeTableSettings } from '../../../helpers/tableSettings';
 import { createMuiTheme } from '../../../lib/themes';
+import reducers from '../../../redux/reducers/reducers';
 import { TestContext } from '../../../test';
 import ResourceTable from './ResourceTable';
+
+function createStoreWithNamespaces(namespaces: string[]) {
+  return configureStore({
+    reducer: reducers,
+    preloadedState: {
+      filter: { namespaces: new Set(namespaces) },
+    },
+    middleware: getDefaultMiddleware =>
+      getDefaultMiddleware({
+        serializableCheck: false,
+        thunk: true,
+      }),
+  });
+}
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
@@ -225,5 +241,89 @@ describe('ResourceTable Column Visibility', () => {
     );
 
     expect(lastTablePropsHolder.current.enableFacetedValues).toBe(true);
+  });
+});
+
+describe('ResourceTable noNamespaceFilter row filtering', () => {
+  beforeEach(() => {
+    lastTablePropsHolder.current = null;
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      configurable: true,
+      value: vi.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // A pod from a namespace other than the one selected in the global filter.
+  const otherNamespacePod = {
+    kind: 'Pod',
+    apiVersion: 'v1',
+    metadata: { name: 'other-ns-pod', namespace: 'namespace-b', uid: 'uid-2' },
+  } as any;
+
+  it('ignores the stale global namespace filter when noNamespaceFilter is true', () => {
+    const store = createStoreWithNamespaces(['namespace-a']);
+
+    render(
+      <TestContext store={store}>
+        <ThemeProvider theme={theme}>
+          <ResourceTable
+            id="ns-scoped-table"
+            columns={[]}
+            data={[otherNamespacePod]}
+            noNamespaceFilter
+          />
+        </ThemeProvider>
+      </TestContext>
+    );
+
+    expect(lastTablePropsHolder.current.filterFunction(otherNamespacePod)).toBe(true);
+  });
+
+  it('still applies the global namespace filter when noNamespaceFilter is false', () => {
+    const store = createStoreWithNamespaces(['namespace-a']);
+
+    render(
+      <TestContext store={store}>
+        <ThemeProvider theme={theme}>
+          <ResourceTable id="ns-filtered-table" columns={[]} data={[otherNamespacePod]} />
+        </ThemeProvider>
+      </TestContext>
+    );
+
+    expect(lastTablePropsHolder.current.filterFunction(otherNamespacePod)).toBe(false);
+  });
+
+  it('does not mutate the global namespace filter when mounted with noNamespaceFilter', () => {
+    const store = createStoreWithNamespaces(['namespace-a']);
+
+    render(
+      <TestContext store={store}>
+        <ThemeProvider theme={theme}>
+          <ResourceTable
+            id="ns-scoped-table"
+            columns={[]}
+            data={[otherNamespacePod]}
+            noNamespaceFilter
+          />
+        </ThemeProvider>
+      </TestContext>
+    );
+
+    expect([...store.getState().filter.namespaces]).toEqual(['namespace-a']);
   });
 });

--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -167,6 +167,14 @@ export interface ResourceTableProps<RowItem> {
   data: Array<RowItem> | null;
   /** Filter out rows from the table */
   filterFunction?: (item: RowItem) => boolean;
+  /**
+   * When true, the table's default row filtering ignores the global namespace
+   * filter, so a stale/unrelated namespace selection elsewhere in the app can't
+   * hide this table's rows. Textual/search filtering is unaffected. Has no effect
+   * on cluster-scoped rows (items without metadata.namespace), and is ignored if
+   * a custom filterFunction is provided.
+   */
+  noNamespaceFilter?: boolean;
   /** Display an error message. Table will be hidden even if data is present */
   errorMessage?: string | null;
   /** Display an errors */
@@ -322,6 +330,7 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
     noProcessing = false,
     hideColumns = [],
     filterFunction,
+    noNamespaceFilter,
     errorMessage,
     reflectInURL,
     data,
@@ -336,7 +345,7 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
   const storeRowsPerPageOptions = useSettings('tableRowsPerPageOptions');
   const clusters = useSelectedClusters();
   const tableProcessors = useTypedSelector(state => state.resourceTable.tableColumnsProcessors);
-  const defaultFilterFunc = useFilterFunc();
+  const defaultFilterFunc = useFilterFunc(undefined, noNamespaceFilter);
   const [columnVisibility, setColumnVisibility] = useState(() =>
     initColumnVisibilityState(columns, id)
   );

--- a/frontend/src/components/project/ProjectDetails.test.tsx
+++ b/frontend/src/components/project/ProjectDetails.test.tsx
@@ -39,6 +39,17 @@ const { MockKubeObject } = vi.hoisted(() => {
 
 vi.mock('../../lib/k8s/KubeObject', () => ({ KubeObject: MockKubeObject }));
 vi.mock('./ProjectDeleteButton', () => ({ ProjectDeleteButton: () => null }));
+
+const { lastResourceTablePropsListHolder } = vi.hoisted(() => ({
+  lastResourceTablePropsListHolder: { current: [] as any[] },
+}));
+
+vi.mock('../common/Resource/ResourceTable', () => ({
+  default: (props: any) => {
+    lastResourceTablePropsListHolder.current.push(props);
+    return null;
+  },
+}));
 const eventProject = {
   id: 'project-1',
   namespaces: ['ns1'],
@@ -504,5 +515,37 @@ describe('ProjectDetailsContent', () => {
     await act(async () => resolveEnablement(true));
 
     expect(screen.queryByRole('button', { name: 'Delayed action' })).not.toBeInTheDocument();
+  });
+});
+
+describe('ProjectDetails Access tab', () => {
+  beforeEach(() => {
+    vi.mocked(useProjectItems).mockReturnValue({ items: [], errors: [], isLoading: false });
+    lastResourceTablePropsListHolder.current = [];
+  });
+
+  it('renders the Role and RoleBinding tables with noNamespaceFilter set', async () => {
+    const accessProject: ProjectDefinition = {
+      id: 'project-access',
+      namespaces: ['ns-a', 'ns-b'],
+      clusters: ['test'],
+    };
+    const store = configureStore({
+      reducer: reducers,
+      middleware: getDefaultMiddleware => getDefaultMiddleware({ serializableCheck: false }),
+    });
+
+    render(
+      <TestContext store={store}>
+        <ProjectDetailsContent project={accessProject} />
+      </TestContext>
+    );
+
+    fireEvent.click(await screen.findByRole('tab', { name: /Access/ }));
+
+    await waitFor(() => expect(lastResourceTablePropsListHolder.current).toHaveLength(2));
+    expect(lastResourceTablePropsListHolder.current.every(props => props.noNamespaceFilter)).toBe(
+      true
+    );
   });
 });

--- a/frontend/src/components/project/ProjectDetails.tsx
+++ b/frontend/src/components/project/ProjectDetails.tsx
@@ -380,6 +380,7 @@ function ProjectAccess({ project }: { project: ProjectDefinition }) {
           columns={['type', 'name', 'age']}
           namespaces={project.namespaces}
           enableRowActions
+          noNamespaceFilter
         />
         <Typography variant="h6">{t('Role Bindings')}</Typography>
         <ResourceTable
@@ -387,6 +388,7 @@ function ProjectAccess({ project }: { project: ProjectDefinition }) {
           columns={['type', 'name', 'age']}
           namespaces={project.namespaces}
           enableRowActions
+          noNamespaceFilter
         />
       </SelectedClustersContext.Provider>
     </Box>

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -315,17 +315,25 @@ export function getResourceMetrics(
  *
  * @returns A filter function that can be used to filter a list of items.
  * @param matchCriteria - The JSONPath criteria to match.
+ * @param ignoreNamespaceFilter - When true, the returned function ignores the global
+ *                                 namespace filter (textual/search filtering still applies).
  */
 export function useFilterFunc<
   T extends { [key: string]: any } | KubeObjectInterface | KubeEvent =
     | KubeObjectInterface
     | KubeEvent
->(matchCriteria?: string[]) {
+>(matchCriteria?: string[], ignoreNamespaceFilter?: boolean) {
   const filter = useTypedSelector(state => state.filter);
 
   return (item: T, search?: string) => {
     if (item?.metadata) {
-      return filterResource(item as KubeObjectInterface | KubeEvent, filter, search, matchCriteria);
+      return filterResource(
+        item as KubeObjectInterface | KubeEvent,
+        filter,
+        search,
+        matchCriteria,
+        ignoreNamespaceFilter
+      );
     }
     return filterGeneric<T>(item, search, matchCriteria);
   };

--- a/frontend/src/redux/filterSlice.test.ts
+++ b/frontend/src/redux/filterSlice.test.ts
@@ -117,4 +117,35 @@ describe('filterSlice', () => {
       expect(filterResource(item, filter, 'nginx')).toBe(true);
     });
   });
+
+  describe('filterResource ignoreNamespaceFilter', () => {
+    const makeItem = (namespace: string) =>
+      ({
+        kind: 'Pod',
+        apiVersion: 'v1',
+        metadata: { uid: 'abc', name: 'my-pod', namespace },
+      } as any);
+
+    it('hides an item from another namespace when the namespace filter applies', () => {
+      const filter: FilterState = { ...initialState, namespaces: new Set(['namespace-a']) };
+      const item = makeItem('namespace-b');
+
+      expect(filterResource(item, filter)).toBe(false);
+    });
+
+    it('keeps an item from another namespace when ignoreNamespaceFilter is set', () => {
+      const filter: FilterState = { ...initialState, namespaces: new Set(['namespace-a']) };
+      const item = makeItem('namespace-b');
+
+      expect(filterResource(item, filter, undefined, undefined, true)).toBe(true);
+    });
+
+    it('still applies textual search when ignoreNamespaceFilter is set', () => {
+      const filter: FilterState = { ...initialState, namespaces: new Set(['namespace-a']) };
+      const item = makeItem('namespace-b');
+
+      expect(filterResource(item, filter, 'no-such-match', undefined, true)).toBe(false);
+      expect(filterResource(item, filter, 'my-pod', undefined, true)).toBe(true);
+    });
+  });
 });

--- a/frontend/src/redux/filterSlice.ts
+++ b/frontend/src/redux/filterSlice.ts
@@ -38,6 +38,10 @@ export const initialState: FilterState = {
  * @param item - The item to filter.
  * @param filter - The filter state.
  * @param matchCriteria - The JSONPath criteria to match.
+ * @param ignoreNamespaceFilter - When true, skips matching the item's namespace against
+ *                                 filter.namespaces. Used by views that are already scoped
+ *                                 to a specific namespace (or are cluster-scoped) so a stale
+ *                                 global namespace selection doesn't hide their rows.
  *
  * @returns True if the item matches the filter, false otherwise.
  */
@@ -45,11 +49,12 @@ export function filterResource(
   item: KubeObjectInterface | KubeEvent,
   filter: FilterState,
   search?: string,
-  matchCriteria?: string[]
+  matchCriteria?: string[],
+  ignoreNamespaceFilter?: boolean
 ) {
   let matches: boolean = true;
 
-  if (item.metadata.namespace && filter.namespaces.size > 0) {
+  if (!ignoreNamespaceFilter && item.metadata.namespace && filter.namespaces.size > 0) {
     matches = filter.namespaces.has(item.metadata.namespace);
   }
 


### PR DESCRIPTION
## Summary

This PR fixes namespace-scoped resource tables being hidden by a stale global
namespace filter.

When a namespace filter was selected elsewhere in Headlamp, namespace-scoped
views could still apply that global filter at the table row-filtering layer even
though the namespace selector was hidden. This caused resources from the
currently viewed namespace to disappear.

Rather than restoring the global filter reset from #5157, which was reverted by
#5271 due to crashes, this change makes `ResourceTable` respect
`noNamespaceFilter` without modifying the global namespace selection.

## Related Issue

Fixes #7467

## Changes

- Allow the default resource row filter to ignore the global namespace filter
  when namespace filtering is disabled for the view.
- Compute one effective `noNamespaceFilter` value in `ResourceListView` and use
  it for both `SectionFilterHeader` and `ResourceTable`, while preserving
  existing caller override semantics.
- Preserve the existing global namespace selection instead of clearing Redux or
  persisted state.
- Prevent Project Access Role/RoleBinding tables from being further restricted
  by an unrelated global namespace filter.
- Prevent Advanced Search results from being silently filtered after the result
  count is computed.
- Add regression tests for row filtering, `ResourceListView` wiring, and the
  Project Access tables.

## Steps to Test

1. In Workloads, select a namespace filter such as namespace A.
2. Navigate to Clusters -> Namespaces and open a different namespace B.
3. Scroll to the Pods section.
4. Verify that pods from namespace B are displayed.
5. Return to a normal namespace-filtered resource list and verify that the
   original global namespace filter still applies.
6. Open a Project Access tab whose namespaces do not overlap the global
   selection and verify its Role/RoleBinding rows remain visible.
7. In Advanced Search, verify the displayed rows remain consistent with the
   reported result count regardless of the global namespace selection.

Automated validation:

- Focused tests: 30 passed
- Full frontend suite: 235/235 files, 3120/3120 tests passed
- `npm run tsc`
- `npm run lint`
- `npm run format-check`
- `git diff --check`

## Screenshots (if applicable)

Not applicable.

## Notes for the Reviewer

- This does not restore the namespace-filter reset approach from #5157.
- The global namespace filter is not mutated or cleared.
- `ResourceListView` now keeps the header and table aligned on the same effective
  namespace-filter behavior, including callers that explicitly pass an
  `undefined` override value.
- A custom `ResourceTable.filterFunction` continues to replace the default
  filter exactly as before and owns its filtering semantics.
- Textual/search filtering remains active when namespace filtering is bypassed.
