### PR TITLE
backend: auth: End expired OIDC sessions on refresh failure

### DIFF
--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -598,7 +598,7 @@ type RefreshAndSetTokenParams struct {
 
 // RefreshAndSetToken refreshes an expiring token, updates the auth cookie,
 // and records telemetry based on the provided parameters.
-func RefreshAndSetToken(params RefreshAndSetTokenParams) {
+func RefreshAndSetToken(params RefreshAndSetTokenParams) error {
 	// The token type to use
 	tokenType := "id_token"
 	if params.OIDCUseAccessToken {
@@ -624,29 +624,37 @@ func RefreshAndSetToken(params RefreshAndSetTokenParams) {
 			err, "failed to refresh token")
 		params.TelemetryHandler.RecordError(params.Span, err, "Token refresh failed")
 		params.TelemetryHandler.RecordErrorCount(params.Ctx, attribute.String("error", "token_refresh_failure"))
-	} else if newToken != nil {
-		var newTokenString string
 
-		var ok bool
-
-		if params.OIDCUseAccessToken {
-			newTokenString, ok = newToken.Extra("access_token").(string)
-		} else {
-			newTokenString, ok = newToken.Extra("id_token").(string)
-		}
-
-		if !ok || newTokenString == "" {
-			logger.Log(logger.LevelError, map[string]string{"cluster": params.Cluster},
-				errors.New("refreshed token missing expected field"), "failed to extract token string")
-			params.TelemetryHandler.RecordError(params.Span,
-				errors.New("refreshed token missing expected field"), "Token extraction failed")
-
-			return
-		}
-
-		// Set refreshed token in cookie
-		SetTokenCookie(params.Writer, params.Request, params.Cluster, newTokenString, params.BaseURL, params.SessionTTL)
-
-		params.TelemetryHandler.RecordEvent(params.Span, "Token refreshed successfully")
+		return err
 	}
+
+	if newToken == nil {
+		return errors.New("token refresh returned no token")
+	}
+
+	var newTokenString string
+
+	var ok bool
+
+	if params.OIDCUseAccessToken {
+		newTokenString, ok = newToken.Extra("access_token").(string)
+	} else {
+		newTokenString, ok = newToken.Extra("id_token").(string)
+	}
+
+	if !ok || newTokenString == "" {
+		extractErr := errors.New("refreshed token missing expected field")
+		logger.Log(logger.LevelError, map[string]string{"cluster": params.Cluster},
+			extractErr, "failed to extract token string")
+		params.TelemetryHandler.RecordError(params.Span,
+			extractErr, "Token extraction failed")
+
+		return extractErr
+	}
+
+	SetTokenCookie(params.Writer, params.Request, params.Cluster, newTokenString, params.BaseURL, params.SessionTTL)
+
+	params.TelemetryHandler.RecordEvent(params.Span, "Token refreshed successfully")
+
+	return nil
 }

--- a/backend/pkg/auth/auth_test.go
+++ b/backend/pkg/auth/auth_test.go
@@ -934,7 +934,7 @@ func TestRefreshAndSetToken_DefaultsToIDToken(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/clusters/"+cluster, nil)
 	rr := httptest.NewRecorder()
 
-	auth.RefreshAndSetToken(auth.RefreshAndSetTokenParams{
+	err := auth.RefreshAndSetToken(auth.RefreshAndSetTokenParams{
 		Ctx:              context.Background(),
 		OIDCAuthConfig:   &kubeconfig.OidcConfig{ClientID: "cid", ClientSecret: "secret", IdpIssuerURL: srv.URL},
 		Cache:            fc,
@@ -946,6 +946,7 @@ func TestRefreshAndSetToken_DefaultsToIDToken(t *testing.T) {
 		OIDCIdpIssuerURL: "",
 		BaseURL:          "",
 	})
+	require.NoError(t, err)
 
 	resp := rr.Result()
 
@@ -984,7 +985,7 @@ func TestRefreshAndSetToken_UsesAccessToken(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/clusters/"+cluster, nil)
 	rr := httptest.NewRecorder()
 
-	auth.RefreshAndSetToken(auth.RefreshAndSetTokenParams{
+	err := auth.RefreshAndSetToken(auth.RefreshAndSetTokenParams{
 		Ctx:                context.Background(),
 		OIDCAuthConfig:     &kubeconfig.OidcConfig{ClientID: "cid", ClientSecret: "secret"},
 		Cache:              fc,
@@ -997,6 +998,7 @@ func TestRefreshAndSetToken_UsesAccessToken(t *testing.T) {
 		OIDCIdpIssuerURL:   srv.URL,
 		BaseURL:            "",
 	})
+	require.NoError(t, err)
 
 	resp := rr.Result()
 
@@ -1022,7 +1024,7 @@ func TestRefreshAndSetToken_ErrorDoesNotSetCookie(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/clusters/"+cluster, nil)
 	rr := httptest.NewRecorder()
 
-	auth.RefreshAndSetToken(auth.RefreshAndSetTokenParams{
+	err := auth.RefreshAndSetToken(auth.RefreshAndSetTokenParams{
 		Ctx:              context.Background(),
 		OIDCAuthConfig:   &kubeconfig.OidcConfig{ClientID: "cid", ClientSecret: "secret"},
 		Cache:            fc,
@@ -1034,6 +1036,7 @@ func TestRefreshAndSetToken_ErrorDoesNotSetCookie(t *testing.T) {
 		OIDCIdpIssuerURL: srv.URL,
 		BaseURL:          "",
 	})
+	require.Error(t, err)
 
 	resp := rr.Result()
 

--- a/backend/pkg/auth/middleware.go
+++ b/backend/pkg/auth/middleware.go
@@ -18,6 +18,7 @@ package auth
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -29,6 +30,7 @@ import (
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/telemetry"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // OIDCTokenRefreshConfig holds the configuration needed by the OIDC token
@@ -131,7 +133,7 @@ func NewOIDCTokenRefreshMiddleware(config OIDCTokenRefreshConfig) func(http.Hand
 				return
 			}
 
-			RefreshAndSetToken(RefreshAndSetTokenParams{
+			err = RefreshAndSetToken(RefreshAndSetTokenParams{
 				Ctx:                       ctx,
 				OIDCAuthConfig:            oidcAuthConfig,
 				Cache:                     config.Cache,
@@ -147,10 +149,36 @@ func NewOIDCTokenRefreshMiddleware(config OIDCTokenRefreshConfig) func(http.Hand
 				BaseURL:                   config.BaseURL,
 				SessionTTL:                config.SessionTTL,
 			})
+			if err != nil {
+				status = "token_refresh_failure"
+
+				ClearTokenCookie(w, r, cluster, config.BaseURL)
+
+				if writeErr := writeExpiredAuthenticationResponse(w); writeErr != nil {
+					logger.Log(logger.LevelError, map[string]string{"cluster": cluster},
+						writeErr, "writing expired authentication response")
+				}
+
+				return
+			}
 
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func writeExpiredAuthenticationResponse(w http.ResponseWriter) error {
+	w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token"`)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnauthorized)
+
+	return json.NewEncoder(w).Encode(metav1.Status{
+		TypeMeta: metav1.TypeMeta{Kind: "Status", APIVersion: "v1"},
+		Status:   metav1.StatusFailure,
+		Message:  "authentication session expired",
+		Reason:   metav1.StatusReasonUnauthorized,
+		Code:     http.StatusUnauthorized,
+	})
 }
 
 // shouldUseUnsafeServiceAccountToken reports whether the config is running

--- a/backend/pkg/auth/middleware_test.go
+++ b/backend/pkg/auth/middleware_test.go
@@ -18,15 +18,19 @@ package auth_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/auth"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/telemetry"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestNewOIDCTokenRefreshMiddleware(t *testing.T) {
@@ -54,6 +58,68 @@ func TestNewOIDCTokenRefreshMiddleware(t *testing.T) {
 	rec = httptest.NewRecorder()
 	middleware.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestOIDCTokenRefreshFailureEndsExpiredSession(t *testing.T) {
+	clusterName := "inventory-cluster"
+	token := makeJWTWithPayload(t, map[string]interface{}{
+		"exp": float64(time.Now().Add(-time.Minute).Unix()),
+	})
+	oidcServer := newOIDCProviderServer(t, "", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "token endpoint must not be reached", http.StatusInternalServerError)
+	})
+
+	kubeConfigStore := kubeconfig.NewContextStore()
+	require.NoError(t, kubeConfigStore.AddContext(&kubeconfig.Context{
+		Name: clusterName,
+		OidcConf: &kubeconfig.OidcConfig{
+			ClientID:     "client",
+			IdpIssuerURL: oidcServer.URL,
+		},
+	}))
+	config := auth.OIDCTokenRefreshConfig{
+		KubeConfigStore:  kubeConfigStore,
+		Cache:            cache.New[interface{}](),
+		TelemetryHandler: &telemetry.RequestHandler{},
+	}
+	nextCalled := false
+	middleware := auth.NewOIDCTokenRefreshMiddleware(config)(http.HandlerFunc(func(
+		w http.ResponseWriter,
+		_ *http.Request,
+	) {
+		nextCalled = true
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		"/clusters/"+clusterName+"/api/v1/pods",
+		nil,
+	)
+	req.AddCookie(&http.Cookie{
+		Name:     "headlamp-auth-" + auth.SanitizeClusterName(clusterName) + ".0",
+		Value:    token,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
+	})
+
+	recorder := httptest.NewRecorder()
+
+	middleware.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+	assert.False(t, nextCalled)
+	assert.Contains(t, recorder.Header().Get("Set-Cookie"), "Max-Age=0")
+	assert.Equal(t, `Bearer error="invalid_token"`, recorder.Header().Get("WWW-Authenticate"))
+	assert.Equal(t, "application/json", recorder.Header().Get("Content-Type"))
+
+	var status metav1.Status
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &status))
+	assert.Equal(t, metav1.StatusFailure, status.Status)
+	assert.Equal(t, metav1.StatusReasonUnauthorized, status.Reason)
+	assert.Equal(t, int32(http.StatusUnauthorized), status.Code)
 }
 
 func TestSetTokenFromCookie(t *testing.T) {


### PR DESCRIPTION
## Summary

Stop an expired OIDC session at Headlamp's authentication boundary when token refresh fails. The middleware now clears the affected cluster cookie and returns a standard Kubernetes 401 response instead of forwarding the stale token to the cluster handler.

## Related Issue

Fixes #7535.

Related but non-overlapping work:

- #6793 tracks concurrent refresh-token rotation failures.
- #6795 already implements refresh deduplication for #6793.

This PR intentionally contains no singleflight coordination, recent-refresh cache, or dependency change. It defines the failure result when a refresh attempt itself cannot succeed and can merge independently of #6795.

## Changes

- Return refresh and token-extraction failures from `RefreshAndSetToken`.
- Stop the middleware chain after a failed refresh.
- Clear the affected cluster's chunked authentication cookie.
- Return HTTP 401 as a Kubernetes `Status` document.
- Include `WWW-Authenticate: Bearer error="invalid_token"`.
- Add regression coverage proving the downstream handler is not called.

## Steps to Test

1. Configure an OIDC-authenticated cluster.
2. Use an expired ID token whose refresh credential is unavailable or rejected.
3. Request a Kubernetes resource through Headlamp.
4. Verify Headlamp returns 401, clears the cookie, and does not invoke the downstream cluster handler.

Automated checks: `npm run backend:lint` and `go test -race ./pkg/auth`.

## Notes for the Reviewer

The response uses Kubernetes-native error semantics so existing Kubernetes clients and the Headlamp frontend see a normal authentication failure rather than a proxy-specific error page.

This PR was written in part with the assistance of generative AI.
