### PR TITLE
charts: Add Prometheus ServiceMonitor support to Helm chart

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -5,6 +5,7 @@
        HEADLAMP_STATIC_PLUGINS_DIR. `hasKey` guards against false being treated
        as empty by `default`, and an unset value defaults to serving them. */}}
 {{- $staticPlugins := .Values.config.staticPlugins | default dict }}
+{{- $metricsEnabled := and .Values.metrics .Values.metrics.enabled }}
 {{- $staticPluginsDisabled := and (hasKey $staticPlugins "enabled") (not $staticPlugins.enabled) }}
 
 {{- $clientID := "" }}
@@ -120,13 +121,13 @@ spec:
             {{- end }}
           image: "{{ .Values.image.registry}}/{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{ if or $oidc .Values.env $staticPluginsDisabled }}
+          {{ if or $oidc .Values.env $staticPluginsDisabled $metricsEnabled }}
           {{- if $oidc.externalSecret.enabled }}
           # Check if externalSecret is enabled
           envFrom:
           - secretRef:
               name: {{ $oidc.externalSecret.name }}
-          {{- if or .Values.env $staticPluginsDisabled }}
+          {{- if or .Values.env $staticPluginsDisabled $metricsEnabled }}
           env:
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
@@ -134,6 +135,10 @@ spec:
             {{- if $staticPluginsDisabled }}
             - name: HEADLAMP_STATIC_PLUGINS_DIR
               value: ""
+            {{- end }}
+            {{- if $metricsEnabled }}
+            - name: HEADLAMP_CONFIG_METRICS_ENABLED
+              value: "true"
             {{- end }}
           {{- end }}
           {{- else }}
@@ -257,6 +262,10 @@ spec:
             {{- if $staticPluginsDisabled }}
             - name: HEADLAMP_STATIC_PLUGINS_DIR
               value: ""
+            {{- end }}
+            {{- if $metricsEnabled }}
+            - name: HEADLAMP_CONFIG_METRICS_ENABLED
+              value: "true"
             {{- end }}
           {{- end }}
           {{- end }}

--- a/charts/headlamp/templates/servicemonitor.yaml
+++ b/charts/headlamp/templates/servicemonitor.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "headlamp.fullname" . }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace | default (include "headlamp.namespace" .) }}
+  labels:
+    {{- include "headlamp.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.metrics.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "headlamp.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ include "headlamp.namespace" . }}
+  endpoints:
+    - port: http
+      path: /metrics
+      {{- with .Values.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: true
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/headlamp/tests/expected_templates/metrics-servicemonitor.yaml
+++ b/charts/headlamp/tests/expected_templates/metrics-servicemonitor.yaml
@@ -1,0 +1,171 @@
+---
+# Source: headlamp/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.45.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.45.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: headlamp/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oidc
+  namespace: default
+type: Opaque
+data:
+---
+# Source: headlamp/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+  labels:
+    helm.sh/chart: headlamp-0.45.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.45.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: headlamp
+  namespace: default
+---
+# Source: headlamp/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.45.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.45.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+---
+# Source: headlamp/templates/deployment.yaml
+# This block of code is used to extract the values from the env.
+# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.45.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.45.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+      app.kubernetes.io/instance: headlamp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: headlamp
+        app.kubernetes.io/instance: headlamp
+    spec:
+      serviceAccountName: headlamp
+      automountServiceAccountToken: true
+      hostUsers: true
+      securityContext:
+        {}
+      containers:
+        - name: headlamp
+          securityContext:
+            privileged: false
+            runAsGroup: 101
+            runAsNonRoot: true
+            runAsUser: 100
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.45.0"
+          imagePullPolicy: IfNotPresent
+          
+          env:
+            - name: HEADLAMP_CONFIG_METRICS_ENABLED
+              value: "true"
+          args:
+            - "-in-cluster"
+            - "-in-cluster-context-name=main"
+            - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
+            # Check if externalSecret is disabled
+          ports:
+            - name: http
+              containerPort: 4466
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: "/"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            {}
+---
+# Source: headlamp/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.45.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.45.0"
+    app.kubernetes.io/managed-by: Helm
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+      app.kubernetes.io/instance: headlamp
+  namespaceSelector:
+    matchNames:
+      - default
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 15s
+      scrapeTimeout: 5s

--- a/charts/headlamp/tests/test_cases/metrics-servicemonitor.yaml
+++ b/charts/headlamp/tests/test_cases/metrics-servicemonitor.yaml
@@ -1,0 +1,12 @@
+# Test case: metrics enabled with ServiceMonitor
+config:
+  inCluster: true
+
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: kube-prometheus-stack
+    interval: "15s"
+    scrapeTimeout: "5s"

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -1005,6 +1005,69 @@
         "required": ["ip", "hostnames"],
         "additionalProperties": false
       }
+    },
+    "metrics": {
+      "type": "object",
+      "description": "Prometheus metrics configuration. Enables the /metrics endpoint and optional ServiceMonitor creation",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable the Prometheus /metrics endpoint on the Headlamp backend",
+          "default": false
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "description": "ServiceMonitor resource configuration for Prometheus Operator auto-discovery",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Create a ServiceMonitor resource. Requires metrics.enabled and Prometheus Operator CRDs",
+              "default": false
+            },
+            "namespace": {
+              "type": "string",
+              "description": "Namespace for the ServiceMonitor. Defaults to the release namespace"
+            },
+            "labels": {
+              "type": "object",
+              "description": "Additional labels for the ServiceMonitor (e.g. for Prometheus selector matching)"
+            },
+            "annotations": {
+              "type": "object",
+              "description": "Annotations for the ServiceMonitor"
+            },
+            "interval": {
+              "type": "string",
+              "description": "Prometheus scrape interval",
+              "default": "30s"
+            },
+            "scrapeTimeout": {
+              "type": "string",
+              "description": "Prometheus scrape timeout",
+              "default": "10s"
+            },
+            "honorLabels": {
+              "type": "boolean",
+              "description": "Whether to honor labels from the scraped data over labels attached by Prometheus",
+              "default": false
+            },
+            "metricRelabelings": {
+              "type": "array",
+              "description": "MetricRelabelConfigs to apply to samples before ingestion",
+              "items": {
+                "type": "object"
+              }
+            },
+            "relabelings": {
+              "type": "array",
+              "description": "RelabelConfigs to apply to samples before scraping",
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -287,6 +287,35 @@ service:
   #   protocol: TCP
   #   nodePort: null
 
+# Prometheus metrics configuration.
+# The Headlamp backend exposes a /metrics endpoint when metrics are enabled.
+# This section controls that endpoint and optional ServiceMonitor creation
+# for automatic discovery by kube-prometheus-stack.
+metrics:
+  # -- Enable the Prometheus /metrics endpoint on the Headlamp backend.
+  # Sets the HEADLAMP_CONFIG_METRICS_ENABLED environment variable.
+  enabled: false
+  serviceMonitor:
+    # -- Create a ServiceMonitor resource for Prometheus Operator.
+    # Requires metrics.enabled to be true and the Prometheus Operator CRDs to be installed.
+    enabled: false
+    # -- Namespace for the ServiceMonitor. Defaults to the release namespace.
+    namespace: ""
+    # -- Additional labels to add to the ServiceMonitor (e.g. for Prometheus selector matching)
+    labels: {}
+    # -- Annotations to add to the ServiceMonitor
+    annotations: {}
+    # -- Prometheus scrape interval
+    interval: "30s"
+    # -- Prometheus scrape timeout
+    scrapeTimeout: "10s"
+    # -- Whether to honor labels from the scraped data over labels attached by Prometheus
+    honorLabels: false
+    # -- MetricRelabelConfigs to apply to samples before ingestion
+    metricRelabelings: []
+    # -- RelabelConfigs to apply to samples before scraping
+    relabelings: []
+
 # -- Headlamp containers volume mounts
 volumeMounts: []
 


### PR DESCRIPTION
 ## Summary
This PR adds Prometheus ServiceMonitor support to the Headlamp Helm chart. It introduces a `metrics` section in `values.yaml` that enables the backend's existing `/metrics` endpoint and optionally creates a `monitoring.coreos.com/v1` ServiceMonitor for auto-discovery by Prometheus Operator (kube-prometheus-stack).

## Related Issue
Fixes #7518

## Changes
- Added `templates/servicemonitor.yaml`, a new template that creates a ServiceMonitor when `metrics.serviceMonitor.enabled` is true
- Updated `templates/deployment.yaml` to inject `HEADLAMP_CONFIG_METRICS_ENABLED=true` env var when `metrics.enabled` is true (both OIDC external-secret and regular env branches)
- Updated `values.yaml`, added a `metrics:` section with `enabled`, `serviceMonitor.enabled`, `interval`, `scrapeTimeout`, `labels`, `annotations`, `namespace`, `honorLabels`, `metricRelabelings`, and `relabelings`
- Updated `values.schema.json` with JSON schema validation for the new `metrics` section
- Added `tests/test_cases/metrics-servicemonitor.yaml` as a test case values file
- Added `tests/expected_templates/metrics-servicemonitor.yaml` as the expected rendered output for that test case

## Steps to Test
1. Run `helm lint charts/headlamp --strict`, should pass with 0 failures
2. Run `helm lint charts/headlamp --strict --set metrics.enabled=true --set metrics.serviceMonitor.enabled=true`, should also pass
3. Run `helm template test charts/headlamp`, should NOT render a ServiceMonitor (disabled by default)
4. Run `helm template test charts/headlamp --set metrics.enabled=true --set metrics.serviceMonitor.enabled=true`, should render a valid ServiceMonitor and include `HEADLAMP_CONFIG_METRICS_ENABLED` env var in the deployment
5. Run `helm template test charts/headlamp --set metrics.enabled=true --set metrics.serviceMonitor.enabled=true --set metrics.serviceMonitor.labels.release=kube-prometheus`, verify custom labels appear on the ServiceMonitor
6. Run `make helm-template-test` (or `bash charts/headlamp/tests/test.sh`), all existing and new test cases should pass

## Notes for the Reviewer
- This is a chart only change, no Go or React code is modified. The backend `/metrics` endpoint already exists and is fully functional.
- `metrics.enabled` and `metrics.serviceMonitor.enabled` are both `false` by default, so this is a zero impact change for existing deployments.
- The ServiceMonitor template follows the same pattern used by the Grafana Helm chart  and the ArgoCD Helm chart .
- `HEADLAMP_CONFIG_METRICS_ENABLED` env var injection was added to both the `externalSecret` and the regular OIDC env branches in `deployment.yaml` so it works regardless of OIDC configuration.
- The `ct install` CI step uses default values (`metrics.enabled=false`), so the ServiceMonitor CRD isn't required during CI installation tests.