### PR TITLE
frontend: AlertNotification: Stop polling health on the auth routes

### DIFF
--- a/frontend/src/components/common/AlertNotification.test.tsx
+++ b/frontend/src/components/common/AlertNotification.test.tsx
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 
-import { act, cleanup, render } from '@testing-library/react';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { MemoryRouter, useHistory } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { TestContext } from '../../test';
+import { ApiError } from '../../lib/k8s/api/v2/ApiError';
+import store from '../../redux/stores/store';
 import { PureAlertNotification } from './AlertNotification';
 
 vi.mock('../../lib/cluster', async importOriginal => ({
@@ -24,47 +28,237 @@ vi.mock('../../lib/cluster', async importOriginal => ({
   getCluster: () => 'test-cluster',
 }));
 
-describe('PureAlertNotification', () => {
-  // The suite-wide config fakes Date + setTimeout/clearTimeout; opt setInterval/clearInterval
-  // (the health-check poller) in as well for these timing assertions.
-  beforeEach(() =>
-    vi.useFakeTimers({
-      toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval'],
-    })
+const CLUSTER_PATH = '/c/test-cluster/pods';
+const OTHER_CLUSTER_PATH = '/c/test-cluster/services';
+const LOGIN_PATH = '/c/test-cluster/login';
+
+function Navigator({ to }: { to: string }) {
+  const history = useHistory();
+  return (
+    <button type="button" onClick={() => history.push(to)}>
+      {`navigate to ${to}`}
+    </button>
   );
-  // Unmount before restoring real timers so the effect's clearInterval runs
-  // against the same fake implementation that created the interval.
+}
+
+function renderNotification(
+  checkerFunction: () => Promise<any>,
+  path = CLUSTER_PATH,
+  to: string | string[] = []
+) {
+  // One button per destination, so a test can walk a route and come back.
+  const destinations = (Array.isArray(to) ? to : [to]).filter(Boolean);
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[path]}>
+        {destinations.map(destination => (
+          <Navigator key={destination} to={destination} />
+        ))}
+        <PureAlertNotification checkerFunction={checkerFunction} />
+      </MemoryRouter>
+    </Provider>
+  );
+}
+
+function navigateTo(user: ReturnType<typeof userEvent.setup>, to: string) {
+  return user.click(screen.getByRole('button', { name: `navigate to ${to}` }));
+}
+
+function banner() {
+  return screen.queryByText('Lost connection to the cluster.');
+}
+
+describe('PureAlertNotification', () => {
+  // The suite-wide config fakes Date + setTimeout/clearTimeout, which is all the
+  // health-check poller uses; Date is faked here too so the assertions on the
+  // scheduled delays stay deterministic.
+  beforeEach(() => vi.useFakeTimers({ toFake: ['Date', 'setTimeout', 'clearTimeout'] }));
   afterEach(() => {
     cleanup();
     vi.useRealTimers();
   });
 
-  // A failed check backs the poll interval off from 5s to 10s. Once a check
-  // succeeds the interval must return to 5s; otherwise it stays elevated for
-  // the rest of the session and the banner lingers after recovery (issue #6445).
-  it('resets the poll interval back to the base cadence after a recovery', async () => {
-    // First check fails (→ next interval 10s), the rest succeed.
+  it('checks the cluster health as soon as it is mounted', async () => {
+    const checkerFunction = vi.fn().mockResolvedValue({});
+
+    await act(async () => {
+      renderNotification(checkerFunction);
+    });
+
+    expect(checkerFunction).toHaveBeenCalledTimes(1);
+    expect(banner()).not.toBeInTheDocument();
+  });
+
+  it('shows the banner once a check fails and hides it again on recovery', async () => {
     const checkerFunction = vi.fn().mockRejectedValueOnce(new Error('down')).mockResolvedValue({});
 
     await act(async () => {
-      render(
-        <TestContext>
-          <PureAlertNotification checkerFunction={checkerFunction} />
-        </TestContext>
-      );
+      renderNotification(checkerFunction);
     });
+    expect(banner()).toBeInTheDocument();
 
-    // t=5s: first tick fails, backoff bumps the next interval to 10s.
-    await act(async () => await vi.advanceTimersByTimeAsync(5000));
-    expect(checkerFunction).toHaveBeenCalledTimes(1);
-
-    // t=15s: second tick (10s later) succeeds and should reset the backoff to 5s.
+    // The failure backs the next check off from 5s to 10s.
     await act(async () => await vi.advanceTimersByTimeAsync(10000));
     expect(checkerFunction).toHaveBeenCalledTimes(2);
+    expect(banner()).not.toBeInTheDocument();
 
-    // t=20s: with the reset, the next tick fires 5s later. Without the reset the
-    // interval would still be 10s and this advance would see no new call.
+    // The recovery resets the backoff, so the following check is 5s later.
     await act(async () => await vi.advanceTimersByTimeAsync(5000));
     expect(checkerFunction).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not check the cluster health on the auth routes', async () => {
+    const checkerFunction = vi.fn().mockRejectedValue(new Error('down'));
+
+    await act(async () => {
+      renderNotification(checkerFunction, LOGIN_PATH);
+    });
+    await act(async () => await vi.advanceTimersByTimeAsync(60000));
+
+    expect(checkerFunction).not.toHaveBeenCalled();
+    expect(banner()).not.toBeInTheDocument();
+  });
+
+  // The banner used to keep the failure collected while the user was being
+  // authenticated, and only cleared it whenever the backed off poller ran again.
+  it('drops a pending failure and re-checks when moving to an auth route and back', async () => {
+    const checkerFunction = vi.fn().mockRejectedValue(new Error('down'));
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    await act(async () => {
+      renderNotification(checkerFunction, CLUSTER_PATH, [LOGIN_PATH, CLUSTER_PATH]);
+    });
+    expect(checkerFunction).toHaveBeenCalledTimes(1);
+    expect(banner()).toBeInTheDocument();
+
+    await act(async () => await navigateTo(user, LOGIN_PATH));
+    expect(banner()).not.toBeInTheDocument();
+    expect(checkerFunction).toHaveBeenCalledTimes(1);
+
+    checkerFunction.mockResolvedValue({});
+    await act(async () => await navigateTo(user, CLUSTER_PATH));
+
+    // Coming back has to re-check instead of restoring the failure it left behind.
+    expect(checkerFunction).toHaveBeenCalledTimes(2);
+    expect(banner()).not.toBeInTheDocument();
+  });
+
+  // showOnRoute stays true across these, so only the pathname tells the poller to rerun.
+  it('re-checks when moving between two ordinary cluster routes', async () => {
+    const checkerFunction = vi.fn().mockResolvedValue({});
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    await act(async () => {
+      renderNotification(checkerFunction, CLUSTER_PATH, OTHER_CLUSTER_PATH);
+    });
+    expect(checkerFunction).toHaveBeenCalledTimes(1);
+
+    await act(async () => await navigateTo(user, OTHER_CLUSTER_PATH));
+
+    expect(checkerFunction).toHaveBeenCalledTimes(2);
+  });
+
+  // The token can still be missing on the first check after the login redirect.
+  it('stays hidden when the check right after the login redirect is still unauthorized', async () => {
+    const checkerFunction = vi
+      .fn()
+      .mockRejectedValue(
+        new ApiError('Cluster main is not healthy: Unauthorized', { status: 401 })
+      );
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    await act(async () => {
+      renderNotification(checkerFunction, LOGIN_PATH, CLUSTER_PATH);
+    });
+    expect(checkerFunction).not.toHaveBeenCalled();
+
+    await act(async () => await navigateTo(user, CLUSTER_PATH));
+    expect(checkerFunction).toHaveBeenCalledTimes(1);
+    expect(banner()).not.toBeInTheDocument();
+
+    checkerFunction.mockResolvedValue({});
+    await act(async () => await vi.advanceTimersByTimeAsync(5000));
+
+    expect(checkerFunction).toHaveBeenCalledTimes(2);
+    expect(banner()).not.toBeInTheDocument();
+  });
+
+  it.each([401, 403])('does not show the banner for a %s response', async status => {
+    const checkerFunction = vi
+      .fn()
+      .mockRejectedValue(new ApiError('Cluster test-cluster is not healthy', { status }));
+
+    await act(async () => {
+      renderNotification(checkerFunction);
+    });
+    expect(banner()).not.toBeInTheDocument();
+
+    // Auth errors must not back the poller off either, so the next check is 5s later.
+    await act(async () => await vi.advanceTimersByTimeAsync(5000));
+    expect(checkerFunction).toHaveBeenCalledTimes(2);
+    expect(banner()).not.toBeInTheDocument();
+  });
+
+  it('caps the backoff so a recovery is never more than 35s away', async () => {
+    const checkerFunction = vi.fn().mockRejectedValue(new Error('down'));
+
+    await act(async () => {
+      renderNotification(checkerFunction);
+    });
+
+    // Delays grow by 5s per failure: 10s, 15s, … until the 35s ceiling.
+    for (const delay of [10000, 15000, 20000, 25000, 30000, 35000]) {
+      await act(async () => await vi.advanceTimersByTimeAsync(delay));
+    }
+    expect(checkerFunction).toHaveBeenCalledTimes(7);
+
+    await act(async () => await vi.advanceTimersByTimeAsync(35000));
+    expect(checkerFunction).toHaveBeenCalledTimes(8);
+
+    await act(async () => await vi.advanceTimersByTimeAsync(35000));
+    expect(checkerFunction).toHaveBeenCalledTimes(9);
+  });
+
+  it('queues a retry behind the check that is still in flight', async () => {
+    let settleFirstCheck: () => void = () => {};
+    const checkerFunction = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>(resolve => {
+            settleFirstCheck = () => resolve();
+          })
+      )
+      .mockResolvedValue({});
+
+    await act(async () => {
+      renderNotification(checkerFunction);
+    });
+    expect(checkerFunction).toHaveBeenCalledTimes(1);
+
+    // Each of these restarts the effect while the first request is still open.
+    await act(async () => {
+      window.dispatchEvent(new Event('online'));
+      window.dispatchEvent(new Event('online'));
+    });
+    expect(checkerFunction).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      settleFirstCheck();
+    });
+
+    // The queued retries collapse into the single check that follows the first one.
+    expect(checkerFunction).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not start a check while the previous one is still pending', async () => {
+    const checkerFunction = vi.fn().mockReturnValue(new Promise(() => {}));
+
+    await act(async () => {
+      renderNotification(checkerFunction);
+    });
+    await act(async () => await vi.advanceTimersByTimeAsync(60000));
+
+    expect(checkerFunction).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/common/AlertNotification.tsx
+++ b/frontend/src/components/common/AlertNotification.tsx
@@ -26,12 +26,21 @@ import { useTranslation } from 'react-i18next';
 import { matchPath, useLocation } from 'react-router-dom';
 import { getCluster } from '../../lib/cluster';
 import { testClusterHealth } from '../../lib/k8s/api/v1/clusterApi';
+import type { ApiError } from '../../lib/k8s/api/v2/ApiError';
 import { getRoute } from '../../lib/router/getRoute';
 import { getRoutePath } from '../../lib/router/getRoutePath';
 import Link from './Link';
 
 // in ms
 const NETWORK_STATUS_CHECK_TIME = 5000;
+
+// Upper bound for the failure backoff, so a recovery is never more than
+// (MAX_BACKOFF_FACTOR + 1) * NETWORK_STATUS_CHECK_TIME away.
+const MAX_BACKOFF_FACTOR = 6;
+
+// Statuses that mean "not authenticated (yet)" rather than "cluster unreachable".
+// The auth routes take care of these, see AuthRoute.
+const AUTH_ERROR_STATUSES = [401, 403];
 
 // Safety cap in case a reason is unexpectedly long.
 const MAX_ERROR_DETAIL_LENGTH = 200;
@@ -56,68 +65,35 @@ export interface PureAlertNotificationProps {
   checkerFunction(): Promise<any>;
 }
 
-const ROUTES_WITHOUT_ALERT = ['login', 'token', 'settingsCluster'];
+const ROUTES_WITHOUT_HEALTH_CHECK = ['login', 'token', 'oidcAuth', 'settingsCluster'];
 
 export function PureAlertNotification({ checkerFunction }: PureAlertNotificationProps) {
-  const [networkStatusCheckTimeFactor, setNetworkStatusCheckTimeFactor] = React.useState(0);
   const [error, setError] = React.useState<null | string | boolean>(null);
   const [dismissed, setDismissed] = React.useState(false);
+  const [retryCount, setRetryCount] = React.useState(0);
 
   const { t } = useTranslation();
   const { pathname } = useLocation();
 
-  function registerSetInterval(): NodeJS.Timeout {
-    return setInterval(() => {
-      if (!window.navigator.onLine) {
-        setError(t('translation|Offline') as string);
-        return;
-      }
+  const cluster = getCluster();
 
-      if (!getCluster()) {
-        setError(null);
-        return;
-      }
-
-      checkerFunction()
-        .then(() => {
-          setError(false);
-          // Reset the backoff so polling returns to the normal cadence once the
-          // cluster recovers; otherwise the interval stays elevated for the rest
-          // of the session and the banner lingers after connectivity is restored.
-          setNetworkStatusCheckTimeFactor(0);
-        })
-        .catch(err => {
-          const message = err instanceof Error ? err.message : String(err);
-          setError(message);
-          setNetworkStatusCheckTimeFactor(
-            (networkStatusCheckTimeFactor: number) => networkStatusCheckTimeFactor + 1
-          );
-        });
-    }, (networkStatusCheckTimeFactor + 1) * NETWORK_STATUS_CHECK_TIME);
-  }
-
+  const checkerRef = React.useRef(checkerFunction);
   React.useEffect(() => {
-    if (!getCluster()) {
-      setError(null);
-    }
-  }, [pathname]);
+    checkerRef.current = checkerFunction;
+  }, [checkerFunction]);
 
-  // Show the bar again whenever the error changes, even if it was dismissed before.
-  React.useEffect(() => {
-    setDismissed(false);
-  }, [error]);
+  const retry = React.useCallback(() => setRetryCount(count => count + 1), []);
 
-  React.useEffect(
-    () => {
-      const id = registerSetInterval();
-      return () => clearInterval(id);
-    },
-    // eslint-disable-next-line
-    [networkStatusCheckTimeFactor]
-  );
+  // A health check cannot be aborted, so a route change or a "Try Again" restarts the
+  // effect below while a request may still be open. Every check is chained onto this
+  // promise, which keeps at most one /healthz request in flight and queues the next one
+  // behind it instead of piling overlapping requests up.
+  const inFlightRef = React.useRef<Promise<void>>(Promise.resolve());
 
+  // The auth routes cannot answer a health check yet: polling them only piles up
+  // transient failures whose backoff then delays the recovery.
   const showOnRoute = React.useMemo(() => {
-    for (const routeName of ROUTES_WITHOUT_ALERT) {
+    for (const routeName of ROUTES_WITHOUT_HEALTH_CHECK) {
       const maybeRoute = getRoute(routeName);
       if (maybeRoute) {
         const routePath = getRoutePath(maybeRoute);
@@ -130,6 +106,96 @@ export function PureAlertNotification({ checkerFunction }: PureAlertNotification
     }
     return true;
   }, [pathname]);
+
+  React.useEffect(() => {
+    if (!cluster || !showOnRoute) {
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    let timeoutId: NodeJS.Timeout | undefined;
+    let backoffFactor = 0;
+
+    function scheduleNextCheck() {
+      if (cancelled) {
+        return;
+      }
+      const factor = Math.min(backoffFactor, MAX_BACKOFF_FACTOR);
+      timeoutId = setTimeout(runCheck, (factor + 1) * NETWORK_STATUS_CHECK_TIME);
+    }
+
+    async function runCheck() {
+      if (cancelled) {
+        return;
+      }
+
+      if (!window.navigator.onLine) {
+        setError(t('translation|Offline') as string);
+        scheduleNextCheck();
+        return;
+      }
+
+      // Queued rather than started right away; a check whose effect was torn down while
+      // it waited for its turn resolves to nothing instead of sending a request.
+      const check = inFlightRef.current.then(() => (cancelled ? undefined : checkerRef.current()));
+      inFlightRef.current = check.then(
+        () => undefined,
+        () => undefined
+      );
+
+      try {
+        await check;
+        if (cancelled) {
+          return;
+        }
+        setError(false);
+        backoffFactor = 0;
+      } catch (err) {
+        if (cancelled) {
+          return;
+        }
+        const status = (err as ApiError)?.status;
+        if (status !== undefined && AUTH_ERROR_STATUSES.includes(status)) {
+          setError(null);
+        } else {
+          setError(err instanceof Error ? err.message : String(err));
+          backoffFactor += 1;
+        }
+      }
+
+      scheduleNextCheck();
+    }
+
+    // Check right away so the banner reflects the current state instead of the
+    // one from before the last route change, login or connectivity event.
+    runCheck();
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timeoutId);
+    };
+  }, [cluster, pathname, showOnRoute, retryCount, t]);
+
+  React.useEffect(() => {
+    function onVisibilityChange() {
+      if (document.visibilityState === 'visible') {
+        retry();
+      }
+    }
+
+    window.addEventListener('online', retry);
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      window.removeEventListener('online', retry);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [retry]);
+
+  // Show the bar again whenever the error changes, even if it was dismissed before.
+  React.useEffect(() => {
+    setDismissed(false);
+  }, [error]);
 
   if (!error || !showOnRoute || dismissed) {
     return null;
@@ -174,7 +240,7 @@ export function PureAlertNotification({ checkerFunction }: PureAlertNotification
                 background: theme.palette.error.dark,
               },
             })}
-            onClick={() => setNetworkStatusCheckTimeFactor(0)}
+            onClick={retry}
             size="small"
           >
             {t('translation|Try Again')}

--- a/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
+++ b/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
@@ -1067,6 +1067,19 @@ describe('apiProxy', () => {
         await expect(apiProxy.testClusterHealth(clusterName)).rejects.toThrow(errorResponse.error);
       }
     );
+
+    it('Keeps the response status on the rejected error', async () => {
+      nock.cleanAll();
+      nock(baseApiUrl)
+        .persist()
+        .get(`/clusters/${clusterName}${apiPath}`)
+        .reply(401, { message: errorResponse401.error });
+
+      await expect(apiProxy.testClusterHealth(clusterName)).rejects.toMatchObject({
+        status: 401,
+        cluster: clusterName,
+      });
+    });
   });
 
   describe('setCluster, deleteCluster', () => {

--- a/frontend/src/lib/k8s/api/v1/clusterApi.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterApi.ts
@@ -24,6 +24,7 @@ import { storeStatelessClusterKubeconfig } from '../../../../stateless';
 import { deleteClusterKubeconfig } from '../../../../stateless/deleteClusterKubeconfig';
 import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
 import { getCluster, getSelectedClusters } from '../../../cluster';
+import { ApiError } from '../v2/ApiError';
 import type { ClusterRequest } from './clusterRequests';
 import { clusterRequest, post, request } from './clusterRequests';
 import { JSON_HEADERS } from './constants';
@@ -127,7 +128,10 @@ export async function testClusterHealth(cluster?: string) {
 
   const healthChecks = clusterNames.map(clusterName => {
     return clusterRequest('/healthz', { isJSON: false, cluster: clusterName }).catch(error => {
-      throw new Error(`Cluster ${clusterName} is not healthy: ${error.message}`);
+      throw new ApiError(`Cluster ${clusterName} is not healthy: ${error.message}`, {
+        status: error?.status,
+        cluster: clusterName,
+      });
     });
   });
 


### PR DESCRIPTION
Closes #7469

## Summary

This PR fixes the "Lost connection to the cluster." banner sticking around after a successful OIDC login, by not polling the cluster health check on the auth routes and by treating a 401/403 as an authentication state rather than a lost connection.
While the user is signed out, a deep link redirects through the cluster login route, where every `/healthz` call answers 401 until the token is applied. Those failures were recorded as a lost connection, and each one backed the poller off by another 5 seconds, so once the login redirected back the banner showed the stale failure and only cleared on the next check, which by then could be far away.

## Related Issue

Fixes #7469

## Changes

* Updated `AlertNotification` to skip the health check on the routes that cannot answer it yet (`login`, `token`, `oidcAuth`, `settingsCluster`), and to clear any pending error when entering them. The route list governed only the rendering before.
* Fixed the banner being raised by 401/403 responses, which are an auth state that `AuthRoute` already handles by redirecting to the login route. They no longer back the poller off either.
* Refactored the poller from `setInterval` to a self-scheduling `setTimeout`, so a check is only scheduled once the previous one settles and the two can no longer overlap. The backoff is now capped at 35s instead of growing without bound.
* Added an immediate check whenever the route, the cluster or the connectivity changes (`online`, tab visibility, "Try Again"), so a recovery shows up right away instead of waiting out the backoff.
* Updated `testClusterHealth` to reject with an `ApiError` carrying the response `status` and `cluster`. The message is unchanged, so the `apiProxy` surface used by plugins stays compatible.

## Steps to Test

1. Configure a cluster with OIDC auth (e.g. a Keycloak realm), in-cluster.
2. While signed out, navigate directly to a deep link, e.g. a PVC list under a namespace, so the app redirects through `/c/main/login`.
3. Complete the login.
4. Observe that no "Lost connection to the cluster." banner appears at any point, and that the resource list loads as usual. On `main`, the banner shows up as the page loads and stays until a later health check happens to succeed.
5. Check the network tab: no `/clusters/main/healthz` request is sent while the login route is open.
6. Regression check: with a genuinely unreachable cluster, the banner still appears, and "Try Again" re-checks immediately. Stopping and restarting the cluster clears the banner on its own within 35s.

## Notes for the Reviewer

* No new user-facing strings, so the i18n files are untouched.
* The 401/403 rule is deliberately a second layer of defence: route gating already covers the reported flow, but the reporter runs behind a TCP passthrough proxy where the very first check after the redirect can still answer 401 before the cookie applies. There is a test for exactly that case.
* I considered gating the poller on the `['auth', cluster]` React Query cache that `AuthRoute` populates, since that is the authoritative signal. I went with route gating instead, to avoid making a presentational component depend on route-level query keys, and because the query-based approach behaves poorly in multi-cluster mode.
* Test coverage in `AlertNotification.test.tsx` (9 tests): immediate check on mount, failure then recovery, no polling on auth routes, the reported login round trip, 401 and 403, an unauthorized first check after the redirect, the backoff cap, and non-overlapping checks. Plus a case in `apiProxy.test.ts` for the preserved status.
* Not verified: I have not run this against a live Keycloak-backed cluster, only the test suite.
