### PR TITLE
frontend: daemonset: Fix tolerationSeconds not shown for NoExecute

### DIFF
--- a/frontend/src/components/daemonset/Details.test.tsx
+++ b/frontend/src/components/daemonset/Details.test.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { createMuiTheme } from '../../lib/themes';
+import { TestContext } from '../../test';
+import DaemonSetDetails from './Details';
+
+const theme = createMuiTheme({ name: 'light', base: 'light' });
+
+const { mockDetailsGrid } = vi.hoisted(() => ({
+  mockDetailsGrid: vi.fn(),
+}));
+
+vi.mock('../common/Resource', () => ({
+  DetailsGrid: (props: any) => {
+    mockDetailsGrid(props);
+    return null;
+  },
+  ContainersSection: () => null,
+  LogsButton: () => null,
+  MetadataDictGrid: () => null,
+  OwnedPodsSection: () => null,
+  RevisionHistorySection: () => null,
+  RollbackButton: () => null,
+}));
+
+vi.mock('../../lib/k8s/daemonSet', () => ({
+  default: { kind: 'DaemonSet' },
+}));
+
+const fakeDaemonSet: any = {
+  spec: {
+    template: {
+      spec: {
+        tolerations: [
+          {
+            key: 'node.kubernetes.io/unreachable',
+            operator: 'Exists',
+            effect: 'NoExecute',
+            tolerationSeconds: 300,
+          },
+          {
+            key: 'node.kubernetes.io/not-ready',
+            operator: 'Exists',
+            effect: 'NoExecute',
+          },
+          {
+            key: 'dedicated',
+            operator: 'Equal',
+            value: 'infra',
+            effect: 'NoSchedule',
+          },
+        ],
+      },
+    },
+  },
+};
+
+describe('DaemonSetDetails', () => {
+  beforeEach(() => {
+    mockDetailsGrid.mockReset();
+  });
+
+  it('shows the tolerationSeconds value for NoExecute tolerations', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'test-daemonset' }}>
+        <DaemonSetDetails />
+      </TestContext>
+    );
+
+    expect(mockDetailsGrid).toHaveBeenCalled();
+    const props = mockDetailsGrid.mock.calls[0][0];
+
+    const sections = props.extraSections(fakeDaemonSet);
+    const tolerationsSection = sections.find((s: any) => s.id === 'headlamp.daemonset-tolerations');
+
+    expect(tolerationsSection).toBeDefined();
+
+    render(
+      <ThemeProvider theme={theme}>
+        <TestContext>{tolerationsSection.section}</TestContext>
+      </ThemeProvider>
+    );
+
+    expect(screen.getByText('NoExecute (300s)')).toBeInTheDocument();
+    expect(screen.getByText('NoExecute (forever)')).toBeInTheDocument();
+    expect(screen.getByText('NoSchedule')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/daemonset/Details.tsx
+++ b/frontend/src/components/daemonset/Details.tsx
@@ -45,7 +45,7 @@ function TolerationsSection(props: TolerationsSection) {
   const tolerations = resource.spec.template.spec?.tolerations || [];
 
   function getEffectString(effect: string, seconds?: number) {
-    if (effect === 'NoExecute' && seconds === undefined) {
+    if (effect === 'NoExecute') {
       const secondsLabel = seconds === undefined ? 'forever' : `${seconds}s`;
       return `${effect} (${secondsLabel})`;
     }


### PR DESCRIPTION
## Summary

Fixes the Tolerations table on the DaemonSet details page so `tolerationSeconds` is actually shown for `NoExecute` tolerations.

## Related Issue

Closes #7478

## Changes

`getEffectString` in `frontend/src/components/daemonset/Details.tsx` had an outer condition that only entered the seconds-formatting branch when `seconds === undefined` — which is exactly the case where the inner ternary's `${seconds}s` path can never be reached. Any `NoExecute` toleration with a real `tolerationSeconds` value (e.g. `300`) fell through to the plain `return effect`, so the UI always showed `"NoExecute"` and silently dropped the seconds.

The fix drops the redundant `&& seconds === undefined` from the outer check, so the existing ternary can do what it was already written to do:
- `NoExecute` + `tolerationSeconds: 300` → `NoExecute (300s)`
- `NoExecute` + no `tolerationSeconds` → `NoExecute (forever)` (unchanged)
- Any other effect → unchanged

One line changed in the component.

## Steps to Test

1. `cd frontend && npx vitest run src/components/daemonset/Details.test.tsx`
2. Or manually: open a DaemonSet whose pod template has a toleration with `effect: NoExecute` and `tolerationSeconds: 300`, check the Tolerations table on its details page shows `NoExecute (300s)`.

Added `frontend/src/components/daemonset/Details.test.tsx`, which renders the real `TolerationsSection`/`SimpleTable` output (not mocked) for a fixture with three tolerations — `NoExecute` with `tolerationSeconds: 300`, `NoExecute` with no seconds, and a plain `NoSchedule` — and asserts all three render correctly. This test fails on `main` (reproduces the bug) and passes with the fix.

Existing DaemonSet storyshots (`Details.Default`, `Details.NoTolerations`) are unaffected — their fixtures don't set `tolerationSeconds`, so both effects already rendered "forever" before and after this change.

## Notes for the Reviewer

Confirmed no open issue or PR covers this before filing #7478.
