### PR TITLE
0007: app: build-manifest: Configure package resources

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -70,6 +70,28 @@ and `x64`; macOS supports `arm64`, `universal`, and `x64`; and Windows supports
 `arm64`, `ia32`, and `x64`. Invalid target configuration stops the build before
 Electron Builder packaging.
 
+A manifest can also append files and directories to Electron Builder's common
+or platform-specific `extraResources`. Resource `from` paths are resolved
+relative to the selected manifest file, so product assets can live beside their
+manifest:
+
+```json
+{
+  "resources": {
+    "common": [{ "from": "./shared", "to": "shared" }],
+    "linux": [{ "from": "./tools/linux", "to": "tools" }],
+    "mac": [{ "from": "./tools/mac", "to": "tools", "filter": ["**/*"] }],
+    "win": [{ "from": "./tools/windows.exe", "to": "tools/tool.exe" }]
+  }
+}
+```
+
+Only `common`, `linux`, `mac`, and `win` resource groups are supported. Each
+group must be an array of objects containing a `from` string and optional `to`
+string or `filter` string array. Manifest resources are appended to Headlamp's
+existing resources rather than replacing them. Invalid resource configuration
+stops the build before Electron Builder packaging.
+
 For example, from the repository root:
 
 ```bash

--- a/app/e2e-tests/tests/buildManifest.spec.ts
+++ b/app/e2e-tests/tests/buildManifest.spec.ts
@@ -32,7 +32,7 @@ test('keeps the MCP adapter out of the Electron startup bundle', () => {
   expect(fs.statSync(adapterBundlePath).size).toBeGreaterThan(100_000);
 });
 
-test('custom platform settings reach the Electron Builder configuration', () => {
+test('custom manifest settings reach the Electron Builder configuration', () => {
   const manifestDir = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-build-manifest-'));
   const manifestFile = path.join(manifestDir, 'app-build-manifest.json');
   fs.writeFileSync(
@@ -48,6 +48,12 @@ test('custom platform settings reach the Electron Builder configuration', () => 
         mac: [{ target: 'dmg', arch: ['arm64'] }],
         win: [{ target: 'nsis', arch: ['x64'] }],
       },
+      resources: {
+        common: [{ from: './shared', to: 'shared' }],
+        linux: [{ from: './tools/linux', to: 'tools' }],
+        mac: [{ from: './tools/mac', to: 'tools' }],
+        win: [{ from: './tools/windows.exe', to: 'tools/tool.exe' }],
+      },
     })
   );
 
@@ -56,7 +62,7 @@ test('custom platform settings reach the Electron Builder configuration', () => 
       process.execPath,
       [
         '-e',
-        "const { getConfig } = require('app-builder-lib/out/util/config/config'); getConfig(process.cwd(), 'electron-builder.config.ts', {}).then(config => process.stdout.write('HEADLAMP_CONFIG_JSON=' + JSON.stringify({ linux: config.linux, mac: config.mac, win: config.win })));",
+        "const { getConfig } = require('app-builder-lib/out/util/config/config'); getConfig(process.cwd(), 'electron-builder.config.ts', {}).then(config => process.stdout.write('HEADLAMP_CONFIG_JSON=' + JSON.stringify({ extraResources: config.extraResources, linux: config.linux, mac: config.mac, win: config.win })));",
       ],
       {
         cwd: appPath,
@@ -66,14 +72,30 @@ test('custom platform settings reach the Electron Builder configuration', () => 
     );
     const config = JSON.parse(output.split('HEADLAMP_CONFIG_JSON=')[1]);
 
+    expect(config.extraResources).toContainEqual({
+      from: path.join(manifestDir, 'shared'),
+      to: 'shared',
+    });
     expect(config.linux.executableName).toBe('branded-headlamp');
     expect(config.linux.category).toBe('Network');
     expect(config.linux.target).toEqual([{ target: 'AppImage', arch: ['x64'] }]);
+    expect(config.linux.extraResources).toContainEqual({
+      from: path.join(manifestDir, 'tools/linux'),
+      to: 'tools',
+    });
     expect(config.mac.appId).toBe('io.example.branded-headlamp');
     expect(config.mac.hardenedRuntime).toBe(true);
     expect(config.mac.target).toEqual([{ target: 'dmg', arch: ['arm64'] }]);
+    expect(config.mac.extraResources).toContainEqual({
+      from: path.join(manifestDir, 'tools/mac'),
+      to: 'tools',
+    });
     expect(config.win.artifactName).toBe('branded-${version}.${ext}');
     expect(config.win.target).toEqual([{ target: 'nsis', arch: ['x64'] }]);
+    expect(config.win.extraResources).toContainEqual({
+      from: path.join(manifestDir, 'tools/windows.exe'),
+      to: 'tools/tool.exe',
+    });
   } finally {
     fs.rmSync(manifestDir, { recursive: true, force: true });
   }

--- a/app/electron-builder.config.ts
+++ b/app/electron-builder.config.ts
@@ -28,6 +28,7 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
+  applyBuildResources,
   applyBuildTargets,
   applyPlatformMetadata,
   applyProductMetadata,
@@ -57,27 +58,31 @@ const manifest = loadBuildManifest(manifestFile);
 const defaultManifest = path.resolve(DEFAULT_MANIFEST_FILE);
 const packageBuild = packageJson.build as ElectronBuilderConfiguration;
 
-const config: Configuration = applyBuildTargets(
-  applyPlatformMetadata(
-    applyProductMetadata(
-      {
-        ...packageBuild,
-        extraResources: packageBuild.extraResources.map(resource => {
-          // Preserve every resource except the default manifest entry.
-          if (
-            typeof resource === 'string' ||
-            path.resolve(configDirectory, resource.from) !== defaultManifest
-          ) {
-            return resource;
-          }
-          return { ...resource, from: manifestFile, to: 'app-build-manifest.json' };
-        }),
-      },
+const config: Configuration = applyBuildResources(
+  applyBuildTargets(
+    applyPlatformMetadata(
+      applyProductMetadata(
+        {
+          ...packageBuild,
+          extraResources: packageBuild.extraResources.map(resource => {
+            // Preserve every resource except the default manifest entry.
+            if (
+              typeof resource === 'string' ||
+              path.resolve(configDirectory, resource.from) !== defaultManifest
+            ) {
+              return resource;
+            }
+            return { ...resource, from: manifestFile, to: 'app-build-manifest.json' };
+          }),
+        },
+        manifest
+      ),
       manifest
     ),
     manifest
   ),
-  manifest
+  manifest,
+  manifestFile
 );
 
 export default config;

--- a/app/electron/build-backend.test.ts
+++ b/app/electron/build-backend.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 The Kubernetes Authors
+ * Copyright 2025 The Kubernetes Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/electron/build-manifest.test.ts
+++ b/app/electron/build-manifest.test.ts
@@ -23,6 +23,7 @@ import path from 'node:path';
 import * as tar from 'tar';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  applyBuildResources,
   applyBuildTargets,
   applyPlatformMetadata,
   applyProductMetadata,
@@ -45,6 +46,155 @@ import {
 const require = createRequire(import.meta.url);
 const { getConfig } = require('app-builder-lib/out/util/config/config');
 const appPath = path.resolve(__dirname, '..');
+
+describe('build resource validation', () => {
+  it.each([null, [], 'manifest'])('rejects an invalid manifest value: %j', manifest => {
+    expect(() => applyBuildResources({}, manifest)).toThrow('Build manifest must be an object');
+  });
+
+  it('preserves the configuration when build resources are absent', () => {
+    const defaults = { extraResources: [{ from: '/headlamp/frontend' }] };
+
+    expect(applyBuildResources(defaults, {})).toBe(defaults);
+  });
+
+  it.each([null, [], 'resources'])('rejects an invalid resources value: %j', resources => {
+    expect(() => applyBuildResources({}, { resources })).toThrow(
+      'Build manifest resources must be an object'
+    );
+  });
+
+  it('rejects unsupported resource groups', () => {
+    expect(() => applyBuildResources({}, { resources: { windows: [] } })).toThrow(
+      'Unsupported build manifest resource group: windows'
+    );
+  });
+
+  it.each([null, {}, 'tools'])('rejects invalid common resources: %j', common => {
+    expect(() => applyBuildResources({}, { resources: { common } })).toThrow(
+      'Build manifest resources.common must be an array'
+    );
+  });
+
+  it('resolves and appends common and platform resources without mutating defaults', () => {
+    const manifestFile = path.join('/product', 'config', 'app-build-manifest.json');
+    const manifestDirectory = path.dirname(manifestFile);
+    const defaults = {
+      extraResources: [{ from: '/headlamp/frontend' }],
+      linux: { category: 'Network', extraResources: [{ from: '/headlamp/backend' }] },
+      mac: { hardenedRuntime: true },
+      win: null,
+    };
+
+    expect(
+      applyBuildResources(
+        defaults,
+        {
+          resources: {
+            common: [{ from: '../shared', to: 'shared', filter: ['**/*'] }],
+            linux: [{ from: './tools/linux', to: 'tools' }],
+            mac: [{ from: './tools/mac' }],
+            win: [{ from: '/absolute/tool.exe', to: 'tools/tool.exe' }],
+          },
+        },
+        manifestFile
+      )
+    ).toEqual({
+      extraResources: [
+        { from: '/headlamp/frontend' },
+        {
+          from: path.resolve(manifestDirectory, '../shared'),
+          to: 'shared',
+          filter: ['**/*'],
+        },
+      ],
+      linux: {
+        category: 'Network',
+        extraResources: [
+          { from: '/headlamp/backend' },
+          { from: path.resolve(manifestDirectory, './tools/linux'), to: 'tools' },
+        ],
+      },
+      mac: {
+        hardenedRuntime: true,
+        extraResources: [{ from: path.resolve(manifestDirectory, './tools/mac') }],
+      },
+      win: {
+        extraResources: [
+          { from: path.resolve(manifestDirectory, '/absolute/tool.exe'), to: 'tools/tool.exe' },
+        ],
+      },
+    });
+    expect(defaults).toEqual({
+      extraResources: [{ from: '/headlamp/frontend' }],
+      linux: { category: 'Network', extraResources: [{ from: '/headlamp/backend' }] },
+      mac: { hardenedRuntime: true },
+      win: null,
+    });
+  });
+
+  it.each([
+    {
+      commonResource: '../frontend/build',
+      platformResource: { from: '../backend/headlamp-server', to: 'backend/headlamp-server' },
+    },
+    {
+      commonResource: { from: '../frontend/build', to: 'frontend' },
+      platformResource: '../backend/headlamp-server',
+    },
+  ])(
+    'preserves singleton common and platform resources: %j',
+    ({ commonResource, platformResource }) => {
+      const manifestFile = path.join('/product', 'app-build-manifest.json');
+
+      expect(
+        applyBuildResources(
+          {
+            extraResources: commonResource,
+            mac: { extraResources: platformResource },
+          },
+          {
+            resources: {
+              common: [{ from: './shared' }],
+              mac: [{ from: './tools/mac' }],
+            },
+          },
+          manifestFile
+        )
+      ).toEqual({
+        extraResources: [
+          commonResource,
+          { from: path.resolve(path.dirname(manifestFile), './shared') },
+        ],
+        mac: {
+          extraResources: [
+            platformResource,
+            { from: path.resolve(path.dirname(manifestFile), './tools/mac') },
+          ],
+        },
+      });
+    }
+  );
+
+  it.each([null, [], 'tools', {}, { to: 'tools' }, { from: 1 }, { from: 'tools', to: 1 }])(
+    'rejects an invalid resource entry: %j',
+    resource => {
+      expect(() => applyBuildResources({}, { resources: { common: [resource] } })).toThrow(
+        'Invalid build manifest resources.common[0]'
+      );
+    }
+  );
+
+  it.each([
+    { from: 'tools', filter: 'bin' },
+    { from: 'tools', filter: [1] },
+    { from: 'tools', unsafe: true },
+  ])('rejects invalid resource options: %j', resource => {
+    expect(() => applyBuildResources({}, { resources: { mac: [resource] } })).toThrow(
+      'Invalid build manifest resources.mac[0]'
+    );
+  });
+});
 
 describe('build target validation', () => {
   it('replaces platform targets without changing other platform settings', () => {

--- a/app/scripts/build-manifest.ts
+++ b/app/scripts/build-manifest.ts
@@ -33,6 +33,9 @@ export type BuildManifest = {
   /** Product identity fields consumed by Electron Builder. */
   product?: Record<string, unknown>;
 
+  /** Common and per-platform resources copied into desktop packages. */
+  resources?: Record<string, unknown>;
+
   /** Per-platform package targets consumed by Electron Builder. */
   targets?: Record<string, unknown>;
 
@@ -51,6 +54,18 @@ type BuildTargetDescriptor = {
 /** A supported package target declaration from a build manifest. */
 type BuildTarget = string | BuildTargetDescriptor;
 
+/** An Electron Builder resource declared by a product manifest. */
+type BuildResource = {
+  /** Glob patterns included beneath the source path. */
+  filter?: string[];
+
+  /** Source path, resolved relative to the selected manifest. */
+  from: string;
+
+  /** Optional destination beneath the packaged resources directory. */
+  to?: string;
+};
+
 type ProductMetadata = {
   name?: string;
   productName?: string;
@@ -59,6 +74,19 @@ type ProductMetadata = {
   artifactName?: string;
   protocols?: Record<string, unknown>;
 };
+
+/**
+ * Converts Electron Builder's optional singleton-or-array resources to an array.
+ *
+ * @param resources Existing Electron Builder extra resources.
+ * @returns An empty array for nullish input, the original array, or a wrapped singleton.
+ */
+function normalizeExtraResources(resources: unknown): unknown[] {
+  if (resources === undefined || resources === null) {
+    return [];
+  }
+  return Array.isArray(resources) ? resources : [resources];
+}
 
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 
@@ -216,6 +244,89 @@ export function applyProductMetadata<T extends object>(config: T, manifest: unkn
       ...(metadata.version && { version: metadata.version }),
     },
   } as T;
+}
+
+/**
+ * Appends manifest-declared resources to Electron Builder configuration.
+ *
+ * @param config Electron Builder configuration to extend.
+ * @param manifest Parsed application build manifest.
+ * @param manifestFile Path used to resolve resource source paths.
+ * @returns The original configuration when resources are absent, or a copy with resources applied.
+ * @throws When resource groups or entries are malformed.
+ */
+export function applyBuildResources<T extends object>(
+  config: T,
+  manifest: unknown,
+  manifestFile: string = resolveBuildManifestPath()
+): T {
+  if (typeof manifest !== 'object' || manifest === null || Array.isArray(manifest)) {
+    throw new Error('Build manifest must be an object');
+  }
+
+  const resources = (manifest as BuildManifest).resources;
+  if (resources === undefined) {
+    return config;
+  }
+  if (typeof resources !== 'object' || resources === null || Array.isArray(resources)) {
+    throw new Error('Build manifest resources must be an object');
+  }
+
+  const supportedGroups = new Set(['common', 'linux', 'mac', 'win']);
+  for (const group of Object.keys(resources)) {
+    if (!supportedGroups.has(group)) {
+      throw new Error(`Unsupported build manifest resource group: ${group}`);
+    }
+  }
+
+  const resolveResources = (entries: unknown, group: string): BuildResource[] => {
+    if (!Array.isArray(entries)) {
+      throw new Error(`Build manifest resources.${group} must be an array`);
+    }
+    return entries.map((entry, index) => {
+      if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+        throw new Error(`Invalid build manifest resources.${group}[${index}]`);
+      }
+      const resource = entry as Record<string, unknown>;
+      if (
+        typeof resource.from !== 'string' ||
+        Object.keys(resource).some(key => !['filter', 'from', 'to'].includes(key)) ||
+        (resource.to !== undefined && typeof resource.to !== 'string') ||
+        (resource.filter !== undefined &&
+          (!Array.isArray(resource.filter) ||
+            resource.filter.some(value => typeof value !== 'string')))
+      ) {
+        throw new Error(`Invalid build manifest resources.${group}[${index}]`);
+      }
+      return {
+        ...(resource as BuildResource),
+        from: path.resolve(path.dirname(manifestFile), resource.from),
+      };
+    });
+  };
+
+  const configRecord = config as Record<string, unknown>;
+  const result: Record<string, unknown> = { ...configRecord };
+  if (resources.common !== undefined) {
+    const extraResources = normalizeExtraResources(configRecord.extraResources);
+    result.extraResources = [...extraResources, ...resolveResources(resources.common, 'common')];
+  }
+  for (const platform of ['linux', 'mac', 'win']) {
+    if (resources[platform] === undefined) {
+      continue;
+    }
+    const defaults = configRecord[platform];
+    const platformDefaults =
+      typeof defaults === 'object' && defaults !== null
+        ? (defaults as Record<string, unknown>)
+        : {};
+    const extraResources = normalizeExtraResources(platformDefaults.extraResources);
+    result[platform] = {
+      ...platformDefaults,
+      extraResources: [...extraResources, ...resolveResources(resources[platform], platform)],
+    };
+  }
+  return result as T;
 }
 
 /**

--- a/docs/development/app.md
+++ b/docs/development/app.md
@@ -133,6 +133,37 @@ npm run app:package:mac      # macOS
 npm run app:package:win:msi  # Windows MSI installer
 ```
 
+### Build manifest resources
+
+Set `HEADLAMP_BUILD_MANIFEST` to package Headlamp with a product-specific build
+manifest. Relative environment paths use the current working directory, while
+resource `from` paths use the directory containing the selected manifest.
+
+The `resources` field appends common or platform-specific files and directories
+to Electron Builder's existing `extraResources`:
+
+```json
+{
+  "resources": {
+    "common": [{ "from": "./shared", "to": "shared" }],
+    "linux": [{ "from": "./tools/linux", "to": "tools" }],
+    "mac": [{ "from": "./tools/mac", "to": "tools", "filter": ["**/*"] }],
+    "win": [{ "from": "./tools/windows.exe", "to": "tools/tool.exe" }]
+  }
+}
+```
+
+Only `common`, `linux`, `mac`, and `win` resource groups are supported. Each
+group must be an array of objects with a `from` string and optional `to` string
+or `filter` string array. Invalid resource configuration stops packaging before
+Electron Builder runs.
+
+For example, from the repository root:
+
+```bash
+HEADLAMP_BUILD_MANIFEST=./product/app-build-manifest.json npm run app:package
+```
+
 ## Development workflow
 
 The typical development workflow for the desktop app:


### PR DESCRIPTION
## Summary

- let product build manifests append common and platform-specific Electron Builder resources
- resolve resource source paths relative to the selected manifest while preserving Headlamp defaults and singleton resource declarations
- reject unsupported resource groups, malformed entries, and unsupported Electron Builder resource options before packaging
- cover resource validation with unit tests and the effective Electron Builder configuration with a process-level e2e test
- document the resource manifest contract and packaging behavior

## Provenance

This upstreams `patches/0007-headlamp-upstream-build-manifest-resources.patch` from [Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823).

- Original patch commit recorded by the patch header: `44916ad20559f6ddaab8f7d0b66115fbea6be145`, authored by Joaquim Rocha on 2026-08-01 (the generated SHA is not present on a published Azure ref)
- Published Azure commit retaining the numbered patch: [387eb27e3f586211610dda61949255e7264a9c95](https://github.com/Azure/aks-desktop/commit/387eb27e3f586211610dda61949255e7264a9c95)
- Published Azure commit consuming the retained patch series: [4404d719e98f04c51c9504671a7ba2f169d97005](https://github.com/Azure/aks-desktop/commit/4404d719e98f04c51c9504671a7ba2f169d97005)
- Related Azure PR carrying both published commits: [Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823)

No separate published Azure PR was found for the generated patch-header commit. The behavior commit preserves Joaquim Rocha as author and the original author date, with René Dudfield added as co-author.

## Improvements over the existing changes

- port the original JavaScript helper to the current typed build-manifest module and document the manifest fields, resource type, parameters, return value, and errors with TSDoc, because Headlamp's build-manifest implementation moved to TypeScript after the downstream patch was generated
- reject unsupported resource group names instead of silently ignoring misspellings, because a typo should stop packaging rather than omit a required product resource
- preserve common and platform-specific defaults without mutating the supplied configuration, including valid singleton strings and FileSets, so product manifests compose safely with Headlamp packaging defaults
- expand unit coverage across pass-through behavior, every supported resource group, relative and absolute paths, optional fields, singleton strings and FileSets, immutability, malformed manifests, malformed groups, malformed entries, and unsupported options; the touched module reaches 97.93% branch coverage
- extend the registered build-manifest process spec to verify common and per-platform resources reach Electron Builder, because helper-only tests would not catch missing configuration wiring
- document `HEADLAMP_BUILD_MANIFEST` and resource packaging in the desktop development guide as well as the app README, because this is Electron packaging configuration rather than frontend runtime configuration
- keep implementation, documentation, unit tests, and e2e coverage in one buildable commit so every reviewed snapshot passes its checks
- correct the license header on the package-target test merged immediately before this patch, because the repository's literal header rule otherwise prevents app lint from running on current main

## Testing

- `npm --prefix app test` (24 files, 441 tests)
- `npm --prefix app test -- electron/build-manifest.test.ts --coverage.enabled --coverage.provider=istanbul --coverage.reporter=text --coverage.include=scripts/build-manifest.ts --coverage.thresholds.branches=80` (134 tests; 97.27% statements, 97.93% branches, 100% functions, 97.26% lines)
- `npm --prefix app run tsc`
- `npm --prefix app run lint`
- `npm --prefix app/e2e-tests run test-app -- buildManifest.spec.ts` (2 passed)
- Prettier checks for all changed TypeScript and Markdown files
- `git diff --check refs/remotes/upstream/main..HEAD`

## Manual steps to reproduce

1. Create a product build manifest with `resources.common` and one or more of `resources.linux`, `resources.mac`, or `resources.win`.
2. Set `HEADLAMP_BUILD_MANIFEST` to that manifest and load `app/electron-builder.config.ts` through Electron Builder.
3. Confirm common resources are appended to top-level `extraResources` and platform resources are appended to the matching platform configuration.
4. Confirm each relative `from` path resolves beside the selected manifest and Headlamp's existing resources remain present.
5. Add an unsupported resource group or option and confirm configuration loading fails before packaging.

## Screenshots

Not applicable. This changes non-visual desktop packaging configuration and does not alter the rendered interface.

Assisted by copilot
