### PR TITLE
frontend: storybook graphview contrast fixed for Performance Testing Pods 20000 and 100000

### DIFF
--- a/frontend/src/components/resourceMap/GraphView.stories.tsx
+++ b/frontend/src/components/resourceMap/GraphView.stories.tsx
@@ -1346,12 +1346,15 @@ export const PerformanceTest20000Pods = () => {
           </div>
           <div
             style={{
-              fontSize: '12px',
-              color: '#d32f2f',
+              fontSize: '13px',
               fontWeight: 'bold',
-              padding: '8px',
+              color: '#b71c1c',
               backgroundColor: '#ffebee',
+              border: '1px solid #ef9a9a',
               borderRadius: '4px',
+              padding: '8px',
+              width: '100%',
+              boxSizing: 'border-box',
             }}
           >
             ⚠️ EXTREME STRESS TEST with {allResources.length} resources (~60k edges). Initial render
@@ -1576,12 +1579,14 @@ export const PerformanceTest100000Pods = () => {
           <div
             style={{
               fontSize: '13px',
-              color: '#d32f2f',
               fontWeight: 'bold',
-              border: '2px solid #d32f2f',
-              padding: '8px',
-              borderRadius: '4px',
+              color: '#b71c1c',
               backgroundColor: '#ffebee',
+              border: '1px solid #ef9a9a',
+              borderRadius: '4px',
+              padding: '8px',
+              width: '100%',
+              boxSizing: 'border-box',
             }}
           >
             🚨 ULTIMATE STRESS TEST: {allResources.length} resources (~{edges.length} edges).

--- a/frontend/src/components/resourceMap/__snapshots__/GraphView.PerformanceTest100000Pods.stories.storyshot
+++ b/frontend/src/components/resourceMap/__snapshots__/GraphView.PerformanceTest100000Pods.stories.storyshot
@@ -125,7 +125,7 @@
            resources)
         </div>
         <div
-          style="font-size: 13px; color: rgb(211, 47, 47); font-weight: bold; border: 2px solid rgb(211, 47, 47); padding: 8px; border-radius: 4px; background-color: rgb(255, 235, 238);"
+          style="font-size: 13px; font-weight: bold; color: rgb(183, 28, 28); background-color: rgb(255, 235, 238); border: 1px solid rgb(239, 154, 154); border-radius: 4px; padding: 8px; width: 100%; box-sizing: border-box;"
         >
           🚨 ULTIMATE STRESS TEST: 
           105060

--- a/frontend/src/components/resourceMap/__snapshots__/GraphView.PerformanceTest20000Pods.stories.storyshot
+++ b/frontend/src/components/resourceMap/__snapshots__/GraphView.PerformanceTest20000Pods.stories.storyshot
@@ -130,7 +130,7 @@
            resources)
         </div>
         <div
-          style="font-size: 12px; color: rgb(211, 47, 47); font-weight: bold; padding: 8px; background-color: rgb(255, 235, 238); border-radius: 4px;"
+          style="font-size: 13px; font-weight: bold; color: rgb(183, 28, 28); background-color: rgb(255, 235, 238); border: 1px solid rgb(239, 154, 154); border-radius: 4px; padding: 8px; width: 100%; box-sizing: border-box;"
         >
           ⚠️ EXTREME STRESS TEST with 
           34350


### PR DESCRIPTION
Fixes #7174
### Summary
Fixes WCAG AA contrast failure and inconsistent warning bar styles in the Storybook GraphView for **PerformanceTest20000Pods** and **PerformanceTest100000Pods**.

### Changes
- color changed from #**d32f2f** to #**b71c1c** in both warning bars, raises contrast ratio from **~4.36:1** to **~5.1:1** against **#ffebee**, meeting WCAG AA (4.5:1)
- border unified to 1px solid #ef9a9a across both stories — previously `PerformanceTest100000Pods` had `2px solid #d32f2f` while `PerformanceTest20000Pods` had none
- Added `width: '100%'` and `boxSizing: 'border-box'` so the warning bar occupies its own row in the flex layout instead of sitting inline with the controls

### Steps to Test
1. Run `npm run frontend:storybook`
2. Navigate to GraphView in Storybook
3. Open **PerformanceTest20000Pods** and **PerformanceTest100000Pods**
4. Verify the warning bar is full-width, readable, and visually consistent between the two stories

### Screenshots (Before)
<img width="1919" height="977" alt="image" src="https://github.com/user-attachments/assets/4967b96b-dd85-4730-a11d-d30f5fe31751" />

### Screenshots (After)
<img width="1919" height="978" alt="image" src="https://github.com/user-attachments/assets/02538144-6516-4ffc-86e2-b069c159a1d1" />
