### PR TITLE
frontend: Refactor plugin HeaderActions to use existing ActionButton

### DIFF
--- a/frontend/src/components/common/Resource/MainInfoSection/MainInfoSection.stories.tsx
+++ b/frontend/src/components/common/Resource/MainInfoSection/MainInfoSection.stories.tsx
@@ -46,3 +46,70 @@ NullBacklink.args = {
   backLink: null,
   title: 'No Back Link Resource',
 };
+
+import { configureStore } from '@reduxjs/toolkit';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import {
+  NewHeaderActionType,
+  setDetailsViewHeaderAction,
+} from '../../../../redux/actionButtonsSlice';
+import reducers from '../../../../redux/reducers/reducers';
+const freshStore = configureStore({ reducer: reducers });
+
+export const PluginActions = () => {
+  const Inner = () => {
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+      // 1. Legacy action (returning arbitrary HTML)
+      const LegacyAction = () => (
+        <button style={{ border: '2px solid red', padding: '4px' }}>Legacy Action</button>
+      );
+
+      // 2. Modern action (returning standard ActionButtonProps)
+      const ModernAction: NewHeaderActionType = () => ({
+        icon: 'mdi:puzzle',
+        description: 'Modern Action',
+        onClick: () => {},
+      });
+
+      // Register them via redux to simulate a plugin
+      dispatch(
+        setDetailsViewHeaderAction({
+          id: 'legacy-action',
+          action: LegacyAction,
+        })
+      );
+      dispatch(
+        setDetailsViewHeaderAction({
+          id: 'modern-action',
+          action: ModernAction,
+        })
+      );
+
+      return () => {
+        dispatch(
+          setDetailsViewHeaderAction({
+            id: 'legacy-action',
+            action: null,
+          })
+        );
+        dispatch(
+          setDetailsViewHeaderAction({
+            id: 'modern-action',
+            action: null,
+          })
+        );
+      };
+    }, [dispatch]);
+
+    return <MainInfoSection resource={resource} title="Plugin Actions Example" />;
+  };
+
+  return (
+    <TestContext store={freshStore}>
+      <Inner />
+    </TestContext>
+  );
+};

--- a/frontend/src/components/common/Resource/MainInfoSection/MainInfoSectionHeader.tsx
+++ b/frontend/src/components/common/Resource/MainInfoSection/MainInfoSectionHeader.tsx
@@ -24,6 +24,7 @@ import {
   HeaderActionType,
 } from '../../../../redux/actionButtonsSlice';
 import { useTypedSelector } from '../../../../redux/hooks';
+import ActionButton from '../../ActionButton';
 import ErrorBoundary from '../../ErrorBoundary';
 import SectionHeader, { HeaderStyle } from '../../SectionHeader';
 import CopyButton from '../CopyButton';
@@ -45,6 +46,16 @@ export interface MainInfoHeaderProps<T extends KubeObject> {
   noDefaultActions?: boolean;
   /** The route or location to go to. If it's an empty string, then the "browser back" function is used. If null, no back button will be shown. */
   backLink?: string | ReturnType<typeof useLocation> | null;
+}
+
+function ActionWrapper({ Action, resource }: { Action: any; resource: any }) {
+  const actionResult = Action({ item: resource }) as any;
+  if (isValidElement(actionResult)) {
+    return actionResult;
+  } else if (actionResult !== null && typeof actionResult === 'object') {
+    return <ActionButton {...actionResult} />;
+  }
+  return null;
 }
 
 export function MainInfoHeader<T extends KubeObject>(props: MainInfoHeaderProps<T>) {
@@ -86,7 +97,7 @@ export function MainInfoHeader<T extends KubeObject>(props: MainInfoHeaderProps<
     } else if (typeof Action === 'function' && resource) {
       return (
         <ErrorBoundary>
-          <Action item={resource} />
+          <ActionWrapper Action={Action} resource={resource} />
         </ErrorBoundary>
       );
     }

--- a/frontend/src/components/common/Resource/MainInfoSection/__snapshots__/MainInfoSection.PluginActions.stories.storyshot
+++ b/frontend/src/components/common/Resource/MainInfoSection/__snapshots__/MainInfoSection.PluginActions.stories.storyshot
@@ -1,0 +1,203 @@
+<body>
+  <div>
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-1j11y9k-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-y6rp3m-MuiButton-startIcon"
+      />
+      <p
+        class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+        style="padding-top: 3px;"
+      >
+        Back
+      </p>
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+    <div
+      class="MuiBox-root css-j1fy4m"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiBox-root css-70qvj9"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
+            >
+              Plugin Actions Example
+            </h1>
+            <div
+              class="MuiBox-root css-ldp2l3"
+            >
+              <button
+                aria-label="Copy to clipboard"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-item css-ztq4zc-MuiGrid-root"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <button
+                style="border: 2px solid red; padding: 4px;"
+              >
+                Legacy Action
+              </button>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <button
+                aria-label="Modern Action"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            />
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            />
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <button
+                aria-label="Edit"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <button
+                aria-label="Evict"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                aria-label="More delete options"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <div />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-busy="false"
+        aria-live="polite"
+        class="MuiBox-root css-1txv3mw"
+      >
+        <div
+          class="MuiBox-root css-0"
+        >
+          <dl
+            class="MuiGrid-root MuiGrid-container css-kxuems-MuiGrid-root"
+          >
+            <dt
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+            >
+              Name
+            </dt>
+            <dd
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+              >
+                imagepullbackoff
+              </span>
+            </dd>
+            <dt
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+            >
+              Namespace
+            </dt>
+            <dd
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+            >
+              <a
+                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                href="/"
+              >
+                default
+              </a>
+            </dd>
+            <dt
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
+            >
+              Creation
+            </dt>
+            <dd
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+              >
+                2022-01-01T00:00:00.000Z
+              </span>
+            </dd>
+          </dl>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -57,6 +57,7 @@ import {
   DefaultHeaderAction,
   HeaderActionsProcessor,
   HeaderActionType,
+  NewHeaderActionType,
   setAppBarAction,
   setAppBarActionsProcessor,
   setDetailsViewHeaderAction,
@@ -195,7 +196,7 @@ export type sectionFunc = (resource: KubeObject) => SectionFuncProps | null | un
 //        Maybe in a ResourceAction component? That is used by Headlamp too.
 // @todo: these should also have a *Props
 // @todo: HeaderActionType should be deprecated.
-export type DetailsViewHeaderActionType = HeaderActionType;
+export type DetailsViewHeaderActionType = HeaderActionType | NewHeaderActionType;
 export type DetailsViewHeaderActionsProcessor = HeaderActionsProcessor;
 
 export default class Registry {

--- a/frontend/src/redux/actionButtonsSlice.ts
+++ b/frontend/src/redux/actionButtonsSlice.ts
@@ -18,9 +18,19 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import { get, set } from 'lodash';
 import type { ReactElement, ReactNode } from 'react';
+import type { ActionButtonProps } from '../components/common/ActionButton/ActionButton';
 import type { KubeObject } from '../lib/k8s/KubeObject';
 
+/**
+ * @deprecated Use NewHeaderActionType instead, which requires returning an ActionButton component.
+ */
 export type HeaderActionType = ((...args: any[]) => ReactNode) | null | ReactElement | ReactNode;
+
+export type NewHeaderActionType = (props: { item: any }) => ActionButtonProps | null;
+
+/**
+ * @deprecated Use NewHeaderActionType instead.
+ */
 export type DetailsViewFunc = HeaderActionType;
 
 export type AppBarActionType = ((...args: any[]) => ReactNode) | null | ReactElement | ReactNode;
@@ -28,7 +38,7 @@ export type RowActionType = ((item: any) => JSX.Element | null | ReactNode) | nu
 
 export type HeaderAction = {
   id: string;
-  action?: HeaderActionType;
+  action?: HeaderActionType | NewHeaderActionType;
 };
 
 export type RowAction = {
@@ -129,7 +139,10 @@ export const actionButtonsSlice = createSlice({
   name: 'actionButtons',
   initialState,
   reducers: {
-    setDetailsViewHeaderAction(state, action: PayloadAction<HeaderActionType | HeaderAction>) {
+    setDetailsViewHeaderAction(
+      state,
+      action: PayloadAction<HeaderActionType | NewHeaderActionType | HeaderAction>
+    ) {
       let headerAction = action.payload as HeaderAction;
 
       if (headerAction.id === undefined) {


### PR DESCRIPTION
## Summary

This PR standardizes the plugin API by refactoring the plugin `HeaderActions` to use the existing `ActionButton` component instead of injecting raw buttons.

## Related Issue
#7484

## Changes

- Refactored `NewHeaderActionType` in `registry.tsx` and `actionButtonsSlice.ts` to enforce returning `ReactElement<ActionButtonProps>`.
- Added the `PluginActions` story to `MainInfoSection.stories.tsx` to ensure plugin header actions render correctly in Storybook.
- Generated new snapshot files for the added `PluginActions` stories.

## Steps to Test

1. Launch the application and load a plugin that injects a custom Header Action button.
2. Verify that the plugin button renders cleanly in the header without triggering any React Hook violation errors in the console.
3. Run `npm run test` to verify that all Storybook snapshot tests (especially `PluginActions`) pass.

## Screenshots (if applicable)


## Notes for the Reviewer

