### PR TITLE
0024: frontend: storybook: Mock batch workload lists

### DIFF
--- a/e2e-tests/tests/workloads.spec.ts
+++ b/e2e-tests/tests/workloads.spec.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import { HeadlampPage } from './headlampPage';
+
+const appsWorkloads = [
+  {
+    resource: 'daemonsets',
+    kind: 'DaemonSet',
+    name: 'logging-agent',
+    title: /DaemonSets/,
+  },
+  {
+    resource: 'deployments',
+    kind: 'Deployment',
+    name: 'web-server',
+    title: /Deployments/,
+  },
+  {
+    resource: 'replicasets',
+    kind: 'ReplicaSet',
+    name: 'web-server-replica',
+    title: /ReplicaSets/,
+  },
+  {
+    resource: 'statefulsets',
+    kind: 'StatefulSet',
+    name: 'database',
+    title: /StatefulSets/,
+  },
+];
+
+test('loads apps workload list pages', async ({ page }) => {
+  const requestedResources = new Set<string>();
+
+  for (const workload of appsWorkloads) {
+    const collectionUrl = new RegExp(`/clusters/test/apis/apps/v1/${workload.resource}(?:\\?.*)?$`);
+    await page.route(collectionUrl, async route => {
+      requestedResources.add(workload.resource);
+      await route.fulfill({
+        json: {
+          apiVersion: 'apps/v1',
+          kind: `${workload.kind}List`,
+          metadata: { resourceVersion: '1' },
+          items: [
+            {
+              apiVersion: 'apps/v1',
+              kind: workload.kind,
+              metadata: {
+                name: workload.name,
+                namespace: 'default',
+                resourceVersion: '1',
+                creationTimestamp: '2026-01-01T00:00:00Z',
+                uid: `${workload.resource}-uid`,
+              },
+              spec: { replicas: 1 },
+              status: {
+                desiredNumberScheduled: 1,
+                numberReady: 1,
+                readyReplicas: 1,
+                replicas: 1,
+              },
+            },
+          ],
+        },
+      });
+    });
+  }
+
+  const headlampPage = new HeadlampPage(page);
+  await headlampPage.navigateToCluster('test', process.env.HEADLAMP_TEST_TOKEN);
+
+  for (const workload of appsWorkloads) {
+    await headlampPage.navigateTopage(`/c/test/${workload.resource}`, workload.title);
+    await expect.poll(() => requestedResources.has(workload.resource)).toBe(true);
+    await expect(page.getByRole('link', { name: workload.name, exact: true })).toBeVisible();
+  }
+});

--- a/e2e-tests/tests/workloads.spec.ts
+++ b/e2e-tests/tests/workloads.spec.ts
@@ -22,25 +22,137 @@ const appsWorkloads = [
     resource: 'daemonsets',
     kind: 'DaemonSet',
     name: 'logging-agent',
-    title: /DaemonSets/,
+    title: / - DaemonSets - .+$/,
+    spec: {
+      selector: { matchLabels: { app: 'logging-agent' } },
+      template: {
+        metadata: { labels: { app: 'logging-agent' } },
+        spec: {
+          containers: [{ name: 'log-collector', image: 'fluent-bit:3.2' }],
+          nodeSelector: { 'kubernetes.io/os': 'linux' },
+        },
+      },
+    },
+    status: {
+      currentNumberScheduled: 1,
+      desiredNumberScheduled: 1,
+      numberAvailable: 1,
+      numberReady: 1,
+    },
   },
   {
     resource: 'deployments',
     kind: 'Deployment',
     name: 'web-server',
-    title: /Deployments/,
+    title: / - Deployments - .+$/,
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { app: 'web-server' } },
+      template: {
+        metadata: { labels: { app: 'web-server' } },
+        spec: { containers: [{ name: 'server', image: 'nginx:1.27' }] },
+      },
+    },
+    status: {
+      availableReplicas: 1,
+      readyReplicas: 1,
+      replicas: 1,
+      updatedReplicas: 1,
+    },
   },
   {
     resource: 'replicasets',
     kind: 'ReplicaSet',
     name: 'web-server-replica',
-    title: /ReplicaSets/,
+    title: / - ReplicaSets - .+$/,
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { app: 'web-server-replica' } },
+      template: {
+        metadata: { labels: { app: 'web-server-replica' } },
+        spec: { containers: [{ name: 'replica-server', image: 'nginx:1.27-alpine' }] },
+      },
+    },
+    status: {
+      availableReplicas: 1,
+      fullyLabeledReplicas: 1,
+      readyReplicas: 1,
+      replicas: 1,
+    },
   },
   {
     resource: 'statefulsets',
     kind: 'StatefulSet',
     name: 'database',
-    title: /StatefulSets/,
+    title: / - StatefulSets - .+$/,
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { app: 'database' } },
+      serviceName: 'database',
+      template: {
+        metadata: { labels: { app: 'database' } },
+        spec: { containers: [{ name: 'postgres', image: 'postgres:17' }] },
+      },
+    },
+    status: {
+      currentReplicas: 1,
+      currentRevision: 'database-1',
+      readyReplicas: 1,
+      replicas: 1,
+      updateRevision: 'database-1',
+      updatedReplicas: 1,
+    },
+  },
+];
+
+const batchWorkloads = [
+  {
+    resource: 'jobs',
+    kind: 'Job',
+    name: 'data-import',
+    title: / - Jobs - .+$/,
+    spec: {
+      completions: 1,
+      parallelism: 1,
+      template: {
+        metadata: { labels: { job: 'data-import' } },
+        spec: {
+          containers: [{ name: 'importer', image: 'busybox:1.37' }],
+          restartPolicy: 'Never',
+        },
+      },
+    },
+    status: {
+      active: 1,
+      startTime: '2026-01-01T00:00:00Z',
+    },
+  },
+  {
+    resource: 'cronjobs',
+    kind: 'CronJob',
+    name: 'nightly-backup',
+    title: / - CronJobs - .+$/,
+    spec: {
+      concurrencyPolicy: 'Forbid',
+      jobTemplate: {
+        spec: {
+          template: {
+            metadata: { labels: { job: 'nightly-backup' } },
+            spec: {
+              containers: [{ name: 'backup', image: 'postgres:17' }],
+              restartPolicy: 'Never',
+            },
+          },
+        },
+      },
+      schedule: '0 0 * * *',
+      suspend: false,
+    },
+    status: {
+      active: [],
+      lastScheduleTime: '2026-01-01T00:00:00Z',
+      lastSuccessfulTime: '2026-01-01T00:00:00Z',
+    },
   },
 ];
 
@@ -67,13 +179,8 @@ test('loads apps workload list pages', async ({ page }) => {
                 creationTimestamp: '2026-01-01T00:00:00Z',
                 uid: `${workload.resource}-uid`,
               },
-              spec: { replicas: 1 },
-              status: {
-                desiredNumberScheduled: 1,
-                numberReady: 1,
-                readyReplicas: 1,
-                replicas: 1,
-              },
+              spec: workload.spec,
+              status: workload.status,
             },
           ],
         },
@@ -87,6 +194,54 @@ test('loads apps workload list pages', async ({ page }) => {
   for (const workload of appsWorkloads) {
     await headlampPage.navigateTopage(`/c/test/${workload.resource}`, workload.title);
     await expect.poll(() => requestedResources.has(workload.resource)).toBe(true);
-    await expect(page.getByRole('link', { name: workload.name, exact: true })).toBeVisible();
+    const workloadLink = page.getByRole('link', { name: workload.name, exact: true });
+
+    await expect(workloadLink).toBeVisible();
+  }
+});
+
+test('loads batch workload list pages', async ({ page }) => {
+  const requestedResources = new Set<string>();
+
+  for (const workload of batchWorkloads) {
+    const collectionUrl = new RegExp(
+      `/clusters/test/apis/batch/v1/${workload.resource}(?:\\?.*)?$`
+    );
+    await page.route(collectionUrl, async route => {
+      requestedResources.add(workload.resource);
+      await route.fulfill({
+        json: {
+          apiVersion: 'batch/v1',
+          kind: `${workload.kind}List`,
+          metadata: { resourceVersion: '1' },
+          items: [
+            {
+              apiVersion: 'batch/v1',
+              kind: workload.kind,
+              metadata: {
+                name: workload.name,
+                namespace: 'default',
+                resourceVersion: '1',
+                creationTimestamp: '2026-01-01T00:00:00Z',
+                uid: `${workload.resource}-uid`,
+              },
+              spec: workload.spec,
+              status: workload.status,
+            },
+          ],
+        },
+      });
+    });
+  }
+
+  const headlampPage = new HeadlampPage(page);
+  await headlampPage.navigateToCluster('test', process.env.HEADLAMP_TEST_TOKEN);
+
+  for (const workload of batchWorkloads) {
+    await headlampPage.navigateTopage(`/c/test/${workload.resource}`, workload.title);
+    await expect.poll(() => requestedResources.has(workload.resource)).toBe(true);
+    const workloadLink = page.getByRole('link', { name: workload.name, exact: true });
+
+    await expect(workloadLink).toBeVisible();
   }
 });

--- a/frontend/.storybook/baseMocks.ts
+++ b/frontend/.storybook/baseMocks.ts
@@ -266,4 +266,36 @@ export const fallbackMocks = [
       items: [],
     })
   ),
+  http.get('http://localhost:4466/apis/apps/v1/deployments', () =>
+    HttpResponse.json({
+      kind: 'DeploymentList',
+      apiVersion: 'apps/v1',
+      metadata: {},
+      items: [],
+    })
+  ),
+  http.get('http://localhost:4466/apis/apps/v1/statefulsets', () =>
+    HttpResponse.json({
+      kind: 'StatefulSetList',
+      apiVersion: 'apps/v1',
+      metadata: {},
+      items: [],
+    })
+  ),
+  http.get('http://localhost:4466/apis/apps/v1/daemonsets', () =>
+    HttpResponse.json({
+      kind: 'DaemonSetList',
+      apiVersion: 'apps/v1',
+      metadata: {},
+      items: [],
+    })
+  ),
+  http.get('http://localhost:4466/apis/apps/v1/replicasets', () =>
+    HttpResponse.json({
+      kind: 'ReplicaSetList',
+      apiVersion: 'apps/v1',
+      metadata: {},
+      items: [],
+    })
+  ),
 ];

--- a/frontend/.storybook/baseMocks.ts
+++ b/frontend/.storybook/baseMocks.ts
@@ -266,6 +266,22 @@ export const fallbackMocks = [
       items: [],
     })
   ),
+  http.get('http://localhost:4466/apis/batch/v1/jobs', () =>
+    HttpResponse.json({
+      kind: 'JobList',
+      apiVersion: 'batch/v1',
+      metadata: {},
+      items: [],
+    })
+  ),
+  http.get('http://localhost:4466/apis/batch/v1/cronjobs', () =>
+    HttpResponse.json({
+      kind: 'CronJobList',
+      apiVersion: 'batch/v1',
+      metadata: {},
+      items: [],
+    })
+  ),
   http.get('http://localhost:4466/apis/apps/v1/deployments', () =>
     HttpResponse.json({
       kind: 'DeploymentList',

--- a/frontend/src/test/storybookBaseMocks.test.ts
+++ b/frontend/src/test/storybookBaseMocks.test.ts
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-import fs from 'fs';
 import { setupServer } from 'msw/node';
-import path from 'path';
 import { afterAll, afterEach, beforeAll, expect, test } from 'vitest';
 import * as storybookMocks from '../../.storybook/baseMocks';
 import {
   APPS_WORKLOAD_COLLECTION_URLS,
-  appsWorkloadCollectionUrls,
+  BATCH_WORKLOAD_COLLECTION_URLS,
   CLUSTER_WIDE_PODS_URL,
   NAMESPACED_PODS_URL,
   podCollectionUrls,
+  workloadCollectionUrls,
 } from './storybookBaseMocks.testHelper';
 
 const server = setupServer();
@@ -33,6 +32,10 @@ const appsWorkloadKinds: Record<string, string> = {
   deployments: 'Deployment',
   replicasets: 'ReplicaSet',
   statefulsets: 'StatefulSet',
+};
+const batchWorkloadKinds: Record<string, string> = {
+  cronjobs: 'CronJob',
+  jobs: 'Job',
 };
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
@@ -64,12 +67,24 @@ test('returns empty PodList responses for exported Pod collections', async () =>
   }
 });
 
-test('returns empty apps workload lists from the frontend mocks', async () => {
-  const handlers = [...storybookMocks.baseMocks, ...storybookMocks.fallbackMocks];
-  server.use(...handlers);
-  const workloadUrls = appsWorkloadCollectionUrls(handlers);
+/**
+ * Verifies that one Storybook mock module serves workload defaults as fallbacks.
+ *
+ * @param apiGroup - Kubernetes API group served by the expected handlers.
+ * @param expectedUrls - Exact fallback collection URLs expected for the group.
+ * @param workloadKinds - Kubernetes resource kinds keyed by collection name.
+ * @returns A promise that resolves after every fallback response is verified.
+ */
+async function expectWorkloadFallbacks(
+  apiGroup: string,
+  expectedUrls: string[],
+  workloadKinds: Record<string, string>
+): Promise<void> {
+  expect(workloadCollectionUrls(storybookMocks.baseMocks, apiGroup)).toEqual([]);
 
-  expect(workloadUrls).toEqual(APPS_WORKLOAD_COLLECTION_URLS);
+  const workloadUrls = workloadCollectionUrls(storybookMocks.fallbackMocks, apiGroup);
+  expect(workloadUrls).toEqual(expectedUrls);
+  server.use(...storybookMocks.fallbackMocks);
 
   for (const url of workloadUrls) {
     const resource = new URL(url).pathname.split('/').at(-1)!;
@@ -77,24 +92,18 @@ test('returns empty apps workload lists from the frontend mocks', async () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
-      kind: `${appsWorkloadKinds[resource]}List`,
-      apiVersion: 'apps/v1',
+      kind: `${workloadKinds[resource]}List`,
+      apiVersion: `${apiGroup}/v1`,
       metadata: {},
       items: [],
     });
   }
+}
+
+test('returns apps workload lists from the frontend fallbacks', async () => {
+  await expectWorkloadFallbacks('apps', APPS_WORKLOAD_COLLECTION_URLS, appsWorkloadKinds);
 });
 
-test('keeps the plugin template apps workload mocks synchronized', () => {
-  const source = fs.readFileSync(
-    path.resolve(__dirname, '../../../plugins/headlamp-plugin/config/.storybook/baseMocks.ts'),
-    'utf8'
-  );
-
-  for (const url of APPS_WORKLOAD_COLLECTION_URLS) {
-    const resource = new URL(url).pathname.split('/').at(-1)!;
-
-    expect(source).toContain(url);
-    expect(source).toContain(`kind: '${appsWorkloadKinds[resource]}List'`);
-  }
+test('returns batch workload lists from the frontend fallbacks', async () => {
+  await expectWorkloadFallbacks('batch', BATCH_WORKLOAD_COLLECTION_URLS, batchWorkloadKinds);
 });

--- a/frontend/src/test/storybookBaseMocks.test.ts
+++ b/frontend/src/test/storybookBaseMocks.test.ts
@@ -14,16 +14,26 @@
  * limitations under the License.
  */
 
+import fs from 'fs';
 import { setupServer } from 'msw/node';
+import path from 'path';
 import { afterAll, afterEach, beforeAll, expect, test } from 'vitest';
 import * as storybookMocks from '../../.storybook/baseMocks';
 import {
+  APPS_WORKLOAD_COLLECTION_URLS,
+  appsWorkloadCollectionUrls,
   CLUSTER_WIDE_PODS_URL,
   NAMESPACED_PODS_URL,
   podCollectionUrls,
 } from './storybookBaseMocks.testHelper';
 
 const server = setupServer();
+const appsWorkloadKinds: Record<string, string> = {
+  daemonsets: 'DaemonSet',
+  deployments: 'Deployment',
+  replicasets: 'ReplicaSet',
+  statefulsets: 'StatefulSet',
+};
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => server.resetHandlers());
@@ -51,5 +61,40 @@ test('returns empty PodList responses for exported Pod collections', async () =>
       metadata: {},
       items: [],
     });
+  }
+});
+
+test('returns empty apps workload lists from the frontend mocks', async () => {
+  const handlers = [...storybookMocks.baseMocks, ...storybookMocks.fallbackMocks];
+  server.use(...handlers);
+  const workloadUrls = appsWorkloadCollectionUrls(handlers);
+
+  expect(workloadUrls).toEqual(APPS_WORKLOAD_COLLECTION_URLS);
+
+  for (const url of workloadUrls) {
+    const resource = new URL(url).pathname.split('/').at(-1)!;
+    const response = await fetch(url);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      kind: `${appsWorkloadKinds[resource]}List`,
+      apiVersion: 'apps/v1',
+      metadata: {},
+      items: [],
+    });
+  }
+});
+
+test('keeps the plugin template apps workload mocks synchronized', () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../../../plugins/headlamp-plugin/config/.storybook/baseMocks.ts'),
+    'utf8'
+  );
+
+  for (const url of APPS_WORKLOAD_COLLECTION_URLS) {
+    const resource = new URL(url).pathname.split('/').at(-1)!;
+
+    expect(source).toContain(url);
+    expect(source).toContain(`kind: '${appsWorkloadKinds[resource]}List'`);
   }
 });

--- a/frontend/src/test/storybookBaseMocks.testHelper.ts
+++ b/frontend/src/test/storybookBaseMocks.testHelper.ts
@@ -18,7 +18,15 @@ import type { http } from 'msw';
 
 export const CLUSTER_WIDE_PODS_URL = 'http://localhost:4466/api/v1/pods';
 export const NAMESPACED_PODS_URL = 'http://localhost:4466/api/v1/namespaces/default/pods';
+/** The complete set of apps/v1 workload collections expected in Storybook fallbacks. */
+export const APPS_WORKLOAD_COLLECTION_URLS = [
+  'http://localhost:4466/apis/apps/v1/daemonsets',
+  'http://localhost:4466/apis/apps/v1/deployments',
+  'http://localhost:4466/apis/apps/v1/replicasets',
+  'http://localhost:4466/apis/apps/v1/statefulsets',
+];
 
+const APPS_WORKLOAD_COLLECTION_PATH = /\/apis\/apps\/v1\/(\w+)$/;
 const POD_COLLECTION_PATH = /\/api\/v1(?:\/namespaces\/[^/]+)?\/pods$/;
 
 type HttpHandler = ReturnType<typeof http.get>;
@@ -34,6 +42,23 @@ export function podCollectionUrls(handlers: HttpHandler[]): string[] {
     .filter(
       handler =>
         handler.info.method === 'GET' && POD_COLLECTION_PATH.test(String(handler.info.path))
+    )
+    .map(handler => String(handler.info.path))
+    .sort();
+}
+
+/**
+ * Returns the apps/v1 workload collection URLs handled by a Storybook mock set.
+ *
+ * @param handlers - Storybook request handlers to inspect.
+ * @returns Sorted workload collection URLs.
+ */
+export function appsWorkloadCollectionUrls(handlers: HttpHandler[]): string[] {
+  return handlers
+    .filter(
+      handler =>
+        handler.info.method === 'GET' &&
+        APPS_WORKLOAD_COLLECTION_PATH.test(String(handler.info.path))
     )
     .map(handler => String(handler.info.path))
     .sort();

--- a/frontend/src/test/storybookBaseMocks.testHelper.ts
+++ b/frontend/src/test/storybookBaseMocks.testHelper.ts
@@ -18,15 +18,19 @@ import type { http } from 'msw';
 
 export const CLUSTER_WIDE_PODS_URL = 'http://localhost:4466/api/v1/pods';
 export const NAMESPACED_PODS_URL = 'http://localhost:4466/api/v1/namespaces/default/pods';
-/** The complete set of apps/v1 workload collections expected in Storybook fallbacks. */
+/** The apps/v1 workload collection fallbacks maintained by Storybook. */
 export const APPS_WORKLOAD_COLLECTION_URLS = [
   'http://localhost:4466/apis/apps/v1/daemonsets',
   'http://localhost:4466/apis/apps/v1/deployments',
   'http://localhost:4466/apis/apps/v1/replicasets',
   'http://localhost:4466/apis/apps/v1/statefulsets',
 ];
+/** The batch/v1 workload collection fallbacks maintained by Storybook. */
+export const BATCH_WORKLOAD_COLLECTION_URLS = [
+  'http://localhost:4466/apis/batch/v1/cronjobs',
+  'http://localhost:4466/apis/batch/v1/jobs',
+];
 
-const APPS_WORKLOAD_COLLECTION_PATH = /\/apis\/apps\/v1\/(\w+)$/;
 const POD_COLLECTION_PATH = /\/api\/v1(?:\/namespaces\/[^/]+)?\/pods$/;
 
 type HttpHandler = ReturnType<typeof http.get>;
@@ -48,18 +52,25 @@ export function podCollectionUrls(handlers: HttpHandler[]): string[] {
 }
 
 /**
- * Returns the apps/v1 workload collection URLs handled by a Storybook mock set.
+ * Returns workload collection URLs for an API group handled by a Storybook mock set.
  *
  * @param handlers - Storybook request handlers to inspect.
+ * @param apiGroup - Kubernetes API group whose v1 collection handlers should be returned.
  * @returns Sorted workload collection URLs.
  */
-export function appsWorkloadCollectionUrls(handlers: HttpHandler[]): string[] {
+export function workloadCollectionUrls(handlers: HttpHandler[], apiGroup: string): string[] {
+  const collectionPathPrefix = `/apis/${apiGroup}/v1/`;
+
   return handlers
-    .filter(
-      handler =>
-        handler.info.method === 'GET' &&
-        APPS_WORKLOAD_COLLECTION_PATH.test(String(handler.info.path))
-    )
+    .filter(handler => {
+      if (handler.info.method !== 'GET') {
+        return false;
+      }
+
+      const pathname = new URL(String(handler.info.path)).pathname;
+      const resourcePath = pathname.slice(collectionPathPrefix.length);
+      return pathname.startsWith(collectionPathPrefix) && !resourcePath.includes('/');
+    })
     .map(handler => String(handler.info.path))
     .sort();
 }

--- a/plugins/headlamp-plugin/config/.storybook/baseMocks.ts
+++ b/plugins/headlamp-plugin/config/.storybook/baseMocks.ts
@@ -339,4 +339,36 @@ export const fallbackMocks = [
       items: [],
     })
   ),
+  http.get('http://localhost:4466/apis/apps/v1/deployments', () =>
+    HttpResponse.json({
+      kind: 'DeploymentList',
+      apiVersion: 'apps/v1',
+      metadata: {},
+      items: [],
+    })
+  ),
+  http.get('http://localhost:4466/apis/apps/v1/statefulsets', () =>
+    HttpResponse.json({
+      kind: 'StatefulSetList',
+      apiVersion: 'apps/v1',
+      metadata: {},
+      items: [],
+    })
+  ),
+  http.get('http://localhost:4466/apis/apps/v1/daemonsets', () =>
+    HttpResponse.json({
+      kind: 'DaemonSetList',
+      apiVersion: 'apps/v1',
+      metadata: {},
+      items: [],
+    })
+  ),
+  http.get('http://localhost:4466/apis/apps/v1/replicasets', () =>
+    HttpResponse.json({
+      kind: 'ReplicaSetList',
+      apiVersion: 'apps/v1',
+      metadata: {},
+      items: [],
+    })
+  ),
 ];

--- a/plugins/headlamp-plugin/config/.storybook/baseMocks.ts
+++ b/plugins/headlamp-plugin/config/.storybook/baseMocks.ts
@@ -339,6 +339,22 @@ export const fallbackMocks = [
       items: [],
     })
   ),
+  http.get('http://localhost:4466/apis/batch/v1/jobs', () =>
+    HttpResponse.json({
+      kind: 'JobList',
+      apiVersion: 'batch/v1',
+      metadata: {},
+      items: [],
+    })
+  ),
+  http.get('http://localhost:4466/apis/batch/v1/cronjobs', () =>
+    HttpResponse.json({
+      kind: 'CronJobList',
+      apiVersion: 'batch/v1',
+      metadata: {},
+      items: [],
+    })
+  ),
   http.get('http://localhost:4466/apis/apps/v1/deployments', () =>
     HttpResponse.json({
       kind: 'DeploymentList',

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -11,6 +11,7 @@
     "bundle-examples": "node scripts/bundle-examples.js",
     "fetch-official-plugins": "node scripts/fetch-official-plugins.js",
     "prepare-bundle": "npm run bundle-examples && npm run fetch-official-plugins",
+    "test:storybook-mocks": "vitest run -c config/vite.config.mjs storybookBaseMocks.test.ts",
     "update-dependencies": "node dependencies-sync.js update && npm install && node scripts/copy-package-lock.js",
     "check-dependencies": "node dependencies-sync.js check",
     "copy-package-lock": "node scripts/copy-package-lock.js"

--- a/plugins/headlamp-plugin/storybookBaseMocks.test.ts
+++ b/plugins/headlamp-plugin/storybookBaseMocks.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, expect, test } from 'vitest';
+import { baseMocks, fallbackMocks } from './config/.storybook/baseMocks';
+
+const server = setupServer();
+const appsWorkloads = [
+  { url: 'http://localhost:4466/apis/apps/v1/daemonsets', kind: 'DaemonSetList' },
+  { url: 'http://localhost:4466/apis/apps/v1/deployments', kind: 'DeploymentList' },
+  { url: 'http://localhost:4466/apis/apps/v1/replicasets', kind: 'ReplicaSetList' },
+  { url: 'http://localhost:4466/apis/apps/v1/statefulsets', kind: 'StatefulSetList' },
+];
+const batchWorkloads = [
+  { url: 'http://localhost:4466/apis/batch/v1/cronjobs', kind: 'CronJobList' },
+  { url: 'http://localhost:4466/apis/batch/v1/jobs', kind: 'JobList' },
+];
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+// Keep this executable contract in the plugin package, where its MSW and Vite
+// dependencies are installed. It catches fallback handlers accidentally moving
+// into baseMocks and verifies that each URL returns its matching Kubernetes kind.
+test.each([
+  ['apps', appsWorkloads],
+  ['batch', batchWorkloads],
+])('returns %s workload lists from plugin-template fallbacks', async (apiGroup, workloads) => {
+  const basePaths = baseMocks.map(handler => String(handler.info.path));
+  const fallbackPaths = fallbackMocks.map(handler => String(handler.info.path));
+  server.use(...fallbackMocks);
+
+  for (const workload of workloads) {
+    expect(basePaths).not.toContain(workload.url);
+    expect(fallbackPaths).toContain(workload.url);
+
+    const response = await fetch(workload.url);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      kind: workload.kind,
+      apiVersion: `${apiGroup}/v1`,
+      metadata: {},
+      items: [],
+    });
+  }
+});

--- a/plugins/headlamp-plugin/test-headlamp-plugin.js
+++ b/plugins/headlamp-plugin/test-headlamp-plugin.js
@@ -31,6 +31,7 @@ function testHeadlampPlugin() {
 
   // Make a package file of headlamp-plugin we can test
   run('npm', ['install']);
+  run('npm', ['run', 'test:storybook-mocks']);
   run('npm', ['run', 'build']);
   checkFileContains(join('lib', 'index.js'), 'DefaultCreateProject');
   checkFileContains(join('lib', 'index.d.ts'), 'DefaultCreateProject');


### PR DESCRIPTION
## Summary

Adds empty `batch/v1` Job and CronJob collection responses to the frontend and
plugin-template Storybook mocks. This keeps workload list stories independent
of unhandled Kubernetes API requests.

## Stacked on

- https://github.com/kubernetes-sigs/headlamp/pull/7438

There is no semantic dependency on 0023; this patch uses its Storybook mock
insertion context.

## Original change and provenance

- Original Azure patch-series PR: https://github.com/Azure/aks-desktop/pull/823
- Original patch commit recorded by the retained patch:
  `077f862239570c843f73a6d3ae9cebbea5b92093`, authored by Evangelos
  Skopelitis on 2026-07-31.
- Azure commit that first retained the batch workload patch pair:
  https://github.com/Azure/aks-desktop/commit/f4fc06a535432b3cba6e62469f0c7c085f7b4198
- Azure commit that organized it as numbered patch 0024:
  https://github.com/Azure/aks-desktop/commit/387eb27e3f586211610dda61949255e7264a9c95

GitHub reports no separate Azure PR association for the initial retained-patch
commit; Azure/aks-desktop#823 is the source PR containing this change.

## Changes

- Mock empty `JobList` and `CronJobList` responses as fallbacks in both
  Storybook configs.
- Execute both frontend and plugin-template handlers and verify their payloads.
- Exercise kind-correct workload responses and rendered resource links in
  Playwright.

## Improvements over the existing changes

The original patch supplied the two mock pairs without focused regression
coverage. The added unit contract executes both handlers, verifies their exact
Kubernetes list payloads, requires fallback placement, and prevents the plugin
template from drifting from the frontend configuration.

The workload e2e uses per-kind Kubernetes objects and verifies collection
requests, rendered resource links, and exact product-aware page titles. It
avoids assertions against optional table cells because responsive column hiding
can omit those cells based on the inner table width.
The history keeps the e2e coverage first and bundles the mock implementation
with its regression tests so every commit remains buildable.

## Testing

- Frontend Storybook mock contract: 3 tests passed.
- Plugin-template Storybook mock contract: 2 tests passed.
- Targeted mock test/helper coverage: 100% branches, exceeding 80%.
- Focused ESLint: no errors.
- `playwright test tests/workloads.spec.ts --list`: both workload tests found.
- Affected Job/List and workload/Overview snapshots passed.
- Full Playwright execution was not run locally because Docker was unavailable
  and no reusable Headlamp e2e environment was running; CI provides that setup.

## Steps to Test

1. Run `npm --prefix frontend test -- --run src/test/storybookBaseMocks.test.ts`.
2. Start the documented Headlamp e2e environment.
3. Run `npx --prefix e2e-tests playwright test tests/workloads.spec.ts`.

## Screenshots

Not applicable. This changes Storybook API fallback behavior and tests without a
visual UI difference.

Assisted by copilot
