### PR TITLE
0008: app: build-manifest: Verify packaged resources

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -92,6 +92,27 @@ string or `filter` string array. Manifest resources are appended to Headlamp's
 existing resources rather than replacing them. Invalid resource configuration
 stops the build before Electron Builder packaging.
 
+Packagers can also require selected files to match SHA-256 digests after
+Electron Builder copies them. Verification paths are relative to the packaged
+resources directory and must resolve to regular files beneath that directory:
+
+```json
+{
+  "verify": [
+    {
+      "path": "tools/helper",
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "platforms": ["linux", "mac"]
+    }
+  ]
+}
+```
+
+The optional `platforms` array accepts `linux`, `mac`, and `win`; entries without
+it apply to every package. Verification runs from Electron Builder's `afterPack`
+hook and stops packaging when a resource is missing, outside the resources
+directory, not a regular file, or does not match its declared digest.
+
 For example, from the repository root:
 
 ```bash

--- a/app/e2e-tests/tests/buildManifest.spec.ts
+++ b/app/e2e-tests/tests/buildManifest.spec.ts
@@ -15,7 +15,8 @@
  */
 
 import { expect, test } from '@playwright/test';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -98,5 +99,57 @@ test('custom manifest settings reach the Electron Builder configuration', () => 
     });
   } finally {
     fs.rmSync(manifestDir, { recursive: true, force: true });
+  }
+});
+
+test('after-pack rejects a packaged resource after it is tampered with', () => {
+  const packageDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-package-'));
+  const resourcesDirectory = path.join(packageDirectory, 'packaged-resources');
+  const resourceFile = path.join(resourcesDirectory, 'tools', 'tool');
+  const manifestFile = path.join(packageDirectory, 'app-build-manifest.json');
+  fs.mkdirSync(path.dirname(resourceFile), { recursive: true });
+  fs.writeFileSync(resourceFile, 'bundled tool');
+  fs.writeFileSync(
+    manifestFile,
+    JSON.stringify({
+      verify: [
+        {
+          path: 'tools/tool',
+          sha256: crypto.createHash('sha256').update('bundled tool').digest('hex'),
+          platforms: ['linux'],
+        },
+      ],
+    })
+  );
+  const hookScript = [
+    "const path = require('node:path');",
+    "const hook = require('./scripts/after-pack.js').default;",
+    'const appOutDir = process.argv[1];',
+    'hook({',
+    '  appOutDir,',
+    "  electronPlatformName: 'linux',",
+    '  packager: { getResourcesDir: directory => path.join(directory, "packaged-resources") },',
+    '}).catch(error => { console.error(error.message); process.exitCode = 1; });',
+  ].join('\n');
+  const runHook = () =>
+    spawnSync(
+      process.execPath,
+      ['--no-experimental-strip-types', '-e', hookScript, packageDirectory],
+      {
+        cwd: appPath,
+        encoding: 'utf8',
+        env: { ...process.env, HEADLAMP_BUILD_MANIFEST: manifestFile },
+      }
+    );
+
+  try {
+    expect(runHook().status).toBe(0);
+
+    fs.writeFileSync(resourceFile, 'tampered tool');
+    const tampered = runHook();
+    expect(tampered.status).not.toBe(0);
+    expect(tampered.stderr).toContain('SHA-256 mismatch for packaged resource tools/tool');
+  } finally {
+    fs.rmSync(packageDirectory, { recursive: true, force: true });
   }
 });

--- a/app/electron/build-manifest.test.ts
+++ b/app/electron/build-manifest.test.ts
@@ -30,6 +30,7 @@ import {
   DEFAULT_MANIFEST_FILE,
   loadBuildManifest,
   resolveBuildManifestPath,
+  verifyPackagedResources,
 } from '../scripts/build-manifest.ts';
 import {
   applyEnabledByDefault,
@@ -539,6 +540,193 @@ function temporaryFile(contents: string): string {
   fs.writeFileSync(file, contents);
   return file;
 }
+
+describe('packaged resource verification', () => {
+  it('preserves packages when verification is absent', () => {
+    expect(() => verifyPackagedResources('/missing', {}, 'linux')).not.toThrow();
+  });
+
+  it.each([
+    { runtimePlatform: 'darwin', manifestPlatform: 'mac' },
+    { runtimePlatform: 'mas', manifestPlatform: 'mac' },
+    { runtimePlatform: 'win32', manifestPlatform: 'win' },
+    { runtimePlatform: 'linux', manifestPlatform: 'linux' },
+  ])(
+    'accepts a matching digest for $runtimePlatform packages',
+    ({ runtimePlatform, manifestPlatform }) => {
+      const file = temporaryFile('bundled tool');
+      const digest = crypto.createHash('sha256').update('bundled tool').digest('hex').toUpperCase();
+
+      expect(() =>
+        verifyPackagedResources(
+          path.dirname(file),
+          {
+            verify: [{ path: path.basename(file), sha256: digest, platforms: [manifestPlatform] }],
+          },
+          runtimePlatform
+        )
+      ).not.toThrow();
+    }
+  );
+
+  it('skips entries for other packaged platforms', () => {
+    expect(() =>
+      verifyPackagedResources(
+        '/missing',
+        { verify: [{ path: 'tool.exe', sha256: '0'.repeat(64), platforms: ['win'] }] },
+        'linux'
+      )
+    ).not.toThrow();
+  });
+
+  it.each([null, [], 'manifest'])('rejects an invalid manifest value: %j', manifest => {
+    expect(() => verifyPackagedResources('/resources', manifest, 'linux')).toThrow(
+      'Build manifest must be an object'
+    );
+  });
+
+  it.each([null, {}, 'resource'])('rejects an invalid verify value: %j', verify => {
+    expect(() => verifyPackagedResources('/resources', { verify }, 'linux')).toThrow(
+      'Build manifest verify must be an array'
+    );
+  });
+
+  it.each([
+    null,
+    [],
+    'resource',
+    {},
+    { path: '', sha256: '0'.repeat(64) },
+    { path: 1, sha256: '0'.repeat(64) },
+    { path: 'tool', sha256: 1 },
+    { path: 'tool', sha256: '0'.repeat(64), platforms: 'linux' },
+    { path: 'tool', sha256: '0'.repeat(64), platforms: ['android'] },
+    { path: 'tool', sha256: '0'.repeat(64), unsafe: true },
+  ])('rejects an invalid verification entry: %j', verification => {
+    expect(() =>
+      verifyPackagedResources('/resources', { verify: [verification] }, 'linux')
+    ).toThrow('Invalid build manifest verify[0]');
+  });
+
+  it.each(['0', 'g'.repeat(64), `${'0'.repeat(64)}00`])(
+    'rejects an invalid SHA-256 digest: %s',
+    sha256 => {
+      expect(() =>
+        verifyPackagedResources('/resources', { verify: [{ path: 'tool', sha256 }] }, 'linux')
+      ).toThrow('Invalid SHA-256 for packaged resource tool');
+    }
+  );
+
+  it.each(['../tool', '/outside/tool'])(
+    'rejects a resource path outside the package: %s',
+    entry => {
+      const resourcesDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-resources-'));
+      temporaryDirectories.push(resourcesDirectory);
+
+      expect(() =>
+        verifyPackagedResources(
+          resourcesDirectory,
+          { verify: [{ path: entry, sha256: '0'.repeat(64) }] },
+          'linux'
+        )
+      ).toThrow('escapes the resources directory');
+    }
+  );
+
+  it('rejects resources reached through a parent directory symlink', () => {
+    const resourcesDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-resources-'));
+    const outsideDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-outside-'));
+    temporaryDirectories.push(resourcesDirectory, outsideDirectory);
+    const contents = 'bundled tool';
+    fs.writeFileSync(path.join(outsideDirectory, 'tool'), contents);
+    fs.symlinkSync(
+      outsideDirectory,
+      path.join(resourcesDirectory, 'tools'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    );
+
+    expect(() =>
+      verifyPackagedResources(
+        resourcesDirectory,
+        {
+          verify: [
+            {
+              path: 'tools/tool',
+              sha256: crypto.createHash('sha256').update(contents).digest('hex'),
+            },
+          ],
+        },
+        'linux'
+      )
+    ).toThrow('escapes the resources directory');
+  });
+
+  it.each([
+    { name: 'missing files', prepare: () => undefined },
+    { name: 'directories', prepare: (resource: string) => fs.mkdirSync(resource) },
+    {
+      name: 'symbolic links',
+      prepare: (resource: string) => {
+        const target = `${resource}-target`;
+        fs.writeFileSync(target, 'bundled tool');
+        fs.symlinkSync(target, resource);
+      },
+    },
+  ])('rejects $name', ({ prepare }) => {
+    const resourcesDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-resources-'));
+    temporaryDirectories.push(resourcesDirectory);
+    const resource = path.join(resourcesDirectory, 'tool');
+    prepare(resource);
+
+    expect(() =>
+      verifyPackagedResources(
+        resourcesDirectory,
+        { verify: [{ path: 'tool', sha256: '0'.repeat(64) }] },
+        'linux'
+      )
+    ).toThrow('Packaged resource is not a regular file: tool');
+  });
+
+  it('rejects digest mismatches', () => {
+    const file = temporaryFile('bundled tool');
+
+    expect(() =>
+      verifyPackagedResources(
+        path.dirname(file),
+        { verify: [{ path: path.basename(file), sha256: '0'.repeat(64) }] },
+        'linux'
+      )
+    ).toThrow(`SHA-256 mismatch for packaged resource ${path.basename(file)}`);
+  });
+
+  it('hashes packaged resources without reading the whole file at once', () => {
+    const contents = Buffer.alloc(128 * 1024, 'a');
+    const resourcesDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-resources-'));
+    temporaryDirectories.push(resourcesDirectory);
+    fs.writeFileSync(path.join(resourcesDirectory, 'tool'), contents);
+    const readFileSync = vi.spyOn(fs, 'readFileSync');
+
+    try {
+      expect(() =>
+        verifyPackagedResources(
+          resourcesDirectory,
+          {
+            verify: [
+              {
+                path: 'tool',
+                sha256: crypto.createHash('sha256').update(contents).digest('hex'),
+              },
+            ],
+          },
+          'linux'
+        )
+      ).not.toThrow();
+      expect(readFileSync).not.toHaveBeenCalled();
+    } finally {
+      readFileSync.mockRestore();
+    }
+  });
+});
 
 describe('build manifest selection', () => {
   it('uses Headlamp defaults when no product manifest is configured', () => {

--- a/app/scripts/after-pack.js
+++ b/app/scripts/after-pack.js
@@ -4,12 +4,21 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 exports.default = async context => {
+  const { loadBuildManifest, verifyPackagedResources } = await import(
+    '../build/build-manifest.mjs'
+  );
+  const resourcesDirectory = context.packager?.getResourcesDir
+    ? context.packager.getResourcesDir(context.appOutDir)
+    : path.join(context.appOutDir, 'resources');
+
   if (fs.existsSync('.env')) {
     console.info('Copying .env file to app resources directory!');
     try {
-      fs.copyFileSync('.env', path.join(context.appOutDir, 'resources', '.env'));
+      fs.copyFileSync('.env', path.join(resourcesDirectory, '.env'));
     } catch (err) {
       console.error('Failed to copy .env after pack:', err);
     }
   }
+
+  verifyPackagedResources(resourcesDirectory, loadBuildManifest(), context.electronPlatformName);
 };

--- a/app/scripts/build-electron.js
+++ b/app/scripts/build-electron.js
@@ -8,6 +8,7 @@ const isDev = process.argv.includes('--dev');
 // CJS bundling would otherwise inline these dynamic imports into main.js.
 // Separate entries keep their module graphs out of startup memory until first use.
 const mcpAdapterEntry = path.resolve(__dirname, '../electron/mcp/MCPAdapter.ts');
+const buildManifestEntry = path.resolve(__dirname, './build-manifest.ts');
 const lazyDependencies = {
   'find-process': './lazy/find-process.js',
   semver: './lazy/semver.js',
@@ -59,6 +60,11 @@ const entryPoints = [
   {
     entryPoints: [mcpAdapterEntry],
     outfile: path.resolve(__dirname, '../build/mcp/MCPAdapter.js'),
+  },
+  {
+    entryPoints: [buildManifestEntry],
+    format: 'esm',
+    outfile: path.resolve(__dirname, '../build/build-manifest.mjs'),
   },
   {
     entryPoints: [require.resolve('find-process')],

--- a/app/scripts/build-manifest.ts
+++ b/app/scripts/build-manifest.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -38,6 +39,9 @@ export type BuildManifest = {
 
   /** Per-platform package targets consumed by Electron Builder. */
   targets?: Record<string, unknown>;
+
+  /** Packaged files whose SHA-256 digests must match after packaging. */
+  verify?: BuildVerification[];
 
   [key: string]: unknown;
 };
@@ -64,6 +68,18 @@ type BuildResource = {
 
   /** Optional destination beneath the packaged resources directory. */
   to?: string;
+};
+
+/** A packaged resource integrity requirement from a product manifest. */
+type BuildVerification = {
+  /** Relative path beneath the packaged resources directory. */
+  path: string;
+
+  /** Platforms on which the resource must be verified. */
+  platforms?: Array<'linux' | 'mac' | 'win'>;
+
+  /** Expected hexadecimal SHA-256 digest. */
+  sha256: string;
 };
 
 type ProductMetadata = {
@@ -118,6 +134,124 @@ export function loadBuildManifest(
 ): BuildManifest {
   const manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf8')) as unknown;
   return validateBuildManifest(manifest);
+}
+
+/**
+ * Reports whether a candidate path is the root or is contained beneath it.
+ *
+ * @param root Absolute root path.
+ * @param candidate Absolute candidate path.
+ * @returns Whether the candidate is contained by the root.
+ */
+function isPathWithinRoot(root: string, candidate: string): boolean {
+  const relativePath = path.relative(root, candidate);
+  return (
+    relativePath === '' ||
+    (relativePath !== '..' &&
+      !relativePath.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relativePath))
+  );
+}
+
+/**
+ * Calculates a file's SHA-256 digest with bounded memory usage.
+ *
+ * @param filePath Path to the file to hash.
+ * @returns The lowercase hexadecimal SHA-256 digest.
+ */
+function calculateFileSha256(filePath: string): string {
+  const hash = crypto.createHash('sha256');
+  const buffer = Buffer.allocUnsafe(64 * 1024);
+  const descriptor = fs.openSync(filePath, 'r');
+  try {
+    let bytesRead: number;
+    do {
+      bytesRead = fs.readSync(descriptor, buffer, 0, buffer.length, null);
+      if (bytesRead > 0) {
+        hash.update(buffer.subarray(0, bytesRead));
+      }
+    } while (bytesRead > 0);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+  return hash.digest('hex');
+}
+
+/**
+ * Verifies manifest-declared files in a packaged app's resources directory.
+ *
+ * @param resourcesDirectory Root directory containing packaged resources.
+ * @param manifest Parsed application build manifest.
+ * @param platform Electron runtime platform name for the package being verified.
+ * @throws When verification declarations are malformed or a resource is unsafe or mismatched.
+ */
+export function verifyPackagedResources(
+  resourcesDirectory: string,
+  manifest: unknown,
+  platform: string
+): void {
+  if (typeof manifest !== 'object' || manifest === null || Array.isArray(manifest)) {
+    throw new Error('Build manifest must be an object');
+  }
+
+  const verification = (manifest as BuildManifest).verify;
+  if (verification === undefined) {
+    return;
+  }
+  if (!Array.isArray(verification)) {
+    throw new Error('Build manifest verify must be an array');
+  }
+
+  const platformName = { darwin: 'mac', mas: 'mac', win32: 'win' }[platform] ?? platform;
+  const root = path.resolve(resourcesDirectory);
+  for (const [index, entry] of verification.entries()) {
+    if (
+      typeof entry !== 'object' ||
+      entry === null ||
+      Array.isArray(entry) ||
+      typeof entry.path !== 'string' ||
+      entry.path.trim() === '' ||
+      typeof entry.sha256 !== 'string' ||
+      Object.keys(entry).some(key => !['path', 'platforms', 'sha256'].includes(key)) ||
+      (entry.platforms !== undefined &&
+        (!Array.isArray(entry.platforms) ||
+          entry.platforms.some(value => !['linux', 'mac', 'win'].includes(value))))
+    ) {
+      throw new Error(`Invalid build manifest verify[${index}]`);
+    }
+    if (entry.platforms && !entry.platforms.includes(platformName as 'linux' | 'mac' | 'win')) {
+      continue;
+    }
+    if (!/^[a-f0-9]{64}$/i.test(entry.sha256)) {
+      throw new Error(`Invalid SHA-256 for packaged resource ${entry.path}`);
+    }
+
+    const resource = path.resolve(root, entry.path);
+    if (!isPathWithinRoot(root, resource)) {
+      throw new Error(`Packaged resource escapes the resources directory: ${entry.path}`);
+    }
+
+    let stat: fs.Stats;
+    try {
+      stat = fs.lstatSync(resource);
+    } catch {
+      throw new Error(`Packaged resource is not a regular file: ${entry.path}`);
+    }
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw new Error(`Packaged resource is not a regular file: ${entry.path}`);
+    }
+
+    const canonicalRoot = fs.realpathSync(root);
+    const canonicalResource = fs.realpathSync(resource);
+    if (!isPathWithinRoot(canonicalRoot, canonicalResource)) {
+      throw new Error(`Packaged resource escapes the resources directory: ${entry.path}`);
+    }
+
+    const actualDigest = calculateFileSha256(resource);
+    if (actualDigest.toLowerCase() !== entry.sha256.toLowerCase()) {
+      throw new Error(`SHA-256 mismatch for packaged resource ${entry.path}`);
+    }
+  }
 }
 
 /**

--- a/docs/development/app.md
+++ b/docs/development/app.md
@@ -164,6 +164,29 @@ For example, from the repository root:
 HEADLAMP_BUILD_MANIFEST=./product/app-build-manifest.json npm run app:package
 ```
 
+#### Packaged resource verification
+
+The `verify` field checks selected files after Electron Builder copies them into
+the package. Each entry declares a path relative to the packaged resources
+directory and its expected SHA-256 digest:
+
+```json
+{
+  "verify": [
+    {
+      "path": "tools/helper",
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "platforms": ["linux", "mac"]
+    }
+  ]
+}
+```
+
+The optional `platforms` array accepts `linux`, `mac`, and `win`. An entry without
+`platforms` applies to every package. Verification stops packaging when a file
+is missing, escapes the resources directory, is a directory or symbolic link,
+or does not match its declared digest.
+
 ## Development workflow
 
 The typical development workflow for the desktop app:


### PR DESCRIPTION
## Summary

- verify manifest-declared packaged resources with SHA-256 after Electron Builder copies them
- reject path traversal, missing files, directories, symbolic links, malformed entries, unsupported options, and digest mismatches
- normalize Electron platform names and apply optional Linux, macOS, and Windows filters
- use Electron Builder's resolved resources directory for verification and `.env` copying
- cover verifier branches with unit tests and the real after-pack hook with a process-level e2e test
- document build-manifest resources and verification in the public desktop development guide

## Depends on

- https://github.com/kubernetes-sigs/headlamp/pull/7472

## Provenance

This upstreams `patches/0008-headlamp-upstream-build-manifest-resource-verification.patch` from [Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823).

- Original patch commit recorded by the patch header: `b39b97d8d7f2feaf6e0d335d146ab85132b079c4`, authored by Joaquim Rocha on 2026-08-01 (the generated SHA is not present on a published Azure ref)
- Published Azure commit retaining the numbered patch: [387eb27e3f586211610dda61949255e7264a9c95](https://github.com/Azure/aks-desktop/commit/387eb27e3f586211610dda61949255e7264a9c95)
- Published Azure commit consuming the retained patch series: [4404d719e98f04c51c9504671a7ba2f169d97005](https://github.com/Azure/aks-desktop/commit/4404d719e98f04c51c9504671a7ba2f169d97005)
- Related Azure PR carrying both published commits: [Azure/aks-desktop#823](https://github.com/Azure/aks-desktop/pull/823)

No separate published Azure PR was found for the generated patch-header commit. The behavior commit preserves Joaquim Rocha as author and the original author date, with René Dudfield added as co-author.

## Improvements over the existing changes

- port the original JavaScript helper to the current typed build-manifest module and document the manifest field, verification entry fields, parameters, return type, and errors with TSDoc, because Headlamp's build-manifest implementation moved to TypeScript after the downstream patch was generated
- reject blank paths and unknown verification properties, because accepting ambiguous or misspelled integrity declarations could leave a required resource unchecked
- report missing files with the same actionable regular-file error as directories and symbolic links, instead of exposing a raw filesystem exception
- use Electron Builder's `getResourcesDir` result for both `.env` copying and verification, because platform-specific package layouts do not always use `<appOutDir>/resources`
- compile the typed build-manifest helper to JavaScript before packaging and load that artifact from `afterPack`, because Headlamp supports Node 22.6 and native unflagged TypeScript loading was not enabled across that full runtime range
- compare canonical resource paths after rejecting final symbolic links, because lexical containment alone does not stop an intermediate directory symlink from reaching outside the package
- hash packaged resources in fixed 64 KiB chunks, because reading an entire bundled binary would make packaging memory scale with the largest verified file
- derive expected manifest resource paths with Node's platform-aware path helpers, because hardcoded POSIX expectations failed the Windows app test job even though the implementation resolved Windows paths correctly
- expand unit coverage across absent verification, all runtime platform aliases, platform filtering, uppercase digests, malformed manifests and entries, invalid digests, traversal, absolute escapes, parent-directory symlinks, missing files, directories, final symbolic links, bounded hashing, and digest mismatches; the touched module reaches 98.31% branch coverage
- add a process-level e2e test that invokes the real after-pack hook with native TypeScript loading disabled and proves a package passes before tampering and fails afterward, because helper-only tests would not catch hook integration or minimum-Node compatibility regressions
- document `HEADLAMP_BUILD_MANIFEST`, `resources`, and `verify` in `docs/development/app.md`, because these product packaging options need to be discoverable outside the package-local app README
- place unit and e2e characterization commits before the implementation commit so the expected behavior is reviewable independently

## Testing

- `npm --prefix app test` (25 files, 504 tests)
- `npm --prefix app test -- electron/build-manifest.test.ts --coverage.enabled --coverage.provider=istanbul --coverage.reporter=text --coverage.include=scripts/build-manifest.ts --coverage.thresholds.branches=80` (167 tests; 97.91% statements, 98.32% branches, 100% functions, 97.9% lines)
- `npm --prefix app run tsc`
- `npm --prefix app run lint`
- `npm --prefix app/e2e-tests run test-app -- buildManifest.spec.ts` (3 passed)
- Prettier checks for all changed TypeScript, JavaScript, and Markdown files
- `git diff --check upstream/main..HEAD`

## Manual steps to reproduce

1. Add a regular file beneath an Electron Builder package's resources directory.
2. Add a `verify` entry to the selected build manifest with the file's relative path, SHA-256 digest, and optional platform list.
3. Run the after-pack hook and confirm verification succeeds.
4. Change the packaged file without updating the digest and run the hook again.
5. Confirm packaging fails with a SHA-256 mismatch.

## Screenshots

Not applicable. This changes non-visual desktop packaging verification and does not alter the rendered interface.

Assisted by copilot
