### PR TITLE
backend: clusterinventory: Support OIDC credential sources

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -557,6 +557,7 @@ func startClusterInventory(ctx context.Context, config *HeadlampConfig) error {
 		HubConfig:             hubConfig,
 		HubNamespace:          hubNamespace,
 		DiscoverFromStore:     !config.UseInCluster,
+		OIDCConfig:            clusterInventoryOIDCConfig(config),
 	})
 	if err != nil {
 		return err
@@ -565,6 +566,27 @@ func startClusterInventory(ctx context.Context, config *HeadlampConfig) error {
 	go runner.Run(ctx)
 
 	return nil
+}
+
+func clusterInventoryOIDCConfig(config *HeadlampConfig) *kubeconfig.OidcConfig {
+	if config.OidcIdpIssuerURL == "" || config.OidcClientID == "" {
+		return nil
+	}
+
+	skipTLSVerify := config.OidcSkipTLSVerify
+
+	var caCert *string
+
+	if config.OidcCACert != "" {
+		value := config.OidcCACert
+		caCert = &value
+	}
+
+	return &kubeconfig.OidcConfig{
+		ClientID: config.OidcClientID, ClientSecret: config.OidcClientSecret,
+		IdpIssuerURL: config.OidcIdpIssuerURL, Scopes: append([]string(nil), config.OidcScopes...),
+		SkipTLSVerify: &skipTLSVerify, CACert: caCert,
+	}
 }
 
 func setupInClusterContext(config *HeadlampConfig) {

--- a/backend/pkg/clusterinventory/clusterinventory.go
+++ b/backend/pkg/clusterinventory/clusterinventory.go
@@ -28,6 +28,7 @@ import (
 	"hash"
 	"net/http"
 	"net/url"
+	"os"
 	"slices"
 	"sort"
 	"strings"
@@ -65,6 +66,7 @@ const (
 	storeRootPrefix               = "store/"
 
 	clusterExecConfigExtensionKey = "client.authentication.k8s.io/exec"
+	credentialSourceOIDC          = "oidc"
 )
 
 // Structured-log field names that recur across many log sites.
@@ -98,6 +100,9 @@ type Options struct {
 	HubNamespace string
 	// DiscoverFromStore enables discovery from non-internal contexts already in Store.
 	DiscoverFromStore bool
+	// OIDCConfig is inherited by discovered contexts whose provider selects the
+	// OIDC credential source.
+	OIDCConfig *kubeconfig.OidcConfig
 }
 
 // Runner watches ClusterProfile resources and syncs them into Headlamp's context store.
@@ -111,6 +116,8 @@ type Runner struct {
 	hubConfig             *rest.Config
 	hubNamespace          string
 	discoverFromStore     bool
+	oidcConfig            *kubeconfig.OidcConfig
+	credentialProviders   []credentialProvider
 
 	clientForConfig func(*rest.Config) (ciaclient.Interface, error)
 	now             func() time.Time
@@ -160,9 +167,9 @@ func NewRunner(opts Options) (*Runner, error) {
 		return nil, errors.New("cluster inventory provider file is required")
 	}
 
-	accessConfig, err := access.NewFromFile(opts.ProviderFile)
+	accessConfig, credentialProviders, err := loadProviderConfiguration(opts.ProviderFile, opts.OIDCConfig != nil)
 	if err != nil {
-		return nil, fmt.Errorf("load cluster inventory provider file: %w", err)
+		return nil, err
 	}
 
 	labelSelector, err := normalizeLabelSelector(opts.LabelSelector)
@@ -195,6 +202,8 @@ func NewRunner(opts Options) (*Runner, error) {
 		hubConfig:             opts.HubConfig,
 		hubNamespace:          opts.HubNamespace,
 		discoverFromStore:     opts.DiscoverFromStore,
+		oidcConfig:            copyOIDCConfig(opts.OIDCConfig),
+		credentialProviders:   credentialProviders,
 		clientForConfig: func(config *rest.Config) (ciaclient.Interface, error) {
 			return ciaclient.NewForConfig(config)
 		},
@@ -204,6 +213,28 @@ func NewRunner(opts Options) (*Runner, error) {
 		profileKeysByRoot: map[string]map[string]string{},
 		noCRD:             map[string]time.Time{},
 	}, nil
+}
+
+func loadProviderConfiguration(path string, oidcConfigured bool) (*access.Config, []credentialProvider, error) {
+	accessConfig, err := access.NewFromFile(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load cluster inventory provider file: %w", err)
+	}
+
+	credentialProviders, err := loadCredentialProviders(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load cluster inventory credential sources: %w", err)
+	}
+
+	if !oidcConfigured {
+		for _, provider := range credentialProviders {
+			if provider.source == credentialSourceOIDC {
+				return nil, nil, errors.New("cluster inventory OIDC credential source requires Headlamp OIDC configuration")
+			}
+		}
+	}
+
+	return accessConfig, credentialProviders, nil
 }
 
 // Run blocks until ctx is cancelled and reconciles long-lived root informers.
@@ -598,7 +629,7 @@ func (r *Runner) contextFromClusterProfile(
 		return nil, false
 	}
 
-	restConfig, err := copyAccessConfig(r.accessConfig).BuildConfigFromCP(accessOnlyClusterProfile(cp))
+	restConfig, usesOIDC, err := r.restConfigFromClusterProfile(cp)
 	if err != nil {
 		logger.Log(logger.LevelWarn, map[string]string{logFieldClusterProfile: profileKey}, err,
 			"cluster-inventory: failed to build rest config")
@@ -608,7 +639,12 @@ func (r *Runner) contextFromClusterProfile(
 
 	contextName := contextNameFromProfileKey(profileKey)
 
-	headlampContext, err := restConfigToContext(restConfig, contextName, profileKey)
+	var oidcConfig *kubeconfig.OidcConfig
+	if usesOIDC {
+		oidcConfig = r.oidcConfig
+	}
+
+	headlampContext, err := restConfigToContext(restConfig, contextName, profileKey, oidcConfig)
 	if err != nil {
 		logger.Log(logger.LevelWarn, map[string]string{logFieldClusterProfile: profileKey}, err,
 			"cluster-inventory: failed to convert rest config")
@@ -626,6 +662,104 @@ func (r *Runner) contextFromClusterProfile(
 	headlampContext.ClusterInventory = clusterInventoryMetadataFromProfile(profileKey, cp)
 
 	return headlampContext, true
+}
+
+// restConfigFromClusterProfile resolves the first configured provider advertised
+// by the ClusterProfile using that provider's declared credential source.
+func (r *Runner) restConfigFromClusterProfile(cp *apisv1alpha1.ClusterProfile) (*rest.Config, bool, error) {
+	accessProviders := make(map[string]apisv1alpha1.AccessProvider, len(cp.Status.AccessProviders))
+	for _, provider := range cp.Status.AccessProviders {
+		accessProviders[provider.Name] = provider
+	}
+
+	for _, configuredProvider := range r.credentialProviders {
+		provider, ok := accessProviders[configuredProvider.name]
+		if !ok {
+			continue
+		}
+
+		if configuredProvider.source != credentialSourceOIDC {
+			restConfig, err := copyAccessConfig(r.accessConfig).BuildConfigFromCP(accessOnlyClusterProfile(cp))
+
+			return restConfig, false, err
+		}
+
+		server, parseErr := url.Parse(provider.Cluster.Server)
+		if parseErr != nil || server.Host == "" || server.Scheme != "https" {
+			return nil, false, fmt.Errorf(
+				"OIDC provider %q has an invalid server URL: HTTPS is required",
+				configuredProvider.name,
+			)
+		}
+
+		result := &rest.Config{
+			Host: provider.Cluster.Server,
+			TLSClientConfig: rest.TLSClientConfig{
+				CAData:     append([]byte(nil), provider.Cluster.CertificateAuthorityData...),
+				Insecure:   provider.Cluster.InsecureSkipTLSVerify,
+				ServerName: provider.Cluster.TLSServerName,
+			},
+		}
+		if provider.Cluster.ProxyURL != "" {
+			proxyURL, proxyErr := url.Parse(provider.Cluster.ProxyURL)
+			if proxyErr != nil || proxyURL.Host == "" {
+				return nil, false, fmt.Errorf("OIDC provider %q has an invalid proxy URL", configuredProvider.name)
+			}
+
+			result.Proxy = http.ProxyURL(proxyURL)
+		}
+
+		return result, true, nil
+	}
+
+	restConfig, err := copyAccessConfig(r.accessConfig).BuildConfigFromCP(accessOnlyClusterProfile(cp))
+
+	return restConfig, false, err
+}
+
+type credentialProvider struct {
+	name   string
+	source string
+}
+
+type providerCredentialConfig struct {
+	Name             string          `json:"name"`
+	ExecConfig       *api.ExecConfig `json:"execConfig"`
+	CredentialSource string          `json:"credentialSource,omitempty"`
+}
+
+type providerFileConfig struct {
+	Providers []providerCredentialConfig `json:"providers"`
+}
+
+func loadCredentialProviders(path string) ([]credentialProvider, error) {
+	// #nosec G304 -- path is the operator-configured provider file already read by the Cluster Inventory SDK.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var config providerFileConfig
+	if err := json.Unmarshal(data, &config); err != nil {
+		return nil, err
+	}
+
+	providers := make([]credentialProvider, 0, len(config.Providers))
+
+	for _, provider := range config.Providers {
+		if provider.CredentialSource == credentialSourceOIDC {
+			if provider.ExecConfig != nil {
+				return nil, fmt.Errorf("provider %q cannot configure both credentialSource and execConfig", provider.Name)
+			}
+		} else if provider.CredentialSource != "" {
+			return nil, fmt.Errorf("provider %q has unsupported credentialSource %q", provider.Name,
+				provider.CredentialSource)
+		}
+
+		providers = append(providers, credentialProvider{name: provider.Name, source: provider.CredentialSource})
+	}
+
+	return providers, nil
 }
 
 // clusterInventoryMetadataFromProfile copies non-sensitive ClusterProfile status metadata.
@@ -1345,7 +1479,12 @@ func proxyURLFromRestConfig(restConfig *rest.Config) (string, error) {
 }
 
 // restConfigToContext builds a Headlamp kubeconfig.Context from a generated rest.Config.
-func restConfigToContext(restConfig *rest.Config, contextName, profileKey string) (*kubeconfig.Context, error) {
+func restConfigToContext(
+	restConfig *rest.Config,
+	contextName string,
+	profileKey string,
+	oidcConfig *kubeconfig.OidcConfig,
+) (*kubeconfig.Context, error) {
 	if restConfig == nil {
 		return nil, errors.New("restConfig is nil")
 	}
@@ -1400,5 +1539,28 @@ func restConfigToContext(restConfig *rest.Config, contextName, profileKey string
 		Source:         kubeconfig.ClusterInventory,
 		KubeConfigPath: "",
 		ClusterID:      clusterInventoryIDPrefix + profileKey,
+		OidcConf:       copyOIDCConfig(oidcConfig),
 	}, nil
+}
+
+func copyOIDCConfig(source *kubeconfig.OidcConfig) *kubeconfig.OidcConfig {
+	if source == nil {
+		return nil
+	}
+
+	copied := &kubeconfig.OidcConfig{
+		ClientID: source.ClientID, ClientSecret: source.ClientSecret,
+		IdpIssuerURL: source.IdpIssuerURL, Scopes: append([]string(nil), source.Scopes...),
+	}
+	if source.SkipTLSVerify != nil {
+		value := *source.SkipTLSVerify
+		copied.SkipTLSVerify = &value
+	}
+
+	if source.CACert != nil {
+		value := *source.CACert
+		copied.CACert = &value
+	}
+
+	return copied
 }

--- a/backend/pkg/clusterinventory/clusterinventory_test.go
+++ b/backend/pkg/clusterinventory/clusterinventory_test.go
@@ -76,6 +76,15 @@ func writeProviderFile(t *testing.T) string {
 	return path
 }
 
+func writeOIDCProviderFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "providers.json")
+	require.NoError(t, os.WriteFile(path,
+		[]byte(`{"providers":[{"name":"oidc","credentialSource":"oidc"}]}`), 0o600))
+
+	return path
+}
+
 func newTestRunner(t *testing.T, opts Options) *Runner {
 	t.Helper()
 
@@ -304,6 +313,21 @@ func TestNewRunnerValidatesProviderFile(t *testing.T) {
 		Namespaces:   "team-a,*",
 	})
 	require.ErrorContains(t, err, `"*" must be used on its own`)
+
+	_, err = NewRunner(Options{Store: store, ProviderFile: writeOIDCProviderFile(t)})
+	require.ErrorContains(t, err, "requires Headlamp OIDC configuration")
+
+	unsupported := filepath.Join(t.TempDir(), "unsupported.json")
+	require.NoError(t, os.WriteFile(unsupported,
+		[]byte(`{"providers":[{"name":"other","credentialSource":"other"}]}`), 0o600))
+	_, err = NewRunner(Options{Store: store, ProviderFile: unsupported})
+	require.ErrorContains(t, err, `unsupported credentialSource "other"`)
+
+	both := filepath.Join(t.TempDir(), "both.json")
+	require.NoError(t, os.WriteFile(both, []byte(`{"providers":[{"name":"oidc","credentialSource":"oidc",`+
+		`"execConfig":{"apiVersion":"client.authentication.k8s.io/v1","command":"/bin/echo"}}]}`), 0o600))
+	_, err = NewRunner(Options{Store: store, ProviderFile: both, OIDCConfig: &kubeconfig.OidcConfig{}})
+	require.ErrorContains(t, err, "cannot configure both credentialSource and execConfig")
 }
 
 func TestNormalizeNamespaces(t *testing.T) {
@@ -386,7 +410,12 @@ func TestRestConfigToContextPreservesConfig(t *testing.T) {
 		},
 	}
 
-	ctx, err := restConfigToContext(restConfig, "ctx-name", "root/ns/spoke")
+	skipTLSVerify := false
+	oidcConfig := &kubeconfig.OidcConfig{
+		ClientID: "kubernetes-client", IdpIssuerURL: "https://identity.example.com",
+		Scopes: []string{"openid", "profile", "groups"}, SkipTLSVerify: &skipTLSVerify,
+	}
+	ctx, err := restConfigToContext(restConfig, "ctx-name", "root/ns/spoke", oidcConfig)
 	require.NoError(t, err)
 
 	assert.Equal(t, "ctx-name", ctx.Name)
@@ -402,6 +431,131 @@ func TestRestConfigToContextPreservesConfig(t *testing.T) {
 	assert.Equal(t, "/bin/token", ctx.AuthInfo.Exec.Command)
 	assert.Equal(t, clientcmdapi.NeverExecInteractiveMode, ctx.AuthInfo.Exec.InteractiveMode)
 	assert.Equal(t, execConfig.Config, ctx.Cluster.Extensions[clusterExecConfigExtensionKey])
+	require.NotNil(t, ctx.OidcConf)
+	assert.Equal(t, "kubernetes-client", ctx.OidcConf.ClientID)
+	assert.Equal(t, []string{"openid", "profile", "groups"}, ctx.OidcConf.Scopes)
+	assert.NotSame(t, oidcConfig, ctx.OidcConf)
+}
+
+func TestOIDCCredentialSourceUsesHeadlampOIDC(t *testing.T) {
+	oidc := &kubeconfig.OidcConfig{ClientID: "kubernetes-client", IdpIssuerURL: "https://identity.example.com"}
+	runner := newTestRunner(t, Options{ProviderFile: writeOIDCProviderFile(t), OIDCConfig: oidc})
+	cp := clusterProfile("spoke", "oidc", "https://gateway.example.com/clusters/spoke/kubernetes")
+	cp.Status.AccessProviders[0].Cluster.TLSServerName = "kubernetes.internal"
+
+	restConfig, usesOIDC, err := runner.restConfigFromClusterProfile(cp)
+	require.NoError(t, err)
+	assert.True(t, usesOIDC)
+	assert.Equal(t, cp.Status.AccessProviders[0].Cluster.Server, restConfig.Host)
+	assert.Equal(t, "kubernetes.internal", restConfig.ServerName)
+	assert.Nil(t, restConfig.ExecProvider)
+
+	context, ok := runner.contextFromClusterProfile("in-cluster/default/spoke", cp)
+	require.True(t, ok)
+	require.NotNil(t, context.OidcConf)
+	assert.Equal(t, oidc.ClientID, context.OidcConf.ClientID)
+	assert.Nil(t, context.AuthInfo.Exec)
+}
+
+func TestExecCredentialSourceDoesNotInheritHeadlampOIDC(t *testing.T) {
+	runner := newTestRunner(t, Options{
+		ProviderFile: writeProviderFile(t),
+		OIDCConfig: &kubeconfig.OidcConfig{
+			ClientID: "kubernetes-client", IdpIssuerURL: "https://identity.example.com",
+		},
+	})
+	cp := clusterProfile("spoke", "static-token", "https://spoke.example.com")
+
+	context, ok := runner.contextFromClusterProfile("in-cluster/default/spoke", cp)
+	require.True(t, ok)
+	assert.Nil(t, context.OidcConf)
+	require.NotNil(t, context.AuthInfo.Exec)
+	assert.Equal(t, "/bin/echo", context.AuthInfo.Exec.Command)
+}
+
+func TestOIDCCredentialSourceUsesProviderFileOrder(t *testing.T) {
+	providerFile := filepath.Join(t.TempDir(), "providers.json")
+	require.NoError(t, os.WriteFile(providerFile, []byte(`{
+		"providers": [
+			{"name":"oidc-b","credentialSource":"oidc"},
+			{"name":"oidc-a","credentialSource":"oidc"}
+		]
+	}`), 0o600))
+	runner := newTestRunner(t, Options{
+		ProviderFile: providerFile,
+		OIDCConfig:   &kubeconfig.OidcConfig{ClientID: "kubernetes-client"},
+	})
+	cp := clusterProfile("spoke", "oidc-a", "https://a.example.com")
+	cp.Status.AccessProviders = append(cp.Status.AccessProviders, apisv1alpha1.AccessProvider{
+		Name: "oidc-b",
+		Cluster: clientcmdv1.Cluster{
+			Server: "https://b.example.com",
+		},
+	})
+
+	restConfig, usesOIDC, err := runner.restConfigFromClusterProfile(cp)
+	require.NoError(t, err)
+	assert.True(t, usesOIDC)
+	assert.Equal(t, "https://b.example.com", restConfig.Host)
+}
+
+func TestExecProviderErrorDoesNotFallBackToOIDC(t *testing.T) {
+	providerFile := filepath.Join(t.TempDir(), "providers.json")
+	require.NoError(t, os.WriteFile(providerFile, []byte(`{
+		"providers": [
+			{
+				"name":"exec",
+				"execConfig":{
+					"apiVersion":"client.authentication.k8s.io/v1",
+					"command":"/bin/echo"
+				},
+				"profileSourcedCLIArgsPolicy":"Append"
+			},
+			{"name":"oidc","credentialSource":"oidc"}
+		]
+	}`), 0o600))
+	runner := newTestRunner(t, Options{
+		ProviderFile: providerFile,
+		OIDCConfig:   &kubeconfig.OidcConfig{ClientID: "kubernetes-client"},
+	})
+	cp := clusterProfile("spoke", "exec", "https://exec.example.com")
+	cp.Status.AccessProviders[0].Cluster.Extensions = []clientcmdv1.NamedExtension{
+		{
+			Name: "clusterprofiles.multicluster.x-k8s.io/exec/additional-args",
+			Extension: k8sruntime.RawExtension{
+				Raw: []byte(`{"not":"a list"}`),
+			},
+		},
+	}
+	cp.Status.AccessProviders = append(cp.Status.AccessProviders, apisv1alpha1.AccessProvider{
+		Name: "oidc",
+		Cluster: clientcmdv1.Cluster{
+			Server: "https://oidc.example.com",
+		},
+	})
+
+	restConfig, usesOIDC, err := runner.restConfigFromClusterProfile(cp)
+	require.ErrorContains(t, err, "failed to unmarshal additional CLI args extension")
+	assert.False(t, usesOIDC)
+	assert.Nil(t, restConfig)
+}
+
+func TestOIDCCredentialSourceRejectsInvalidConnectionURLs(t *testing.T) {
+	oidc := &kubeconfig.OidcConfig{ClientID: "kubernetes-client", IdpIssuerURL: "https://identity.example.com"}
+	runner := newTestRunner(t, Options{ProviderFile: writeOIDCProviderFile(t), OIDCConfig: oidc})
+
+	invalidServer := clusterProfile("spoke", "oidc", "file:///etc/kubernetes/admin.conf")
+	_, _, err := runner.restConfigFromClusterProfile(invalidServer)
+	require.ErrorContains(t, err, "invalid server URL")
+
+	insecureServer := clusterProfile("spoke", "oidc", "http://gateway.example.com")
+	_, _, err = runner.restConfigFromClusterProfile(insecureServer)
+	require.ErrorContains(t, err, "HTTPS is required")
+
+	invalidProxy := clusterProfile("spoke", "oidc", "https://gateway.example.com")
+	invalidProxy.Status.AccessProviders[0].Cluster.ProxyURL = "not-a-proxy-url"
+	_, _, err = runner.restConfigFromClusterProfile(invalidProxy)
+	require.ErrorContains(t, err, "invalid proxy URL")
 }
 
 func TestContextFromClusterProfilePreservesInventoryMetadata(t *testing.T) {

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -247,6 +247,11 @@ read-only into the Headlamp container. If an access provider `execConfig.command
 is configured, the command must be under one of the absolute
 `plugins[].mountPath` values.
 
+When a matching `ClusterProfile` publishes connection metadata without
+credentials, set `credentialSource: oidc` on the provider to use Headlamp's
+configured OIDC login for Kubernetes API requests. Do not configure
+`credentialSource` and `execConfig` on the same provider.
+
 ### Deployment Configuration
 
 | Key | Type | Default | Description |

--- a/charts/headlamp/tests/expected_templates/cluster-inventory.yaml
+++ b/charts/headlamp/tests/expected_templates/cluster-inventory.yaml
@@ -34,7 +34,7 @@ metadata:
     app.kubernetes.io/version: "0.45.0"
     app.kubernetes.io/managed-by: Helm
 data:
-  config.json: "{\"providers\":[{\"name\":\"static-provider\"}]}"
+  config.json: "{\"providers\":[{\"credentialSource\":\"oidc\",\"name\":\"static-provider\"}]}"
 ---
 # Source: headlamp/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/headlamp/tests/test_cases/cluster-inventory.yaml
+++ b/charts/headlamp/tests/test_cases/cluster-inventory.yaml
@@ -4,6 +4,7 @@ config:
     accessProvidersConfig:
       providers:
         - name: static-provider
+          credentialSource: oidc
     namespaces:
       - inventory-e2e
       - shared-inventory

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -147,6 +147,8 @@ config:
     accessProvidersConfig: {}
     # accessProvidersConfig:
     #   providers:
+    #     - name: oidc
+    #       credentialSource: oidc
     #     - name: secretreader
     #       execConfig:
     #         apiVersion: client.authentication.k8s.io/v1

--- a/docs/installation/in-cluster/index.md
+++ b/docs/installation/in-cluster/index.md
@@ -81,6 +81,21 @@ scoped to the Headlamp pod's namespace. This follows the namespaced consumer
 model for ClusterProfile: each Headlamp instance reads the profiles published
 for that consumer's namespace.
 
+When a matching `ClusterProfile` publishes connection metadata without
+credentials, Headlamp can use its configured OIDC login for Kubernetes API
+requests:
+
+```yaml
+config:
+  clusterInventory:
+    accessProvidersConfig:
+      providers:
+        - name: oidc
+          credentialSource: oidc
+```
+
+Do not configure `credentialSource` and `execConfig` on the same provider.
+
 To watch specific namespaces, set:
 
 ```yaml


### PR DESCRIPTION
## Summary

Allow a Cluster Inventory access provider to declare `credentialSource: oidc`. The matching ClusterProfile supplies only Kubernetes connection metadata; Headlamp uses its configured OIDC login for Kubernetes API authentication.

This is a focused extension of the existing Cluster Inventory context-store model. It does not add a live registration API, SSE updates, or federated HTTP/WebSocket routing.

## Related Work

- #7383 is an active draft for a broader live federated cluster-registration architecture. This PR is intentionally smaller and can be evaluated as an incremental credential-source capability or prerequisite.
- #6857 discusses later role selection and RFC 8693 token exchange. This PR does not implement token exchange.

## Changes

- Preserve the existing Cluster Inventory exec-provider path.
- Parse and validate the explicit `oidc` credential source.
- Build credential-free REST configuration from the matching ClusterProfile endpoint, CA, TLS, and proxy metadata.
- Attach Headlamp's configured OIDC settings to discovered contexts.
- Reject unknown credential sources, mixed `credentialSource`/`execConfig`, and OIDC providers without Headlamp OIDC configuration.
- Document Helm and in-cluster configuration.

## Steps to Test

1. Configure Headlamp OIDC and a Cluster Inventory provider with `credentialSource: oidc`.
2. Publish a matching ClusterProfile containing API server and TLS metadata.
3. Sign in through OIDC and open the discovered cluster.
4. Verify Kubernetes evaluates the signed-in user through its normal RBAC policy.

Automated checks: `npm run backend:lint`, `npm run backend:test`, and `make helm-template-test`.

## Notes for the Reviewer

This is provider-neutral and stores no Kubernetes credential in ClusterProfile or Headlamp's inventory configuration. Existing exec providers are unchanged.

This PR was written in part with the assistance of generative AI.
