### PR TITLE
backend: cmd: Protect plugin list and static file routes

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -360,7 +360,7 @@ func addPluginRoutes(config *HeadlampConfig, r *mux.Router) {
 		pluginHandler = serveWithNoCacheHeader(pluginHandler)
 	}
 
-	r.PathPrefix("/plugins/").Handler(pluginHandler)
+	r.PathPrefix("/plugins/").Handler(auth.NewBackendTokenMiddleware(config.UseInCluster)(pluginHandler))
 
 	// Serve user-installed plugins
 	if config.UserPluginDir != "" {
@@ -370,7 +370,7 @@ func addPluginRoutes(config *HeadlampConfig, r *mux.Router) {
 			userPluginsHandler = serveWithNoCacheHeader(userPluginsHandler)
 		}
 
-		r.PathPrefix("/user-plugins/").Handler(userPluginsHandler)
+		r.PathPrefix("/user-plugins/").Handler(auth.NewBackendTokenMiddleware(config.UseInCluster)(userPluginsHandler))
 	}
 
 	// Serve shipped/static plugins
@@ -381,7 +381,7 @@ func addPluginRoutes(config *HeadlampConfig, r *mux.Router) {
 			staticPluginsHandler = serveWithNoCacheHeader(staticPluginsHandler)
 		}
 
-		r.PathPrefix("/static-plugins/").Handler(staticPluginsHandler)
+		r.PathPrefix("/static-plugins/").Handler(auth.NewBackendTokenMiddleware(config.UseInCluster)(staticPluginsHandler))
 	}
 }
 
@@ -455,53 +455,54 @@ func addPluginDeleteRoute(config *HeadlampConfig, r *mux.Router) {
 // addPluginListRoute registers a GET endpoint handler at "/plugins" that serves the list of available plugins.
 // It handles Telemetry, metrics collection, and plugin list caching.
 func addPluginListRoute(config *HeadlampConfig, r *mux.Router) {
-	r.HandleFunc("/plugins", func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
+	r.Handle("/plugins", auth.NewBackendTokenMiddleware(config.UseInCluster)(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
 
-		var span trace.Span
+			var span trace.Span
 
-		// Start tracing for listPlugins.
-		if config.Telemetry != nil {
-			_, span = telemetry.CreateSpan(ctx, r, "plugins", "listPlugins")
-
-			defer span.End()
-		}
-
-		// Increment metric for plugin loads
-		if config.Telemetry != nil && config.Metrics != nil {
-			config.Metrics.PluginLoadCount.Add(ctx, 1)
-		}
-
-		logger.Log(logger.LevelInfo, nil, nil, "Received GET request for plugin list")
-
-		w.Header().Set("Content-Type", "application/json")
-
-		pluginsList, err := config.Cache.Get(context.Background(), plugins.PluginListKey)
-		if err != nil && errors.Is(err, cache.ErrNotFound) {
-			pluginsList = []plugins.PluginMetadata{}
-
+			// Start tracing for listPlugins.
 			if config.Telemetry != nil {
-				span.SetAttributes(attribute.Int("plugins.count", 0))
-			}
-		} else if config.Telemetry != nil && pluginsList != nil {
-			if list, ok := pluginsList.([]plugins.PluginMetadata); ok {
-				span.SetAttributes(attribute.Int("plugins.count", len(list)))
-			}
-		}
+				_, span = telemetry.CreateSpan(ctx, r, "plugins", "listPlugins")
 
-		if err := json.NewEncoder(w).Encode(pluginsList); err != nil {
-			logger.Log(logger.LevelError, nil, err, "encoding plugins base paths list")
-		} else {
-			// Notify that the client has requested the plugins list. So we can start sending
-			// refresh requests.
-			if err := config.Cache.Set(context.Background(), plugins.PluginCanSendRefreshKey, true); err != nil {
-				config.TelemetryHandler.RecordError(span, err, "Failed to set plugin-can-send-refresh key")
-				logger.Log(logger.LevelError, nil, err, "setting plugin-can-send-refresh key failed")
-			} else if config.Telemetry != nil {
-				span.SetStatus(codes.Ok, "Plugin list retrieved successfully")
+				defer span.End()
 			}
-		}
-	}).Methods("GET")
+
+			// Increment metric for plugin loads
+			if config.Telemetry != nil && config.Metrics != nil {
+				config.Metrics.PluginLoadCount.Add(ctx, 1)
+			}
+
+			logger.Log(logger.LevelInfo, nil, nil, "Received GET request for plugin list")
+
+			w.Header().Set("Content-Type", "application/json")
+
+			pluginsList, err := config.Cache.Get(context.Background(), plugins.PluginListKey)
+			if err != nil && errors.Is(err, cache.ErrNotFound) {
+				pluginsList = []plugins.PluginMetadata{}
+
+				if config.Telemetry != nil {
+					span.SetAttributes(attribute.Int("plugins.count", 0))
+				}
+			} else if config.Telemetry != nil && pluginsList != nil {
+				if list, ok := pluginsList.([]plugins.PluginMetadata); ok {
+					span.SetAttributes(attribute.Int("plugins.count", len(list)))
+				}
+			}
+
+			if err := json.NewEncoder(w).Encode(pluginsList); err != nil {
+				logger.Log(logger.LevelError, nil, err, "encoding plugins base paths list")
+			} else {
+				// Notify that the client has requested the plugins list. So we can start sending
+				// refresh requests.
+				if err := config.Cache.Set(context.Background(), plugins.PluginCanSendRefreshKey, true); err != nil {
+					config.TelemetryHandler.RecordError(span, err, "Failed to set plugin-can-send-refresh key")
+					logger.Log(logger.LevelError, nil, err, "setting plugin-can-send-refresh key failed")
+				} else if config.Telemetry != nil {
+					span.SetStatus(codes.Ok, "Plugin list retrieved successfully")
+				}
+			}
+		}))).Methods("GET")
 }
 
 func readServiceAccountNamespace() (string, error) {

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -1617,6 +1617,30 @@ func TestRestrictedEndpointsRequireToken(t *testing.T) {
 			body:   nil,
 		},
 		{
+			name:   "GET /plugins (listPlugins)",
+			method: http.MethodGet,
+			path:   "/plugins",
+			body:   nil,
+		},
+		{
+			name:   "GET /plugins/{path} (dev plugin static file)",
+			method: http.MethodGet,
+			path:   "/plugins/test-plugin/main.js",
+			body:   nil,
+		},
+		{
+			name:   "GET /user-plugins/{path}",
+			method: http.MethodGet,
+			path:   "/user-plugins/main.js",
+			body:   nil,
+		},
+		{
+			name:   "GET /static-plugins/{path}",
+			method: http.MethodGet,
+			path:   "/static-plugins/main.js",
+			body:   nil,
+		},
+		{
 			name:   "GET /clusters/{name}/helm/releases (handleClusterHelm)",
 			method: http.MethodGet,
 			path:   "/clusters/" + minikubeName + "/helm/releases",
@@ -1697,6 +1721,12 @@ func newRestrictedEndpointsHandler(t *testing.T) http.Handler {
 
 	devPluginDir := filepath.Join(pluginRoot, "plugins")
 	require.NoError(t, os.Mkdir(devPluginDir, 0o750))
+
+	staticPluginDir := filepath.Join(pluginRoot, "static-plugins")
+	require.NoError(t, os.Mkdir(staticPluginDir, 0o750))
+	// createHeadlampHandler re-derives StaticPluginDir from this env var, overwriting
+	// whatever is set on the config struct below.
+	t.Setenv("HEADLAMP_STATIC_PLUGINS_DIR", staticPluginDir)
 
 	pluginDir := filepath.Join(devPluginDir, "test-plugin")
 	require.NoError(t, os.Mkdir(pluginDir, 0o750))
@@ -1801,6 +1831,8 @@ func TestRestrictedEndpointsBypassedWithoutConfiguredToken(t *testing.T) {
 		{http.MethodPost, "/cluster"},
 		{http.MethodDelete, "/cluster/" + minikubeName},
 		{http.MethodDelete, "/plugins/test-plugin"},
+		{http.MethodGet, "/plugins"},
+		{http.MethodGet, "/user-plugins/main.js"},
 	}
 
 	for _, route := range routes {
@@ -1850,6 +1882,8 @@ func TestRestrictedEndpointsBypassedInCluster(t *testing.T) {
 		{http.MethodPost, "/cluster"},
 		{http.MethodDelete, "/cluster/" + minikubeName},
 		{http.MethodDelete, "/plugins/test-plugin"},
+		{http.MethodGet, "/plugins"},
+		{http.MethodGet, "/user-plugins/main.js"},
 		{http.MethodGet, "/clusters/" + minikubeName + "/helm/releases"},
 	}
 


### PR DESCRIPTION
Plugin list, dev, user, and static-plugin routes were the only local API surface not gated by the desktop backend token, letting any local caller enumerate and download installed plugins without it. Wrap them in the same `NewBackendTokenMiddleware` used by every other route. Route tests cover the new gate without touching standalone or in-cluster launches.

## Summary

This PR fixes a bug where plugin-serving routes were not protected by `NewBackendTokenMiddleware`, inconsistent with the rest of the desktop backend token hardening from #7353.

## Related Issue

Fixes #7487

## Changes

- Wrapped `GET /plugins`, `/plugins/{path}`, `/user-plugins/{path}`, and `/static-plugins/{path}` in `auth.NewBackendTokenMiddleware(config.UseInCluster)`
- Added four test cases to `TestRestrictedEndpointsRequireToken`
- Extended `newRestrictedEndpointsHandler` with a `static-plugins` temp dir and `HEADLAMP_STATIC_PLUGINS_DIR` env var so the route is registered during tests
- Added GET /plugins and GET /user-plugins/main.js to the bypass tables in TestRestrictedEndpointsBypassedWithoutConfiguredToken and TestRestrictedEndpointsBypassedInCluster

## Steps to Test

1. Build and launch Headlamp desktop with a backend token configured
2. `curl http://localhost:<port>/plugins` without the token header — expect 403
3. `curl -H "X-HEADLAMP_BACKEND-TOKEN: <token>" http://localhost:<port>/plugins` — expect 200
4. `go test ./cmd/...` — all new and existing cases pass

## Notes for the Reviewer

- The `addPluginListRoute` diff looks large but is indentation-only inside the handler — the only real change is the middleware wrapper
- Frontend needs no changes — `installBackendTokenFetch` already injects the token on all localhost requests