### PR TITLE
frontend: Table: Provide select filter options when faceting is off

### DIFF
--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -133,19 +133,22 @@ function EventsSection() {
     refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS,
   });
 
-  const warningActionFilterFunc = (event: Event, search?: string) => {
-    if (!filterFunc(event, search)) {
-      return false;
-    }
+  const warningActionFilterFunc = React.useCallback(
+    (event: Event, search?: string) => {
+      if (!filterFunc(event, search)) {
+        return false;
+      }
 
-    if (isWarningEventSwitchChecked) {
-      return event.jsonData.type === 'Warning';
-    }
+      if (isWarningEventSwitchChecked) {
+        return event.jsonData.type === 'Warning';
+      }
 
-    // Return true because if we reach this point, it means we're only filtering by
-    // the default filterFunc (and its result was 'true').
-    return true;
-  };
+      // Return true because if we reach this point, it means we're only filtering by
+      // the default filterFunc (and its result was 'true').
+      return true;
+    },
+    [filterFunc, isWarningEventSwitchChecked]
+  );
 
   const numWarnings = React.useMemo(
     () => events?.filter(e => e.type === 'Warning').length ?? '?',

--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -721,8 +721,9 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
   const filterFunc = filterFunction ?? defaultFilterFunc;
 
   // Faceted values build a unique-value map per column across the full dataset.
-  // On large clusters this is the dominant cause of OOM crashes, so we disable
-  // it once the dataset exceeds a threshold where the cost outweighs the UX benefit.
+  // On large clusters this is the dominant cause of OOM crashes, so we disable it once the
+  // dataset exceeds a threshold. Table then fills the select filters from a bounded walk of
+  // the dropdown columns alone, which keeps those filters usable without the full map.
   const enableFacetedValues = (data?.length ?? 0) <= 500;
 
   return (

--- a/frontend/src/components/common/Table/Table.facetedFilterOptions.test.tsx
+++ b/frontend/src/components/common/Table/Table.facetedFilterOptions.test.tsx
@@ -28,10 +28,15 @@ import { ThemeProvider } from '@mui/material/styles';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { createMuiTheme } from '../../../lib/themes';
-import Table from './Table';
+import Table, { TableColumn, TableProps } from './Table';
 
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+  useTranslation: () => ({
+    // Keys stand in for their translation, with the interpolation i18next would do.
+    t: (key: string, values?: Record<string, unknown>) =>
+      key.replace(/{{(\w+)}}/g, (_match, name) => String(values?.[name])),
+    i18n: { language: 'en' },
+  }),
 }));
 
 vi.mock('../../../lib/useShortcut', () => ({ useShortcut: vi.fn() }));
@@ -51,22 +56,26 @@ const theme = createMuiTheme({ base: 'light', name: 'light' });
 
 interface StatusRow {
   status: unknown;
+  tier?: string;
 }
 
 /** Enough rows that ResourceTable-style callers turn faceted values off. */
 const largeData: StatusRow[] = Array.from({ length: 501 }, (_, index) => ({
   status: index % 2 === 0 ? 'Running' : 'Completed',
+  tier: index % 2 === 0 ? 'gold' : 'silver',
 }));
 
-/** The page-size selector is a combobox too, so take the one in the table head. */
-function statusFilterInput() {
-  const combobox = screen.getAllByRole('combobox').find(element => element.closest('th') !== null);
-  expect(combobox).toBeDefined();
-  return combobox!;
+/** The page-size selector is a combobox too, so take the ones in the table head. */
+function statusFilterInput(index = 0) {
+  const comboboxes = screen
+    .getAllByRole('combobox')
+    .filter(element => element.closest('th') !== null);
+  expect(comboboxes.length).toBeGreaterThan(index);
+  return comboboxes[index];
 }
 
-function openStatusFilterDropdown() {
-  fireEvent.mouseDown(statusFilterInput());
+function openStatusFilterDropdown(index = 0) {
+  fireEvent.mouseDown(statusFilterInput(index));
 }
 
 /** One distinct value per row, far past MAX_FILTER_OPTIONS. */
@@ -76,32 +85,40 @@ const highCardinalityData: StatusRow[] = Array.from({ length: 1500 }, (_, index)
 
 function statusTable({
   accessorFn = (row: StatusRow) => row.status,
+  columns,
   data = largeData,
   enableColumnFilterModes,
+  enableFacetedValues = false,
   filterVariant = 'multi-select' as 'multi-select' | 'select' | 'autocomplete',
+  initialState,
   showColumnFilters = true,
 }: {
   accessorFn?: (row: StatusRow) => unknown;
+  columns?: TableColumn<StatusRow>[];
   data?: StatusRow[];
   enableColumnFilterModes?: boolean;
+  enableFacetedValues?: boolean;
   filterVariant?: 'multi-select' | 'select' | 'autocomplete';
+  initialState?: TableProps<StatusRow>['initialState'];
   showColumnFilters?: boolean;
 } = {}) {
   return (
     <ThemeProvider theme={theme}>
       <Table<StatusRow>
-        columns={[
-          {
-            id: 'status',
-            header: 'Status',
-            filterVariant,
-            accessorFn,
-          },
-        ]}
+        columns={
+          columns ?? [
+            {
+              id: 'status',
+              header: 'Status',
+              filterVariant,
+              accessorFn,
+            },
+          ]
+        }
         data={data}
         enableColumnFilterModes={enableColumnFilterModes}
-        enableFacetedValues={false}
-        initialState={showColumnFilters ? { showColumnFilters } : undefined}
+        enableFacetedValues={enableFacetedValues}
+        initialState={{ ...(showColumnFilters ? { showColumnFilters } : {}), ...initialState }}
       />
     </ThemeProvider>
   );
@@ -150,21 +167,28 @@ describe('Table select filter options with real MRT', () => {
     });
   });
 
-  it('explains the empty dropdown of a column above the option cap', () => {
-    // Rendering a menu item per value is what would freeze the tab, so the values
-    // are replaced by a notice.
-    renderStatusTable({ data: highCardinalityData });
+  it('serves only the most common options for a column past the cap', () => {
+    // Ported from #7226 by @simonepri. Plain DOM queries: computing accessible names for
+    // 1000 options is too slow for jsdom, and the "value (count)" shape drops MRT's
+    // placeholder item.
+    // The common value comes last, so keeping it proves the list is cut by frequency.
+    const data: StatusRow[] = [
+      ...Array.from({ length: 1000 }, (_, index) => ({ status: `rare-${index}` })),
+      ...Array.from({ length: 500 }, () => ({ status: 'common' })),
+    ];
+    renderStatusTable({ data });
 
     openStatusFilterDropdown();
 
-    const listbox = screen.getByRole('listbox');
-    expect(listbox.textContent).not.toContain('node-');
-
-    // The notice replaces the values and cannot be picked as a filter.
-    const options = within(listbox).getAllByRole('option');
-    expect(options).toHaveLength(1);
-    expect(options[0]).toHaveTextContent('Too many values to filter');
-    expect(options[0]).toHaveAttribute('aria-disabled', 'true');
+    const options = Array.from(
+      screen.getByRole('listbox').querySelectorAll('[role="option"]'),
+      option => option.textContent?.trim()
+    ).filter(text => / \(\d+\)$/.test(text ?? ''));
+    expect(options).toHaveLength(1000);
+    expect(options).toContain('common (500)');
+    expect(options).not.toContain('rare-999 (1)');
+    // The shortened list says so, so nobody hunts for a value that is not offered.
+    expect(screen.getByText('Showing the 1000 most common values')).toBeVisible();
   });
 
   it('follows the data while the dropdown stays open', () => {
@@ -175,17 +199,19 @@ describe('Table select filter options with real MRT', () => {
     // A background refresh pushes the column past the cap while the viewer is looking at it.
     rendered.rerender(statusTable({ data: highCardinalityData }));
 
-    expect(dropdownOptions()).toEqual(['Too many values to filter']);
+    expect(dropdownOptions()).toHaveLength(1000);
+    expect(screen.getByText('Showing the 1000 most common values')).toBeVisible();
   });
 
   it('restores the options when the data drops back under the cap', () => {
     const rendered = renderStatusTable({ data: highCardinalityData });
     openStatusFilterDropdown();
-    expect(dropdownOptions()).toEqual(['Too many values to filter']);
+    expect(dropdownOptions()).toHaveLength(1000);
 
     rendered.rerender(statusTable({ data: largeData }));
 
     expect(dropdownOptions()).toEqual(['Completed (250)', 'Running (251)']);
+    expect(screen.queryByText('Showing the 1000 most common values')).not.toBeInTheDocument();
   });
 
   it('serves no options for a column MRT cannot sort', () => {
@@ -202,33 +228,87 @@ describe('Table select filter options with real MRT', () => {
     expect(screen.getByRole('listbox').textContent).not.toContain('Too many values');
   });
 
-  it('tells an autocomplete filter why it has no options, and takes it back', () => {
+  it('tells an autocomplete filter that its list is shortened, and takes it back', () => {
     // The autocomplete variant renders a MUI Autocomplete, whose no-options popup stays
-    // hidden under freeSolo, so the notice belongs under the input.
+    // hidden under freeSolo, so the note belongs under the input for every variant.
     const rendered = renderStatusTable({
       data: highCardinalityData,
       filterVariant: 'autocomplete',
     });
 
-    expect(screen.getByText('Too many values to filter')).toBeVisible();
+    expect(screen.getByText('Showing the 1000 most common values')).toBeVisible();
 
     rendered.rerender(statusTable({ data: largeData, filterVariant: 'autocomplete' }));
 
-    expect(screen.queryByText('Too many values to filter')).not.toBeInTheDocument();
+    expect(screen.queryByText('Showing the 1000 most common values')).not.toBeInTheDocument();
     fireEvent.keyDown(statusFilterInput(), { key: 'ArrowDown' });
     expect(dropdownOptions()).toEqual(['Completed', 'Running']);
   });
 
-  it('yields the input to MRT filter mode label on a capped autocomplete column', () => {
+  it('yields the input to MRT filter mode label on a truncated autocomplete column', () => {
     renderStatusTable({
       data: highCardinalityData,
       filterVariant: 'autocomplete',
       enableColumnFilterModes: true,
     });
 
-    // MRT owns the helper text with filter modes enabled; the notice must not replace it.
-    expect(screen.queryByText('Too many values to filter')).not.toBeInTheDocument();
+    // MRT owns the helper text with filter modes enabled; the note must not replace it.
+    expect(screen.queryByText('Showing the 1000 most common values')).not.toBeInTheDocument();
     expect(screen.getByText(/Filter Mode:/i)).toBeVisible();
+  });
+
+  it('keeps the full faceting contract for non-dropdown columns while faceting is on', () => {
+    // Ported from #7226 by @simonepri.
+    let uniqueCount = -1;
+    renderStatusTable({
+      data: largeData.slice(0, 100),
+      enableFacetedValues: true,
+      columns: [
+        {
+          id: 'status',
+          header: 'Status',
+          filterVariant: 'multi-select',
+          accessorFn: r => r.status,
+        },
+        {
+          id: 'tier',
+          header: 'Tier',
+          accessorFn: row => row.tier,
+          // A custom filter reading the faceted values directly, like a plugin could.
+          Filter: ({ column }) => {
+            uniqueCount = column.getFacetedUniqueValues().size;
+            return null;
+          },
+        },
+      ],
+    });
+
+    // Faceting is on, so a text column still gets its full unique-value map.
+    expect(uniqueCount).toBe(2);
+  });
+
+  it('keeps small-list options narrowing with other active filters', () => {
+    // Ported from #7226 by @simonepri.
+    renderStatusTable({
+      data: largeData.slice(0, 100),
+      enableFacetedValues: true,
+      columns: [
+        {
+          id: 'status',
+          header: 'Status',
+          filterVariant: 'multi-select',
+          accessorFn: r => r.status,
+        },
+        { id: 'tier', header: 'Tier', filterVariant: 'multi-select', accessorFn: row => row.tier },
+      ],
+      initialState: { columnFilters: [{ id: 'status', value: ['Running'] }] },
+    });
+
+    // Faceting is on, so the tier options should only reflect the Running rows.
+    openStatusFilterDropdown(1);
+    const listbox = screen.getByRole('listbox');
+    expect(within(listbox).getByRole('option', { name: /gold \(50\)/ })).toBeInTheDocument();
+    expect(within(listbox).queryByRole('option', { name: /silver/ })).toBeNull();
   });
 
   it('walks the rows only once the filter UI becomes visible', () => {

--- a/frontend/src/components/common/Table/Table.facetedFilterOptions.test.tsx
+++ b/frontend/src/components/common/Table/Table.facetedFilterOptions.test.tsx
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Regression cover for the undocumented MRT behavior the custom getFacetedUniqueValues in
+ * Table.tsx relies on.
+ * Caller options override MRT's `enableFacetedValues ? ... : undefined`, and the dropdown pipeline
+ * reads faceted values even while faceting is turned off.
+ * These tests run against the real material-react-table, Table.test.tsx mocks it away and would
+ * not notice an MRT upgrade breaking either behavior.
+ * Without them the select filters would just go back to empty dropdowns on large lists.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { createMuiTheme } from '../../../lib/themes';
+import Table from './Table';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}));
+
+vi.mock('../../../lib/useShortcut', () => ({ useShortcut: vi.fn() }));
+vi.mock('../../../lib/util', () => ({
+  useURLState: (_key: string, options: { defaultValue: number }) => [options.defaultValue, vi.fn()],
+}));
+vi.mock('../../../helpers/tablesRowsPerPage', () => ({
+  getTablesRowsPerPage: () => 10,
+  setTablesRowsPerPage: vi.fn(),
+}));
+vi.mock('../../App/Settings/hook', () => ({ useSettings: () => [10] }));
+vi.mock('../../resourceMap/useQueryParamsState', () => ({
+  useQueryParamsState: (_key: string, initialValue: unknown) => [initialValue, vi.fn()],
+}));
+
+const theme = createMuiTheme({ base: 'light', name: 'light' });
+
+interface StatusRow {
+  status: unknown;
+}
+
+/** Enough rows that ResourceTable-style callers turn faceted values off. */
+const largeData: StatusRow[] = Array.from({ length: 501 }, (_, index) => ({
+  status: index % 2 === 0 ? 'Running' : 'Completed',
+}));
+
+/** The page-size selector is a combobox too, so take the one in the table head. */
+function statusFilterInput() {
+  const combobox = screen.getAllByRole('combobox').find(element => element.closest('th') !== null);
+  expect(combobox).toBeDefined();
+  return combobox!;
+}
+
+function openStatusFilterDropdown() {
+  fireEvent.mouseDown(statusFilterInput());
+}
+
+/** One distinct value per row, far past MAX_FILTER_OPTIONS. */
+const highCardinalityData: StatusRow[] = Array.from({ length: 1500 }, (_, index) => ({
+  status: `node-${index}`,
+}));
+
+function statusTable({
+  accessorFn = (row: StatusRow) => row.status,
+  data = largeData,
+  enableColumnFilterModes,
+  filterVariant = 'multi-select' as 'multi-select' | 'select' | 'autocomplete',
+  showColumnFilters = true,
+}: {
+  accessorFn?: (row: StatusRow) => unknown;
+  data?: StatusRow[];
+  enableColumnFilterModes?: boolean;
+  filterVariant?: 'multi-select' | 'select' | 'autocomplete';
+  showColumnFilters?: boolean;
+} = {}) {
+  return (
+    <ThemeProvider theme={theme}>
+      <Table<StatusRow>
+        columns={[
+          {
+            id: 'status',
+            header: 'Status',
+            filterVariant,
+            accessorFn,
+          },
+        ]}
+        data={data}
+        enableColumnFilterModes={enableColumnFilterModes}
+        enableFacetedValues={false}
+        initialState={showColumnFilters ? { showColumnFilters } : undefined}
+      />
+    </ThemeProvider>
+  );
+}
+
+function renderStatusTable(props: Parameters<typeof statusTable>[0] = {}) {
+  return render(statusTable(props));
+}
+
+/** The options a viewer can actually pick, MRT's disabled placeholder excluded. */
+function dropdownOptions() {
+  return within(screen.getByRole('listbox'))
+    .queryAllByRole('option')
+    .map(option => option.textContent);
+}
+
+describe('Table select filter options with real MRT', () => {
+  it.each(['multi-select', 'select'] as const)(
+    'fills the %s dropdown although faceted values are disabled',
+    filterVariant => {
+      renderStatusTable({ filterVariant });
+
+      // MRT renders both dropdown variants as a MUI Select, open it.
+      openStatusFilterDropdown();
+
+      const listbox = screen.getByRole('listbox');
+      expect(within(listbox).getByRole('option', { name: /Completed/ })).toBeInTheDocument();
+      expect(within(listbox).getByRole('option', { name: /Running/ })).toBeInTheDocument();
+    }
+  );
+
+  it('filters the rows when a dropdown option is selected', async () => {
+    renderStatusTable();
+
+    openStatusFilterDropdown();
+    const listbox = screen.getByRole('listbox');
+    fireEvent.click(within(listbox).getByRole('option', { name: /Completed/ }));
+    // Close the menu, MUI's modal hides the table from the accessibility tree while it is open.
+    fireEvent.keyDown(listbox, { key: 'Escape' });
+
+    // MRT debounces filter updates, so wait for the rows to settle.
+    await waitFor(() => {
+      const cells = screen.getAllByRole('cell').map(cell => cell.textContent);
+      expect(cells.length).toBeGreaterThan(0);
+      expect(cells.every(text => text === 'Completed')).toBe(true);
+    });
+  });
+
+  it('explains the empty dropdown of a column above the option cap', () => {
+    // Rendering a menu item per value is what would freeze the tab, so the values
+    // are replaced by a notice.
+    renderStatusTable({ data: highCardinalityData });
+
+    openStatusFilterDropdown();
+
+    const listbox = screen.getByRole('listbox');
+    expect(listbox.textContent).not.toContain('node-');
+
+    // The notice replaces the values and cannot be picked as a filter.
+    const options = within(listbox).getAllByRole('option');
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent('Too many values to filter');
+    expect(options[0]).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('follows the data while the dropdown stays open', () => {
+    const rendered = renderStatusTable();
+    openStatusFilterDropdown();
+    expect(dropdownOptions()).toEqual(['Completed (250)', 'Running (251)']);
+
+    // A background refresh pushes the column past the cap while the viewer is looking at it.
+    rendered.rerender(statusTable({ data: highCardinalityData }));
+
+    expect(dropdownOptions()).toEqual(['Too many values to filter']);
+  });
+
+  it('restores the options when the data drops back under the cap', () => {
+    const rendered = renderStatusTable({ data: highCardinalityData });
+    openStatusFilterDropdown();
+    expect(dropdownOptions()).toEqual(['Too many values to filter']);
+
+    rendered.rerender(statusTable({ data: largeData }));
+
+    expect(dropdownOptions()).toEqual(['Completed (250)', 'Running (251)']);
+  });
+
+  it('serves no options for a column MRT cannot sort', () => {
+    // MRT sorts the options with localeCompare, so a numeric column would throw during the
+    // header render. It keeps the empty dropdown it had before instead.
+    renderStatusTable({
+      data: [{ status: 1 }, { status: 2 }, { status: 3 }],
+      accessorFn: row => row.status,
+    });
+
+    openStatusFilterDropdown();
+
+    expect(dropdownOptions()).toEqual([]);
+    expect(screen.getByRole('listbox').textContent).not.toContain('Too many values');
+  });
+
+  it('tells an autocomplete filter why it has no options, and takes it back', () => {
+    // The autocomplete variant renders a MUI Autocomplete, whose no-options popup stays
+    // hidden under freeSolo, so the notice belongs under the input.
+    const rendered = renderStatusTable({
+      data: highCardinalityData,
+      filterVariant: 'autocomplete',
+    });
+
+    expect(screen.getByText('Too many values to filter')).toBeVisible();
+
+    rendered.rerender(statusTable({ data: largeData, filterVariant: 'autocomplete' }));
+
+    expect(screen.queryByText('Too many values to filter')).not.toBeInTheDocument();
+    fireEvent.keyDown(statusFilterInput(), { key: 'ArrowDown' });
+    expect(dropdownOptions()).toEqual(['Completed', 'Running']);
+  });
+
+  it('yields the input to MRT filter mode label on a capped autocomplete column', () => {
+    renderStatusTable({
+      data: highCardinalityData,
+      filterVariant: 'autocomplete',
+      enableColumnFilterModes: true,
+    });
+
+    // MRT owns the helper text with filter modes enabled; the notice must not replace it.
+    expect(screen.queryByText('Too many values to filter')).not.toBeInTheDocument();
+    expect(screen.getByText(/Filter Mode:/i)).toBeVisible();
+  });
+
+  it('walks the rows only once the filter UI becomes visible', () => {
+    const accessorFn = vi.fn((row: StatusRow) => row.status);
+    renderStatusTable({ accessorFn, showColumnFilters: false });
+
+    // MRT's header filter label reads the faceted values on every render even
+    // while the filter row is hidden. Only the visible page's cells may have
+    // resolved the accessor at this point, not the full 501-row data set.
+    const callsWhileHidden = accessorFn.mock.calls.length;
+    expect(callsWhileHidden).toBeLessThanOrEqual(10);
+
+    fireEvent.click(screen.getByRole('button', { name: /filter/i }));
+
+    openStatusFilterDropdown();
+    const listbox = screen.getByRole('listbox');
+    expect(within(listbox).getByRole('option', { name: /Completed/ })).toBeInTheDocument();
+    expect(accessorFn.mock.calls.length).toBeGreaterThan(callsWhileHidden);
+  });
+});

--- a/frontend/src/components/common/Table/Table.test.tsx
+++ b/frontend/src/components/common/Table/Table.test.tsx
@@ -34,7 +34,12 @@ const { tableMocks } = vi.hoisted(() => ({
 }));
 
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+  useTranslation: () => ({
+    // Keys stand in for their translation, with the interpolation i18next would do.
+    t: (key: string, values?: Record<string, unknown>) =>
+      key.replace(/{{(\w+)}}/g, (_match, name) => String(values?.[name])),
+    i18n: { language: 'en' },
+  }),
 }));
 
 vi.mock('../../../lib/useShortcut', () => ({ useShortcut: vi.fn() }));
@@ -499,26 +504,29 @@ describe('Table select filter faceted values', () => {
   );
 
   it.each([
-    ['keeps the options of a column at the cap', 1000, 1000],
-    ['drops the options of a column above the cap', 1001, 0],
-  ])('%s', (_description: string, distinctValues: number, expectedSize: number) => {
+    ['serves every option of a column at the cap', 1000],
+    ['serves the cap worth of options for a column above it', 1001],
+  ])('%s', (_description: string, distinctValues: number) => {
     const rows = Array.from({ length: distinctValues }, (_, index) => ({ status: `s${index}` }));
     renderTable({ columns: [statusColumn('multi-select')], data: rows as any });
 
-    expect(facetedUniqueValues('status', rows).size).toBe(expectedSize);
+    expect(facetedUniqueValues('status', rows).size).toBe(1000);
   });
 
-  it('stops walking the rows once a column is above the cap', () => {
-    const rows = Array.from({ length: 5000 }, (_, index) => ({ status: `s${index}` }));
+  it('keeps the most common values when it has to shorten the list', () => {
+    // The common value comes last, so keeping it proves the list is cut by frequency and
+    // not simply by insertion order.
+    const rows = [
+      ...Array.from({ length: 1000 }, (_, index) => ({ status: `rare-${index}` })),
+      ...Array.from({ length: 5 }, () => ({ status: 'common' })),
+    ];
     renderTable({ columns: [statusColumn('multi-select')], data: rows as any });
 
-    const accessorFn = vi.fn((row: any) => row.status);
-    const columnDef = { ...tableMocks.options.columns[0], accessorFn };
-    const table = makeFacetedTable(makeFacetedColumn(columnDef, rows));
+    const values = facetedUniqueValues('status', rows);
 
-    expect(tableMocks.options.getFacetedUniqueValues(table, 'status')().size).toBe(0);
-    // Walking all 5000 rows is what the cap avoids.
-    expect(accessorFn.mock.calls.length).toBeLessThanOrEqual(1001);
+    expect(values.size).toBe(1000);
+    expect(values.get('common')).toBe(5);
+    expect(values.has('rare-999')).toBe(false);
   });
 
   /**
@@ -563,14 +571,11 @@ describe('Table select filter faceted values', () => {
     return tableMocks.options.muiFilterTextFieldProps({ column, table });
   }
 
-  it('replaces the options of a capped column with a disabled notice', () => {
+  it('notes under the input that a shortened list is shown', () => {
     const rows = Array.from({ length: 1001 }, (_, index) => ({ status: `s${index}` }));
     renderTable({ columns: [statusColumn('multi-select')], data: rows as any });
 
-    const { children } = filterTextFieldProps(rows);
-
-    expect(children.props.disabled).toBe(true);
-    expect(children.props.children).toBe('Too many values to filter');
+    expect(filterTextFieldProps(rows).helperText).toBe('Showing the 1000 most common values');
   });
 
   it('drops the notice when the column definition gains caller filter options', () => {
@@ -580,18 +585,18 @@ describe('Table select filter faceted values', () => {
     const { column, table } = makeFilterColumn(rows);
     const props = () => tableMocks.options.muiFilterTextFieldProps({ column, table });
 
-    expect(props().children.props.disabled).toBe(true);
+    expect(props().helperText).toBe('Showing the 1000 most common values');
 
     // Same column instance, definition swapped in place: the verdict must not survive.
     column.columnDef = { ...column.columnDef, filterSelectOptions: ['Custom'] };
-    expect(props().children).toBeUndefined();
+    expect(props().helperText).toBeUndefined();
 
     column.columnDef = {
       ...column.columnDef,
       filterSelectOptions: undefined,
       filterVariant: 'text',
     };
-    expect(props().children).toBeUndefined();
+    expect(props().helperText).toBeUndefined();
   });
 
   it('adds no notice when the caller replaces getFacetedUniqueValues', () => {
@@ -605,13 +610,15 @@ describe('Table select filter faceted values', () => {
     const { column, table } = makeFilterColumn(rows);
     column.getFacetedUniqueValues = () => new Map();
 
-    expect(tableMocks.options.muiFilterTextFieldProps({ column, table }).children).toBeUndefined();
+    expect(
+      tableMocks.options.muiFilterTextFieldProps({ column, table }).helperText
+    ).toBeUndefined();
   });
 
   it('adds no notice while a column stays below the cap', () => {
     renderTable({ columns: [statusColumn('multi-select')], data: statusRows as any });
 
-    expect(filterTextFieldProps(statusRows).children).toBeUndefined();
+    expect(filterTextFieldProps(statusRows).helperText).toBeUndefined();
   });
 
   it.each([
@@ -628,7 +635,7 @@ describe('Table select filter faceted values', () => {
     const props = filterTextFieldProps(rows);
 
     expect(props.placeholder).toBe('caller');
-    expect(props.children.props.disabled).toBe(true);
+    expect(props.helperText).toBe('Showing the 1000 most common values');
   });
 
   it('skips the computation when the caller provides filter options', () => {
@@ -710,28 +717,28 @@ describe('Table select filter faceted values', () => {
     // MRT reads the table-level flag, a column can only opt out of it.
     [
       'adds',
-      'the hint when only the column asks for modes',
+      'the note when only the column asks for modes',
       {},
       { enableColumnFilterModes: true },
-      'Too many values to filter',
+      'Showing the 1000 most common values',
     ],
     [
       'adds',
-      'the hint when the column opts out of modes',
+      'the note when the column opts out of modes',
       { enableColumnFilterModes: true },
       { enableColumnFilterModes: false },
-      'Too many values to filter',
+      'Showing the 1000 most common values',
     ],
     // MRT renders no mode button, and no label, without options to switch between.
     [
       'adds',
-      'the hint when no filter mode is left to pick',
+      'the note when no filter mode is left to pick',
       { enableColumnFilterModes: true, columnFilterModeOptions: [] },
       {},
-      'Too many values to filter',
+      'Showing the 1000 most common values',
     ],
   ])(
-    '%s %s on a capped autocomplete column',
+    '%s %s on a truncated autocomplete column',
     (_verb, _case, tableSettings: object, columnSettings: object, expected) => {
       const rows = Array.from({ length: 1001 }, (_, index) => ({ status: `s${index}` }));
       renderTable({
@@ -750,7 +757,7 @@ describe('Table select filter faceted values', () => {
 
     // MRT sorts the options with localeCompare, so non-strings would throw on render.
     expect(facetedUniqueValues('status', rows).size).toBe(0);
-    expect(filterTextFieldProps(rows).children).toBeUndefined();
+    expect(filterTextFieldProps(rows).helperText).toBeUndefined();
   });
 
   it.each([

--- a/frontend/src/components/common/Table/Table.test.tsx
+++ b/frontend/src/components/common/Table/Table.test.tsx
@@ -55,9 +55,6 @@ vi.mock('../../resourceMap/useQueryParamsState', () => ({
 vi.mock('./ColumnVisibilityButton', () => ({
   ColumnVisibilityButton: () => <button data-testid="column-visibility" />,
 }));
-vi.mock('./useScrollPreservation', () => ({
-  useScrollPreservationOnDataChange: () => ({ ref: { current: null }, onScroll: vi.fn() }),
-}));
 
 vi.mock('material-react-table', () => ({
   MRT_BottomToolbar: () => <div data-testid="bottom-toolbar" />,
@@ -165,18 +162,18 @@ function toolbarTable(selectedRows: object[] = []) {
   };
 }
 
-describe('Table toolbar and selection props', () => {
-  beforeEach(() => {
-    tableMocks.cellContext = 'plain';
-    tableMocks.columnVisibility = {};
-    tableMocks.forceNoRows = false;
-    tableMocks.options = null;
-    tableMocks.setColumnVisibility.mockClear();
-    tableMocks.setRowSelection.mockClear();
-    tableMocks.setTablesRowsPerPage.mockClear();
-    tableMocks.setURLState.mockClear();
-  });
+beforeEach(() => {
+  tableMocks.cellContext = 'plain';
+  tableMocks.columnVisibility = {};
+  tableMocks.forceNoRows = false;
+  tableMocks.options = null;
+  tableMocks.setColumnVisibility.mockClear();
+  tableMocks.setRowSelection.mockClear();
+  tableMocks.setTablesRowsPerPage.mockClear();
+  tableMocks.setURLState.mockClear();
+});
 
+describe('Table toolbar and selection props', () => {
   it.each([
     ['by default', {}],
     ['when enabled', { enableTopToolbar: true }],
@@ -243,17 +240,6 @@ describe('Table toolbar and selection props', () => {
 });
 
 describe('Table states and options', () => {
-  beforeEach(() => {
-    tableMocks.cellContext = 'plain';
-    tableMocks.columnVisibility = {};
-    tableMocks.forceNoRows = false;
-    tableMocks.options = null;
-    tableMocks.setColumnVisibility.mockClear();
-    tableMocks.setRowSelection.mockClear();
-    tableMocks.setTablesRowsPerPage.mockClear();
-    tableMocks.setURLState.mockClear();
-  });
-
   it('renders error, loading, and empty states', () => {
     const errorResult = renderTable({ errorMessage: 'Unable to load rows' });
     expect(screen.getByText('Unable to load rows')).toBeVisible();
@@ -443,5 +429,428 @@ describe('Table states and options', () => {
     renderTable({ columns: [{ accessorKey: 'selected', header: 'Selection' }] });
 
     expect(tableMocks.setColumnVisibility).toHaveBeenCalledOnce();
+  });
+});
+
+describe('Table select filter faceted values', () => {
+  const statusRows = [
+    { name: 'a', selected: false, status: 'Running' },
+    { name: 'b', selected: false, status: 'Completed' },
+    { name: 'c', selected: false, status: 'Running' },
+    { name: 'd', selected: false, status: '' },
+  ];
+
+  const statusColumn = (filterVariant: string) =>
+    ({
+      id: 'status',
+      header: 'Status',
+      filterVariant,
+      accessorFn: (row: any) => row.status,
+    } as any);
+
+  /**
+   * Builds the minimal slice of a TanStack column that the custom
+   * getFacetedUniqueValues implementation touches: the column definition and
+   * a faceted row model whose rows resolve unique values through the column
+   * accessor, like TanStack's own rows do.
+   */
+  function makeFacetedColumn(columnDef: any, rows: Record<string, any>[]) {
+    const rowModel = {
+      flatRows: rows.map(original => ({
+        getUniqueValues: () => [columnDef.accessorFn(original)],
+      })),
+    };
+    return { columnDef, getFacetedRowModel: () => rowModel, getIsFiltered: () => false };
+  }
+
+  /** Minimal TanStack table slice; the filter UI is visible unless stated otherwise. */
+  function makeFacetedTable(
+    column: any,
+    { showColumnFilters = true, columnFilterDisplayMode = 'subheader' } = {}
+  ) {
+    return {
+      getColumn: () => column,
+      getState: () => ({ showColumnFilters }),
+      options: { columnFilterDisplayMode },
+    };
+  }
+
+  function facetedUniqueValues(
+    columnId: string,
+    rows: Record<string, any>[],
+    tableState?: { showColumnFilters: boolean }
+  ) {
+    const columnDef = tableMocks.options.columns.find((column: any) => column.id === columnId);
+    const table = makeFacetedTable(makeFacetedColumn(columnDef, rows), tableState);
+    return tableMocks.options.getFacetedUniqueValues(table, columnId)();
+  }
+
+  it.each(['select', 'multi-select', 'autocomplete'])(
+    'counts unique values for %s filter columns',
+    filterVariant => {
+      renderTable({ columns: [statusColumn(filterVariant)], data: statusRows as any });
+
+      expect(Object.fromEntries(facetedUniqueValues('status', statusRows))).toEqual({
+        Running: 2,
+        Completed: 1,
+        '': 1,
+      });
+    }
+  );
+
+  it.each([
+    ['keeps the options of a column at the cap', 1000, 1000],
+    ['drops the options of a column above the cap', 1001, 0],
+  ])('%s', (_description: string, distinctValues: number, expectedSize: number) => {
+    const rows = Array.from({ length: distinctValues }, (_, index) => ({ status: `s${index}` }));
+    renderTable({ columns: [statusColumn('multi-select')], data: rows as any });
+
+    expect(facetedUniqueValues('status', rows).size).toBe(expectedSize);
+  });
+
+  it('stops walking the rows once a column is above the cap', () => {
+    const rows = Array.from({ length: 5000 }, (_, index) => ({ status: `s${index}` }));
+    renderTable({ columns: [statusColumn('multi-select')], data: rows as any });
+
+    const accessorFn = vi.fn((row: any) => row.status);
+    const columnDef = { ...tableMocks.options.columns[0], accessorFn };
+    const table = makeFacetedTable(makeFacetedColumn(columnDef, rows));
+
+    expect(tableMocks.options.getFacetedUniqueValues(table, 'status')().size).toBe(0);
+    // Walking all 5000 rows is what the cap avoids.
+    expect(accessorFn.mock.calls.length).toBeLessThanOrEqual(1001);
+  });
+
+  /**
+   * Mimics what MRT does on every render: the row model stays, while TanStack builds a new
+   * column object around a freshly spread column definition. Returns a function that renders
+   * the column once more and reads its faceted values.
+   */
+  function renderableColumn(rows: Record<string, any>[]) {
+    let columnDef: any;
+    const rowModel = {
+      flatRows: rows.map(original => ({ getUniqueValues: () => [columnDef.accessorFn(original)] })),
+    };
+    return (overrides: object = {}) => {
+      columnDef = { ...tableMocks.options.columns[0], ...overrides };
+      const column = {
+        id: 'status',
+        columnDef,
+        getFacetedRowModel: () => rowModel,
+        getIsFiltered: () => false,
+      };
+      return tableMocks.options.getFacetedUniqueValues(makeFacetedTable(column), 'status')();
+    };
+  }
+
+  /**
+   * Builds the column MRT hands to muiFilterTextFieldProps: the faceted slice above plus the
+   * getFacetedUniqueValues closure TanStack installs on the column.
+   */
+  function makeFilterColumn(
+    rows: Record<string, any>[],
+    columnDef = tableMocks.options.columns[0]
+  ) {
+    const column: any = { id: 'status', ...makeFacetedColumn(columnDef, rows) };
+    const table = makeFacetedTable(column);
+    column.getFacetedUniqueValues = tableMocks.options.getFacetedUniqueValues(table, 'status');
+    return { column, table };
+  }
+
+  /** Calls the filter text field props for a column, like MRT does while rendering it. */
+  function filterTextFieldProps(rows: Record<string, any>[]) {
+    const { column, table } = makeFilterColumn(rows);
+    return tableMocks.options.muiFilterTextFieldProps({ column, table });
+  }
+
+  it('replaces the options of a capped column with a disabled notice', () => {
+    const rows = Array.from({ length: 1001 }, (_, index) => ({ status: `s${index}` }));
+    renderTable({ columns: [statusColumn('multi-select')], data: rows as any });
+
+    const { children } = filterTextFieldProps(rows);
+
+    expect(children.props.disabled).toBe(true);
+    expect(children.props.children).toBe('Too many values to filter');
+  });
+
+  it('drops the notice when the column definition gains caller filter options', () => {
+    const rows = Array.from({ length: 1001 }, (_, index) => ({ status: `s${index}` }));
+    renderTable({ columns: [statusColumn('multi-select')], data: rows as any });
+
+    const { column, table } = makeFilterColumn(rows);
+    const props = () => tableMocks.options.muiFilterTextFieldProps({ column, table });
+
+    expect(props().children.props.disabled).toBe(true);
+
+    // Same column instance, definition swapped in place: the verdict must not survive.
+    column.columnDef = { ...column.columnDef, filterSelectOptions: ['Custom'] };
+    expect(props().children).toBeUndefined();
+
+    column.columnDef = {
+      ...column.columnDef,
+      filterSelectOptions: undefined,
+      filterVariant: 'text',
+    };
+    expect(props().children).toBeUndefined();
+  });
+
+  it('adds no notice when the caller replaces getFacetedUniqueValues', () => {
+    const rows = Array.from({ length: 1001 }, (_, index) => ({ status: `s${index}` }));
+    renderTable({
+      columns: [statusColumn('multi-select')],
+      data: rows as any,
+      getFacetedUniqueValues: (() => () => new Map()) as any,
+    });
+
+    const { column, table } = makeFilterColumn(rows);
+    column.getFacetedUniqueValues = () => new Map();
+
+    expect(tableMocks.options.muiFilterTextFieldProps({ column, table }).children).toBeUndefined();
+  });
+
+  it('adds no notice while a column stays below the cap', () => {
+    renderTable({ columns: [statusColumn('multi-select')], data: statusRows as any });
+
+    expect(filterTextFieldProps(statusRows).children).toBeUndefined();
+  });
+
+  it.each([
+    ['object', { placeholder: 'caller' }],
+    ['function', () => ({ placeholder: 'caller' })],
+  ])('keeps caller filter text field props in %s form', (_description, muiFilterTextFieldProps) => {
+    const rows = Array.from({ length: 1001 }, (_, index) => ({ status: `s${index}` }));
+    renderTable({
+      columns: [statusColumn('multi-select')],
+      data: rows as any,
+      muiFilterTextFieldProps: muiFilterTextFieldProps as any,
+    });
+
+    const props = filterTextFieldProps(rows);
+
+    expect(props.placeholder).toBe('caller');
+    expect(props.children.props.disabled).toBe(true);
+  });
+
+  it('skips the computation when the caller provides filter options', () => {
+    const accessorFn = vi.fn((row: any) => row.status);
+    renderTable({
+      columns: [{ ...statusColumn('multi-select'), filterSelectOptions: ['Running'] }],
+      data: statusRows as any,
+    });
+
+    const columnDef = { ...tableMocks.options.columns[0], accessorFn };
+    const table = makeFacetedTable(makeFacetedColumn(columnDef, statusRows));
+
+    expect(tableMocks.options.getFacetedUniqueValues(table, 'status')().size).toBe(0);
+    expect(accessorFn).not.toHaveBeenCalled();
+  });
+
+  it('walks a row model once, even though MRT rebuilds its columns every render', () => {
+    const rows = Array.from({ length: 50 }, (_, index) => ({ status: `s${index}` }));
+    renderTable({ columns: [statusColumn('multi-select')], data: rows as any });
+
+    const accessorFn = vi.fn((row: any) => row.status);
+    const readAgain = renderableColumn(rows);
+
+    readAgain({ accessorFn });
+    const callsAfterFirstRender = accessorFn.mock.calls.length;
+    readAgain({ accessorFn });
+
+    expect(callsAfterFirstRender).toBe(rows.length);
+    expect(accessorFn.mock.calls.length).toBe(callsAfterFirstRender);
+  });
+
+  it('serves the cached values regardless of column identity churn', () => {
+    // TanStack freezes row.getUniqueValues per row and column for the row model's lifetime,
+    // so recomputing on a column-definition change could not observe anything new anyway.
+    const rows = [{ status: 'Running' }, { status: 'Done' }];
+    renderTable({ columns: [statusColumn('multi-select')], data: rows as any });
+    const readAgain = renderableColumn(rows);
+
+    const first = readAgain({ accessorFn: (row: any) => row.status });
+    const second = readAgain({ accessorFn: (row: any) => `${row.status}!` });
+
+    expect([...first.keys()]).toEqual(['Running', 'Done']);
+    expect(second).toBe(first);
+  });
+
+  it('leaves the menu and the helper text to a caller that provides them', () => {
+    const rows = Array.from({ length: 1001 }, (_, index) => ({ status: `s${index}` }));
+
+    renderTable({
+      columns: [statusColumn('multi-select')],
+      data: rows as any,
+      muiFilterTextFieldProps: { children: 'mine' } as any,
+    });
+    expect(filterTextFieldProps(rows).children).toBe('mine');
+
+    renderTable({
+      columns: [statusColumn('autocomplete')],
+      data: rows as any,
+      muiFilterTextFieldProps: { helperText: 'mine' } as any,
+    });
+    expect(filterTextFieldProps(rows).helperText).toBe('mine');
+  });
+
+  it('counts only the values MRT would offer against the cap', () => {
+    // MAX_FILTER_OPTIONS worth of real values plus rows the accessor leaves empty.
+    const rows = [
+      ...Array.from({ length: 1000 }, (_, index) => ({ status: `s${index}` })),
+      { status: null },
+      { status: undefined },
+    ];
+    renderTable({ columns: [statusColumn('multi-select')], data: rows as any });
+
+    expect(facetedUniqueValues('status', rows).size).toBe(1000);
+    expect(filterTextFieldProps(rows).children).toBeUndefined();
+  });
+
+  it.each([
+    ['keeps', 'the filter mode label', { enableColumnFilterModes: true }, {}, undefined],
+    // MRT reads the table-level flag, a column can only opt out of it.
+    [
+      'adds',
+      'the hint when only the column asks for modes',
+      {},
+      { enableColumnFilterModes: true },
+      'Too many values to filter',
+    ],
+    [
+      'adds',
+      'the hint when the column opts out of modes',
+      { enableColumnFilterModes: true },
+      { enableColumnFilterModes: false },
+      'Too many values to filter',
+    ],
+    // MRT renders no mode button, and no label, without options to switch between.
+    [
+      'adds',
+      'the hint when no filter mode is left to pick',
+      { enableColumnFilterModes: true, columnFilterModeOptions: [] },
+      {},
+      'Too many values to filter',
+    ],
+  ])(
+    '%s %s on a capped autocomplete column',
+    (_verb, _case, tableSettings: object, columnSettings: object, expected) => {
+      const rows = Array.from({ length: 1001 }, (_, index) => ({ status: `s${index}` }));
+      renderTable({
+        columns: [{ ...statusColumn('autocomplete'), ...columnSettings }],
+        data: rows as any,
+        ...tableSettings,
+      });
+
+      expect(filterTextFieldProps(rows).helperText).toBe(expected);
+    }
+  );
+
+  it('serves no values for a column MRT cannot sort', () => {
+    const rows = [{ status: 1 }, { status: 2 }];
+    renderTable({ columns: [statusColumn('multi-select')], data: rows as any });
+
+    // MRT sorts the options with localeCompare, so non-strings would throw on render.
+    expect(facetedUniqueValues('status', rows).size).toBe(0);
+    expect(filterTextFieldProps(rows).children).toBeUndefined();
+  });
+
+  it.each([
+    ['faceting is on', { enableFacetedValues: true }],
+    ['the caller brings its own', { getFacetedUniqueValues: (() => () => new Map()) as any }],
+  ])('leaves getFacetedUniqueValues alone when %s', (_description, props) => {
+    renderTable({
+      columns: [statusColumn('multi-select')],
+      data: statusRows as any,
+      ...props,
+    });
+
+    // MRT applies caller options over its own wiring, so ours must not be set at all here.
+    expect(tableMocks.options.getFacetedUniqueValues).toBe((props as any).getFacetedUniqueValues);
+  });
+
+  it('returns an empty map for columns without a dropdown filter', () => {
+    renderTable({
+      columns: [{ id: 'name', header: 'Name', accessorFn: (row: any) => row.name }],
+      data: statusRows as any,
+    });
+
+    expect(facetedUniqueValues('name', statusRows).size).toBe(0);
+  });
+
+  it('recomputes only when the faceted rows change', () => {
+    renderTable({ columns: [statusColumn('multi-select')], data: statusRows as any });
+
+    const columnDef = tableMocks.options.columns[0];
+    let column = makeFacetedColumn(columnDef, statusRows);
+    const getValues = tableMocks.options.getFacetedUniqueValues(
+      {
+        getColumn: () => column,
+        getState: () => ({ showColumnFilters: true }),
+        options: {},
+      },
+      'status'
+    );
+
+    const first = getValues();
+    expect(getValues()).toBe(first);
+
+    column = makeFacetedColumn(columnDef, [{ status: 'Failed' }]);
+    expect(Object.fromEntries(getValues())).toEqual({ Failed: 1 });
+  });
+
+  it('does not walk the rows while the filter UI is hidden and no filter is active', () => {
+    renderTable({ columns: [statusColumn('multi-select')], data: statusRows as any });
+
+    const values = facetedUniqueValues('status', statusRows, { showColumnFilters: false });
+
+    expect(values.size).toBe(0);
+  });
+
+  it.each(['popover', 'custom'])(
+    'computes the options in %s mode, where the filter UI is not tied to showColumnFilters',
+    columnFilterDisplayMode => {
+      renderTable({ columns: [statusColumn('multi-select')], data: statusRows as any });
+
+      const columnDef = tableMocks.options.columns[0];
+      const table = makeFacetedTable(makeFacetedColumn(columnDef, statusRows), {
+        showColumnFilters: false,
+        columnFilterDisplayMode,
+      });
+
+      expect(tableMocks.options.getFacetedUniqueValues(table, 'status')().size).toBe(3);
+    }
+  );
+
+  it('computes the options for an active filter even while the filter UI is hidden', () => {
+    renderTable({ columns: [statusColumn('multi-select')], data: statusRows as any });
+
+    const columnDef = tableMocks.options.columns[0];
+    const column = { ...makeFacetedColumn(columnDef, statusRows), getIsFiltered: () => true };
+    const table = makeFacetedTable(column, { showColumnFilters: false });
+
+    const values = tableMocks.options.getFacetedUniqueValues(table, 'status')();
+
+    expect(Object.fromEntries(values)).toEqual({ Running: 2, Completed: 1, '': 1 });
+  });
+
+  it('keeps a caller-provided getFacetedUniqueValues implementation', () => {
+    const custom = vi.fn();
+    renderTable({ getFacetedUniqueValues: custom as any });
+
+    expect(tableMocks.options.getFacetedUniqueValues).toBe(custom);
+  });
+
+  it('passes caller filter options through to the columns untouched', () => {
+    renderTable({
+      columns: [{ ...statusColumn('multi-select'), filterSelectOptions: ['Custom'] }],
+      data: statusRows as any,
+    });
+
+    expect(tableMocks.options.columns[0].filterSelectOptions).toEqual(['Custom']);
+  });
+
+  it('leaves filterSelectOptions to MRT instead of injecting them into columns', () => {
+    renderTable({ columns: [statusColumn('multi-select')], data: statusRows as any });
+
+    expect(tableMocks.options.columns[0].filterSelectOptions).toBeUndefined();
   });
 });

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -16,6 +16,7 @@
 
 import { Icon } from '@iconify/react';
 import Box from '@mui/material/Box';
+import MenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
 import { useTheme } from '@mui/material/styles';
 import MuiTable from '@mui/material/Table';
@@ -26,6 +27,7 @@ import { visuallyHidden } from '@mui/utils';
 import {
   MRT_BottomToolbar,
   MRT_Cell,
+  MRT_Column,
   MRT_ColumnDef as MaterialTableColumn,
   MRT_Header,
   MRT_TableBodyCell,
@@ -172,6 +174,124 @@ const StyledBody = styled('tbody')({ display: 'contents' });
  * Approximate minimum width (px) used to decide whether a column still fits.
  */
 const DEFAULT_MIN_COLUMN_WIDTH = 100;
+
+/**
+ * Upper bound for the options of a single select filter. MRT renders one unvirtualized menu
+ * item per option, so a high-cardinality column (Node on a large cluster) keeps the empty
+ * dropdown it had before instead of freezing the tab on every open.
+ */
+const MAX_FILTER_OPTIONS = 1000;
+
+/** Served when a column has no options to offer, which is what MRT reads as "no dropdown". */
+const NO_FACETED_VALUES = new Map<any, number>();
+
+/**
+ * Served instead of NO_FACETED_VALUES when MAX_FILTER_OPTIONS dropped the options, so the
+ * dropdown can say why it is empty. A distinct instance keeps the two cases apart without
+ * remembering a verdict that a column definition change could leave stale.
+ */
+const CAPPED_FACETED_VALUES = new Map<any, number>();
+
+/**
+ * Faceted values per row model and column. MRT rebuilds its column array on every render
+ * (prepareColumns is not memoized), and TanStack binds one closure per column object along
+ * with a freshly spread column definition, so neither can hold or validate a cache across
+ * renders. The row model is the one identity that lives exactly as long as the values it
+ * yields: TanStack freezes row.getUniqueValues per row and column for the model's lifetime,
+ * so recomputing any sooner could not even observe a changed accessor.
+ */
+const facetedValuesByRows = new WeakMap<object, Map<string, Map<any, number>>>();
+
+/** Whether a column's options were dropped by MAX_FILTER_OPTIONS rather than never existing. */
+function isOverOptionCap<RowItem extends Record<string, any>>(column: MRT_Column<RowItem>) {
+  return column.getFacetedUniqueValues() === CAPPED_FACETED_VALUES;
+}
+
+/**
+ * Select-filter dropdowns get their options from MRT's faceted values, but callers turn
+ * faceting off above a dataset threshold (TanStack's default builds a unique-value map for
+ * every column), which left those dropdowns empty on large lists. This walks the dropdown
+ * columns only, and only while their options are on screen, since MRT reads faceted values
+ * on every header render. It relies on two undocumented MRT behaviors, pinned in
+ * Table.facetedFilterOptions.test.tsx: caller options win over MRT's own
+ * `enableFacetedValues ? ... : undefined`, and the dropdown reads faceted values regardless
+ * of that flag.
+ */
+const getDropdownFacetedUniqueValues: NonNullable<
+  MaterialTableOptions<Record<string, any>>['getFacetedUniqueValues']
+> = (table, columnId) => {
+  // TanStack types the option's table without MRT's additions; at runtime it is the
+  // MRT instance.
+  const mrtTable = table as unknown as MRT_TableInstance<Record<string, any>>;
+  return () => {
+    const column = table.getColumn(columnId);
+    const columnDef = column?.columnDef as TableColumn<Record<string, any>> | undefined;
+    const filterVariant = columnDef?.filterVariant;
+    if (
+      !column ||
+      (filterVariant !== 'select' &&
+        filterVariant !== 'multi-select' &&
+        filterVariant !== 'autocomplete') ||
+      // Caller options win in MRT, which then also drops the value counts these feed.
+      columnDef?.filterSelectOptions
+    ) {
+      return NO_FACETED_VALUES;
+    }
+    // Faceting on: the column's faceted row model. Faceting off: TanStack falls back to
+    // the pre-filtered rows (post-filterFunction), so the options are a superset of what
+    // the table shows and the counts MRT renders next to them are dataset-wide. Narrowing
+    // them would need the per-column faceted row models the guard turned off.
+    const { flatRows } = column.getFacetedRowModel();
+    const cachedColumns = facetedValuesByRows.get(flatRows);
+    const cached = cachedColumns?.get(columnId);
+    if (cached) {
+      return cached;
+    }
+    // Nobody can see the options while the filter UI is hidden and no filter is active,
+    // so do not walk the rows for them. Showing the UI re-renders the headers and lands
+    // here again with the walk allowed. From there every data update walks again, which
+    // measured around 8 ms per dropdown column per 10k rows.
+    // Only the subheader mode ties the filter UI to showColumnFilters, the popover and
+    // custom modes render it on their own terms — there the walk also runs while no popover
+    // is open, since opening one does not re-render the headers, so empty options would
+    // stick. The cap and the per-row-model cache bound that idle cost.
+    const optionsAreVisible =
+      mrtTable.getState().showColumnFilters ||
+      (mrtTable.options.columnFilterDisplayMode ?? 'subheader') !== 'subheader' ||
+      column.getIsFiltered();
+    if (!optionsAreVisible) {
+      return NO_FACETED_VALUES;
+    }
+    const values = new Map<any, number>();
+    // MRT sorts the options with localeCompare, so anything but a string throws during
+    // the header render. Such a column keeps the empty dropdown it had before.
+    let sortable = true;
+    let capped = false;
+    for (const row of flatRows) {
+      for (const value of row.getUniqueValues(columnId) ?? []) {
+        // MRT drops these before rendering the options, so they must not count either.
+        if (value === null || value === undefined) {
+          continue;
+        }
+        if (typeof value !== 'string') {
+          sortable = false;
+          break;
+        }
+        values.set(value, (values.get(value) ?? 0) + 1);
+      }
+      // Past the cap MRT would render thousands of unvirtualized menu items.
+      capped = values.size > MAX_FILTER_OPTIONS;
+      if (!sortable || capped) {
+        break;
+      }
+    }
+    const result = !sortable ? NO_FACETED_VALUES : capped ? CAPPED_FACETED_VALUES : values;
+    const perColumn = cachedColumns ?? new Map();
+    perColumn.set(columnId, result);
+    facetedValuesByRows.set(flatRows, perColumn);
+    return result;
+  };
+};
 
 /**
  * Tracks the current width of an element using a ResizeObserver.
@@ -357,10 +477,68 @@ export default function Table<RowItem extends Record<string, any>>({
     [tableProps.state?.columnVisibility, columnVisibility, responsiveHidden]
   );
 
+  // With faceting on, MRT installs TanStack's own implementation for every column, so ours
+  // is only needed to fill the gap it leaves behind when faceting is off.
+  const ownFacetedValues = !tableProps.enableFacetedValues && !tableProps.getFacetedUniqueValues;
+
   const table = useMaterialReactTable({
     ...tableProps,
     columns: tableColumns ?? [],
     data: tableData,
+    // The key has to be absent, not undefined: MRT applies caller options over its own
+    // wiring, so an undefined value would drop TanStack's default and its faceting contract.
+    // The implementation only reads generic column metadata, so the erased row type is safe.
+    ...(ownFacetedValues
+      ? {
+          getFacetedUniqueValues:
+            getDropdownFacetedUniqueValues as MaterialTableOptions<RowItem>['getFacetedUniqueValues'],
+        }
+      : {}),
+    // Tell the user why a capped dropdown has no options. MRT renders `children` instead of
+    // the option list, so the entry cannot be picked as a filter value.
+    muiFilterTextFieldProps: args => {
+      const callerProps =
+        (typeof tableProps.muiFilterTextFieldProps === 'function'
+          ? tableProps.muiFilterTextFieldProps(args)
+          : tableProps.muiFilterTextFieldProps) ?? {};
+      // Only the implementation above signals the cap by serving an empty map.
+      if (!ownFacetedValues || !isOverOptionCap(args.column)) {
+        return callerProps;
+      }
+      const notice = t('Too many values to filter');
+      const columnDef = args.column.columnDef as TableColumn<RowItem>;
+      // MRT reads `children` in its select branches only. The autocomplete variant renders a
+      // MUI Autocomplete, which never shows its no-options popup while `freeSolo` is set, so
+      // the reason goes under the input there. Both branches share this text field.
+      if (columnDef.filterVariant === 'autocomplete') {
+        // That spot already carries MRT's filter-mode label where modes are enabled, and
+        // saying which mode is active beats saying why the options are missing. MRT decides
+        // that from the table-level flag, with the column able to opt out only.
+        const filterModeOptions =
+          columnDef.columnFilterModeOptions ?? tableProps.columnFilterModeOptions;
+        const showsFilterMode =
+          tableProps.enableColumnFilterModes &&
+          columnDef.enableColumnFilterModes !== false &&
+          (filterModeOptions === undefined || !!filterModeOptions?.length);
+        // A caller-provided helperText keeps precedence, as it did before the notice existed.
+        return showsFilterMode || callerProps.helperText !== undefined
+          ? callerProps
+          : { ...callerProps, helperText: notice };
+      }
+      // Same for caller-provided children: whoever replaces the menu owns it.
+      if (callerProps.children !== undefined) {
+        return callerProps;
+      }
+      return {
+        ...callerProps,
+        // MRT renders this into an array next to its placeholder item, hence the key.
+        children: (
+          <MenuItem disabled key="too-many-values">
+            {notice}
+          </MenuItem>
+        ),
+      };
+    },
     enablePagination: tableData.length > rowsPerPageOptions[0],
     enableDensityToggle: tableProps.enableDensityToggle ?? false,
     enableFullScreenToggle: tableProps.enableFullScreenToggle ?? false,

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -16,7 +16,6 @@
 
 import { Icon } from '@iconify/react';
 import Box from '@mui/material/Box';
-import MenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
 import { useTheme } from '@mui/material/styles';
 import MuiTable from '@mui/material/Table';
@@ -177,8 +176,8 @@ const DEFAULT_MIN_COLUMN_WIDTH = 100;
 
 /**
  * Upper bound for the options of a single select filter. MRT renders one unvirtualized menu
- * item per option, so a high-cardinality column (Node on a large cluster) keeps the empty
- * dropdown it had before instead of freezing the tab on every open.
+ * item per option, so a high-cardinality column (Node on a large cluster) is served its most
+ * common values instead of freezing the tab on every open.
  */
 const MAX_FILTER_OPTIONS = 1000;
 
@@ -186,11 +185,11 @@ const MAX_FILTER_OPTIONS = 1000;
 const NO_FACETED_VALUES = new Map<any, number>();
 
 /**
- * Served instead of NO_FACETED_VALUES when MAX_FILTER_OPTIONS dropped the options, so the
- * dropdown can say why it is empty. A distinct instance keeps the two cases apart without
- * remembering a verdict that a column definition change could leave stale.
+ * The maps MAX_FILTER_OPTIONS truncated, so the dropdown can say that it lists only part of
+ * the values. Marked by identity rather than remembered per column, so a column definition
+ * that changes at runtime cannot leave a stale verdict behind.
  */
-const CAPPED_FACETED_VALUES = new Map<any, number>();
+const truncatedFacetedValues = new WeakSet<Map<any, number>>();
 
 /**
  * Faceted values per row model and column. MRT rebuilds its column array on every render
@@ -202,9 +201,9 @@ const CAPPED_FACETED_VALUES = new Map<any, number>();
  */
 const facetedValuesByRows = new WeakMap<object, Map<string, Map<any, number>>>();
 
-/** Whether a column's options were dropped by MAX_FILTER_OPTIONS rather than never existing. */
-function isOverOptionCap<RowItem extends Record<string, any>>(column: MRT_Column<RowItem>) {
-  return column.getFacetedUniqueValues() === CAPPED_FACETED_VALUES;
+/** Whether a column's options were truncated by MAX_FILTER_OPTIONS. */
+function isTruncated<RowItem extends Record<string, any>>(column: MRT_Column<RowItem>) {
+  return truncatedFacetedValues.has(column.getFacetedUniqueValues());
 }
 
 /**
@@ -266,7 +265,6 @@ const getDropdownFacetedUniqueValues: NonNullable<
     // MRT sorts the options with localeCompare, so anything but a string throws during
     // the header render. Such a column keeps the empty dropdown it had before.
     let sortable = true;
-    let capped = false;
     for (const row of flatRows) {
       for (const value of row.getUniqueValues(columnId) ?? []) {
         // MRT drops these before rendering the options, so they must not count either.
@@ -279,13 +277,19 @@ const getDropdownFacetedUniqueValues: NonNullable<
         }
         values.set(value, (values.get(value) ?? 0) + 1);
       }
-      // Past the cap MRT would render thousands of unvirtualized menu items.
-      capped = values.size > MAX_FILTER_OPTIONS;
-      if (!sortable || capped) {
+      if (!sortable) {
         break;
       }
     }
-    const result = !sortable ? NO_FACETED_VALUES : capped ? CAPPED_FACETED_VALUES : values;
+    let result = values;
+    if (!sortable) {
+      result = NO_FACETED_VALUES;
+    } else if (values.size > MAX_FILTER_OPTIONS) {
+      // MRT renders one unvirtualized menu item per option, so keep the most frequent values,
+      // which are the ones worth offering as a filter.
+      result = new Map([...values].sort(([, a], [, b]) => b - a).slice(0, MAX_FILTER_OPTIONS));
+      truncatedFacetedValues.add(result);
+    }
     const perColumn = cachedColumns ?? new Map();
     perColumn.set(columnId, result);
     facetedValuesByRows.set(flatRows, perColumn);
@@ -494,49 +498,34 @@ export default function Table<RowItem extends Record<string, any>>({
             getDropdownFacetedUniqueValues as MaterialTableOptions<RowItem>['getFacetedUniqueValues'],
         }
       : {}),
-    // Tell the user why a capped dropdown has no options. MRT renders `children` instead of
-    // the option list, so the entry cannot be picked as a filter value.
+    // Say so when the dropdown lists only part of the values. MRT renders this text field
+    // for every filter variant, so all three dropdowns carry the note in the same place.
     muiFilterTextFieldProps: args => {
       const callerProps =
         (typeof tableProps.muiFilterTextFieldProps === 'function'
           ? tableProps.muiFilterTextFieldProps(args)
           : tableProps.muiFilterTextFieldProps) ?? {};
-      // Only the implementation above signals the cap by serving an empty map.
-      if (!ownFacetedValues || !isOverOptionCap(args.column)) {
+      // Only the implementation above marks a map as truncated.
+      if (!ownFacetedValues || !isTruncated(args.column)) {
         return callerProps;
       }
-      const notice = t('Too many values to filter');
+      // That spot already carries MRT's filter-mode label where modes are enabled, and saying
+      // which mode is active beats saying that the list is shortened. MRT decides that from
+      // the table-level flag, with the column able to opt out only. A caller-provided
+      // helperText keeps precedence too, as it did before the note existed.
       const columnDef = args.column.columnDef as TableColumn<RowItem>;
-      // MRT reads `children` in its select branches only. The autocomplete variant renders a
-      // MUI Autocomplete, which never shows its no-options popup while `freeSolo` is set, so
-      // the reason goes under the input there. Both branches share this text field.
-      if (columnDef.filterVariant === 'autocomplete') {
-        // That spot already carries MRT's filter-mode label where modes are enabled, and
-        // saying which mode is active beats saying why the options are missing. MRT decides
-        // that from the table-level flag, with the column able to opt out only.
-        const filterModeOptions =
-          columnDef.columnFilterModeOptions ?? tableProps.columnFilterModeOptions;
-        const showsFilterMode =
-          tableProps.enableColumnFilterModes &&
-          columnDef.enableColumnFilterModes !== false &&
-          (filterModeOptions === undefined || !!filterModeOptions?.length);
-        // A caller-provided helperText keeps precedence, as it did before the notice existed.
-        return showsFilterMode || callerProps.helperText !== undefined
-          ? callerProps
-          : { ...callerProps, helperText: notice };
-      }
-      // Same for caller-provided children: whoever replaces the menu owns it.
-      if (callerProps.children !== undefined) {
+      const filterModeOptions =
+        columnDef.columnFilterModeOptions ?? tableProps.columnFilterModeOptions;
+      const showsFilterMode =
+        tableProps.enableColumnFilterModes &&
+        columnDef.enableColumnFilterModes !== false &&
+        (filterModeOptions === undefined || !!filterModeOptions?.length);
+      if (showsFilterMode || callerProps.helperText !== undefined) {
         return callerProps;
       }
       return {
         ...callerProps,
-        // MRT renders this into an array next to its placeholder item, hence the key.
-        children: (
-          <MenuItem disabled key="too-many-values">
-            {notice}
-          </MenuItem>
-        ),
+        helperText: t('Showing the {{max}} most common values', { max: MAX_FILTER_OPTIONS }),
       };
     },
     enablePagination: tableData.length > rowsPerPageOptions[0],

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -579,7 +579,7 @@
   "Loading table data": "جارٍ تحميل بيانات الجدول",
   "Refresh": "تحديث",
   "No data matching the filter criteria.": "لا توجد بيانات تطابق معايير التصفية",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "لم يتم العثور على نتائج",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "سيظهر أي إخراج جديد لعملية هذه الحاوية أدناه وفي حال لم يظهر اضغط Enter",
   "Failed to run \"{{command}}\"…": "فشل تشغيل \"{{command}}\"…",

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -579,6 +579,7 @@
   "Loading table data": "جارٍ تحميل بيانات الجدول",
   "Refresh": "تحديث",
   "No data matching the filter criteria.": "لا توجد بيانات تطابق معايير التصفية",
+  "Too many values to filter": "",
   "No results found": "لم يتم العثور على نتائج",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "سيظهر أي إخراج جديد لعملية هذه الحاوية أدناه وفي حال لم يظهر اضغط Enter",
   "Failed to run \"{{command}}\"…": "فشل تشغيل \"{{command}}\"…",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -559,7 +559,7 @@
   "Loading table data": "টেবিল Data লোড হচ্ছে",
   "Refresh": "Refresh",
   "No data matching the filter criteria.": "ফিল্টার মানদণ্ডের সাথে মেলে কোনও Data নেই।",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "কোনও result পাওয়া যায় নি",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "এই container process এর জন্য যে কোনও নতুন output নীচে দেখানো উচিত। যদি এটি প্রদর্শিত না হয় তবে Enter টিপুন…",
   "Failed to run \"{{command}}\"…": "Run করতে Failed \"{{command}}\"…",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -559,6 +559,7 @@
   "Loading table data": "টেবিল Data লোড হচ্ছে",
   "Refresh": "Refresh",
   "No data matching the filter criteria.": "ফিল্টার মানদণ্ডের সাথে মেলে কোনও Data নেই।",
+  "Too many values to filter": "",
   "No results found": "কোনও result পাওয়া যায় নি",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "এই container process এর জন্য যে কোনও নতুন output নীচে দেখানো উচিত। যদি এটি প্রদর্শিত না হয় তবে Enter টিপুন…",
   "Failed to run \"{{command}}\"…": "Run করতে Failed \"{{command}}\"…",

--- a/frontend/src/i18n/locales/cs/translation.json
+++ b/frontend/src/i18n/locales/cs/translation.json
@@ -569,7 +569,7 @@
   "Loading table data": "Načítají se data tabulky.",
   "Refresh": "Aktualizovat",
   "No data matching the filter criteria.": "Kritériím filtru neodpovídají žádná data.",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "Nenašly se žádné výsledky.",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Níže by se měl zobrazit jakýkoli nový výstup procesu tohoto kontejneru. Pokud se nezobrazí, stiskněte Enter...",
   "Failed to run \"{{command}}\"…": "Nepodařilo se spustit {{command}}...",

--- a/frontend/src/i18n/locales/cs/translation.json
+++ b/frontend/src/i18n/locales/cs/translation.json
@@ -569,6 +569,7 @@
   "Loading table data": "Načítají se data tabulky.",
   "Refresh": "Aktualizovat",
   "No data matching the filter criteria.": "Kritériím filtru neodpovídají žádná data.",
+  "Too many values to filter": "",
   "No results found": "Nenašly se žádné výsledky.",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Níže by se měl zobrazit jakýkoli nový výstup procesu tohoto kontejneru. Pokud se nezobrazí, stiskněte Enter...",
   "Failed to run \"{{command}}\"…": "Nepodařilo se spustit {{command}}...",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -559,6 +559,7 @@
   "Loading table data": "Laden von Tabellendaten",
   "Refresh": "Aktualisieren",
   "No data matching the filter criteria.": "Keine Daten, die den Filterkriterien entsprechen.",
+  "Too many values to filter": "Zu viele Werte zum Filtern",
   "No results found": "",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Jede neue Ausgabe für den Prozess dieses Containers sollte unten angezeigt werden. Falls sie nicht angezeigt wird, drücken Sie Enter…",
   "Failed to run \"{{command}}\"…": "Fehler bei der Ausführung von \"{{command}}\"…",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -559,7 +559,7 @@
   "Loading table data": "Laden von Tabellendaten",
   "Refresh": "Aktualisieren",
   "No data matching the filter criteria.": "Keine Daten, die den Filterkriterien entsprechen.",
-  "Too many values to filter": "Zu viele Werte zum Filtern",
+  "Showing the {{max}} most common values": "Die {{max}} häufigsten Werte werden angezeigt",
   "No results found": "",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Jede neue Ausgabe für den Prozess dieses Containers sollte unten angezeigt werden. Falls sie nicht angezeigt wird, drücken Sie Enter…",
   "Failed to run \"{{command}}\"…": "Fehler bei der Ausführung von \"{{command}}\"…",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -559,6 +559,7 @@
   "Loading table data": "Loading table data",
   "Refresh": "Refresh",
   "No data matching the filter criteria.": "No data matching the filter criteria.",
+  "Too many values to filter": "Too many values to filter",
   "No results found": "No results found",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…",
   "Failed to run \"{{command}}\"…": "Failed to run \"{{command}}\"…",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -559,7 +559,7 @@
   "Loading table data": "Loading table data",
   "Refresh": "Refresh",
   "No data matching the filter criteria.": "No data matching the filter criteria.",
-  "Too many values to filter": "Too many values to filter",
+  "Showing the {{max}} most common values": "Showing the {{max}} most common values",
   "No results found": "No results found",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…",
   "Failed to run \"{{command}}\"…": "Failed to run \"{{command}}\"…",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -564,6 +564,7 @@
   "Loading table data": "Cargando datos de la tabla",
   "Refresh": "Recargar",
   "No data matching the filter criteria.": "Sin datos que correspondan a los criterios de filtrado",
+  "Too many values to filter": "",
   "No results found": "No se encontraron resultados",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Cualquier nuevo output para el proceso de este contenedor debería mostrarse abajo. En caso de que no aparezca, pulse intro…",
   "Failed to run \"{{command}}\"…": "Fallor al ejecutar \"{{command}}\"…",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -564,7 +564,7 @@
   "Loading table data": "Cargando datos de la tabla",
   "Refresh": "Recargar",
   "No data matching the filter criteria.": "Sin datos que correspondan a los criterios de filtrado",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "No se encontraron resultados",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Cualquier nuevo output para el proceso de este contenedor debería mostrarse abajo. En caso de que no aparezca, pulse intro…",
   "Failed to run \"{{command}}\"…": "Fallor al ejecutar \"{{command}}\"…",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -564,7 +564,7 @@
   "Loading table data": "Chargement des données de la table",
   "Refresh": "Actualiser",
   "No data matching the filter criteria.": "Aucune donnée ne correspond aux critères de filtrage.",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "Aucun résultat trouvé",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Toute nouvelle sortie pour le processus de ce conteneur devrait être affichée ci-dessous. Si elle n'apparaît pas, appuyez sur Entrée…",
   "Failed to run \"{{command}}\"…": "Échec de l'exécution de \"{{command}}\"…",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -564,6 +564,7 @@
   "Loading table data": "Chargement des données de la table",
   "Refresh": "Actualiser",
   "No data matching the filter criteria.": "Aucune donnée ne correspond aux critères de filtrage.",
+  "Too many values to filter": "",
   "No results found": "Aucun résultat trouvé",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Toute nouvelle sortie pour le processus de ce conteneur devrait être affichée ci-dessous. Si elle n'apparaît pas, appuyez sur Entrée…",
   "Failed to run \"{{command}}\"…": "Échec de l'exécution de \"{{command}}\"…",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -564,6 +564,7 @@
   "Loading table data": "Loading table data",
   "Refresh": "Refresh",
   "No data matching the filter criteria.": "No data matching the filter criteria.",
+  "Too many values to filter": "",
   "No results found": "No results found",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…",
   "Failed to run \"{{command}}\"…": "Failed to run \"{{command}}\"…",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -564,7 +564,7 @@
   "Loading table data": "Loading table data",
   "Refresh": "Refresh",
   "No data matching the filter criteria.": "No data matching the filter criteria.",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "No results found",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…",
   "Failed to run \"{{command}}\"…": "Failed to run \"{{command}}\"…",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -559,6 +559,7 @@
   "Loading table data": "",
   "Refresh": "",
   "No data matching the filter criteria.": "",
+  "Too many values to filter": "",
   "No results found": "",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "",
   "Failed to run \"{{command}}\"…": "",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -559,7 +559,7 @@
   "Loading table data": "",
   "Refresh": "",
   "No data matching the filter criteria.": "",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "",
   "Failed to run \"{{command}}\"…": "",

--- a/frontend/src/i18n/locales/hu/translation.json
+++ b/frontend/src/i18n/locales/hu/translation.json
@@ -559,7 +559,7 @@
   "Loading table data": "Táblaadatok betöltése",
   "Refresh": "Frissítés",
   "No data matching the filter criteria.": "Nincsenek a szűrési feltételeknek megfelelő adatok.",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "Nincs találat",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "A tárolófolyamat minden új kimenetének meg kell jelennie alább. Ha nem jelenik meg, nyomja le az Enter billentyűt…",
   "Failed to run \"{{command}}\"…": "A(z) {{command}} futtatása nem sikerült…",

--- a/frontend/src/i18n/locales/hu/translation.json
+++ b/frontend/src/i18n/locales/hu/translation.json
@@ -559,6 +559,7 @@
   "Loading table data": "Táblaadatok betöltése",
   "Refresh": "Frissítés",
   "No data matching the filter criteria.": "Nincsenek a szűrési feltételeknek megfelelő adatok.",
+  "Too many values to filter": "",
   "No results found": "Nincs találat",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "A tárolófolyamat minden új kimenetének meg kell jelennie alább. Ha nem jelenik meg, nyomja le az Enter billentyűt…",
   "Failed to run \"{{command}}\"…": "A(z) {{command}} futtatása nem sikerült…",

--- a/frontend/src/i18n/locales/id/translation.json
+++ b/frontend/src/i18n/locales/id/translation.json
@@ -554,7 +554,7 @@
   "Loading table data": "Memuat data tabel",
   "Refresh": "Refresh",
   "No data matching the filter criteria.": "Tidak ada data yang cocok dengan kriteria filter.",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "Hasil tidak ditemukan",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Output baru untuk proses kontainer ini harus ditampilkan di bawah ini. Jika tidak muncul, tekan Enter…",
   "Failed to run \"{{command}}\"…": "Gagal menjalankan \"{{command}}\"…",

--- a/frontend/src/i18n/locales/id/translation.json
+++ b/frontend/src/i18n/locales/id/translation.json
@@ -554,6 +554,7 @@
   "Loading table data": "Memuat data tabel",
   "Refresh": "Refresh",
   "No data matching the filter criteria.": "Tidak ada data yang cocok dengan kriteria filter.",
+  "Too many values to filter": "",
   "No results found": "Hasil tidak ditemukan",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Output baru untuk proses kontainer ini harus ditampilkan di bawah ini. Jika tidak muncul, tekan Enter…",
   "Failed to run \"{{command}}\"…": "Gagal menjalankan \"{{command}}\"…",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -564,7 +564,7 @@
   "Loading table data": "Caricamento dati della tabella",
   "Refresh": "Aggiorna",
   "No data matching the filter criteria.": "Nessun dato corrispondente ai criteri di filtro.",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "Nessun risultato trovato",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Qualsiasi nuovo output per il processo di questo container verrà mostrato qui sotto. Nel caso in cui non appaia, premi invio…",
   "Failed to run \"{{command}}\"…": "Impossibile eseguire \"{{command}}\"…",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -564,6 +564,7 @@
   "Loading table data": "Caricamento dati della tabella",
   "Refresh": "Aggiorna",
   "No data matching the filter criteria.": "Nessun dato corrispondente ai criteri di filtro.",
+  "Too many values to filter": "",
   "No results found": "Nessun risultato trovato",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Qualsiasi nuovo output per il processo di questo container verrà mostrato qui sotto. Nel caso in cui non appaia, premi invio…",
   "Failed to run \"{{command}}\"…": "Impossibile eseguire \"{{command}}\"…",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -554,6 +554,7 @@
   "Loading table data": "テーブルデータを読み込み中",
   "Refresh": "更新",
   "No data matching the filter criteria.": "フィルター条件に一致するデータがありません。",
+  "Too many values to filter": "",
   "No results found": "結果が見つかりません",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "このコンテナーのプロセスの新しい出力は以下に表示されます。表示されない場合は、Enter キーを押してください…",
   "Failed to run \"{{command}}\"…": "\"{{command}}\" の実行に失敗しました…",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -554,7 +554,7 @@
   "Loading table data": "テーブルデータを読み込み中",
   "Refresh": "更新",
   "No data matching the filter criteria.": "フィルター条件に一致するデータがありません。",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "結果が見つかりません",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "このコンテナーのプロセスの新しい出力は以下に表示されます。表示されない場合は、Enter キーを押してください…",
   "Failed to run \"{{command}}\"…": "\"{{command}}\" の実行に失敗しました…",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -554,6 +554,7 @@
   "Loading table data": "테이블 데이터 로딩 중",
   "Refresh": "Refresh",
   "No data matching the filter criteria.": "필터 기준과 일치하는 데이터가 없습니다.",
+  "Too many values to filter": "",
   "No results found": "결과가 없습니다.",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "이 컨테이너 프로세스의 새로운 출력은 아래에 표시되어야 합니다. 표시되지 않으면 엔터 키를 눌러 주세요…",
   "Failed to run \"{{command}}\"…": "\"{{command}}\" 실행에 실패했습니다…",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -554,7 +554,7 @@
   "Loading table data": "테이블 데이터 로딩 중",
   "Refresh": "Refresh",
   "No data matching the filter criteria.": "필터 기준과 일치하는 데이터가 없습니다.",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "결과가 없습니다.",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "이 컨테이너 프로세스의 새로운 출력은 아래에 표시되어야 합니다. 표시되지 않으면 엔터 키를 눌러 주세요…",
   "Failed to run \"{{command}}\"…": "\"{{command}}\" 실행에 실패했습니다…",

--- a/frontend/src/i18n/locales/nl/translation.json
+++ b/frontend/src/i18n/locales/nl/translation.json
@@ -559,6 +559,7 @@
   "Loading table data": "Tabelgegevens laden...",
   "Refresh": "Vernieuwen",
   "No data matching the filter criteria.": "Er zijn geen gegevens die overeenkomen met de filtercriteria.",
+  "Too many values to filter": "",
   "No results found": "Geen resultaten gevonden",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Alle nieuwe uitvoer voor het proces van deze container wordt hieronder weergegeven. Druk op Enter als het niet verschijnt...",
   "Failed to run \"{{command}}\"…": "Kan \"{{command}}\" niet uitvoeren…",

--- a/frontend/src/i18n/locales/nl/translation.json
+++ b/frontend/src/i18n/locales/nl/translation.json
@@ -559,7 +559,7 @@
   "Loading table data": "Tabelgegevens laden...",
   "Refresh": "Vernieuwen",
   "No data matching the filter criteria.": "Er zijn geen gegevens die overeenkomen met de filtercriteria.",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "Geen resultaten gevonden",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Alle nieuwe uitvoer voor het proces van deze container wordt hieronder weergegeven. Druk op Enter als het niet verschijnt...",
   "Failed to run \"{{command}}\"…": "Kan \"{{command}}\" niet uitvoeren…",

--- a/frontend/src/i18n/locales/pl/translation.json
+++ b/frontend/src/i18n/locales/pl/translation.json
@@ -569,7 +569,7 @@
   "Loading table data": "Trwa ładowanie danych tabeli",
   "Refresh": "Odśwież",
   "No data matching the filter criteria.": "Brak danych spełniających kryteria filtru.",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "Nie znaleziono wyników",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Wszystkie nowe dane wyjściowe procesu tego kontenera powinny być wyświetlane poniżej. Jeśli nie pojawi się, naciśnij klawisz Enter...",
   "Failed to run \"{{command}}\"…": "Nie można uruchomić „{{command}}”...",

--- a/frontend/src/i18n/locales/pl/translation.json
+++ b/frontend/src/i18n/locales/pl/translation.json
@@ -569,6 +569,7 @@
   "Loading table data": "Trwa ładowanie danych tabeli",
   "Refresh": "Odśwież",
   "No data matching the filter criteria.": "Brak danych spełniających kryteria filtru.",
+  "Too many values to filter": "",
   "No results found": "Nie znaleziono wyników",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Wszystkie nowe dane wyjściowe procesu tego kontenera powinny być wyświetlane poniżej. Jeśli nie pojawi się, naciśnij klawisz Enter...",
   "Failed to run \"{{command}}\"…": "Nie można uruchomić „{{command}}”...",

--- a/frontend/src/i18n/locales/pt-br/translation.json
+++ b/frontend/src/i18n/locales/pt-br/translation.json
@@ -564,6 +564,7 @@
   "Loading table data": "A carregar dados da tabela",
   "Refresh": "Recarregar",
   "No data matching the filter criteria.": "Sem dados que verifiquem os critérios de filtro.",
+  "Too many values to filter": "",
   "No results found": "Nenhum resultado encontrado",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Qualquer novo output para o processo deste container deverá ser mostrado abaixo. Caso não apareça, pressione enter…",
   "Failed to run \"{{command}}\"…": "Falha ao executar \"{{command}}\"…",

--- a/frontend/src/i18n/locales/pt-br/translation.json
+++ b/frontend/src/i18n/locales/pt-br/translation.json
@@ -564,7 +564,7 @@
   "Loading table data": "A carregar dados da tabela",
   "Refresh": "Recarregar",
   "No data matching the filter criteria.": "Sem dados que verifiquem os critérios de filtro.",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "Nenhum resultado encontrado",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Qualquer novo output para o processo deste container deverá ser mostrado abaixo. Caso não apareça, pressione enter…",
   "Failed to run \"{{command}}\"…": "Falha ao executar \"{{command}}\"…",

--- a/frontend/src/i18n/locales/pt-pt/translation.json
+++ b/frontend/src/i18n/locales/pt-pt/translation.json
@@ -564,6 +564,7 @@
   "Loading table data": "",
   "Refresh": "",
   "No data matching the filter criteria.": "",
+  "Too many values to filter": "",
   "No results found": "",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "",
   "Failed to run \"{{command}}\"…": "",

--- a/frontend/src/i18n/locales/pt-pt/translation.json
+++ b/frontend/src/i18n/locales/pt-pt/translation.json
@@ -564,7 +564,7 @@
   "Loading table data": "",
   "Refresh": "",
   "No data matching the filter criteria.": "",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "",
   "Failed to run \"{{command}}\"…": "",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -569,7 +569,7 @@
   "Loading table data": "Загрузка данных таблицы",
   "Refresh": "Обновить",
   "No data matching the filter criteria.": "Нет данных, соответствующих критериям фильтра.",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "Результаты не найдены",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Любой новый результат процесса этого контейнера должен быть показан ниже. Если он не появился, нажмите Enter…",
   "Failed to run \"{{command}}\"…": "Не удалось запустить «{{command}}»…",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -569,6 +569,7 @@
   "Loading table data": "Загрузка данных таблицы",
   "Refresh": "Обновить",
   "No data matching the filter criteria.": "Нет данных, соответствующих критериям фильтра.",
+  "Too many values to filter": "",
   "No results found": "Результаты не найдены",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Любой новый результат процесса этого контейнера должен быть показан ниже. Если он не появился, нажмите Enter…",
   "Failed to run \"{{command}}\"…": "Не удалось запустить «{{command}}»…",

--- a/frontend/src/i18n/locales/sv/translation.json
+++ b/frontend/src/i18n/locales/sv/translation.json
@@ -559,6 +559,7 @@
   "Loading table data": "Läser in tabelldata",
   "Refresh": "Uppdatera",
   "No data matching the filter criteria.": "Inga data matchar filtervillkoren.",
+  "Too many values to filter": "",
   "No results found": "Inga resultat hittades",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Alla nya utdata för den här containerprocessen bör visas nedan. Om de inte visas trycker du på Retur...",
   "Failed to run \"{{command}}\"…": "Det gick inte att köra {{command}}…",

--- a/frontend/src/i18n/locales/sv/translation.json
+++ b/frontend/src/i18n/locales/sv/translation.json
@@ -559,7 +559,7 @@
   "Loading table data": "Läser in tabelldata",
   "Refresh": "Uppdatera",
   "No data matching the filter criteria.": "Inga data matchar filtervillkoren.",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "Inga resultat hittades",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Alla nya utdata för den här containerprocessen bör visas nedan. Om de inte visas trycker du på Retur...",
   "Failed to run \"{{command}}\"…": "Det gick inte att köra {{command}}…",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -559,7 +559,7 @@
   "Loading table data": "டேபிள் டேட்டாவை ஏற்றுகிறது",
   "Refresh": "ரிஃப்ரெஷ்",
   "No data matching the filter criteria.": "ஃபில்டர் அளவுகோல்களுடன் பொருந்தும் டேட்டா இல்லை.",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "முடிவுகள் எதுவும் காணப்படவில்லை",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "இந்த கண்டெய்னரின் ப்ராசஸுக்கான எந்தவொரு புதிய அவுட்புட்டும் கீழே காட்டப்பட வேண்டும். அது காட்டப்படாவிட்டால், என்டர் அழுத்தவும்...",
   "Failed to run \"{{command}}\"…": "\"{{command}}\"-ஐ இயக்குவதில் தோல்வி...",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -559,6 +559,7 @@
   "Loading table data": "டேபிள் டேட்டாவை ஏற்றுகிறது",
   "Refresh": "ரிஃப்ரெஷ்",
   "No data matching the filter criteria.": "ஃபில்டர் அளவுகோல்களுடன் பொருந்தும் டேட்டா இல்லை.",
+  "Too many values to filter": "",
   "No results found": "முடிவுகள் எதுவும் காணப்படவில்லை",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "இந்த கண்டெய்னரின் ப்ராசஸுக்கான எந்தவொரு புதிய அவுட்புட்டும் கீழே காட்டப்பட வேண்டும். அது காட்டப்படாவிட்டால், என்டர் அழுத்தவும்...",
   "Failed to run \"{{command}}\"…": "\"{{command}}\"-ஐ இயக்குவதில் தோல்வி...",

--- a/frontend/src/i18n/locales/tr/translation.json
+++ b/frontend/src/i18n/locales/tr/translation.json
@@ -559,7 +559,7 @@
   "Loading table data": "Tablo verileri yükleniyor",
   "Refresh": "Yenile",
   "No data matching the filter criteria.": "Filtre ölçütleriyle eşleşen veri yok.",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "Sonuç bulunamadı",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Bu kapsayıcının işlemi için tüm yeni çıktılar aşağıda gösterilmelidir. Gösterilmiyorsa Enter tuşuna basın…",
   "Failed to run \"{{command}}\"…": "\"{{command}}\" çalıştırılamadı…",

--- a/frontend/src/i18n/locales/tr/translation.json
+++ b/frontend/src/i18n/locales/tr/translation.json
@@ -559,6 +559,7 @@
   "Loading table data": "Tablo verileri yükleniyor",
   "Refresh": "Yenile",
   "No data matching the filter criteria.": "Filtre ölçütleriyle eşleşen veri yok.",
+  "Too many values to filter": "",
   "No results found": "Sonuç bulunamadı",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "Bu kapsayıcının işlemi için tüm yeni çıktılar aşağıda gösterilmelidir. Gösterilmiyorsa Enter tuşuna basın…",
   "Failed to run \"{{command}}\"…": "\"{{command}}\" çalıştırılamadı…",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -559,6 +559,7 @@
   "Loading table data": "ٹیبل کا ڈیٹا لوڈ ہو رہا ہے",
   "Refresh": "ریفریش",
   "No data matching the filter criteria.": "فلٹر کے معیار سے مطابقت رکھنے والا کوئی ڈیٹا نہیں ملا",
+  "Too many values to filter": "",
   "No results found": "کوئی نتائج نہیں ملے",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "اس کنٹینر کے عمل کا کوئی بھی نیا آؤٹ پٹ نیچے دکھایا جائے گا، اگر ظاہر نہ ہو تو انٹر دبائیں…",
   "Failed to run \"{{command}}\"…": "\"{{command}}\" چلانے میں ناکامی…",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -559,7 +559,7 @@
   "Loading table data": "ٹیبل کا ڈیٹا لوڈ ہو رہا ہے",
   "Refresh": "ریفریش",
   "No data matching the filter criteria.": "فلٹر کے معیار سے مطابقت رکھنے والا کوئی ڈیٹا نہیں ملا",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "کوئی نتائج نہیں ملے",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "اس کنٹینر کے عمل کا کوئی بھی نیا آؤٹ پٹ نیچے دکھایا جائے گا، اگر ظاہر نہ ہو تو انٹر دبائیں…",
   "Failed to run \"{{command}}\"…": "\"{{command}}\" چلانے میں ناکامی…",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -554,6 +554,7 @@
   "Loading table data": "讀取表格資料",
   "Refresh": "更新",
   "No data matching the filter criteria.": "沒有符合篩選條件的資料。",
+  "Too many values to filter": "",
   "No results found": "未找到結果",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "此容器程序的任何新輸出應顯示在下方。如果未顯示，請按 Enter…",
   "Failed to run \"{{command}}\"…": "執行 \"{{command}}\" 失敗…",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -554,7 +554,7 @@
   "Loading table data": "讀取表格資料",
   "Refresh": "更新",
   "No data matching the filter criteria.": "沒有符合篩選條件的資料。",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "未找到結果",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "此容器程序的任何新輸出應顯示在下方。如果未顯示，請按 Enter…",
   "Failed to run \"{{command}}\"…": "執行 \"{{command}}\" 失敗…",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -554,6 +554,7 @@
   "Loading table data": "读取表格信息",
   "Refresh": "更新",
   "No data matching the filter criteria.": "没有符合筛选条件的数据。",
+  "Too many values to filter": "",
   "No results found": "未找到结果",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "此容器程序的任何新输出应显示在下方。如果未显示，请按 Enter…",
   "Failed to run \"{{command}}\"…": "执行 \"{{command}}\" 失败…",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -554,7 +554,7 @@
   "Loading table data": "读取表格信息",
   "Refresh": "更新",
   "No data matching the filter criteria.": "没有符合筛选条件的数据。",
-  "Too many values to filter": "",
+  "Showing the {{max}} most common values": "",
   "No results found": "未找到结果",
   "Any new output for this container's process should be shown below. In case it doesn't show up, press enter…": "此容器程序的任何新输出应显示在下方。如果未显示，请按 Enter…",
   "Failed to run \"{{command}}\"…": "执行 \"{{command}}\" 失败…",

--- a/frontend/src/lib/util.test.ts
+++ b/frontend/src/lib/util.test.ts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import store from '../redux/stores/store';
 import {
   combineClusterListErrors,
   compareUnits,
@@ -23,6 +27,7 @@ import {
   isValidTimezone,
   normalizeUnit,
   timeAgo,
+  useFilterFunc,
 } from './util';
 
 const SECOND = 1000;
@@ -445,5 +450,57 @@ describe('compareUnits', () => {
     expect(compareUnits('abc', '1')).toBe(false);
     expect(compareUnits('1', 'abc')).toBe(false);
     expect(compareUnits('', '')).toBe(false);
+  });
+});
+
+describe('useFilterFunc', () => {
+  // The file is plain TypeScript, so the provider is built without JSX.
+  const withStore = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(Provider as React.ComponentType<any>, { store }, children);
+
+  it('keeps the same function across renders', () => {
+    const { result, rerender } = renderHook(() => useFilterFunc(), { wrapper: withStore });
+    const first = result.current;
+
+    rerender();
+
+    // Tables memoize their rows on this function, a new identity would discard them.
+    expect(result.current).toBe(first);
+  });
+
+  it('keeps the same function when the criteria arrive as a new array each render', () => {
+    // Every caller passes an inline literal, so identity alone would never hold.
+    const { result, rerender } = renderHook(() => useFilterFunc(['.jsonData.kind']), {
+      wrapper: withStore,
+    });
+    const first = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+
+  it('tells apart criteria a plain separator join would conflate', () => {
+    const { result, rerender } = renderHook(({ criteria }) => useFilterFunc(criteria), {
+      initialProps: { criteria: ['a', 'b'] },
+      wrapper: withStore,
+    });
+    const first = result.current;
+
+    rerender({ criteria: ['a\u0000b'] });
+
+    expect(result.current).not.toBe(first);
+  });
+
+  it('returns a new function when the match criteria change', () => {
+    const { result, rerender } = renderHook(({ criteria }) => useFilterFunc(criteria), {
+      initialProps: { criteria: ['a'] },
+      wrapper: withStore,
+    });
+    const first = result.current;
+
+    rerender({ criteria: ['b'] });
+
+    expect(result.current).not.toBe(first);
   });
 });

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -323,12 +323,26 @@ export function useFilterFunc<
 >(matchCriteria?: string[]) {
   const filter = useTypedSelector(state => state.filter);
 
-  return (item: T, search?: string) => {
-    if (item?.metadata) {
-      return filterResource(item as KubeObjectInterface | KubeEvent, filter, search, matchCriteria);
-    }
-    return filterGeneric<T>(item, search, matchCriteria);
-  };
+  // Callers pass the criteria as an inline array, so the memo keys on their content.
+  const criteriaKey = matchCriteria && JSON.stringify(matchCriteria);
+
+  // Tables memoize their rows on this function, so a new identity per render would throw away
+  // everything derived from those rows, filter dropdown options included.
+  return React.useMemo(
+    () => (item: T, search?: string) => {
+      if (item?.metadata) {
+        return filterResource(
+          item as KubeObjectInterface | KubeEvent,
+          filter,
+          search,
+          matchCriteria
+        );
+      }
+      return filterGeneric<T>(item, search, matchCriteria);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [filter, criteriaKey]
+  );
 }
 
 export function useErrorState(dependentSetter?: (...args: any) => void) {


### PR DESCRIPTION
## What this fixes

On large clusters the select-filter dropdowns (Status, Namespace, Node, …)
open empty, so filtering a list down to e.g. the pods that are not Running is
no longer possible.

Steps to reproduce (Headlamp 0.45.0, cluster with >500 pods):
1. Open the cluster-wide Pods list.
2. Open the column filters.
3. Click the Status or Namespace filter — the dropdown has no options.

**Why it happens**
`ResourceTable` disables faceted values above 500 rows:

```const enableFacetedValues = (data?.length ?? 0) <= 500;```

That guard is correct and was added for a real problem — TanStacks default getFacetedUniqueValues builds a unique-value map for every column, which is what made large pod lists run the browser out of memory (#5660, commit 1f35a61 "frontend: pod list: Add pagination").

The side effect is that MRTs useDropdownOptions sources the select-filter options from those same faceted values, so turning faceting off leaves every dropdown without options.

**What this changes**
Instead of disabling faceting, Table now passes its own getFacetedUniqueValues implementation that only walks the columns whose filter actually renders a dropdown (select, multi-select, autocomplete) and returns an empty map for every other column. The memory guard is preserved. The expensive part was building maps for all columns, including high cardinality ones like Name and IP — while the columns users actually filter on get their options back.

The map is built lazily (on first dropdown render) and cached per faceted row model, and MRT's dropdown pipeline is reused unchanged, so filterSelectOptions precedence and option sorting behave as before. Values are kept raw rather than stringified, so they still match what the filter functions compare against. A caller provided getFacetedUniqueValues still wins.

**Relation to #7226**
#7226 addresses the same root cause, but only restores the Namespace column by computing filterSelectOptions for it in ResourceTable. This change fixes it once in Table for every select filter, so Status, Node and any future select column are covered too.

**Tests**
- Table.test.tsx: unit coverage for the implementation itself. Empty map for non dropdown columns, recompute only when the faceted rows change, caller-provided implementation preserved.
- Table.facetedFilterOptions.test.tsx (new): regression tests against the real MRT rather than the module mock, because this fix depends on two behaviors that are not part of MRTs documented API. If an MRT upgrade changes, these tests fail instead of the dropdowns silently going empty again.