### PR TITLE
frontend: api: rename Params to Options in clusterRequests

### DIFF
--- a/docs/development/api/interfaces/lib_k8s_apiProxy.ClusterRequestOptions.md
+++ b/docs/development/api/interfaces/lib_k8s_apiProxy.ClusterRequestOptions.md
@@ -1,16 +1,16 @@
-[API](../API.md) / [lib/k8s/apiProxy](../modules/lib_k8s_apiProxy.md) / ClusterRequestParams
+[API](../API.md) / [lib/k8s/apiProxy](../modules/lib_k8s_apiProxy.md) / ClusterRequestOptions
 
-# Interface: ClusterRequestParams
+# Interface: ClusterRequestOptions
 
-[lib/k8s/apiProxy](../modules/lib_k8s_apiProxy.md).ClusterRequestParams
+[lib/k8s/apiProxy](../modules/lib_k8s_apiProxy.md).ClusterRequestOptions
 
 The options for `clusterRequest`.
 
 ## Hierarchy
 
-- [`RequestParams`](lib_k8s_apiProxy.RequestParams.md)
+- [`RequestOptions`](lib_k8s_apiProxy.RequestOptions.md)
 
-  ↳ **`ClusterRequestParams`**
+  ↳ **`ClusterRequestOptions`**
 
 ## Properties
 
@@ -22,7 +22,7 @@ Whether to automatically log out the user if there is an authentication error.
 
 #### Overrides
 
-[RequestParams](lib_k8s_apiProxy.RequestParams.md).[autoLogoutOnAuthError](lib_k8s_apiProxy.RequestParams.md#autologoutonautherror)
+[RequestOptions](lib_k8s_apiProxy.RequestOptions.md).[autoLogoutOnAuthError](lib_k8s_apiProxy.RequestOptions.md#autologoutonautherror)
 
 #### Defined in
 
@@ -38,7 +38,7 @@ Cluster context name.
 
 #### Overrides
 
-[RequestParams](lib_k8s_apiProxy.RequestParams.md).[cluster](lib_k8s_apiProxy.RequestParams.md#cluster)
+[RequestOptions](lib_k8s_apiProxy.RequestOptions.md).[cluster](lib_k8s_apiProxy.RequestOptions.md#cluster)
 
 #### Defined in
 
@@ -54,7 +54,7 @@ Is the request expected to receive JSON data?
 
 #### Inherited from
 
-[RequestParams](lib_k8s_apiProxy.RequestParams.md).[isJSON](lib_k8s_apiProxy.RequestParams.md#isjson)
+[RequestOptions](lib_k8s_apiProxy.RequestOptions.md).[isJSON](lib_k8s_apiProxy.RequestOptions.md#isjson)
 
 #### Defined in
 
@@ -70,7 +70,7 @@ Number of milliseconds to wait for a response.
 
 #### Inherited from
 
-[RequestParams](lib_k8s_apiProxy.RequestParams.md).[timeout](lib_k8s_apiProxy.RequestParams.md#timeout)
+[RequestOptions](lib_k8s_apiProxy.RequestOptions.md).[timeout](lib_k8s_apiProxy.RequestOptions.md#timeout)
 
 #### Defined in
 

--- a/docs/development/api/interfaces/lib_k8s_apiProxy.RequestOptions.md
+++ b/docs/development/api/interfaces/lib_k8s_apiProxy.RequestOptions.md
@@ -1,8 +1,8 @@
-[API](../API.md) / [lib/k8s/apiProxy](../modules/lib_k8s_apiProxy.md) / RequestParams
+[API](../API.md) / [lib/k8s/apiProxy](../modules/lib_k8s_apiProxy.md) / RequestOptions
 
-# Interface: RequestParams
+# Interface: RequestOptions
 
-[lib/k8s/apiProxy](../modules/lib_k8s_apiProxy.md).RequestParams
+[lib/k8s/apiProxy](../modules/lib_k8s_apiProxy.md).RequestOptions
 
 Options for the request.
 
@@ -10,9 +10,9 @@ Options for the request.
 
 - `RequestInit`
 
-  ↳ **`RequestParams`**
+  ↳ **`RequestOptions`**
 
-  ↳↳ [`ClusterRequestParams`](lib_k8s_apiProxy.ClusterRequestParams.md)
+  ↳↳ [`ClusterRequestOptions`](lib_k8s_apiProxy.ClusterRequestOptions.md)
 
 ## Properties
 

--- a/docs/development/api/modules/lib_k8s_apiProxy.md
+++ b/docs/development/api/modules/lib_k8s_apiProxy.md
@@ -7,9 +7,9 @@
 - [ApiError](../interfaces/lib_k8s_apiProxy.ApiError.md)
 - [ApiInfo](../interfaces/lib_k8s_apiProxy.ApiInfo.md)
 - [ClusterRequest](../interfaces/lib_k8s_apiProxy.ClusterRequest.md)
-- [ClusterRequestParams](../interfaces/lib_k8s_apiProxy.ClusterRequestParams.md)
+- [ClusterRequestOptions](../interfaces/lib_k8s_apiProxy.ClusterRequestOptions.md)
 - [QueryParameters](../interfaces/lib_k8s_apiProxy.QueryParameters.md)
-- [RequestParams](../interfaces/lib_k8s_apiProxy.RequestParams.md)
+- [RequestOptions](../interfaces/lib_k8s_apiProxy.RequestOptions.md)
 - [StreamArgs](../interfaces/lib_k8s_apiProxy.StreamArgs.md)
 - [StreamResultsParams](../interfaces/lib_k8s_apiProxy.StreamResultsParams.md)
 
@@ -171,7 +171,7 @@ be used as a request to the respective Kubernetes server.
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `path` | `string` | The path to the API endpoint. |
-| `params` | [`ClusterRequestParams`](../interfaces/lib_k8s_apiProxy.ClusterRequestParams.md) | Optional parameters for the request. |
+| `params` | [`ClusterRequestOptions`](../interfaces/lib_k8s_apiProxy.ClusterRequestOptions.md) | Optional parameters for the request. |
 | `queryParams?` | [`QueryParameters`](../interfaces/lib_k8s_apiProxy.QueryParameters.md) | Optional query parameters for the k8s request. |
 
 #### Returns
@@ -393,7 +393,7 @@ ___
 | `url` | `string` | `undefined` |
 | `json` | `any` | `undefined` |
 | `autoLogoutOnAuthError` | `boolean` | `true` |
-| `options` | [`ClusterRequestParams`](../interfaces/lib_k8s_apiProxy.ClusterRequestParams.md) | `{}` |
+| `options` | [`ClusterRequestOptions`](../interfaces/lib_k8s_apiProxy.ClusterRequestOptions.md) | `{}` |
 
 #### Returns
 
@@ -416,7 +416,7 @@ ___
 | `url` | `string` | `undefined` |
 | `json` | `object` \| `JSON` \| [`KubeObjectInterface`](../interfaces/lib_k8s_cluster.KubeObjectInterface.md) | `undefined` |
 | `autoLogoutOnAuthError` | `boolean` | `true` |
-| `options` | [`ClusterRequestParams`](../interfaces/lib_k8s_apiProxy.ClusterRequestParams.md) | `{}` |
+| `options` | [`ClusterRequestOptions`](../interfaces/lib_k8s_apiProxy.ClusterRequestOptions.md) | `{}` |
 
 #### Returns
 
@@ -439,7 +439,7 @@ ___
 | `url` | `string` | `undefined` |
 | `json` | `Partial`<[`KubeObjectInterface`](../interfaces/lib_k8s_cluster.KubeObjectInterface.md)\> | `undefined` |
 | `autoLogoutOnAuthError` | `boolean` | `true` |
-| `requestOptions` | [`ClusterRequestParams`](../interfaces/lib_k8s_apiProxy.ClusterRequestParams.md) | `{}` |
+| `requestOptions` | [`ClusterRequestOptions`](../interfaces/lib_k8s_apiProxy.ClusterRequestOptions.md) | `{}` |
 
 #### Returns
 
@@ -460,7 +460,7 @@ ___
 | Name | Type |
 | :------ | :------ |
 | `url` | `string` |
-| `requestOptions` | [`ClusterRequestParams`](../interfaces/lib_k8s_apiProxy.ClusterRequestParams.md) |
+| `requestOptions` | [`ClusterRequestOptions`](../interfaces/lib_k8s_apiProxy.ClusterRequestOptions.md) |
 
 #### Returns
 
@@ -511,7 +511,7 @@ treated as a request to the Kubernetes server of the currently defined (in the U
 | Name | Type | Default value | Description |
 | :------ | :------ | :------ | :------ |
 | `path` | `string` | `undefined` | The path to the API endpoint. |
-| `params` | [`RequestParams`](../interfaces/lib_k8s_apiProxy.RequestParams.md) | `{}` | Optional parameters for the request. |
+| `params` | [`RequestOptions`](../interfaces/lib_k8s_apiProxy.RequestOptions.md) | `{}` | Optional parameters for the request. |
 | `autoLogoutOnAuthError` | `boolean` | `true` | Whether to automatically log out the user if there is an authentication error. |
 | `useCluster` | `boolean` | `true` | Whether to use the current cluster for the request. |
 | `queryParams?` | [`QueryParameters`](../interfaces/lib_k8s_apiProxy.QueryParameters.md) | `undefined` | Optional query parameters for the request. |

--- a/frontend/src/lib/k8s/api/v1/clusterRequests.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterRequests.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-// @todo: Params is a confusing name for options, because params are also query params.
-
 import type { OpPatch } from 'json-patch';
 import { addBackstageAuthHeaders } from '../../../../helpers/addBackstageAuthHeaders';
 import { isDebugVerbose } from '../../../../helpers/debugVerbose';
@@ -36,7 +34,7 @@ import type { QueryParameters } from './queryParameters';
 /**
  * Options for the request.
  */
-export interface RequestParams extends RequestInit {
+export interface RequestOptions extends RequestInit {
   /** Number of milliseconds to wait for a response. */
   timeout?: number;
   /** Is the request expected to receive JSON data? */
@@ -63,7 +61,7 @@ export interface ClusterRequest {
 /**
  * The options for `clusterRequest`.
  */
-export interface ClusterRequestParams extends RequestParams {
+export interface ClusterRequestOptions extends RequestOptions {
   cluster?: string | null;
   autoLogoutOnAuthError?: boolean;
 }
@@ -85,7 +83,7 @@ export function getClusterAuthType(cluster: string): string {
  * treated as a request to the Kubernetes server of the currently defined (in the URL) cluster.
  *
  * @param path - The path to the API endpoint.
- * @param params - Optional parameters for the request.
+ * @param options - Optional options for the request.
  * @param autoLogoutOnAuthError - Whether to automatically log out the user if there is an authentication error.
  * @param useCluster - Whether to use the current cluster for the request.
  * @param queryParams - Optional query parameters for the request.
@@ -95,7 +93,7 @@ export function getClusterAuthType(cluster: string): string {
  */
 export async function request(
   path: string,
-  params: RequestParams = {},
+  options: RequestOptions = {},
   autoLogoutOnAuthError: boolean = true,
   useCluster: boolean = true,
   queryParams?: QueryParameters
@@ -104,10 +102,10 @@ export async function request(
   const cluster = (useCluster && getCluster()) || '';
 
   if (isDebugVerbose('k8s/apiProxy@request')) {
-    console.debug('k8s/apiProxy@request', { path, params, useCluster, queryParams });
+    console.debug('k8s/apiProxy@request', { path, options, useCluster, queryParams });
   }
 
-  return clusterRequest(path, { cluster, autoLogoutOnAuthError, ...params }, queryParams);
+  return clusterRequest(path, { cluster, autoLogoutOnAuthError, ...options }, queryParams);
 }
 
 /**
@@ -115,7 +113,7 @@ export async function request(
  * be used as a request to the respective Kubernetes server.
  *
  * @param path - The path to the API endpoint.
- * @param params - Optional parameters for the request.
+ * @param options - Optional options for the request.
  * @param queryParams - Optional query parameters for the k8s request.
  *
  * @returns A Promise that resolves to the JSON response from the API server.
@@ -123,7 +121,7 @@ export async function request(
  */
 export async function clusterRequest(
   path: string,
-  params: ClusterRequestParams = {},
+  options: ClusterRequestOptions = {},
   queryParams?: QueryParameters
 ): Promise<any> {
   interface RequestHeaders {
@@ -135,22 +133,22 @@ export async function clusterRequest(
 
   const {
     timeout = DEFAULT_TIMEOUT,
-    cluster: paramsCluster,
+    cluster: optionsCluster,
     autoLogoutOnAuthError = true,
     isJSON = true,
-    ...otherParams
-  } = params;
+    ...otherOptions
+  } = options;
 
   const userID = getUserIdFromLocalStorage();
   const headers: RequestHeaders = {};
-  new Headers(otherParams.headers).forEach((value, key) => {
+  new Headers(otherOptions.headers).forEach((value, key) => {
     headers[key] = value;
   });
   Object.entries(getHeadlampAPIHeaders()).forEach(([name, value]) => {
     headers[name.toLowerCase()] = value;
   });
-  const opts = { ...otherParams, headers };
-  const cluster = paramsCluster || '';
+  const opts = { ...otherOptions, headers };
+  const cluster = optionsCluster || '';
 
   let fullPath = path;
   if (cluster) {
@@ -248,7 +246,7 @@ export function post(
   url: string,
   json: JSON | object | KubeObjectInterface,
   autoLogoutOnAuthError: boolean = true,
-  options: ClusterRequestParams = {}
+  options: ClusterRequestOptions = {}
 ) {
   const { cluster: clusterName, ...requestOptions } = options;
   const body = JSON.stringify(json);
@@ -267,7 +265,7 @@ export function patch(
   url: string,
   json: any,
   autoLogoutOnAuthError = true,
-  options: ClusterRequestParams = {}
+  options: ClusterRequestOptions = {}
 ) {
   const { cluster: clusterName, ...requestOptions } = options;
   const body = JSON.stringify(json);
@@ -298,7 +296,7 @@ export function jsonPatch(
   url: string,
   operations: OpPatch[],
   autoLogoutOnAuthError = true,
-  options: ClusterRequestParams = {}
+  options: ClusterRequestOptions = {}
 ) {
   const { cluster: clusterName, ...requestOptions } = options;
   const body = JSON.stringify(operations);
@@ -318,7 +316,7 @@ export function put(
   url: string,
   json: Partial<KubeObjectInterface>,
   autoLogoutOnAuthError = true,
-  requestOptions: ClusterRequestParams = {}
+  requestOptions: ClusterRequestOptions = {}
 ) {
   const body = JSON.stringify(json);
   const { cluster: clusterName, ...restOptions } = requestOptions;
@@ -333,7 +331,7 @@ export function put(
   return clusterRequest(url, opts);
 }
 
-export function remove(url: string, requestOptions: ClusterRequestParams = {}) {
+export function remove(url: string, requestOptions: ClusterRequestOptions = {}) {
   const { cluster: clusterName, ...restOptions } = requestOptions;
   const cluster = clusterName || getCluster() || '';
   const opts = { method: 'DELETE', headers: JSON_HEADERS, cluster, ...restOptions };

--- a/frontend/src/lib/k8s/apiProxy/index.ts
+++ b/frontend/src/lib/k8s/apiProxy/index.ts
@@ -49,8 +49,10 @@ export {
   remove,
   request,
   type ClusterRequest,
-  type ClusterRequestParams,
-  type RequestParams,
+  type ClusterRequestOptions,
+  type ClusterRequestOptions as ClusterRequestParams,
+  type RequestOptions,
+  type RequestOptions as RequestParams,
 } from '../api/v1/clusterRequests';
 
 // Streaming API functions


### PR DESCRIPTION
### Summary
This PR resolves a longstanding `TODO` in `frontend/src/lib/k8s/api/v1/clusterRequests.ts` by renaming `RequestParams` and `ClusterRequestParams` to `RequestOptions` and `ClusterRequestOptions`. 

This change improves code readability by clarifying that these interfaces are for HTTP request *fetch options* (like headers, timeout, auth logic) rather than URL *query params*.

### Changes
- **frontend/src/lib/k8s/api/v1/clusterRequests.ts**: 
  - Renamed `RequestParams` to `RequestOptions`
  - Renamed `ClusterRequestParams` to `ClusterRequestOptions`
  - Updated function arguments globally in this file from `params` to `options`
- **frontend/src/lib/k8s/apiProxy/index.ts**: 
  - Updated exports to reflect the newly renamed type definitions

### Steps to Test
1. Check out this branch and navigate to the project root.
2. Run `npm install` and `npm run frontend:install` to ensure dependencies are present.
3. Run `npm run frontend:tsc` to verify that there are no TypeScript compilation errors.
4. Run `npm run frontend:lint` to verify adherence to style rules.
5. (Optional) Run `npm start` to test the application locally and verify that API requests to the cluster still behave normally.

### Screenshots
*N/A - This is a purely backend/type refactoring with no UI changes.*

### Notes for the Reviewer
- There are no functionality changes in this PR; it strictly consists of safe renames.
- The `tsc` typecheck passes without errors.
- No other files in the `frontend` directory used the old `RequestParams` or `ClusterRequestParams` types.
