### PR TITLE
backend: Retry safe requests after exec credential refresh

### DIFF
--- a/backend/pkg/kubeconfig/execCredentialRetry_test.go
+++ b/backend/pkg/kubeconfig/execCredentialRetry_test.go
@@ -1,0 +1,210 @@
+package kubeconfig_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+type closeTrackingBody struct {
+	io.Reader
+	closed bool
+}
+
+func (b *closeTrackingBody) Close() error {
+	b.closed = true
+
+	return nil
+}
+
+type refreshingExecRoundTripper struct {
+	calls                int
+	authorizationHeaders []string
+	unauthorizedBody     *closeTrackingBody
+}
+
+func (rt *refreshingExecRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.calls++
+	rt.authorizationHeaders = append(rt.authorizationHeaders, req.Header.Get("Authorization"))
+
+	if rt.calls == 1 {
+		// Match client-go's exec transport: it injects the cached credential into
+		// the request, then refreshes its cache after the API returns 401.
+		req.Header.Set("Authorization", "Bearer stale-token")
+
+		rt.unauthorizedBody = &closeTrackingBody{Reader: strings.NewReader("unauthorized")}
+
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Header:     make(http.Header),
+			Body:       rt.unauthorizedBody,
+			Request:    req,
+		}, nil
+	}
+
+	req.Header.Set("Authorization", "Bearer refreshed-token")
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       http.NoBody,
+		Request:    req,
+	}, nil
+}
+
+func TestExecCredentialRetryRoundTripperRetriesSafeRequestAfterUnauthorized(t *testing.T) {
+	base := &refreshingExecRoundTripper{}
+	rt := &kubeconfig.ExecCredentialRetryRoundTripper{Base: base}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://cluster.example/version", nil)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, base.calls)
+	assert.Equal(t, []string{"", ""}, base.authorizationHeaders)
+	assert.True(t, base.unauthorizedBody.closed)
+	assert.Empty(t, req.Header.Get("Authorization"))
+}
+
+func TestExecCredentialRetryRoundTripperDoesNotRetryUnsafeRequests(t *testing.T) {
+	tests := []struct {
+		name      string
+		method    string
+		body      io.Reader
+		authorize bool
+	}{
+		{name: "post", method: http.MethodPost},
+		{name: "get with body", method: http.MethodGet, body: strings.NewReader("body")},
+		{name: "caller authorization", method: http.MethodGet, authorize: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := &refreshingExecRoundTripper{}
+			rt := &kubeconfig.ExecCredentialRetryRoundTripper{Base: base}
+
+			req := httptest.NewRequestWithContext(context.Background(), tt.method, "https://cluster.example/api", tt.body)
+			if tt.authorize {
+				req.Header.Set("Authorization", "Bearer caller-token")
+			}
+
+			resp, err := rt.RoundTrip(req)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			defer func() { _ = resp.Body.Close() }()
+
+			assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+			assert.Equal(t, 1, base.calls)
+		})
+	}
+}
+
+func TestExecCredentialPluginProcess(t *testing.T) {
+	if os.Getenv("HEADLAMP_EXEC_CREDENTIAL_HELPER") != "true" {
+		return
+	}
+
+	tokenFile := os.Getenv("HEADLAMP_EXEC_CREDENTIAL_TOKEN_FILE")
+
+	token, err := os.ReadFile(tokenFile) //nolint:gosec // Test controls the temporary credential path.
+	if err != nil {
+		os.Exit(1)
+	}
+
+	err = json.NewEncoder(os.Stdout).Encode(map[string]interface{}{
+		"apiVersion": "client.authentication.k8s.io/v1",
+		"kind":       "ExecCredential",
+		"status":     map[string]string{"token": strings.TrimSpace(string(token))},
+	})
+	if err != nil {
+		os.Exit(1)
+	}
+
+	os.Exit(0)
+}
+
+func TestSetupProxyRetriesAfterExecCredentialRefresh(t *testing.T) {
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("token-one"), 0o600))
+
+	requests := 0
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requests++
+
+		if req.Header.Get("Authorization") == "Bearer token-one" {
+			require.NoError(t, os.WriteFile(tokenFile, []byte("token-two"), 0o600))
+			w.WriteHeader(http.StatusUnauthorized)
+
+			return
+		}
+
+		assert.Equal(t, "Bearer token-two", req.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx := &kubeconfig.Context{
+		Name:        "exec-context",
+		KubeContext: &api.Context{Cluster: "cluster", AuthInfo: "user"},
+		Cluster:     &api.Cluster{Server: server.URL, InsecureSkipTLSVerify: true},
+		AuthInfo: &api.AuthInfo{Exec: &api.ExecConfig{
+			APIVersion:      "client.authentication.k8s.io/v1",
+			Command:         os.Args[0],
+			Args:            []string{"-test.run=TestExecCredentialPluginProcess"},
+			InteractiveMode: api.NeverExecInteractiveMode,
+			Env: []api.ExecEnvVar{
+				{Name: "HEADLAMP_EXEC_CREDENTIAL_HELPER", Value: "true"},
+				{Name: "HEADLAMP_EXEC_CREDENTIAL_TOKEN_FILE", Value: tokenFile},
+			},
+		}},
+	}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/version", nil)
+	require.NoError(t, ctx.ProxyRequest(recorder, request))
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, 2, requests)
+}
+
+func TestSetupProxyDoesNotRetryNonExecUnauthorized(t *testing.T) {
+	requests := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	ctx := &kubeconfig.Context{
+		Name:        "token-context",
+		KubeContext: &api.Context{Cluster: "cluster", AuthInfo: "user"},
+		Cluster:     &api.Cluster{Server: server.URL},
+		AuthInfo:    &api.AuthInfo{Token: "static-token"},
+	}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/version", nil)
+	require.NoError(t, ctx.ProxyRequest(recorder, request))
+
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+	assert.Equal(t, 1, requests)
+}

--- a/backend/pkg/kubeconfig/export_test.go
+++ b/backend/pkg/kubeconfig/export_test.go
@@ -32,3 +32,15 @@ func (rt *UserAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 
 	return urt.RoundTrip(req)
 }
+
+// ExecCredentialRetryRoundTripper is exported for testing.
+type ExecCredentialRetryRoundTripper struct {
+	Base roundTripperInterface
+}
+
+// RoundTrip implements the http.RoundTripper interface.
+func (rt *ExecCredentialRetryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	retryRT := &execCredentialRetryRoundTripper{base: rt.Base}
+
+	return retryRT.RoundTrip(req)
+}

--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -47,6 +48,51 @@ func (rt *userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 	newReq.Header.Set("User-Agent", rt.userAgent)
 
 	return rt.base.RoundTrip(newReq)
+}
+
+// execCredentialRetryRoundTripper retries safe requests once after client-go
+// refreshes an exec credential in response to a 401. client-go refreshes the
+// credential before returning the 401, but only uses it on the next request.
+type execCredentialRetryRoundTripper struct {
+	base http.RoundTripper
+}
+
+func (rt *execCredentialRetryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get("Authorization") != "" || !isSafeRetryRequest(req) {
+		return rt.base.RoundTrip(req)
+	}
+
+	firstReq := req.Clone(req.Context())
+
+	resp, err := rt.base.RoundTrip(firstReq)
+	if err != nil || resp.StatusCode != http.StatusUnauthorized {
+		return resp, err
+	}
+
+	if resp.Body != nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}
+
+	retryReq := req.Clone(req.Context())
+	// The exec transport adds Authorization to the original request. Remove it
+	// so the retry uses the credential client-go refreshed after the first 401.
+	retryReq.Header.Del("Authorization")
+
+	return rt.base.RoundTrip(retryReq)
+}
+
+func isSafeRetryRequest(req *http.Request) bool {
+	if req.Body != nil && req.Body != http.NoBody {
+		return false
+	}
+
+	switch req.Method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	default:
+		return false
+	}
 }
 
 // buildUserAgent creates a User-Agent string for Headlamp.
@@ -469,6 +515,10 @@ func (c *Context) SetupProxy() error {
 	if err == nil {
 		roundTripper, err := makeTransportFor(restConf)
 		if err == nil {
+			if restConf.ExecProvider != nil {
+				roundTripper = &execCredentialRetryRoundTripper{base: roundTripper}
+			}
+
 			// Wrap the round tripper to add Headlamp User-Agent
 			proxy.Transport = &userAgentRoundTripper{
 				base:      roundTripper,


### PR DESCRIPTION
## Summary

This PR prevents Headlamp from showing the authentication token dialog when client-go has already refreshed an exec credential after a transient Kubernetes API 401.

Client-go refreshes the cached exec credential after receiving the 401, but returns that original response. Headlamp currently surfaces it to the frontend even though the next request would succeed.

## Related Issue

Fixes #7482

Related: #5148, #5402

## Changes

- Wrap exec-auth transports with a one-time retry for bodyless `GET`, `HEAD`, and `OPTIONS` requests.
- Do not retry requests with bodies, unsafe methods, or caller-supplied authorization.
- Drain and close the first 401 response before retrying.
- Remove the stale bearer header injected by client-go so the refreshed credential is used.
- Leave non-exec transports unchanged.
- Add direct transport tests and `SetupProxy` regression tests covering exec credential rotation and non-exec 401 behavior.

## Steps to Test

1. Run `go test ./pkg/kubeconfig -count=1` from `backend/`.
2. Run `go test -race ./pkg/kubeconfig -run 'TestExecCredentialRetryRoundTripper|TestSetupProxyRetriesAfterExecCredentialRefresh|TestSetupProxyDoesNotRetryNonExecUnauthorized' -count=1` from `backend/`.
3. Run `npm run backend:lint` from the repository root.
4. With a long-running Headlamp process using an exec-auth kubeconfig, rotate the API server and exec plugin from `token-one` to `token-two`.
5. Verify the first safe request after rotation succeeds instead of surfacing the transient 401.

The deterministic integration harness reproduces the behavior with a fake exec plugin and TLS API server. Unpatched Headlamp returns 401 and succeeds on the following request; this change succeeds within the first request by retrying once after client-go refreshes the credential.

## Screenshots (if applicable)

Not applicable. This is a backend authentication transport change with no UI changes.

## Notes for the Reviewer

- Retry behavior is limited to exec-backed transports and safe, bodyless methods.
- `SetupProxy` tests verify both the exec retry wiring and the non-exec exclusion.
- Local validation passes: full kubeconfig package tests, focused race tests, and backend lint with 0 issues.
- This PR was written in part with the assistance of generative AI. The author reviewed and tested the resulting changes.
