### PR TITLE
feat: create Storybook stories for PortForward component

### DIFF
--- a/frontend/src/components/common/Resource/PortForward.stories.tsx
+++ b/frontend/src/components/common/Resource/PortForward.stories.tsx
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryObj } from '@storybook/react';
+import { delay, http, HttpResponse } from 'msw';
+import React from 'react';
+import { KubeObject } from '../../../lib/k8s/KubeObject';
+import { TestContext } from '../../../test';
+import PortForward, { PortForwardState } from './PortForward';
+
+// Dummy Pod Resource
+const mockPodResource: KubeObject = {
+  kind: 'Pod',
+  apiVersion: 'v1',
+  metadata: {
+    name: 'my-pod',
+    namespace: 'default',
+    uid: '1234',
+  },
+  cluster: 'my-cluster',
+  status: {
+    phase: 'Running',
+  },
+} as unknown as KubeObject;
+
+const originalProcess = typeof window !== 'undefined' ? (window as any).process : undefined;
+
+const meta: Meta<typeof PortForward> = {
+  title: 'common/Resource/PortForward',
+  component: PortForward,
+  decorators: [
+    Story => {
+      React.useEffect(() => {
+        return () => {
+          if (typeof window !== 'undefined') {
+            (window as any).process = originalProcess;
+          }
+        };
+      }, []);
+
+      if (typeof window !== 'undefined') {
+        (window as any).process = { ...(originalProcess || {}), type: 'renderer' };
+      }
+
+      // Clear localStorage so state doesn't leak between stories
+      localStorage.removeItem('portforwards');
+      return (
+        <TestContext>
+          <div style={{ padding: '20px' }}>
+            <Story />
+          </div>
+        </TestContext>
+      );
+    },
+  ],
+  args: {
+    resource: mockPodResource,
+    containerPort: 8080,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PortForward>;
+
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: {
+        story: [
+          http.get('*/clusters/my-cluster/portforward/list', () => HttpResponse.json([])),
+          http.get('*/api/v1/namespaces/default/pods', () => HttpResponse.json({ items: [] })),
+        ],
+      },
+    },
+  },
+};
+
+export const Loading: Story = {
+  parameters: {
+    storyshots: { disable: true },
+    msw: {
+      handlers: {
+        story: [
+          // Delay indefinitely to show the loading state
+          http.get('*/clusters/my-cluster/portforward/list', async () => {
+            await delay('infinite');
+            return HttpResponse.json([]);
+          }),
+          http.get('*/api/v1/namespaces/default/pods', () => HttpResponse.json({ items: [] })),
+        ],
+      },
+    },
+  },
+};
+
+const activePortForward: PortForwardState = {
+  id: 'pf-123',
+  pod: 'my-pod',
+  service: '',
+  serviceNamespace: 'default',
+  namespace: 'default',
+  cluster: 'my-cluster',
+  port: '8080',
+  targetPort: '8080',
+  status: 'Running',
+};
+
+export const Success: Story = {
+  parameters: {
+    msw: {
+      handlers: {
+        story: [
+          http.get('*/clusters/my-cluster/portforward/list', () =>
+            HttpResponse.json([activePortForward])
+          ),
+          http.get('*/api/v1/namespaces/default/pods', () => HttpResponse.json({ items: [] })),
+        ],
+      },
+    },
+  },
+};
+
+export const ErrorConnectionFailed: Story = {
+  parameters: {
+    msw: {
+      handlers: {
+        story: [
+          http.get('*/clusters/my-cluster/portforward/list', () => {
+            return new HttpResponse(
+              JSON.stringify({ message: 'Network error connecting to cluster' }),
+              {
+                status: 500,
+                headers: { 'Content-Type': 'application/json' },
+              }
+            );
+          }),
+          http.get('*/api/v1/namespaces/default/pods', () => HttpResponse.json({ items: [] })),
+        ],
+      },
+    },
+  },
+};
+
+export const PortAlreadyInUse: Story = {
+  parameters: {
+    msw: {
+      handlers: {
+        story: [
+          http.get('*/clusters/my-cluster/portforward/list', () => {
+            return new HttpResponse(JSON.stringify({ message: 'Port 8080 is already in use' }), {
+              status: 500,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }),
+          http.get('*/api/v1/namespaces/default/pods', () => HttpResponse.json({ items: [] })),
+        ],
+      },
+    },
+  },
+};

--- a/frontend/src/components/common/Resource/__snapshots__/PortForward.Default.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/PortForward.Default.stories.storyshot
@@ -1,0 +1,28 @@
+<body>
+  <div>
+    <div
+      style="padding: 20px;"
+    >
+      <div
+        class="MuiBox-root css-0"
+      >
+        <button
+          aria-label="Start port forward"
+          class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1ftyvt9-MuiButtonBase-root-MuiButton-root"
+          style="text-transform: none;"
+          tabindex="0"
+          type="button"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          >
+            Forward port
+          </p>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/PortForward.ErrorConnectionFailed.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/PortForward.ErrorConnectionFailed.stories.storyshot
@@ -1,0 +1,90 @@
+<body>
+  <div>
+    <div
+      style="padding: 20px;"
+    >
+      <div
+        class="MuiBox-root css-0"
+      >
+        <div
+          class="MuiBox-root css-1qm1lh"
+        >
+          <div
+            class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorError MuiAlert-standardError MuiAlert-standard css-op449e-MuiPaper-root-MuiAlert-root"
+            role="alert"
+          >
+            <div
+              class="MuiAlert-icon css-1ytlwq5-MuiAlert-icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
+                data-testid="ErrorOutlineIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+            </div>
+            <div
+              class="MuiAlert-message css-1pxa9xg-MuiAlert-message"
+            >
+              <div
+                aria-label="Error"
+                class="MuiBox-root css-0"
+                data-mui-internal-clone-element="true"
+                style="overflow: hidden; text-overflow: ellipsis;"
+              >
+                Network error connecting to cluster
+              </div>
+            </div>
+            <div
+              class="MuiAlert-action css-ki1hdl-MuiAlert-action"
+            >
+              <button
+                aria-label="Close"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall css-1l07gxf-MuiButtonBase-root-MuiIconButton-root"
+                tabindex="0"
+                title="Close"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                  data-testid="CloseIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+        <button
+          aria-label="Start port forward"
+          class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1ftyvt9-MuiButtonBase-root-MuiButton-root"
+          style="text-transform: none;"
+          tabindex="0"
+          type="button"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          >
+            Forward port
+          </p>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/PortForward.PortAlreadyInUse.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/PortForward.PortAlreadyInUse.stories.storyshot
@@ -1,0 +1,90 @@
+<body>
+  <div>
+    <div
+      style="padding: 20px;"
+    >
+      <div
+        class="MuiBox-root css-0"
+      >
+        <div
+          class="MuiBox-root css-1qm1lh"
+        >
+          <div
+            class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorError MuiAlert-standardError MuiAlert-standard css-op449e-MuiPaper-root-MuiAlert-root"
+            role="alert"
+          >
+            <div
+              class="MuiAlert-icon css-1ytlwq5-MuiAlert-icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
+                data-testid="ErrorOutlineIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+            </div>
+            <div
+              class="MuiAlert-message css-1pxa9xg-MuiAlert-message"
+            >
+              <div
+                aria-label="Error"
+                class="MuiBox-root css-0"
+                data-mui-internal-clone-element="true"
+                style="overflow: hidden; text-overflow: ellipsis;"
+              >
+                Port 8080 is already in use
+              </div>
+            </div>
+            <div
+              class="MuiAlert-action css-ki1hdl-MuiAlert-action"
+            >
+              <button
+                aria-label="Close"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall css-1l07gxf-MuiButtonBase-root-MuiIconButton-root"
+                tabindex="0"
+                title="Close"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                  data-testid="CloseIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+        <button
+          aria-label="Start port forward"
+          class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1ftyvt9-MuiButtonBase-root-MuiButton-root"
+          style="text-transform: none;"
+          tabindex="0"
+          type="button"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          >
+            Forward port
+          </p>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/PortForward.Success.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/PortForward.Success.stories.storyshot
@@ -1,0 +1,31 @@
+<body>
+  <div>
+    <div
+      style="padding: 20px;"
+    >
+      <div
+        class="MuiBox-root css-0"
+      >
+        <a
+          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+          href="http://127.0.0.1:8080"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          http://127.0.0.1:8080
+        </a>
+        <button
+          aria-label="Stop port forward"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-18expok-MuiButtonBase-root-MuiIconButton-root"
+          data-mui-internal-clone-element="true"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
## Summary
This PR adds Storybook stories for the PortForward component.

## Related Issue
Fixes #7514

## Changes
- Created `frontend/src/components/common/Resource/PortForward.stories.tsx` to mock PortForward states (default, loading, success, error, port in use).

## Steps to Test
1. Run `make frontend-build-storybook`
2. View the PortForward component stories in the generated Storybook.

## Notes for the Reviewer
The loading state snapshot is disabled to prevent infinite timeouts during testing.
