### PR TITLE
0069: build: frontend: Preserve packaged-source metadata

### DIFF
--- a/.github/workflows/build-other-arch.yml
+++ b/.github/workflows/build-other-arch.yml
@@ -65,6 +65,8 @@ jobs:
         uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
+          build-args: |
+            HEADLAMP_SOURCE_COMMIT=${{ github.sha }}
           push: false
           load: true
           platforms: linux/${{ matrix.arch }}

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -70,6 +70,7 @@ jobs:
       run: |
         git fetch --tags --force origin
         git checkout ${{ env.BUILD_TAG }}
+        echo "HEADLAMP_SOURCE_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
     - name: Log in to the Container registry
       uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
       with:
@@ -80,6 +81,8 @@ jobs:
       uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
       with:
         context: .
+        build-args: |
+          HEADLAMP_SOURCE_COMMIT=${{ env.HEADLAMP_SOURCE_COMMIT }}
         push: true
         pull: true
         platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -40,6 +40,8 @@ jobs:
         uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
+          build-args: |
+            HEADLAMP_SOURCE_COMMIT=${{ github.sha }}
           push: true
           pull: true
           platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,23 +28,24 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM --platform=${BUILDPLATFORM} node:22@sha256:0557ac14e0d45d02ed563067b82856ca5e7aa3437fa28d98d4350ea9c3d9494a AS frontend-build
 
-# We need .git and app/ in order to get the version and git version for the frontend/.env file
-# that's generated when building the frontend.
-COPY .git/ ./headlamp/.git/
-
-COPY app/package.json /headlamp/app/package.json
-
 # Keep npm install separated so source changes don't trigger install
 COPY frontend/package*.json /headlamp/frontend/
 WORKDIR /headlamp
 RUN cd ./frontend && npm ci --only=prod
 
 FROM frontend-build AS frontend
+ARG HEADLAMP_SOURCE_COMMIT
+ARG HEADLAMP_BUILD_MANIFEST
+ENV HEADLAMP_SOURCE_COMMIT=${HEADLAMP_SOURCE_COMMIT} \
+    HEADLAMP_BUILD_MANIFEST=${HEADLAMP_BUILD_MANIFEST}
+
 COPY ./frontend /headlamp/frontend
 
 WORKDIR /headlamp
 
-RUN cd ./frontend && npm run build
+# Expose app metadata and manifests only while generating the frontend build.
+RUN --mount=type=bind,source=app,target=/headlamp/app,ro \
+    cd ./frontend && npm run build
 
 RUN echo "*** Built Headlamp with version: ***"
 RUN cat ./frontend/.env

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ DOCKER_EXT_REPO ?= docker.io/headlamp
 DOCKER_IMAGE_NAME ?= headlamp
 DOCKER_PLUGINS_IMAGE_NAME ?= plugins
 DOCKER_IMAGE_VERSION ?= $(shell git describe --tags --match 'v*' --always --dirty)
+HEADLAMP_SOURCE_COMMIT ?= $(shell git rev-parse HEAD)
 DOCKER_IMAGE_EXTRA_TAG ?=
 # Detect platform (Windows, macOS, Linux)
 ifeq ($(OS),Windows_NT)
@@ -396,6 +397,7 @@ image:
 	$(DOCKER_CMD) $(DOCKER_BUILDX_CMD) build \
 	--pull \
 	--platform=$(DOCKER_PLATFORM) \
+	--build-arg HEADLAMP_SOURCE_COMMIT=$(HEADLAMP_SOURCE_COMMIT) \
 	$$BUILD_ARG \
 	--push=$(DOCKER_PUSH) \
 	-t $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_VERSION) \

--- a/app/e2e-tests/playwright.electron.config.ts
+++ b/app/e2e-tests/playwright.electron.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
   testMatch: [
     'backendToken.spec.ts',
     'buildManifest.spec.ts',
+    'buildManifestProduct.spec.ts',
     'clusterRename.spec.ts',
     'namespaces.spec.ts',
     'clusterAutoConnect.spec.ts',

--- a/app/e2e-tests/tests/buildManifestProduct.spec.ts
+++ b/app/e2e-tests/tests/buildManifestProduct.spec.ts
@@ -21,6 +21,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 const appPath = path.resolve(__dirname, '../..');
+const frontendPath = path.resolve(appPath, '../frontend');
 
 test('custom product metadata reaches the Electron Builder configuration', () => {
   const manifestDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-product-manifest-'));
@@ -63,6 +64,52 @@ test('custom product metadata reaches the Electron Builder configuration', () =>
       name: 'example-desktop',
       productName: 'Example Desktop',
       version: '1.2.3',
+    });
+  } finally {
+    fs.rmSync(manifestDirectory, { recursive: true, force: true });
+  }
+});
+
+test('custom product metadata reaches the frontend environment', () => {
+  const manifestDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-product-manifest-'));
+  const manifestFile = path.join(manifestDirectory, 'app-build-manifest.json');
+  const envFile = path.join(manifestDirectory, '.env');
+  fs.writeFileSync(
+    manifestFile,
+    JSON.stringify({
+      product: {
+        productName: 'C# $HOME Desktop',
+        version: '1.2.3=build',
+      },
+    })
+  );
+
+  try {
+    execFileSync(process.execPath, [path.join(frontendPath, 'make-env.js'), envFile], {
+      cwd: frontendPath,
+      env: {
+        ...process.env,
+        HEADLAMP_BUILD_MANIFEST: manifestFile,
+        HEADLAMP_SOURCE_COMMIT: '0123456789abcdef=source',
+      },
+    });
+    const env = JSON.parse(
+      execFileSync(
+        process.execPath,
+        [
+          '--input-type=module',
+          '-e',
+          "import { loadEnv } from 'vite'; process.stdout.write(JSON.stringify(loadEnv('test', process.argv[1], 'REACT_APP_')));",
+          manifestDirectory,
+        ],
+        { cwd: frontendPath, encoding: 'utf8' }
+      )
+    );
+
+    expect(env).toMatchObject({
+      REACT_APP_HEADLAMP_VERSION: '1.2.3=build',
+      REACT_APP_HEADLAMP_GIT_VERSION: '0123456789abcdef=source',
+      REACT_APP_HEADLAMP_PRODUCT_NAME: 'C# $HOME Desktop',
     });
   } finally {
     fs.rmSync(manifestDirectory, { recursive: true, force: true });

--- a/docs/development/app.md
+++ b/docs/development/app.md
@@ -133,14 +133,61 @@ npm run app:package:mac      # macOS
 npm run app:package:win:msi  # Windows MSI installer
 ```
 
+### Custom product builds
+
+Product builds can select an alternative app build manifest and record the
+source revision used to assemble the package:
+
+| Environment variable      | Default                           | Description                                                                                                                          |
+| ------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `HEADLAMP_BUILD_MANIFEST` | `app/app-build-manifest.json`     | Path to the JSON build manifest. The checked-in default configures both Electron packaging and generated frontend metadata.          |
+| `HEADLAMP_SOURCE_COMMIT`  | Current Git revision or `unknown` | Source revision written to `REACT_APP_HEADLAMP_GIT_VERSION`. Set this when building from packaged source without its Git repository. |
+
+The manifest's `product.productName` and `product.version` fields configure the
+identity displayed by the frontend as well as the packaged desktop app. Missing
+or empty fields retain the values from `app/package.json`.
+
+For example:
+
+```json
+{
+  "product": {
+    "name": "example-desktop",
+    "productName": "Example Desktop",
+    "version": "1.2.3"
+  }
+}
+```
+
+Build the app with the selected manifest and source revision:
+
+```bash
+HEADLAMP_BUILD_MANIFEST=./product/app-build-manifest.json \
+HEADLAMP_SOURCE_COMMIT=0123456789abcdef \
+npm run app:build
+```
+
+Frontend environment generation resolves a relative manifest path from the
+`app/` directory. Electron packaging resolves it from the process working
+directory. The root app scripts run Electron packaging from `app/`, so the
+example above selects `app/product/app-build-manifest.json` for both consumers.
+Use an absolute manifest path when invoking either consumer directly from a
+different working directory.
+
+The manifest must remain available throughout the frontend and app packaging
+steps. An unreadable manifest, a non-object `product`, non-string
+`productName`/`version` fields, or values containing newlines stop the frontend
+build rather than silently using an inconsistent product identity. The frontend
+environment generator also rejects values containing both a single quote and a
+backtick when they additionally contain either a double quote or a literal
+backslash-`n`/backslash-`r` sequence, because no dotenv quote delimiter can
+represent them without changing the value.
+
 ### Build manifest resources
 
-Set `HEADLAMP_BUILD_MANIFEST` to package Headlamp with a product-specific build
-manifest. Relative environment paths use the current working directory, while
-resource `from` paths use the directory containing the selected manifest.
-
 The `resources` field appends common or platform-specific files and directories
-to Electron Builder's existing `extraResources`:
+to Electron Builder's existing `extraResources`. Resource `from` paths resolve
+from the directory containing the selected manifest:
 
 ```json
 {

--- a/docs/development/app.md
+++ b/docs/development/app.md
@@ -174,6 +174,17 @@ example above selects `app/product/app-build-manifest.json` for both consumers.
 Use an absolute manifest path when invoking either consumer directly from a
 different working directory.
 
+The standard `make image` and `npm run image:build` commands pass the current
+Git revision to container builds. Direct Docker callers selecting a custom
+product manifest should pass both the manifest path and source revision:
+
+```bash
+docker buildx build \
+  --build-arg HEADLAMP_BUILD_MANIFEST=./product/app-build-manifest.json \
+  --build-arg HEADLAMP_SOURCE_COMMIT=0123456789abcdef \
+  -f Dockerfile .
+```
+
 The manifest must remain available throughout the frontend and app packaging
 steps. An unreadable manifest, a non-object `product`, non-string
 `productName`/`version` fields, or values containing newlines stop the frontend

--- a/docs/development/frontend.md
+++ b/docs/development/frontend.md
@@ -36,6 +36,10 @@ This command starts the Vite development server for the frontend
 We use [react-query](https://tanstack.com/query/latest/docs/framework/react/overview)
 for network requests. If you need the devtools for react-query, you can simply set `REACT_APP_ENABLE_REACT_QUERY_DEVTOOLS=true` in the `.env` file.
 
+Packaged products can generate the frontend version, product name, and source
+revision from app build inputs. See [Custom product builds](./app.md#custom-product-builds)
+for the `HEADLAMP_BUILD_MANIFEST` and `HEADLAMP_SOURCE_COMMIT` configuration.
+
 ## Product error content
 
 Products that build Headlamp can customize the generic error and not-found
@@ -141,18 +145,17 @@ npm run test:a11y
 ```
 
 This command will:
+
 1. Build the Storybook
 2. Run axe accessibility tests on all stories
 3. Report any accessibility violations found
 
 The tests will fail if any accessibility issues are detected, making it useful for CI/CD pipelines.
 
-
 #### Baseline Storybook a11y Configuration
 
 Known failures are tracked in `frontend/.axe-storybook-baseline.test-a11y.json`. This file is
 used by the test suite to allow known failures while catching new violations.
-
 
 ## Property testing (fuzzing)
 

--- a/frontend/make-env.js
+++ b/frontend/make-env.js
@@ -18,22 +18,144 @@
 // Creates the .env file
 import { execSync } from 'child_process';
 import fs from 'fs';
-const appInfo = JSON.parse(fs.readFileSync('../app/package.json', 'utf8'));
+import { fileURLToPath } from 'node:url';
+import path from 'path';
 
-const gitVersion = execSync('git rev-parse HEAD').toString().trim();
+/**
+ * Product fields exposed to the frontend build.
+ *
+ * @typedef {object} ProductInfo
+ * @property {string} [productName] Display name for the product.
+ * @property {string} [version] Product version shown by the frontend.
+ */
+
+const frontendDirectory = path.dirname(fileURLToPath(import.meta.url));
+const appDirectory = path.resolve(frontendDirectory, '../app');
+const defaultManifestFile = path.join(appDirectory, 'app-build-manifest.json');
+
+/** @type {ProductInfo} */
+const appInfo = JSON.parse(fs.readFileSync(path.join(appDirectory, 'package.json'), 'utf8'));
+
+/**
+ * Resolves the app build manifest used to generate frontend metadata.
+ *
+ * @param {NodeJS.ProcessEnv} [env] Environment used to select a custom manifest.
+ * @returns {string} Absolute path to the selected or default app build manifest.
+ */
+function resolveBuildManifestPath(env = process.env) {
+  const configuredPath = env.HEADLAMP_BUILD_MANIFEST;
+  return configuredPath ? path.resolve(appDirectory, configuredPath) : defaultManifestFile;
+}
+
+/**
+ * Validates product fields consumed by the frontend build.
+ *
+ * @param {unknown} manifest Parsed app build manifest.
+ * @returns {ProductInfo} Validated product metadata or app package metadata.
+ * @throws {TypeError} When the manifest, product, or consumed fields have an invalid shape.
+ */
+function validateProductInfo(manifest) {
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+    throw new TypeError('Build manifest must be a JSON object');
+  }
+
+  const product = manifest.product;
+  if (product === undefined) {
+    return appInfo;
+  }
+  if (!product || typeof product !== 'object' || Array.isArray(product)) {
+    throw new TypeError('Build manifest product must be an object');
+  }
+  for (const field of ['productName', 'version']) {
+    if (product[field] !== undefined && typeof product[field] !== 'string') {
+      throw new TypeError(`Build manifest product.${field} must be a string`);
+    }
+  }
+  return product;
+}
+
+/**
+ * Reads product metadata from the selected app build manifest.
+ *
+ * @param {NodeJS.ProcessEnv} [env] Environment used to select a custom manifest.
+ * @returns {ProductInfo} Product metadata from the selected manifest, or app package metadata
+ * when the optional default manifest is absent or has no product override.
+ * @throws {Error} When the configured manifest cannot be read or parsed as JSON.
+ */
+function readProductInfo(env = process.env) {
+  const manifestPath = resolveBuildManifestPath(env);
+  if (!env.HEADLAMP_BUILD_MANIFEST && !fs.existsSync(manifestPath)) {
+    return appInfo;
+  }
+  return validateProductInfo(JSON.parse(fs.readFileSync(manifestPath, 'utf8')));
+}
+
+/**
+ * Resolves the source revision recorded in the frontend environment.
+ *
+ * @returns {string} The configured source revision, the current Git revision, or
+ * `unknown` when Git metadata is unavailable.
+ */
+function readGitVersion() {
+  if (process.env.HEADLAMP_SOURCE_COMMIT) {
+    return process.env.HEADLAMP_SOURCE_COMMIT;
+  }
+  try {
+    return execSync('git rev-parse HEAD').toString().trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+const productInfo = readProductInfo();
 
 const envContents = {
-  REACT_APP_HEADLAMP_VERSION: appInfo.version,
-  REACT_APP_HEADLAMP_GIT_VERSION: gitVersion,
-  REACT_APP_HEADLAMP_PRODUCT_NAME: appInfo.productName,
+  REACT_APP_HEADLAMP_VERSION: productInfo.version || appInfo.version,
+  REACT_APP_HEADLAMP_GIT_VERSION: readGitVersion(),
+  REACT_APP_HEADLAMP_PRODUCT_NAME: productInfo.productName || appInfo.productName,
   REACT_APP_ENABLE_REACT_QUERY_DEVTOOLS: 'false',
-  REACT_APP_HEADLAMP_SIDEBAR_DEFAULT_OPEN: 'true'
+  REACT_APP_HEADLAMP_SIDEBAR_DEFAULT_OPEN: 'true',
 };
 
+/**
+ * Encodes a value for Vite's dotenv parser without variable expansion.
+ *
+ * The parser preserves quoted `#` characters, while dotenv-expand removes one
+ * escaping backslash before each `$`. A quote delimiter absent from the value
+ * therefore preserves both characters without changing the decoded value.
+ *
+ * @param {unknown} value Environment value to encode.
+ * @param {string} key Environment key used in validation errors.
+ * @returns {string} A dotenv-safe representation of the value.
+ * @throws {TypeError} When the value contains newlines or cannot be represented safely.
+ */
+function serializeEnvValue(value, key) {
+  const stringValue = String(value);
+  if (/[\r\n]/.test(stringValue)) {
+    throw new TypeError(`${key} must not contain newlines`);
+  }
+
+  const escapedValue = stringValue.replaceAll('$', '\\$');
+  for (const quote of ["'", '`']) {
+    if (!stringValue.includes(quote)) {
+      return `${quote}${escapedValue}${quote}`;
+    }
+  }
+  if (!stringValue.includes('"') && !/\\[nr]/.test(stringValue)) {
+    return `"${escapedValue}"`;
+  }
+  throw new TypeError(`${key} cannot be represented safely in a dotenv file`);
+}
+
+/**
+ * Serializes the generated frontend environment as newline-delimited entries.
+ *
+ * @returns {string} Environment file contents suitable for Vite.
+ */
 function createEnvText() {
   let text = '';
   Object.entries(envContents).forEach(([key, value]) => {
-    text += `${key}=${value}\n`;
+    text += `${key}=${serializeEnvValue(value, key)}\n`;
   });
 
   return text;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -86,6 +86,7 @@
         "shx": "^0.4.0",
         "simple-eval": "^2.0.0",
         "spacetime": "^7.4.0",
+        "tsx": "4.23.1",
         "typescript": "5.6.2",
         "vite": "^6.4.1",
         "vite-plugin-node-polyfills": "^0.23.0",
@@ -16722,6 +16723,453 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "integrity": "sha1-FwPaAC7kQyuaBTkXQx+RRi/KI1s=",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "integrity": "sha1-v24QMDvPLnxoaXX6Uvk37Cco2Lw=",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "integrity": "sha1-LYTs5qTiaE2SvibuE9QnV9gxw4E=",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "integrity": "sha1-DGJGvI0sTRcqrC2z+xGQ1yvWVQQ=",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "integrity": "sha1-/DjU1jWNjcHPU/CfdYn+Q262SAE=",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "integrity": "sha1-+Dr+6sHX2sAcei/QErPkUaBZH8w=",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "integrity": "sha1-UQFHwFWnlViNu+FP1rG4rQovMN4=",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "integrity": "sha1-CTuSAOzwsRW6Tl4kinSFycX4vV4=",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "integrity": "sha1-C+Irbfkl0hPoQeqHEjr134Cw+vc=",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "integrity": "sha1-vrEq1yuE9y0oSIzBuO6ffrFB11M=",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "integrity": "sha1-G9vGUc2pupmVxT7ZxxzqplCUdi0=",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "integrity": "sha1-uB+dVVKbRcIGpGoTghSxqmh5aWs=",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "integrity": "sha1-WYZnJBoEyZt27W75QKxQA4xBn5g=",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "integrity": "sha1-HFHrnOqQP1PZe1rzsYQdtw9Vlso=",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "integrity": "sha1-Y91h8XzrMagSJ/QT/qyKcbwsUfI=",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "integrity": "sha1-N2Owj95c8lqx+suOd1Lt/kX7/Cc=",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "integrity": "sha1-GhN/8pOoKQbrMXY4W9fo4OXPt8s=",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "integrity": "sha1-Jos2IRwUbKVPj+EsV4qNbviXlIU=",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "integrity": "sha1-Ilca2VHWK7aszILY0frVyMGsC6E=",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "integrity": "sha1-QvzFcpfrCgyj9fxHUpH0waP3wN4=",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "integrity": "sha1-nrMq8QSsPaz07coB9ZZmSqsMc+8=",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "integrity": "sha1-/r7SQC1giCJekfIPtM4lIq0KTv0=",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "integrity": "sha1-hWQcPUZkKL+8zqXyHCaDZmP+9c4=",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "integrity": "sha1-pzb52JYkgQRfxMPlT1R58iyHD7Q=",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "integrity": "sha1-7lq0D60YYgG2UqM/il6xSenkJTI=",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "integrity": "sha1-xA0optmaEn2mcR8q/XSxHLY7Bqc=",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "integrity": "sha1-shr/uATMFnwTPZX0WzodwTI7moc=",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.2",
+      "integrity": "sha1-D0O9G62VW3LSTiJh46vllXzPCBY=",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
     },
     "node_modules/tty-browserify": {
       "version": "0.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -87,6 +87,7 @@
     "shx": "^0.4.0",
     "simple-eval": "^2.0.0",
     "spacetime": "^7.4.0",
+    "tsx": "4.23.1",
     "typescript": "5.6.2",
     "vite": "^6.4.1",
     "vite-plugin-node-polyfills": "^0.23.0",
@@ -112,7 +113,7 @@
     "preview": "vite preview",
     "prebuild": "npm run make-version",
     "build": "cross-env PUBLIC_URL=./ NODE_OPTIONS=--max-old-space-size=8096 vite build && npx shx rm -f build/frontend/index.baseUrl.html",
-    "postbuild": "node --experimental-strip-types ./scripts/precompress-build.ts build",
+    "postbuild": "tsx ./scripts/precompress-build.ts build",
     "pretest": "npm run make-version",
     "test": "vitest",
     "test:a11y": "npm run build-storybook && node test-a11y-with-baseline.mjs",
@@ -129,7 +130,7 @@
     "make-version": "node ./make-env.js",
     "star": "cross-env REACT_APP_HEADLAMP_BACKEND_TOKEN=headlamp rsbuild dev",
     "build:rsbuild": "rsbuild build",
-    "postbuild:rsbuild": "node --experimental-strip-types ./scripts/precompress-build.ts build"
+    "postbuild:rsbuild": "tsx ./scripts/precompress-build.ts build"
   },
   "browserslist": {
     "production": [

--- a/frontend/scripts/precompress-build.test.ts
+++ b/frontend/scripts/precompress-build.test.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+import { spawnSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
-
 import { runPrecompressBuild } from './precompress-build';
 
 const tempDirs: string[] = [];
@@ -37,6 +37,37 @@ function makeTempDir(): string {
 }
 
 describe('precompress-build', () => {
+  it('runs from an installed package with tsx', () => {
+    const packageRoot = path.join(makeTempDir(), 'node_modules', 'headlamp');
+    const scriptDirectory = path.join(packageRoot, 'frontend', 'scripts');
+    const buildDirectory = path.join(packageRoot, 'frontend', 'build');
+    const installedScript = path.join(scriptDirectory, 'precompress-build.ts');
+    const tsxCli = path.resolve(__dirname, '../node_modules/tsx/dist/cli.mjs');
+
+    fs.mkdirSync(scriptDirectory, { recursive: true });
+    fs.mkdirSync(buildDirectory, { recursive: true });
+    fs.copyFileSync(
+      path.resolve(__dirname, '../package.json'),
+      path.join(packageRoot, 'frontend/package.json')
+    );
+    fs.copyFileSync(path.join(__dirname, 'precompress-build.ts'), installedScript);
+    fs.writeFileSync(path.join(buildDirectory, 'main.js'), 'x'.repeat(2048));
+
+    const nodeResult = spawnSync(
+      process.execPath,
+      ['--experimental-strip-types', installedScript, buildDirectory],
+      { encoding: 'utf8' }
+    );
+    expect(nodeResult.status).not.toBe(0);
+    expect(nodeResult.stderr).toContain('ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING');
+
+    const tsxResult = spawnSync(process.execPath, [tsxCli, installedScript, buildDirectory], {
+      encoding: 'utf8',
+    });
+    expect(tsxResult.status, tsxResult.stderr).toBe(0);
+    expect(fs.existsSync(path.join(buildDirectory, 'main.js.br'))).toBe(true);
+  });
+
   it('removes orphan .br sidecars', async () => {
     const buildDir = makeTempDir();
     const orphan = path.join(buildDir, 'assets', 'stale.js.br');

--- a/frontend/src/make-env.test.js
+++ b/frontend/src/make-env.test.js
@@ -17,35 +17,327 @@
 const os = require('os');
 const path = require('path');
 const { execFileSync } = require('child_process');
-const { readFileSync } = require('fs');
+const fs = require('fs');
 
-const envFile = path.join(os.tmpdir(), 'tmpEnv');
+const frontendDirectory = path.resolve(__dirname, '..');
+const repositoryDirectory = path.resolve(frontendDirectory, '..');
+const appInfo = JSON.parse(fs.readFileSync(path.join(frontendDirectory, '../app/package.json')));
 
-test('Create & verify', () => {
-  const execFile = path.resolve(path.join(__dirname, '..', 'make-env.js'));
-  execFileSync('node', [execFile, envFile]);
+function parseEnvFile(envFile) {
+  const childEnv = Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith('REACT_APP_'))
+  );
+  return JSON.parse(
+    execFileSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '-e',
+        "import { loadEnv } from 'vite'; process.stdout.write(JSON.stringify(loadEnv('test', process.argv[1], 'REACT_APP_')));",
+        path.dirname(envFile),
+      ],
+      { cwd: frontendDirectory, encoding: 'utf8', env: childEnv }
+    )
+  );
+}
 
-  const envContents = readFileSync(envFile).toString();
+async function createEnv({ manifest, manifestFile, sourceCommit, gitDirectory } = {}) {
+  const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-make-env-'));
+  const envFile = path.join(tempDirectory, '.env');
+  const generatedManifestFile = path.join(tempDirectory, 'app-build-manifest.json');
+  const previousOutputFile = process.argv[2];
+  const previousManifest = process.env.HEADLAMP_BUILD_MANIFEST;
+  const previousSourceCommit = process.env.HEADLAMP_SOURCE_COMMIT;
+  const previousGitDirectory = process.env.GIT_DIR;
 
-  const lines = envContents.split(/\r?\n/);
-  const envObj = {};
+  if (manifest !== undefined) {
+    fs.writeFileSync(generatedManifestFile, JSON.stringify(manifest));
+  }
 
-  lines.forEach(line => {
-    // Skip empty lines
-    if (!line) {
-      return;
+  process.argv[2] = envFile;
+  if (manifest === undefined && manifestFile === undefined) {
+    delete process.env.HEADLAMP_BUILD_MANIFEST;
+  } else {
+    process.env.HEADLAMP_BUILD_MANIFEST = manifestFile ?? generatedManifestFile;
+  }
+  if (sourceCommit === undefined) {
+    delete process.env.HEADLAMP_SOURCE_COMMIT;
+  } else {
+    process.env.HEADLAMP_SOURCE_COMMIT = sourceCommit;
+  }
+  if (gitDirectory === undefined) {
+    delete process.env.GIT_DIR;
+  } else {
+    process.env.GIT_DIR = gitDirectory;
+  }
+
+  try {
+    vi.resetModules();
+    await import('../make-env.js');
+    return parseEnvFile(envFile);
+  } finally {
+    process.argv[2] = previousOutputFile;
+    restoreEnv('HEADLAMP_BUILD_MANIFEST', previousManifest);
+    restoreEnv('HEADLAMP_SOURCE_COMMIT', previousSourceCommit);
+    restoreEnv('GIT_DIR', previousGitDirectory);
+    fs.rmSync(tempDirectory, { recursive: true, force: true });
+  }
+}
+
+function restoreEnv(name, value) {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+async function createStandaloneEnv({ manifest, manifestPath = 'app-build-manifest.json' } = {}) {
+  const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-standalone-env-'));
+  const tempFrontend = path.join(tempDirectory, 'frontend');
+  const tempApp = path.join(tempDirectory, 'app');
+  const envFile = path.join(tempDirectory, '.env');
+  const selectedManifest = path.join(tempApp, manifestPath);
+  fs.mkdirSync(tempFrontend);
+  fs.mkdirSync(tempApp);
+  fs.copyFileSync(
+    path.join(frontendDirectory, 'make-env.js'),
+    path.join(tempFrontend, 'make-env.mjs')
+  );
+  fs.writeFileSync(
+    path.join(tempApp, 'package.json'),
+    JSON.stringify({ productName: 'Headlamp', version: '0.0.0' })
+  );
+  if (manifest !== undefined) {
+    fs.mkdirSync(path.dirname(selectedManifest), { recursive: true });
+    fs.writeFileSync(selectedManifest, JSON.stringify(manifest));
+  }
+
+  try {
+    const env = { ...process.env, HEADLAMP_SOURCE_COMMIT: 'source-commit' };
+    if (manifestPath !== 'app-build-manifest.json') {
+      env.HEADLAMP_BUILD_MANIFEST = `./${manifestPath}`;
+    } else {
+      delete env.HEADLAMP_BUILD_MANIFEST;
     }
+    execFileSync(process.execPath, [path.join(tempFrontend, 'make-env.mjs'), envFile], {
+      cwd: tempDirectory,
+      env,
+    });
+    return parseEnvFile(envFile);
+  } finally {
+    fs.rmSync(tempDirectory, { recursive: true, force: true });
+  }
+}
 
-    const [key, val] = line.trim().split('=');
+test('writes the default product metadata without requiring Git', async () => {
+  const env = await createEnv({ sourceCommit: 'source-commit' });
 
-    expect(key.trim()).toBeDefined();
-    expect(val.trim()).toBeDefined();
+  expect(env).toMatchObject({
+    REACT_APP_HEADLAMP_VERSION: appInfo.version,
+    REACT_APP_HEADLAMP_GIT_VERSION: 'source-commit',
+    REACT_APP_HEADLAMP_PRODUCT_NAME: appInfo.productName,
+  });
+});
 
-    envObj[key] = val;
+test('reads product metadata from the default manifest', async () => {
+  const env = await createStandaloneEnv({
+    manifest: { product: { productName: 'Default Product', version: '2.3.4' } },
   });
 
-  const keys = Object.keys(envObj);
-  expect(keys).toContain('REACT_APP_HEADLAMP_VERSION');
-  expect(keys).toContain('REACT_APP_HEADLAMP_GIT_VERSION');
-  expect(keys).toContain('REACT_APP_HEADLAMP_PRODUCT_NAME');
+  expect(env).toMatchObject({
+    REACT_APP_HEADLAMP_VERSION: '2.3.4',
+    REACT_APP_HEADLAMP_PRODUCT_NAME: 'Default Product',
+  });
+});
+
+test('falls back to package metadata when the default manifest is absent', async () => {
+  const env = await createStandaloneEnv();
+
+  expect(env).toMatchObject({
+    REACT_APP_HEADLAMP_VERSION: '0.0.0',
+    REACT_APP_HEADLAMP_PRODUCT_NAME: 'Headlamp',
+  });
+});
+
+test('resolves a relative custom manifest from the app directory', async () => {
+  const env = await createStandaloneEnv({
+    manifest: { product: { productName: 'Relative Product', version: '3.4.5' } },
+    manifestPath: 'product/app-build-manifest.json',
+  });
+
+  expect(env).toMatchObject({
+    REACT_APP_HEADLAMP_VERSION: '3.4.5',
+    REACT_APP_HEADLAMP_PRODUCT_NAME: 'Relative Product',
+  });
+});
+
+test('uses custom product metadata and the source commit', async () => {
+  const env = await createEnv({
+    manifest: {
+      product: {
+        version: '1.2.3',
+        productName: 'Example Desktop',
+      },
+    },
+    sourceCommit: '0123456789abcdef',
+  });
+
+  expect(env).toMatchObject({
+    REACT_APP_HEADLAMP_VERSION: '1.2.3',
+    REACT_APP_HEADLAMP_GIT_VERSION: '0123456789abcdef',
+    REACT_APP_HEADLAMP_PRODUCT_NAME: 'Example Desktop',
+  });
+});
+
+test('falls back to package metadata for omitted product fields', async () => {
+  const env = await createEnv({
+    manifest: { product: { productName: 'Example Desktop' } },
+    sourceCommit: 'source-commit',
+  });
+
+  expect(env).toMatchObject({
+    REACT_APP_HEADLAMP_VERSION: appInfo.version,
+    REACT_APP_HEADLAMP_PRODUCT_NAME: 'Example Desktop',
+  });
+});
+
+test('falls back to package metadata for empty product fields', async () => {
+  const env = await createEnv({
+    manifest: { product: { productName: '', version: '' } },
+    sourceCommit: 'source-commit',
+  });
+
+  expect(env).toMatchObject({
+    REACT_APP_HEADLAMP_VERSION: appInfo.version,
+    REACT_APP_HEADLAMP_PRODUCT_NAME: appInfo.productName,
+  });
+});
+
+test('falls back to package metadata when a manifest has no product', async () => {
+  const env = await createEnv({
+    manifest: {},
+    sourceCommit: 'source-commit',
+  });
+
+  expect(env).toMatchObject({
+    REACT_APP_HEADLAMP_VERSION: appInfo.version,
+    REACT_APP_HEADLAMP_PRODUCT_NAME: appInfo.productName,
+  });
+});
+
+test.each([
+  ['a non-object manifest', []],
+  ['a non-object product', { product: 'Example Desktop' }],
+  ['a non-string version', { product: { version: 123 } }],
+  ['a non-string product name', { product: { productName: ['Example Desktop'] } }],
+])('rejects %s', async (_description, manifest) => {
+  await expect(createEnv({ manifest, sourceCommit: 'source-commit' })).rejects.toThrow();
+});
+
+test('preserves dotenv-sensitive characters through Vite', async () => {
+  const env = await createEnv({
+    manifest: {
+      product: {
+        productName: 'C# $HOME O\'Reilly "Desktop" \\path',
+        version: '1.2.3=build',
+      },
+    },
+    sourceCommit: 'source=commit',
+  });
+
+  expect(env).toMatchObject({
+    REACT_APP_HEADLAMP_VERSION: '1.2.3=build',
+    REACT_APP_HEADLAMP_GIT_VERSION: 'source=commit',
+    REACT_APP_HEADLAMP_PRODUCT_NAME: 'C# $HOME O\'Reilly "Desktop" \\path',
+  });
+});
+
+test.each([
+  ['all quote delimiters', '\'"`# Desktop'],
+  ['matching outer delimiters', "'a\"`b'"],
+  ['a leading double quote with an escaped newline', '"a\\nb\'`'],
+])('rejects values dotenv cannot represent safely: %s', async (_description, productName) => {
+  await expect(
+    createEnv({
+      manifest: { product: { productName } },
+      sourceCommit: 'source-commit',
+    })
+  ).rejects.toThrow(/represented safely/);
+});
+
+test.each([
+  ['the product name', { manifest: { product: { productName: 'Example\nInjected' } } }],
+  ['the product version', { manifest: { product: { version: '1.2.3\rInjected' } } }],
+  ['the source commit', { sourceCommit: 'source\nREACT_APP_INJECTED=value' }],
+])('rejects newlines in %s', async (_description, options) => {
+  await expect(createEnv(options)).rejects.toThrow(/newlines/);
+});
+
+test('uses an unknown Git version outside a repository', async () => {
+  const env = await createEnv({ gitDirectory: path.join(os.tmpdir(), 'missing-headlamp-git') });
+
+  expect(env.REACT_APP_HEADLAMP_GIT_VERSION).toBe('unknown');
+});
+
+test('container build entry points pass the source revision', () => {
+  const sourceCommit = '0123456789abcdef';
+  const makeOutput = execFileSync(
+    'make',
+    [
+      '--dry-run',
+      'image',
+      'DOCKER_CMD=echo',
+      'DOCKER_BUILDX_CMD=buildx',
+      `HEADLAMP_SOURCE_COMMIT=${sourceCommit}`,
+    ],
+    { cwd: repositoryDirectory, encoding: 'utf8' }
+  );
+  const rootPackage = JSON.parse(
+    fs.readFileSync(path.join(repositoryDirectory, 'package.json'), 'utf8')
+  );
+  const dockerfile = fs.readFileSync(path.join(repositoryDirectory, 'Dockerfile'), 'utf8');
+  const dependencyInstall = dockerfile.indexOf('RUN cd ./frontend && npm ci --only=prod');
+  const sourceCommitArgument = dockerfile.indexOf('ARG HEADLAMP_SOURCE_COMMIT');
+
+  expect(makeOutput).toContain(`--build-arg HEADLAMP_SOURCE_COMMIT=${sourceCommit}`);
+  expect(rootPackage.scripts['image:build']).toContain(
+    '--build-arg HEADLAMP_SOURCE_COMMIT=$(git rev-parse HEAD)'
+  );
+  expect(dependencyInstall).toBeGreaterThan(-1);
+  expect(sourceCommitArgument).toBeGreaterThan(dependencyInstall);
+  expect(dockerfile).not.toMatch(/^COPY (?:\.\/)?app(?:\/| )/m);
+  expect(dockerfile).toContain(
+    'RUN --mount=type=bind,source=app,target=/headlamp/app,ro \\\n    cd ./frontend && npm run build'
+  );
+});
+
+test('container workflows pass the checked-out source revision', () => {
+  const workflowsDirectory = path.join(repositoryDirectory, '.github/workflows');
+  const dockerWorkflows = fs
+    .readdirSync(workflowsDirectory)
+    .filter(fileName => /\.ya?ml$/.test(fileName))
+    .map(fileName => ({
+      fileName,
+      contents: fs.readFileSync(path.join(workflowsDirectory, fileName), 'utf8'),
+    }))
+    .filter(({ contents }) => contents.includes('docker/build-push-action@'));
+
+  expect(dockerWorkflows.map(({ fileName }) => fileName).sort()).toEqual([
+    'build-other-arch.yml',
+    'container-publish.yml',
+    'nightly-build.yml',
+  ]);
+  for (const { fileName, contents } of dockerWorkflows) {
+    expect(contents, fileName).toMatch(
+      /build-args:\s*\|?\s*\n\s+HEADLAMP_SOURCE_COMMIT=\$\{\{ (?:github\.sha|env\.HEADLAMP_SOURCE_COMMIT) \}\}/
+    );
+  }
+
+  const publishWorkflow = dockerWorkflows.find(
+    ({ fileName }) => fileName === 'container-publish.yml'
+  ).contents;
+  expect(publishWorkflow.indexOf('git checkout ${{ env.BUILD_TAG }}')).toBeLessThan(
+    publishWorkflow.indexOf('HEADLAMP_SOURCE_COMMIT=$(git rev-parse HEAD)')
+  );
 });

--- a/frontend/src/packageScripts.test.js
+++ b/frontend/src/packageScripts.test.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const frontendDirectory = path.resolve(__dirname, '..');
+const repositoryDirectory = path.resolve(frontendDirectory, '..');
+
+/**
+ * Read a JSON file.
+ *
+ * @param {string} filePath Path to the JSON file.
+ * @returns {object} Parsed JSON value.
+ */
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+test('packaged-source scripts use package-owned tsx', () => {
+  const rootPackage = readJson(path.join(repositoryDirectory, 'package.json'));
+  const frontendPackage = readJson(path.join(frontendDirectory, 'package.json'));
+  const dependencySync = fs.readFileSync(
+    path.join(repositoryDirectory, 'plugins/headlamp-plugin/dependencies-sync.js'),
+    'utf8'
+  );
+
+  expect(rootPackage.devDependencies).toHaveProperty('tsx');
+  expect(rootPackage.scripts['app:build']).toContain('tsx ./scripts/setup-plugins.ts');
+  expect(rootPackage.scripts['app:build:dir']).toContain('tsx ./scripts/setup-plugins.ts');
+  expect(rootPackage.scripts['app:start']).toContain('tsx ./scripts/setup-plugins.ts');
+  expect(frontendPackage.dependencies).toHaveProperty('tsx');
+  expect(frontendPackage.scripts.postbuild).toBe('tsx ./scripts/precompress-build.ts build');
+  expect(frontendPackage.scripts['postbuild:rsbuild']).toBe(
+    'tsx ./scripts/precompress-build.ts build'
+  );
+  expect(dependencySync).toMatch(/dependenciesToNotCopy = \[[\s\S]*?'tsx'/);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "concurrently": "^8.2.2"
+        "concurrently": "^8.2.2",
+        "tsx": "4.23.1"
       },
       "engines": {
         "node": ">=22.6.0",
@@ -24,6 +25,422 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "integrity": "sha1-v24QMDvPLnxoaXX6Uvk37Cco2Lw=",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "integrity": "sha1-LYTs5qTiaE2SvibuE9QnV9gxw4E=",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "integrity": "sha1-DGJGvI0sTRcqrC2z+xGQ1yvWVQQ=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "integrity": "sha1-/DjU1jWNjcHPU/CfdYn+Q262SAE=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "integrity": "sha1-+Dr+6sHX2sAcei/QErPkUaBZH8w=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "integrity": "sha1-UQFHwFWnlViNu+FP1rG4rQovMN4=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "integrity": "sha1-CTuSAOzwsRW6Tl4kinSFycX4vV4=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "integrity": "sha1-C+Irbfkl0hPoQeqHEjr134Cw+vc=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "integrity": "sha1-vrEq1yuE9y0oSIzBuO6ffrFB11M=",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "integrity": "sha1-G9vGUc2pupmVxT7ZxxzqplCUdi0=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "integrity": "sha1-uB+dVVKbRcIGpGoTghSxqmh5aWs=",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "integrity": "sha1-WYZnJBoEyZt27W75QKxQA4xBn5g=",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "integrity": "sha1-HFHrnOqQP1PZe1rzsYQdtw9Vlso=",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "integrity": "sha1-Y91h8XzrMagSJ/QT/qyKcbwsUfI=",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "integrity": "sha1-N2Owj95c8lqx+suOd1Lt/kX7/Cc=",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "integrity": "sha1-GhN/8pOoKQbrMXY4W9fo4OXPt8s=",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "integrity": "sha1-Jos2IRwUbKVPj+EsV4qNbviXlIU=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "integrity": "sha1-Ilca2VHWK7aszILY0frVyMGsC6E=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "integrity": "sha1-QvzFcpfrCgyj9fxHUpH0waP3wN4=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "integrity": "sha1-nrMq8QSsPaz07coB9ZZmSqsMc+8=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "integrity": "sha1-/r7SQC1giCJekfIPtM4lIq0KTv0=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "integrity": "sha1-hWQcPUZkKL+8zqXyHCaDZmP+9c4=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "integrity": "sha1-pzb52JYkgQRfxMPlT1R58iyHD7Q=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "integrity": "sha1-7lq0D60YYgG2UqM/il6xSenkJTI=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "integrity": "sha1-xA0optmaEn2mcR8q/XSxHLY7Bqc=",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "integrity": "sha1-shr/uATMFnwTPZX0WzodwTI7moc=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ansi-regex": {
@@ -169,6 +586,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "integrity": "sha1-D0O9G62VW3LSTiJh46vllXzPCBY=",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -177,6 +635,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "integrity": "sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -315,6 +786,24 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "integrity": "sha1-FwPaAC7kQyuaBTkXQx+RRi/KI1s=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "i18n:extract": "cd tools/i18n && npm run extract --",
     "i18n:copy": "cd tools/i18n && npm run copy --",
     "app:install": "cd app && npm install",
-    "app:build": "npm run frontend:build && cd app && node --experimental-strip-types ./scripts/setup-plugins.ts && npm run build",
-    "app:build:dir": "npm run frontend:build && cd app && node --experimental-strip-types ./scripts/setup-plugins.ts && npm run build -- --dir",
+    "app:build": "npm run frontend:build && cd app && tsx ./scripts/setup-plugins.ts && npm run build",
+    "app:build:dir": "npm run frontend:build && cd app && tsx ./scripts/setup-plugins.ts && npm run build -- --dir",
     "app:package": "npm run app:build && cd app && npm run package -- --win --linux --mac",
     "app:package:win": "npm run app:build && cd app && npm run package -- --win",
     "app:package:win:msi": "npm run app:build && cd app && npm run package-msi",
@@ -72,7 +72,7 @@
     "app:format": "cd app && npm run format",
     "app:lint": "cd app && npm run lint",
     "app:lint:fix": "cd app && npm run lint-fix",
-    "app:start": "cd app && node --experimental-strip-types ./scripts/setup-plugins.ts && npm run start",
+    "app:start": "cd app && tsx ./scripts/setup-plugins.ts && npm run start",
     "app:start:client": "cd app && npm run dev-only-app",
     "app:start:client:debug": "cd app && npm run dev-only-app:debug",
     "start:with-app": "concurrently \"npm run backend:start\" \"npm run frontend:start\" \"npm run app:start:client\" --names \"backend,frontend,app\" --prefix-colors \"blue,green,yellow\"",
@@ -89,7 +89,8 @@
     "image:verify-image-digests": "node tools/verify-image-digests.js"
   },
   "devDependencies": {
-    "concurrently": "^8.2.2"
+    "concurrently": "^8.2.2",
+    "tsx": "4.23.1"
   },
   "keywords": [
     "kubernetes",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "app:verify-build-windows": "cd app && npm run verify-build-windows",
     "tools:install": "cd tools && cd i18n && npm install && cd .. && cd releaser && npm install",
     "plugins:test": "cd plugins/headlamp-plugin && npm install && ./test-headlamp-plugin.js && ./test-plugins-examples.sh && cd ../pluginctl/src && npm install && node ./plugin-management.e2e.js && cd .. && npx jest src/multi-plugin-management.test.js && npx jest src/plugin-management.test.js && npm run test",
-    "image:build": "sh -c 'docker buildx build --pull --platform=local -t ghcr.io/headlamp-k8s/headlamp:$(git describe --tags --always --dirty) -f Dockerfile .'",
+    "image:build": "sh -c 'docker buildx build --pull --platform=local --build-arg HEADLAMP_SOURCE_COMMIT=$(git rev-parse HEAD) -t ghcr.io/headlamp-k8s/headlamp:$(git describe --tags --always --dirty) -f Dockerfile .'",
     "image:verify-image-digests": "node tools/verify-image-digests.js"
   },
   "devDependencies": {

--- a/plugins/headlamp-plugin/dependencies-sync.js
+++ b/plugins/headlamp-plugin/dependencies-sync.js
@@ -76,6 +76,7 @@ const dependenciesToNotCopy = [
   'remark-gfm',
   '@typescript/native-preview',
   '@chanzuckerberg/axe-storybook-testing',
+  'tsx',
 ];
 
 // Dependencies that can have different versions


### PR DESCRIPTION
## Summary

- Generate frontend product name and version from the selected app build manifest, including the checked-in default manifest.
- Serialize accepted metadata for Vite's dotenv grammar so `#`, `$`, quotes, backslashes, and `=` round-trip without comments or expansion; reject values that cannot be represented safely.
- Preserve source revisions through `HEADLAMP_SOURCE_COMMIT`, with a safe `unknown` fallback when Git metadata is unavailable.
- Build containers without copying `.git` or `app/` into frontend image layers; bind app metadata and manifests read-only only while the frontend build runs.
- Pass source revisions through Make, npm, nightly, release, and alternate-architecture image builds.
- Keep revision and manifest arguments after the cached dependency-install stage so metadata changes do not rerun `npm ci`.
- Run TypeScript build scripts with package-owned `tsx` so source packages installed under `node_modules` work with Node 22.
- Document manifest defaults, path behavior, fallbacks, validation, and direct Docker build arguments.

## Improvements over the existing changes

- Add focused unit coverage before implementation for default/custom manifests, app-relative paths, package fallbacks, invalid shapes, empty identity fields, missing Git metadata, Vite dotenv round-tripping, unsafe-value rejection, Docker cache-layer ordering, app-copy exclusion, direct image entry points, and TypeScript runner ownership. `frontend/make-env.js` has 87.5% branch coverage and 100% function coverage.
- Add a real installed-package regression under `node_modules/headlamp`: Node's built-in type stripping fails with `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`, while `tsx` executes the same precompression script successfully.
- Align empty `productName` and `version` handling with Electron packaging so both retain values from `app/package.json`.
- Add Playwright e2e coverage before implementation that loads the generated file through Vite and verifies custom product metadata and source revision propagation.
- Remove the ambiguous unquoted dotenv fallback; values containing all supported quote delimiters fail explicitly instead of being transformed silently.
- Keep root `tsx` for app setup scripts and add frontend-owned `tsx` for standalone and Docker frontend installs; exclude it from generated plugin dependencies.
- Pin the `tsx`/`esbuild` graph in both lockfiles without registry-specific `resolved` URLs, so consumers can select their configured registry.
- Avoid persisting Git history or Electron app sources in frontend image layers while preserving dependency-layer caching and arbitrary app-relative manifest selection.
- Record the post-checkout release SHA so manually selected release tags retain accurate source metadata.

## Source and related changes

- Original Azure/aks-desktop PR: https://github.com/Azure/aks-desktop/pull/823
- Source patch-series commit: https://github.com/Azure/aks-desktop/commit/387eb27e3f586211610dda61949255e7264a9c95
- Source patch: `patches/0069-headlamp-package-install-policy.patch`

The 0069 change is introduced by the original PR and source commit above; no separate Azure/aks-desktop PR associated with this patch was found.

## Testing

- `npm test -- --run src/make-env.test.js --coverage --coverage.include=make-env.js`: 22 passed; 87.5% branch coverage and 100% function coverage.
- Packaged-source focused suite after lock-test cleanup: 26 passed across metadata, precompression, and package ownership.
- Full frontend suite with coverage before the final two redundant lockfile cases were removed: 242 test files and 3,174 tests passed.
- `npm run frontend:build`: Vite build passed; frontend-local `tsx` ran postbuild and compressed 293 files.
- `playwright test tests/buildManifestProduct.spec.ts --config=playwright.electron.config.ts`: 2 passed.
- `make --dry-run image ... HEADLAMP_SOURCE_COMMIT=0123456789abcdef`: includes the expected Docker build argument.
- Dockerfile assertions: metadata arguments follow `npm ci`, no app paths are copied, and app metadata is exposed through a read-only build mount.
- Workflow assertions enumerate every direct `docker/build-push-action` caller and verify source revision arguments, including post-checkout release ordering.
- Manual root/frontend lockfile audit: each graph has 28 pinned `tsx`/`esbuild` entries and no registry-specific `resolved` URLs. No committed test reads or asserts the lockfiles.
- Frontend CI lint/format, plugin dependency synchronization, and `git diff --check`: passed.

A fresh local production `npm ci` could not complete because this machine returned `ENOTCONN` for registry.npmjs.org. Both committed lockfiles were audited structurally outside the automated test suite, and GitHub container/build checks exercise the clean install. Dockerfile `buildx --check` could not run locally because the Docker daemon is unavailable.

## Screenshots

Not applicable. This changes build metadata and container assembly without a visual UI change.

Assisted by copilot

