### PR TITLE
frontend: endpoints: Show notReadyAddresses, fix subset URL collision

### DIFF
--- a/frontend/src/components/endpoints/Details.test.tsx
+++ b/frontend/src/components/endpoints/Details.test.tsx
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+
+const { mockDetailsGrid, mockSimpleTable } = vi.hoisted(() => ({
+  mockDetailsGrid: vi.fn(),
+  mockSimpleTable: vi.fn(),
+}));
+
+vi.mock('../common/Resource', () => ({
+  DetailsGrid: (props: any) => {
+    mockDetailsGrid(props);
+    return null;
+  },
+}));
+
+vi.mock('../common/Link', () => ({
+  default: ({ children }: any) => <span>{children}</span>,
+}));
+
+vi.mock('../common/SectionBox', () => ({
+  SectionBox: ({ children, title }: any) => (
+    <div>
+      {title}
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('../common/SectionHeader', () => ({
+  default: ({ title }: any) => <h4>{title}</h4>,
+}));
+
+vi.mock('../common/SimpleTable', () => ({
+  default: (props: any) => {
+    mockSimpleTable(props);
+    return (
+      <div data-testid={`table-${props.reflectInURL}`}>
+        {(props.data || []).map((row: any, i: number) => (
+          <div key={i}>
+            {props.columns.map((col: any) => (col.getter ? col.getter(row) : row[col.datum]))}
+          </div>
+        ))}
+      </div>
+    );
+  },
+}));
+
+vi.mock('../../lib/k8s', () => ({ ResourceClasses: {} }));
+
+vi.mock('../../lib/k8s/endpoints', () => ({
+  default: vi.fn(),
+  __esModule: true,
+}));
+
+vi.mock('../../lib/k8s/cluster', () => ({}));
+
+// Must import after mocks are set up.
+const { default: EndpointDetails } = await import('./Details');
+
+const fakeEndpoint: any = {
+  subsets: [
+    {
+      addresses: [{ ip: '10.0.0.1' }, { ip: '10.0.0.2' }],
+      notReadyAddresses: [
+        { ip: '10.0.0.9', targetRef: { kind: 'Pod', name: 'not-ready-pod', namespace: 'default' } },
+      ],
+      ports: [{ name: 'http', port: 80, protocol: 'TCP' }],
+    },
+    {
+      addresses: [{ ip: '10.0.1.1' }],
+      notReadyAddresses: [],
+      ports: [{ name: 'http', port: 81, protocol: 'TCP' }],
+    },
+  ],
+};
+
+/**
+ * Renders EndpointDetails to capture the extraSections it hands to DetailsGrid,
+ * then renders the returned subsets section so its child tables are mounted.
+ */
+function renderSubsetsSection() {
+  render(
+    <TestContext routerMap={{ namespace: 'default', name: 'my-endpoint' }}>
+      <EndpointDetails />
+    </TestContext>
+  );
+
+  expect(mockDetailsGrid).toHaveBeenCalled();
+  const { extraSections } = mockDetailsGrid.mock.calls[mockDetailsGrid.mock.calls.length - 1][0];
+  const sections = extraSections(fakeEndpoint);
+
+  return render(<TestContext>{sections[0].section}</TestContext>);
+}
+
+describe('EndpointDetails subsets section', () => {
+  beforeEach(() => {
+    mockDetailsGrid.mockReset();
+    mockSimpleTable.mockReset();
+  });
+
+  it('renders notReadyAddresses rows, including their target name', () => {
+    renderSubsetsSection();
+
+    const notReadyRow = screen.getByTestId('table-not-ready-addresses-0');
+    expect(notReadyRow).toHaveTextContent('10.0.0.9');
+    expect(notReadyRow).toHaveTextContent('not-ready-pod');
+  });
+
+  it('gives every subset table its own URL key, keyed by subset index', () => {
+    renderSubsetsSection();
+
+    const reflectInURLValues = mockSimpleTable.mock.calls.map(([props]) => props.reflectInURL);
+
+    expect(reflectInURLValues).toEqual([
+      'addresses-0',
+      'not-ready-addresses-0',
+      'ports-0',
+      'addresses-1',
+      'not-ready-addresses-1',
+      'ports-1',
+    ]);
+    // No two subsets should be able to collide on the same URL-backed state.
+    expect(new Set(reflectInURLValues).size).toBe(reflectInURLValues.length);
+  });
+});

--- a/frontend/src/components/endpoints/Details.tsx
+++ b/frontend/src/components/endpoints/Details.tsx
@@ -17,7 +17,7 @@
 import { useTranslation } from 'react-i18next';
 import { useLocation, useParams } from 'react-router-dom';
 import { ResourceClasses } from '../../lib/k8s';
-import Endpoints, { KubeEndpoint } from '../../lib/k8s/endpoints';
+import Endpoints, { KubeEndpoint, KubeEndpointAddress } from '../../lib/k8s/endpoints';
 import Empty from '../common/EmptyContent';
 import Link from '../common/Link';
 import { DetailsGrid } from '../common/Resource';
@@ -56,80 +56,94 @@ export default function EndpointDetails(props: {
                       <Empty>{t('translation|No data to be shown.')}</Empty>
                     </SectionBox>
                   ) : (
-                    item.subsets?.map((subset, i) => (
-                      <SectionBox key={`subsetDetails_${i}`} outterBoxProps={{ pb: 3 }}>
-                        <SectionHeader
-                          noPadding
-                          title={t('translation|Addresses')}
-                          headerStyle="label"
-                        />
-                        <SimpleTable
-                          data={subset?.addresses || []}
-                          columns={[
-                            {
-                              label: t('IP'),
-                              getter: address => address.ip,
-                            },
-                            {
-                              label: t('Hostname'),
-                              getter: address => address.hostname,
-                            },
-                            {
-                              label: t('Target'),
-                              getter: address => {
-                                const targetRefClass = !!address.targetRef?.kind
-                                  ? ResourceClasses[
-                                      address.targetRef?.kind as keyof typeof ResourceClasses
-                                    ]
-                                  : null;
-                                if (!!targetRefClass) {
-                                  return (
-                                    <Link
-                                      routeName={targetRefClass.detailsRoute}
-                                      params={{
-                                        name: address.targetRef.name,
-                                        namespace: address.targetRef.namespace,
-                                      }}
-                                      state={{
-                                        backLink: location,
-                                      }}
-                                    >
-                                      {address.targetRef.name}
-                                    </Link>
-                                  );
-                                } else {
-                                  return address.targetRef?.name || '';
-                                }
+                    item.subsets?.map((subset, i) => {
+                      const addressColumns = [
+                        {
+                          label: t('IP'),
+                          getter: (address: KubeEndpointAddress) => address.ip,
+                        },
+                        {
+                          label: t('Hostname'),
+                          getter: (address: KubeEndpointAddress) => address.hostname,
+                        },
+                        {
+                          label: t('Target'),
+                          getter: (address: KubeEndpointAddress) => {
+                            const targetRef = address.targetRef;
+                            if (!targetRef?.kind) {
+                              return targetRef?.name || '';
+                            }
+                            const targetRefClass =
+                              ResourceClasses[targetRef.kind as keyof typeof ResourceClasses];
+                            if (!targetRefClass) {
+                              return targetRef.name || '';
+                            }
+                            return (
+                              <Link
+                                routeName={targetRefClass.detailsRoute}
+                                params={{
+                                  name: targetRef.name,
+                                  namespace: targetRef.namespace,
+                                }}
+                                state={{
+                                  backLink: location,
+                                }}
+                              >
+                                {targetRef.name}
+                              </Link>
+                            );
+                          },
+                        },
+                      ];
+
+                      return (
+                        <SectionBox key={`subsetDetails_${i}`} outterBoxProps={{ pb: 3 }}>
+                          <SectionHeader
+                            noPadding
+                            title={t('translation|Addresses')}
+                            headerStyle="label"
+                          />
+                          <SimpleTable
+                            data={subset?.addresses || []}
+                            columns={addressColumns}
+                            reflectInURL={`addresses-${i}`}
+                          />
+                          <SectionHeader
+                            noPadding
+                            title={t('translation|Not Ready Addresses')}
+                            headerStyle="label"
+                          />
+                          <SimpleTable
+                            data={subset?.notReadyAddresses || []}
+                            columns={addressColumns}
+                            reflectInURL={`not-ready-addresses-${i}`}
+                          />
+                          <SectionHeader noPadding title={t('Ports')} headerStyle="label" />
+                          <SimpleTable
+                            data={subset?.ports || []}
+                            columns={[
+                              {
+                                label: t('translation|Name'),
+                                datum: 'name',
+                                sort: true,
                               },
-                            },
-                          ]}
-                          reflectInURL="addresses"
-                        />
-                        <SectionHeader noPadding title={t('Ports')} headerStyle="label" />
-                        <SimpleTable
-                          data={subset?.ports || []}
-                          columns={[
-                            {
-                              label: t('translation|Name'),
-                              datum: 'name',
-                              sort: true,
-                            },
-                            {
-                              label: t('Port'),
-                              datum: 'port',
-                              sort: true,
-                            },
-                            {
-                              label: t('Protocol'),
-                              datum: 'protocol',
-                              sort: true,
-                            },
-                          ]}
-                          defaultSortingColumn={1}
-                          reflectInURL="ports"
-                        />
-                      </SectionBox>
-                    ))
+                              {
+                                label: t('Port'),
+                                datum: 'port',
+                                sort: true,
+                              },
+                              {
+                                label: t('Protocol'),
+                                datum: 'protocol',
+                                sort: true,
+                              },
+                            ]}
+                            defaultSortingColumn={1}
+                            reflectInURL={`ports-${i}`}
+                          />
+                        </SectionBox>
+                      );
+                    })
                   )}
                 </>
               </>

--- a/frontend/src/components/endpoints/EndpointDetails.stories.tsx
+++ b/frontend/src/components/endpoints/EndpointDetails.stories.tsx
@@ -90,10 +90,47 @@ Default.parameters = {
                     },
                   },
                 ],
+                notReadyAddresses: [
+                  {
+                    ip: '127.0.0.3',
+                    nodeName: 'mynode',
+                    targetRef: {
+                      kind: 'Pod',
+                      namespace: 'MyNamespace',
+                      name: 'mypod-not-ready',
+                      uid: 'phony-pod-not-ready',
+                      resourceVersion: '1',
+                      apiVersion: 'v1',
+                    },
+                  },
+                ],
                 ports: [
                   {
                     name: 'myport',
                     port: 8080,
+                    protocol: 'TCP',
+                  },
+                ],
+              },
+              {
+                addresses: [
+                  {
+                    ip: '127.0.1.1',
+                    nodeName: 'mynode-2',
+                    targetRef: {
+                      kind: 'Pod',
+                      namespace: 'MyNamespace',
+                      name: 'mypod-2',
+                      uid: 'phony-pod-2',
+                      resourceVersion: '1',
+                      apiVersion: 'v1',
+                    },
+                  },
+                ],
+                ports: [
+                  {
+                    name: 'myport-2',
+                    port: 9090,
                     protocol: 'TCP',
                   },
                 ],

--- a/frontend/src/components/endpoints/__snapshots__/EndpointDetails.Default.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointDetails.Default.stories.storyshot
@@ -337,6 +337,93 @@
                     <h4
                       class="MuiTypography-root MuiTypography-h4 MuiTypography-noWrap css-15onnfg-MuiTypography-root"
                     >
+                      Not Ready Addresses
+                    </h4>
+                    <div
+                      class="MuiBox-root css-ldp2l3"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
+              <div
+                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-onzayo-MuiPaper-root-MuiTableContainer-root"
+                tabindex="0"
+              >
+                <table
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
+                >
+                  <thead
+                    class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+                    >
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        IP
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Hostname
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Target
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        127.0.0.3
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                          href="/"
+                        >
+                          mypod-not-ready
+                        </a>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1dqop0w-MuiGrid-root"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                >
+                  <div
+                    class="MuiBox-root css-70qvj9"
+                  >
+                    <h4
+                      class="MuiTypography-root MuiTypography-h4 MuiTypography-noWrap css-15onnfg-MuiTypography-root"
+                    >
                       Ports
                     </h4>
                     <div
@@ -432,6 +519,259 @@
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
                       >
                         8080
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        TCP
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-9k64dt"
+          >
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1dqop0w-MuiGrid-root"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                >
+                  <div
+                    class="MuiBox-root css-70qvj9"
+                  >
+                    <h4
+                      class="MuiTypography-root MuiTypography-h4 MuiTypography-noWrap css-15onnfg-MuiTypography-root"
+                    >
+                      Addresses
+                    </h4>
+                    <div
+                      class="MuiBox-root css-ldp2l3"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
+              <div
+                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-onzayo-MuiPaper-root-MuiTableContainer-root"
+                tabindex="0"
+              >
+                <table
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
+                >
+                  <thead
+                    class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+                    >
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        IP
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Hostname
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Target
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        127.0.1.1
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                          href="/"
+                        >
+                          mypod-2
+                        </a>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1dqop0w-MuiGrid-root"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                >
+                  <div
+                    class="MuiBox-root css-70qvj9"
+                  >
+                    <h4
+                      class="MuiTypography-root MuiTypography-h4 MuiTypography-noWrap css-15onnfg-MuiTypography-root"
+                    >
+                      Not Ready Addresses
+                    </h4>
+                    <div
+                      class="MuiBox-root css-ldp2l3"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              >
+                No data to be shown.
+              </div>
+              <div
+                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+              >
+                <div
+                  class="MuiBox-root css-19midj6"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+                  >
+                    No data to be shown.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1dqop0w-MuiGrid-root"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                >
+                  <div
+                    class="MuiBox-root css-70qvj9"
+                  >
+                    <h4
+                      class="MuiTypography-root MuiTypography-h4 MuiTypography-noWrap css-15onnfg-MuiTypography-root"
+                    >
+                      Ports
+                    </h4>
+                    <div
+                      class="MuiBox-root css-ldp2l3"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
+              <div
+                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-onzayo-MuiPaper-root-MuiTableContainer-root"
+                tabindex="0"
+              >
+                <table
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
+                >
+                  <thead
+                    class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+                    >
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-d9iroo-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Name
+                        <button
+                          aria-label="Sort descending"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
+                          data-mui-internal-clone-element="true"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-d9iroo-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Port
+                        <button
+                          aria-label="Sort ascending"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
+                          data-mui-internal-clone-element="true"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-d9iroo-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Protocol
+                        <button
+                          aria-label="Sort ascending"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
+                          data-mui-internal-clone-element="true"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        myport-2
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        9090
                       </td>
                       <td
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -716,6 +716,7 @@
   "Unable to load owned pods for diagnostics": "",
   "Loading diagnostics": "",
   "Addresses": "العناوين",
+  "Not Ready Addresses": "",
   "Address Type": "نوع العنوان",
   "Hostname": "اسم المضيف",
   "Zone": "المنطقة",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -696,6 +696,7 @@
   "Unable to load owned pods for diagnostics": "ডায়াগনস্টিকের জন্য মালিকানাধীন Pod লোড করতে অক্ষম",
   "Loading diagnostics": "ডায়াগনস্টিক লোড হচ্ছে",
   "Addresses": "ঠিকানা",
+  "Not Ready Addresses": "",
   "Address Type": "ঠিকানার ধরন",
   "Hostname": "হোস্টনাম",
   "Zone": "জোন",

--- a/frontend/src/i18n/locales/cs/translation.json
+++ b/frontend/src/i18n/locales/cs/translation.json
@@ -706,6 +706,7 @@
   "Unable to load owned pods for diagnostics": "",
   "Loading diagnostics": "",
   "Addresses": "Adresy",
+  "Not Ready Addresses": "",
   "Address Type": "Typ adresy",
   "Hostname": "Název hostitele",
   "Zone": "Zóna",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -696,6 +696,7 @@
   "Unable to load owned pods for diagnostics": "",
   "Loading diagnostics": "",
   "Addresses": "Adressen",
+  "Not Ready Addresses": "",
   "Address Type": "",
   "Hostname": "",
   "Zone": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -696,6 +696,7 @@
   "Unable to load owned pods for diagnostics": "Unable to load owned pods for diagnostics",
   "Loading diagnostics": "Loading diagnostics",
   "Addresses": "Addresses",
+  "Not Ready Addresses": "Not Ready Addresses",
   "Address Type": "Address Type",
   "Hostname": "Hostname",
   "Zone": "Zone",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -701,6 +701,7 @@
   "Unable to load owned pods for diagnostics": "",
   "Loading diagnostics": "",
   "Addresses": "Direcciones",
+  "Not Ready Addresses": "",
   "Address Type": "",
   "Hostname": "Nombre de host",
   "Zone": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -701,6 +701,7 @@
   "Unable to load owned pods for diagnostics": "",
   "Loading diagnostics": "",
   "Addresses": "Adresses",
+  "Not Ready Addresses": "",
   "Address Type": "Type d'adresse",
   "Hostname": "Nom d'hôte",
   "Zone": "Zone",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -701,6 +701,7 @@
   "Unable to load owned pods for diagnostics": "",
   "Loading diagnostics": "",
   "Addresses": "Addresses",
+  "Not Ready Addresses": "",
   "Address Type": "Address Type",
   "Hostname": "Hostname",
   "Zone": "Zone",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -696,6 +696,7 @@
   "Unable to load owned pods for diagnostics": "",
   "Loading diagnostics": "",
   "Addresses": "",
+  "Not Ready Addresses": "",
   "Address Type": "",
   "Hostname": "",
   "Zone": "",

--- a/frontend/src/i18n/locales/hu/translation.json
+++ b/frontend/src/i18n/locales/hu/translation.json
@@ -696,6 +696,7 @@
   "Unable to load owned pods for diagnostics": "",
   "Loading diagnostics": "",
   "Addresses": "Címek",
+  "Not Ready Addresses": "",
   "Address Type": "Cím típusa",
   "Hostname": "Állomásnév",
   "Zone": "Zóna",

--- a/frontend/src/i18n/locales/id/translation.json
+++ b/frontend/src/i18n/locales/id/translation.json
@@ -691,6 +691,7 @@
   "Unable to load owned pods for diagnostics": "",
   "Loading diagnostics": "",
   "Addresses": "Alamat",
+  "Not Ready Addresses": "",
   "Address Type": "Tipe Alamat",
   "Hostname": "Nama host",
   "Zone": "Zona",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -701,6 +701,7 @@
   "Unable to load owned pods for diagnostics": "",
   "Loading diagnostics": "",
   "Addresses": "Indirizzi",
+  "Not Ready Addresses": "",
   "Address Type": "",
   "Hostname": "Nome host",
   "Zone": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -691,6 +691,7 @@
   "Unable to load owned pods for diagnostics": "",
   "Loading diagnostics": "",
   "Addresses": "アドレス",
+  "Not Ready Addresses": "",
   "Address Type": "",
   "Hostname": "ホスト名",
   "Zone": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -691,6 +691,7 @@
   "Unable to load owned pods for diagnostics": "",
   "Loading diagnostics": "",
   "Addresses": "주소",
+  "Not Ready Addresses": "",
   "Address Type": "",
   "Hostname": "호스트 이름",
   "Zone": "",

--- a/frontend/src/i18n/locales/nl/translation.json
+++ b/frontend/src/i18n/locales/nl/translation.json
@@ -696,6 +696,7 @@
   "Unable to load owned pods for diagnostics": "",
   "Loading diagnostics": "",
   "Addresses": "Adressen",
+  "Not Ready Addresses": "",
   "Address Type": "Adrestype",
   "Hostname": "Hostnaam",
   "Zone": "Zone",

--- a/frontend/src/i18n/locales/pl/translation.json
+++ b/frontend/src/i18n/locales/pl/translation.json
@@ -706,6 +706,7 @@
   "Unable to load owned pods for diagnostics": "",
   "Loading diagnostics": "",
   "Addresses": "Adresy",
+  "Not Ready Addresses": "",
   "Address Type": "Typ adresu",
   "Hostname": "Nazwa hosta",
   "Zone": "Strefa",

--- a/frontend/src/i18n/locales/pt-br/translation.json
+++ b/frontend/src/i18n/locales/pt-br/translation.json
@@ -701,6 +701,7 @@
   "Unable to load owned pods for diagnostics": "",
   "Loading diagnostics": "",
   "Addresses": "Endereços",
+  "Not Ready Addresses": "",
   "Address Type": "Tipo de Endereço",
   "Hostname": "Nome do host",
   "Zone": "Zona",

--- a/frontend/src/i18n/locales/pt-pt/translation.json
+++ b/frontend/src/i18n/locales/pt-pt/translation.json
@@ -701,6 +701,7 @@
   "Unable to load owned pods for diagnostics": "",
   "Loading diagnostics": "",
   "Addresses": "",
+  "Not Ready Addresses": "",
   "Address Type": "",
   "Hostname": "",
   "Zone": "",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -706,6 +706,7 @@
   "Unable to load owned pods for diagnostics": "Не удалось загрузить Поды для диагностики",
   "Loading diagnostics": "Загрузка диагностики",
   "Addresses": "Адреса",
+  "Not Ready Addresses": "",
   "Address Type": "Тип адреса",
   "Hostname": "Имя хоста",
   "Zone": "Зона",

--- a/frontend/src/i18n/locales/sv/translation.json
+++ b/frontend/src/i18n/locales/sv/translation.json
@@ -696,6 +696,7 @@
   "Unable to load owned pods for diagnostics": "",
   "Loading diagnostics": "",
   "Addresses": "Adresser",
+  "Not Ready Addresses": "",
   "Address Type": "Adresstyp",
   "Hostname": "Namn på värddator",
   "Zone": "Zon",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -696,6 +696,7 @@
   "Unable to load owned pods for diagnostics": "",
   "Loading diagnostics": "",
   "Addresses": "முகவரிகள்",
+  "Not Ready Addresses": "",
   "Address Type": "",
   "Hostname": "ஹோஸ்ட்நேம்",
   "Zone": "",

--- a/frontend/src/i18n/locales/tr/translation.json
+++ b/frontend/src/i18n/locales/tr/translation.json
@@ -696,6 +696,7 @@
   "Unable to load owned pods for diagnostics": "",
   "Loading diagnostics": "",
   "Addresses": "Adresler",
+  "Not Ready Addresses": "",
   "Address Type": "Adres Türü",
   "Hostname": "Ana bilgisayar adı",
   "Zone": "Bölge",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -696,6 +696,7 @@
   "Unable to load owned pods for diagnostics": "",
   "Loading diagnostics": "",
   "Addresses": "ایڈریسز",
+  "Not Ready Addresses": "",
   "Address Type": "ایڈریس کی قسم",
   "Hostname": "ہوسٹ نام",
   "Zone": "زون",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -691,6 +691,7 @@
   "Unable to load owned pods for diagnostics": "",
   "Loading diagnostics": "",
   "Addresses": "位址",
+  "Not Ready Addresses": "",
   "Address Type": "位址類型",
   "Hostname": "主機名稱",
   "Zone": "區域",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -691,6 +691,7 @@
   "Unable to load owned pods for diagnostics": "",
   "Loading diagnostics": "",
   "Addresses": "地址",
+  "Not Ready Addresses": "",
   "Address Type": "地址类型",
   "Hostname": "主机名称",
   "Zone": "可用区",


### PR DESCRIPTION
## Summary

Shows `notReadyAddresses` on the Endpoints details page (previously invisible in the UI), and fixes each subset's tables sharing the same `reflectInURL` key across multiple subsets.

## Screenshot


<img width="1280" height="1366" alt="endpoint-details-notready" src="https://github.com/user-attachments/assets/d36fcf08-f460-4076-a72e-ff639a098fd7" />

Rendered from the `endpoints/EndpointsDetailsView` Default story (two subsets, one with `notReadyAddresses` populated).

## Related Issue

Closes #7510

## Changes

`subsets[].notReadyAddresses` is a real, already-typed field (`KubeEndpointSubset.notReadyAddresses` in `lib/k8s/endpoints.ts`) that the details page never rendered — only `subsets[].addresses` (the ready ones) showed up. There was no way to see not-ready endpoints without reading raw YAML.

Added a second `SimpleTable` per subset for `notReadyAddresses`, reusing the same IP/Hostname/Target columns as the existing Addresses table (hoisted into a shared `addressColumns` array to avoid duplicating that column logic twice).

Separately: each subset's Addresses/Ports tables used a hardcoded `reflectInURL="addresses"` / `reflectInURL="ports"`, the same literal string regardless of which subset it's in. For an Endpoints object with more than one subset, all of those tables reflected sort/pagination state into the *same* URL params, so interacting with one subset's table could affect another subset's table state. Suffixed each with the subset index (`addresses-${i}`, `not-ready-addresses-${i}`, `ports-${i}`) so they're independent.

While hoisting the columns out of JSX, TypeScript's strict mode surfaced a pre-existing narrowing gap in the Target column's getter (`address.targetRef` was accessed in a branch strict-mode couldn't prove was defined) — restructured it with early returns on a local `targetRef` const instead of the original ternary, same behavior for every case, just properly type-narrowed.

## Steps to Test

1. `npx tsc --noEmit` — no new type errors.
2. `cd frontend && npx vitest run src/storybook.test.tsx -t "EndpointsDetailsView"` — passes; `EndpointDetails.Default.stories.storyshot` is updated to include the new "Not Ready Addresses" section.
3. Manually: view an Endpoints resource whose subsets include `notReadyAddresses` (e.g. a Service backed by pods that are still starting up), open its details page — a "Not Ready Addresses" table now shows up under each subset alongside "Addresses".

## Notes for the Reviewer

Confirmed no open issue or PR covers this before filing #7510.

