### PR TITLE
frontend: ingress: Fix HTTPS detection for multi-host TLS rules

### DIFF
--- a/frontend/src/components/ingress/Details.test.tsx
+++ b/frontend/src/components/ingress/Details.test.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 import { TestContext } from '../../test';
-import IngressDetails from './Details';
+import IngressDetails, { LinkStringFormat } from './Details';
 
 const { mockDetailsGrid } = vi.hoisted(() => ({
   mockDetailsGrid: vi.fn(),
@@ -179,5 +179,35 @@ describe('IngressDetails', () => {
     expect(sections).toHaveLength(1);
     expect(sections[0].id).toBe('headlamp.ingress-rules');
     expect(sections[0].section).toBeTruthy();
+  });
+});
+
+describe('LinkStringFormat', () => {
+  const multiHostTlsIngress: any = {
+    jsonData: {
+      spec: {
+        tls: [
+          {
+            hosts: ['a.example.com', 'b.example.com'],
+            secretName: 'multi-host-tls',
+          },
+        ],
+      },
+    },
+    spec: {
+      rules: [],
+    },
+  };
+
+  it('detects https for a host covered by a multi-host TLS rule', () => {
+    render(<LinkStringFormat url="b.example.com" item={multiHostTlsIngress} />);
+
+    expect(screen.getByRole('link')).toHaveAttribute('href', 'https://b.example.com/');
+  });
+
+  it('falls back to http for a host not covered by any TLS rule', () => {
+    render(<LinkStringFormat url="other.example.com" item={multiHostTlsIngress} />);
+
+    expect(screen.getByRole('link')).toHaveAttribute('href', 'http://other.example.com/');
   });
 });

--- a/frontend/src/components/ingress/Details.tsx
+++ b/frontend/src/components/ingress/Details.tsx
@@ -31,10 +31,8 @@ import SimpleTable from '../common/SimpleTable';
  * Is https used in the ingress item
  */
 function isHttpsUsed(item: Ingress, url: String) {
-  const hostList = item.jsonData.spec?.tls?.map(({ ...hosts }) => `${hosts.hosts}`) ?? [];
-  const isHttps = hostList.includes(`${url}`);
-
-  return isHttps;
+  const tlsEntries = item.jsonData.spec?.tls ?? [];
+  return tlsEntries.some(tls => (tls.hosts ?? []).includes(`${url}`));
 }
 
 export interface LinkStringFormatProps {


### PR DESCRIPTION
## Summary

Fixes `isHttpsUsed` on the Ingress details page so rule host links correctly show `https://` when the host is covered by a `tls` entry that lists multiple hosts.

## Related Issue

Closes #7480

## Changes

`isHttpsUsed` in `frontend/src/components/ingress/Details.tsx` built its host list like this:

```ts
const hostList = item.jsonData.spec?.tls?.map(({ ...hosts }) => `${hosts.hosts}`) ?? [];
```

`hosts.hosts` is a `string[]`, and template-literal-interpolating an array joins it with commas. So a `tls` entry with `hosts: ["a.example.com", "b.example.com"]` became the single string `"a.example.com,b.example.com"` in `hostList`, and `hostList.includes("a.example.com")` compared against that joined string instead of the individual host — always `false`. Rule links for a host covered by a multi-host TLS entry rendered `http://` instead of `https://`. Single-host `tls` entries happened to still work, which is why this went unnoticed.

Fixed by checking each `tls` entry's actual `hosts` array directly:

```ts
function isHttpsUsed(item: Ingress, url: String) {
  const tlsEntries = item.jsonData.spec?.tls ?? [];
  return tlsEntries.some(tls => (tls.hosts ?? []).includes(`${url}`));
}
```

## Steps to Test

1. `cd frontend && npx vitest run src/components/ingress/Details.test.tsx`
2. Or manually: create an Ingress with `spec.tls: [{ hosts: ["a.example.com", "b.example.com"], secretName: "..." }]` and a rule for `a.example.com`, open its details page, and check the Rules table shows an `https://` link.

Added two tests to the existing `frontend/src/components/ingress/Details.test.tsx`, using the already-exported `LinkStringFormat` component directly:
- a host covered by a multi-host TLS entry resolves to `https://`
- a host not covered by any TLS entry still falls back to `http://`

Confirmed the first of these fails on `main` (renders `http://` instead of `https://`) and passes with the fix.

I checked the two Ingress storyshots that exercise TLS (`Details.WithTLS`, `Details.WithWildcardTLS`) — neither is affected: `WithTLS` uses a single-host `tls` entry (unaffected either way), and `WithWildcardTLS`'s rules render an empty table regardless of this fix, since its fixture rules have no `http.paths` (an unrelated pre-existing quirk of that fixture, out of scope here).

## Notes for the Reviewer

Confirmed no open issue or PR covers this before filing #7480.
