### PR TITLE
frontend: Chart: Make PercentageCircle loading message translatable

### DIFF
--- a/frontend/src/components/common/Chart.tsx
+++ b/frontend/src/components/common/Chart.tsx
@@ -22,6 +22,7 @@ import Typography from '@mui/material/Typography';
 import React, { ReactNode } from 'react';
 import { useRef } from 'react';
 import ReactDOM from 'react-dom';
+import { useTranslation } from 'react-i18next';
 import {
   Bar,
   BarChart,
@@ -57,6 +58,7 @@ export interface PercentageCircleProps {
 
 export function PercentageCircle(props: PercentageCircleProps) {
   const theme = useTheme();
+  const { t } = useTranslation();
   const {
     data,
     size = 200,
@@ -124,7 +126,7 @@ export function PercentageCircle(props: PercentageCircleProps) {
         </Typography>
       )}
       {isLoading ? (
-        <Loader title={`Loading data for ${title}`} />
+        <Loader title={t('Loading data for {{title}}', { title })} />
       ) : (
         <PieChart
           cx={size / 2}

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -291,6 +291,7 @@
   "Dismiss": "إغلاق",
   "Lost connection to the cluster.": "فُقد الاتصال بالكتلة.",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "لا",
   "Yes": "نعم",
   "Create {{ name }}": "إنشاء {{ name }}",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -287,6 +287,7 @@
   "Dismiss": "বরখাস্ত",
   "Lost connection to the cluster.": "Cluster এর সাথে সংযোগ হারিয়েছে।",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "না",
   "Yes": "হ্যাঁ",
   "Create {{ name }}": "Create করুন {{ name }}",

--- a/frontend/src/i18n/locales/cs/translation.json
+++ b/frontend/src/i18n/locales/cs/translation.json
@@ -289,6 +289,7 @@
   "Dismiss": "Zrušit",
   "Lost connection to the cluster.": "Došlo ke ztrátě připojení ke clusteru.",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "Ne",
   "Yes": "Ano",
   "Create {{ name }}": "Vytvořit: {{ name }}",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -287,6 +287,7 @@
   "Dismiss": "Schließen",
   "Lost connection to the cluster.": "",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "Nein",
   "Yes": "Ja",
   "Create {{ name }}": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -287,6 +287,7 @@
   "Dismiss": "Dismiss",
   "Lost connection to the cluster.": "Lost connection to the cluster.",
   "Check cluster settings": "Check cluster settings",
+  "Loading data for {{title}}": "Loading data for {{title}}",
   "No": "No",
   "Yes": "Yes",
   "Create {{ name }}": "Create {{ name }}",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -288,6 +288,7 @@
   "Dismiss": "Descartar",
   "Lost connection to the cluster.": "Perdida de conexión al cluster.",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "No",
   "Yes": "Sí",
   "Create {{ name }}": "Crear {{ name }}",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -288,6 +288,7 @@
   "Dismiss": "Rejeter",
   "Lost connection to the cluster.": "Connexion perdue avec le cluster.",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "Non",
   "Yes": "Oui",
   "Create {{ name }}": "Créer {{ name }}",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -288,6 +288,7 @@
   "Dismiss": "Dismiss",
   "Lost connection to the cluster.": "Lost connection to the cluster.",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "No",
   "Yes": "Yes",
   "Create {{ name }}": "Create {{ name }}",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -287,6 +287,7 @@
   "Dismiss": "",
   "Lost connection to the cluster.": "",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "",
   "Yes": "",
   "Create {{ name }}": "",

--- a/frontend/src/i18n/locales/hu/translation.json
+++ b/frontend/src/i18n/locales/hu/translation.json
@@ -287,6 +287,7 @@
   "Dismiss": "Bezárás",
   "Lost connection to the cluster.": "Megszakadt a kapcsolat a fürttel.",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "Nem",
   "Yes": "Igen",
   "Create {{ name }}": "{{ name }} létrehozása",

--- a/frontend/src/i18n/locales/id/translation.json
+++ b/frontend/src/i18n/locales/id/translation.json
@@ -286,6 +286,7 @@
   "Dismiss": "Tutup",
   "Lost connection to the cluster.": "Koneksi terputus ke kluster.",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "Tidak",
   "Yes": "Ya",
   "Create {{ name }}": "Buat {{ name }}",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -288,6 +288,7 @@
   "Dismiss": "Ignora",
   "Lost connection to the cluster.": "Connessione al cluster persa.",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "No",
   "Yes": "Sì",
   "Create {{ name }}": "Crea {{ name }}",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -286,6 +286,7 @@
   "Dismiss": "却下",
   "Lost connection to the cluster.": "クラスターへの接続が失われました。",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "いいえ",
   "Yes": "はい",
   "Create {{ name }}": "{{ name }} の作成",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -286,6 +286,7 @@
   "Dismiss": "닫기",
   "Lost connection to the cluster.": "클러스터와의 연결이 끊겼습니다.",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "아니오",
   "Yes": "예",
   "Create {{ name }}": "{{ name }} 생성",

--- a/frontend/src/i18n/locales/nl/translation.json
+++ b/frontend/src/i18n/locales/nl/translation.json
@@ -287,6 +287,7 @@
   "Dismiss": "Negeren",
   "Lost connection to the cluster.": "Verbinding met het cluster verbroken.",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "Nee",
   "Yes": "Ja",
   "Create {{ name }}": "{{ name }} maken",

--- a/frontend/src/i18n/locales/pl/translation.json
+++ b/frontend/src/i18n/locales/pl/translation.json
@@ -289,6 +289,7 @@
   "Dismiss": "Odrzuć",
   "Lost connection to the cluster.": "Utracono połączenie z klastrem.",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "Nie",
   "Yes": "Tak",
   "Create {{ name }}": "Utwórz {{ name }}",

--- a/frontend/src/i18n/locales/pt-br/translation.json
+++ b/frontend/src/i18n/locales/pt-br/translation.json
@@ -288,6 +288,7 @@
   "Dismiss": "Dispensar",
   "Lost connection to the cluster.": "Perdeu-se a conexão com o cluster.",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "Não",
   "Yes": "Sim",
   "Create {{ name }}": "Criar {{ name }}",

--- a/frontend/src/i18n/locales/pt-pt/translation.json
+++ b/frontend/src/i18n/locales/pt-pt/translation.json
@@ -288,6 +288,7 @@
   "Dismiss": "",
   "Lost connection to the cluster.": "",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "",
   "Yes": "",
   "Create {{ name }}": "",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -289,6 +289,7 @@
   "Dismiss": "Закрыть",
   "Lost connection to the cluster.": "Потеряно соединение с кластером.",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "Нет",
   "Yes": "Да",
   "Create {{ name }}": "Создать {{ name }}",

--- a/frontend/src/i18n/locales/sv/translation.json
+++ b/frontend/src/i18n/locales/sv/translation.json
@@ -287,6 +287,7 @@
   "Dismiss": "Ignorera",
   "Lost connection to the cluster.": "Anslutningen till klustret bröts.",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "Nej",
   "Yes": "Ja",
   "Create {{ name }}": "Skapa {{ name }}",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -287,6 +287,7 @@
   "Dismiss": "நிராகரி",
   "Lost connection to the cluster.": "க்ளஸ்டருக்கான இணைப்பு துண்டிக்கப்பட்டது.",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "இல்லை",
   "Yes": "ஆம்",
   "Create {{ name }}": "{{ name }} உருவாக்கு",

--- a/frontend/src/i18n/locales/tr/translation.json
+++ b/frontend/src/i18n/locales/tr/translation.json
@@ -287,6 +287,7 @@
   "Dismiss": "Bırak",
   "Lost connection to the cluster.": "Küme bağlantısı kesildi.",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "Hayır",
   "Yes": "Evet",
   "Create {{ name }}": "{{ name }} Oluştur",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -287,6 +287,7 @@
   "Dismiss": "مسترد کریں",
   "Lost connection to the cluster.": "کلسٹر سے رابطہ منقطع ہو گیا",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "نہیں",
   "Yes": "ہاں",
   "Create {{ name }}": "{{ name }} بنائیں",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -286,6 +286,7 @@
   "Dismiss": "忽略",
   "Lost connection to the cluster.": "與叢集的連線遺失。",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "否",
   "Yes": "是",
   "Create {{ name }}": "新增 {{ name }}",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -286,6 +286,7 @@
   "Dismiss": "忽略",
   "Lost connection to the cluster.": "与集群的连接丢失。",
   "Check cluster settings": "",
+  "Loading data for {{title}}": "",
   "No": "否",
   "Yes": "是",
   "Create {{ name }}": "创建 {{ name }}",


### PR DESCRIPTION
## Summary

Makes the `PercentageCircle` loading message translatable instead of hardcoded English.

## Related Issue

Closes #7508

## Changes

`common/Chart.tsx` didn't import `useTranslation` at all, so the loading state built its message with a plain template literal:

```tsx
<Loader title={`Loading data for ${title}`} />
```

which stayed in English no matter what language the app was set to. Fixed by wrapping it with `t()`, matching how the neighboring `Loader` component already handles its own default loading text:

```tsx
<Loader title={t('Loading data for {{title}}', { title })} />
```

Ran `npm run i18n` to extract the new key into all locale `translation.json` files (each locale gets the same untranslated placeholder that i18next falls back to until translated, same as every other new string in this codebase).

## Steps to Test

1. `npx tsc --noEmit` — no new type errors.
2. Manually: switch the app language away from English in Settings, view a page with a loading pie/donut chart (e.g. cluster status charts on the Overview page while data is loading) — the loading label now goes through the translation system instead of always being English.

## Notes for the Reviewer

`npm run i18n` also touched a few `glossary.json` files with an unrelated key reordering (pre-existing drift, nothing to do with this change — `Chart.tsx` doesn't use the glossary namespace at all), so I reverted those and kept only the `translation.json` additions this fix actually needs. Confirmed no open issue or PR covers this before filing #7508.
