### PR TITLE
frontend: globalSearch: Fix keyboard scroll for recent items

### DIFF
--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -485,8 +485,10 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recent, results, query]);
 
+  const displayedOptions = !query ? recentItems : results;
+
   const autocomplete = useAutocomplete<SearchResult, false, false, true>({
-    options: !query ? recentItems : results,
+    options: displayedOptions,
     freeSolo: true, // free user input, not just autocomplete options
     autoHighlight: true, // highlight first option on open
     openOnFocus: true,
@@ -494,7 +496,7 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
     filterOptions: options => options, // we handle filtering ourself
     onHighlightChange(_, option, reason) {
       if (reason === 'keyboard' && option) {
-        const index = results.indexOf(option);
+        const index = displayedOptions.indexOf(option);
         const list = listRef.current;
         list?.scrollToItem(index);
       }


### PR DESCRIPTION
## Summary

Fixes keyboard navigation in Global Search so the virtualized list actually scrolls to follow the highlight when browsing recent items with an empty query.

## Related Issue

Closes #7494

## Changes

The `options` shown to the user switch between `recentItems` (empty query) and `results` (active query):

```ts
options: !query ? recentItems : results,
```

but `onHighlightChange` always looked up the highlighted option's position in `results`:

```ts
onHighlightChange(_, option, reason) {
  if (reason === 'keyboard' && option) {
    const index = results.indexOf(option);
    ...
```

With an empty query, `results` is empty (nothing to search), so this lookup was always `-1` and `scrollToItem(-1)` was a silent no-op — arrow-key navigation through recent items never scrolled the list. Fixed by looking up the index in whichever list is actually displayed:

```ts
const displayedOptions = !query ? recentItems : results;

const autocomplete = useAutocomplete<SearchResult, false, false, true>({
  options: displayedOptions,
  ...
  onHighlightChange(_, option, reason) {
    if (reason === 'keyboard' && option) {
      const index = displayedOptions.indexOf(option);
      ...
```

## Steps to Test

Manually: open Global Search with an empty query so it shows recent items (need enough recent items — more than fit in the ~10-row visible window — to see the scroll behavior), then press the down arrow repeatedly. With the fix, the list scrolls to keep the highlighted row visible; on `main` it doesn't once you arrow past the initially visible rows.

## Notes for the Reviewer

I wasn't able to add an automated test for this one. `GlobalSearchContent.tsx` imports a large number of `lib/k8s/*` resource classes at module scope, and mounting it in isolation via Vitest (outside the app's normal bootstrap/Storybook context) hits a pre-existing circular-import crash unrelated to this change:

```
TypeError: Class extends value undefined is not a constructor or null
  at src/lib/k8s/replicaSet.ts:44:26 (class ReplicaSet extends KubeObject<...>)
  at src/lib/k8s/deployment.ts:24:1
```

I confirmed this reproduces on a bare `import { GlobalSearchContent } from './GlobalSearchContent'` with no other changes, so it's a structural issue with the module's import graph, not something introduced here — happy to file it separately if useful. Verified the fix by tracing the exact code path by hand (confirmed `results` is empty whenever `recentItems` is what's rendered, so the old lookup was unconditionally `-1`) and via the existing Storybook stories for this component, which render fine.

Confirmed no open issue or PR covers this before filing #7494.
