### PR TITLE
frontend: Storybook: alignment of warning bar in PerformanceTest2000 …

### DIFF
--- a/frontend/src/components/resourceMap/GraphView.stories.tsx
+++ b/frontend/src/components/resourceMap/GraphView.stories.tsx
@@ -517,10 +517,11 @@ export const PerformanceTest2000Pods = () => {
               fontSize: '12px',
               color: changePercentage > 20 ? '#d32f2f' : '#2e7d32',
               fontStyle: 'italic',
-              maxWidth: '900px',
+              width: '100%',
               padding: '8px',
               backgroundColor: changePercentage > 20 ? '#ffebee' : '#e8f5e9',
               borderRadius: '4px',
+              boxSizing: 'border-box',
             }}
           >
             💡 <strong>Change {changePercentage}%</strong>:{' '}
@@ -1163,6 +1164,8 @@ export const PerformanceTest5000Pods = () => {
               padding: '8px',
               backgroundColor: changePercentage > 20 ? '#ffebee' : '#e8f5e9',
               borderRadius: '4px',
+              width: '100%',
+              boxSizing: 'border-box',
             }}
           >
             💡 {changePercentage > 20 ? 'Full Processing' : 'Incremental Optimization'} mode. Open
@@ -1352,6 +1355,8 @@ export const PerformanceTest20000Pods = () => {
               padding: '8px',
               backgroundColor: '#ffebee',
               borderRadius: '4px',
+              width: '100%',
+              boxSizing: 'border-box',
             }}
           >
             ⚠️ EXTREME STRESS TEST with {allResources.length} resources (~60k edges). Initial render
@@ -1582,6 +1587,8 @@ export const PerformanceTest100000Pods = () => {
               padding: '8px',
               borderRadius: '4px',
               backgroundColor: '#ffebee',
+              width: '100%',
+              boxSizing: 'border-box',
             }}
           >
             🚨 ULTIMATE STRESS TEST: {allResources.length} resources (~{edges.length} edges).

--- a/frontend/src/components/resourceMap/__snapshots__/GraphView.PerformanceTest100000Pods.stories.storyshot
+++ b/frontend/src/components/resourceMap/__snapshots__/GraphView.PerformanceTest100000Pods.stories.storyshot
@@ -125,7 +125,7 @@
            resources)
         </div>
         <div
-          style="font-size: 13px; color: rgb(211, 47, 47); font-weight: bold; border: 2px solid rgb(211, 47, 47); padding: 8px; border-radius: 4px; background-color: rgb(255, 235, 238);"
+          style="font-size: 13px; color: rgb(211, 47, 47); font-weight: bold; border: 2px solid rgb(211, 47, 47); padding: 8px; border-radius: 4px; background-color: rgb(255, 235, 238); width: 100%; box-sizing: border-box;"
         >
           🚨 ULTIMATE STRESS TEST: 
           105060

--- a/frontend/src/components/resourceMap/__snapshots__/GraphView.PerformanceTest20000Pods.stories.storyshot
+++ b/frontend/src/components/resourceMap/__snapshots__/GraphView.PerformanceTest20000Pods.stories.storyshot
@@ -130,7 +130,7 @@
            resources)
         </div>
         <div
-          style="font-size: 12px; color: rgb(211, 47, 47); font-weight: bold; padding: 8px; background-color: rgb(255, 235, 238); border-radius: 4px;"
+          style="font-size: 12px; color: rgb(211, 47, 47); font-weight: bold; padding: 8px; background-color: rgb(255, 235, 238); border-radius: 4px; width: 100%; box-sizing: border-box;"
         >
           ⚠️ EXTREME STRESS TEST with 
           34350

--- a/frontend/src/components/resourceMap/__snapshots__/GraphView.PerformanceTest2000Pods.stories.storyshot
+++ b/frontend/src/components/resourceMap/__snapshots__/GraphView.PerformanceTest2000Pods.stories.storyshot
@@ -124,7 +124,7 @@
           pods)
         </div>
         <div
-          style="font-size: 12px; color: rgb(46, 125, 50); font-style: italic; max-width: 900px; padding: 8px; background-color: rgb(232, 245, 233); border-radius: 4px;"
+          style="font-size: 12px; color: rgb(46, 125, 50); font-style: italic; width: 100%; padding: 8px; background-color: rgb(232, 245, 233); border-radius: 4px; box-sizing: border-box;"
         >
           💡 
           <strong>

--- a/frontend/src/components/resourceMap/__snapshots__/GraphView.PerformanceTest5000Pods.stories.storyshot
+++ b/frontend/src/components/resourceMap/__snapshots__/GraphView.PerformanceTest5000Pods.stories.storyshot
@@ -130,7 +130,7 @@
            resources)
         </div>
         <div
-          style="font-size: 12px; color: rgb(46, 125, 50); font-style: italic; padding: 8px; background-color: rgb(232, 245, 233); border-radius: 4px;"
+          style="font-size: 12px; color: rgb(46, 125, 50); font-style: italic; padding: 8px; background-color: rgb(232, 245, 233); border-radius: 4px; width: 100%; box-sizing: border-box;"
         >
           💡 
           Incremental Optimization


### PR DESCRIPTION
Related Issue: Fixes #7470 

### Summary:
The warning bar in the PerformanceTest2000Pods story was visually misaligned when the Change % selector was set to 25% or 50%.

**Changes:**
- Added `width: '100%'` and `boxSizing: 'border-box'` to the warning bar <div> in **PerformanceTest2000Pods** in `frontend/src/components/resourceMap/GraphView.stories.tsx`

**Root cause:**
The warning bar is a direct flex child of a container with display: flex, alignItems: center, and flexWrap: wrap. Without width: 100%, it rendered inline alongside the title, controls, and stats text instead of occupying its own row. The misalignment was most visible at 25%/50% because the red "Full Processing" message is longer than the green "Incremental Optimization" message.

**Screenrecording**

https://github.com/user-attachments/assets/b6d430f7-c9a6-471b-ab41-e983e764e499



**Steps to Test:**
1. Run `npm run frontend:storybook`
2. Navigate to GraphView / PerformanceTest2000Pods
3. Change the Change % dropdown to 25% or 50%
4. Verify the warning bar spans the full width on its own row below the controls
