### PR TITLE
frontend: Settings: Use useTheme() instead of TestHelpers theme

### DIFF
--- a/frontend/src/components/App/Settings/Settings.test.tsx
+++ b/frontend/src/components/App/Settings/Settings.test.tsx
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { ThemeProvider } from '@mui/material/styles';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { ReactNode } from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 import App from '../../../App';
@@ -44,9 +44,50 @@ function renderWithProviders(children: ReactNode) {
   );
 }
 
-describe('Settings events', () => {
+describe('Settings theme', () => {
   afterEach(() => {
     window.history.pushState({}, '', '/');
+  });
+
+  it('resolves the theme-picker grid breakpoint from the live theme, not a static import', async () => {
+    // TestHelpers/theme.ts and lib/themes.ts's createMuiTheme both default `sm` to
+    // 600px, so a regression here (reading a hardcoded theme instead of the one
+    // from context) can't be caught by comparing against the *default* theme -
+    // both would render identically. Using a theme with a distinctive `sm` value
+    // makes a hardcoded-theme regression visible: only the live theme has 733.
+    const distinctiveSm = 733;
+    const liveTheme = createTheme({
+      ...createMuiTheme({ name: 'Light', base: 'light' }),
+      breakpoints: { values: { xs: 0, sm: distinctiveSm, md: 960, lg: 1280, xl: 1920 } },
+    });
+
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <TestContext>
+          <ThemeProvider theme={liveTheme}>
+            <Settings />
+          </ThemeProvider>
+        </TestContext>
+      </QueryClientProvider>
+    );
+
+    // The theme swatches are the only "button" role divs in this view; their
+    // parent is the responsive grid whose breakpoint is under test.
+    const swatch = screen.getAllByRole('button').find(el => el.tagName === 'DIV');
+    const grid = swatch!.parentElement!;
+    const gridClass = Array.from(grid.classList).find(className => className.startsWith('css-'));
+
+    const emittedCss = Array.from(document.querySelectorAll('style'))
+      .map(styleTag => styleTag.textContent)
+      .join('\n');
+    // Match just the single @media rule scoped to the grid's own class, e.g.
+    // "@media (max-width:732.95px){.css-abc123{grid-template-columns:...}}" -
+    // not the substring-anywhere-after check a plain split('@media') would give.
+    const gridMediaQueryMatch = emittedCss.match(
+      new RegExp(`@media \\([^)]*\\)\\{\\.${gridClass}\\{[^}]*\\}\\}`)
+    );
+
+    expect(gridMediaQueryMatch?.[0]).toContain(`${distinctiveSm - 0.05}px`);
   });
 
   it('dispatches SETTINGS_VIEW with the active theme', async () => {

--- a/frontend/src/components/App/Settings/Settings.tsx
+++ b/frontend/src/components/App/Settings/Settings.tsx
@@ -15,6 +15,7 @@
  */
 
 import Box from '@mui/material/Box';
+import { useTheme } from '@mui/material/styles';
 import Switch from '@mui/material/Switch';
 import Typography from '@mui/material/Typography';
 import { useEffect, useState } from 'react';
@@ -31,7 +32,6 @@ import ActionButton from '../../common/ActionButton';
 import NameValueTable from '../../common/NameValueTable';
 import SectionBox from '../../common/SectionBox';
 import TimezoneSelect from '../../common/TimezoneSelect';
-import { theme } from '../../TestHelpers/theme';
 import { setTheme, useAppThemes } from '../themeSlice';
 import DrawerModeSettings from './DrawerModeSettings';
 import { useSettings } from './hook';
@@ -41,6 +41,7 @@ import { ThemePreview } from './ThemePreview';
 
 export default function Settings() {
   const { t } = useTranslation(['translation']);
+  const theme = useTheme();
   const settingsObj = useSettings();
   const storedTimezone = settingsObj.timezone;
   const storedRowsPerPageOptions = settingsObj.tableRowsPerPageOptions;
@@ -256,7 +257,7 @@ export default function Settings() {
         >
           <Typography
             variant="body1"
-            sx={theme => ({
+            sx={{
               textAlign: 'left',
               color: theme.palette.text.secondary,
               fontSize: '1rem',
@@ -264,7 +265,7 @@ export default function Settings() {
                 fontSize: '1.5rem',
                 color: theme.palette.text.primary,
               },
-            })}
+            }}
           >
             {t('translation|Theme')}
           </Typography>
@@ -279,12 +280,12 @@ export default function Settings() {
           {forceTheme && (
             <Typography
               variant="body2"
-              sx={theme => ({
+              sx={{
                 textAlign: 'center',
                 color: theme.palette.text.secondary,
                 fontStyle: 'italic',
                 mb: 2,
-              })}
+              }}
             >
               {t('translation|Theme has been forced by your administrator')}
             </Typography>


### PR DESCRIPTION
## Summary

`Settings.tsx` was importing its theme from `TestHelpers/theme.ts` (a test-only fixture) instead of the app's real live theme. Switches it to `useTheme()`.

## Related Issue

Closes #7492

## Changes

Most of the `theme.` references in this file were inside `sx={theme => ({...})}` callbacks, where the callback's own `theme` parameter shadows the module-level import — those already resolved correctly against the real theme via context, despite reading like they used the broken import. One usage wasn't inside a callback though (the responsive grid layout for the theme picker), and that one genuinely read the static test theme's `breakpoints.down('sm')` instead of the live one.

The two themes actually diverge at the `md` breakpoint: the app's real theme (`lib/themes.ts`) sets `md: 960`, while `TestHelpers/theme.ts` never overrides breakpoints, so it falls back to MUI's default `md: 900`. `sm` happens to be `600` in both, which is why this bug produced no visible diff today — the only breakpoint this file actually uses is `sm`. But that's incidental, not guaranteed, and the divergence at `md` shows the two themes are not interchangeable in general.

Regardless of current visible impact, production code importing from a directory literally named `TestHelpers` is a bundle-hygiene problem on its own (ships test-only code in the prod bundle, and the shadowing above shows how easy it is to introduce this kind of hidden coupling without noticing).

Fix:
- Drop the `TestHelpers/theme` import, call `const theme = useTheme()` at the top of the component like other components in the app already do.
- Also removed the two `sx={theme => ({...})}` callback wrappers (lines ~260, ~283) in favor of plain `sx={{...}}` objects that reference the component-level `theme` directly, so every `theme.` reference in the file is now the same binding — not just resolving to the same value by coincidence of context, but literally the same variable. Removes the shadowing idiom inconsistency this file previously had.

## Steps to Test

1. `npx tsc --noEmit` — no new type errors.
2. `cd frontend && npx vitest run src/components/App/Settings/Settings.test.tsx` — passes. Added a new regression test, `resolves the theme-picker grid breakpoint from the live theme, not a static import`, that renders `Settings` inside a `ThemeProvider` with a deliberately distinctive `sm` breakpoint (733px, chosen so it can't coincidentally match either theme's default) and asserts the grid's own emitted `@media` rule uses that value. This test fails against the pre-fix code (confirmed locally by reverting `Settings.tsx` to the `TestHelpers`-import version and re-running it — it emits `599.95px` instead of `732.95px`), and passes against the fix. The previously existing test only asserted the `SETTINGS_VIEW` dispatch event and didn't exercise this path at all.
3. Manually: open Settings, resize the window across the `sm` breakpoint, confirm the theme picker grid still reflows correctly.

## Notes for the Reviewer

No behavior change is expected or intended — this replaces a dead/fragile import with the correct one everywhere it's used, and the `sm` values matching means there's no visual diff from this change today. Confirmed via grep that no other file depends on `Settings.tsx` importing from `TestHelpers/`. Confirmed no open issue or PR covers this before filing #7492.

Thanks to @unlikelyzero's review for flagging that the existing test/Storybook coverage couldn't actually catch a regression here (since both themes coincide at `sm`), and for pointing out the `md` divergence and the callback-shadowing inconsistency — addressed both above.
