### PR TITLE
backend: websocket: Reconnect with refreshed OIDC tokens

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1388,6 +1388,11 @@ func applyRequestTokenToContext(r *http.Request, clusterName string, context *ku
 // The middleware logic was relocated to the auth package to keep authentication
 // concerns together.
 func (c *HeadlampConfig) OIDCTokenRefreshMiddleware(next http.Handler) http.Handler {
+	var onTokenRefreshed func(oldToken, newToken string)
+	if c.Multiplexer != nil {
+		onTokenRefreshed = c.Multiplexer.ReplaceToken
+	}
+
 	config := auth.OIDCTokenRefreshConfig{
 		KubeConfigStore:              c.KubeConfigStore,
 		Cache:                        c.Cache,
@@ -1401,6 +1406,7 @@ func (c *HeadlampConfig) OIDCTokenRefreshMiddleware(next http.Handler) http.Hand
 		SessionTTL:                   c.SessionTTL,
 		UseInCluster:                 c.UseInCluster,
 		UnsafeUseServiceAccountToken: c.UnsafeUseServiceAccountToken,
+		OnTokenRefreshed:             onTokenRefreshed,
 	}
 
 	return auth.NewOIDCTokenRefreshMiddleware(config)(next)

--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"crypto/sha256"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
@@ -100,8 +101,16 @@ type Connection struct {
 	usesServiceAccountToken bool
 	// Authentication token.
 	Token *string
+	// acceptedTokenHashes tracks the refresh chain for this connection so
+	// concurrent refreshes that started from an older token can still advance it.
+	acceptedTokenHashes map[[sha256.Size]byte]struct{}
 	// closeOnce is used to ensure the connection is closed only once.
 	closeOnce sync.Once
+}
+
+type clientTokenScope struct {
+	token               string
+	acceptedTokenHashes map[[sha256.Size]byte]struct{}
 }
 
 // Message represents a WebSocket message structure.
@@ -126,6 +135,9 @@ type Message struct {
 type Multiplexer struct {
 	// connections is a map of connections indexed by the cluster ID and path.
 	connections map[string]*Connection
+	// clientTokens keeps refreshed credentials available to subscriptions
+	// opened later on the same browser WebSocket.
+	clientTokens map[*WSConnLock]map[string]*clientTokenScope
 	// mutex is a mutex to synchronize access to the connections.
 	mutex sync.RWMutex
 	// upgrader is the WebSocket upgrader.
@@ -212,6 +224,7 @@ func (conn *WSConnLock) Close() error {
 func NewMultiplexer(kubeConfigStore kubeconfig.ContextStore, unsafeUseServiceAccountToken bool) *Multiplexer {
 	return &Multiplexer{
 		connections:                  make(map[string]*Connection),
+		clientTokens:                 make(map[*WSConnLock]map[string]*clientTokenScope),
 		kubeConfigStore:              kubeConfigStore,
 		unsafeUseServiceAccountToken: unsafeUseServiceAccountToken,
 		saTokenCache:                 make(map[string]saTokenCacheEntry),
@@ -222,6 +235,100 @@ func NewMultiplexer(kubeConfigStore kubeconfig.ContextStore, unsafeUseServiceAcc
 			},
 		},
 	}
+}
+
+// ReplaceToken keeps long-lived watch connections aligned with a token that
+// was refreshed through the HTTP authentication middleware. Existing upstream
+// sockets remain valid until they close; subsequent reconnects use the new
+// token instead of replaying the expired credential captured at WebSocket
+// establishment time.
+func (m *Multiplexer) ReplaceToken(oldToken, newToken string) {
+	if oldToken == "" || newToken == "" || oldToken == newToken {
+		return
+	}
+
+	oldTokenHash := sha256.Sum256([]byte(oldToken))
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	for _, clusterTokens := range m.clientTokens {
+		for _, scope := range clusterTokens {
+			if _, acceptsOldToken := scope.acceptedTokenHashes[oldTokenHash]; acceptsOldToken {
+				scope.token = newToken
+				scope.acceptedTokenHashes[sha256.Sum256([]byte(newToken))] = struct{}{}
+			}
+		}
+	}
+
+	for _, conn := range m.connections {
+		conn.mu.Lock()
+		if conn.usesServiceAccountToken {
+			conn.mu.Unlock()
+
+			continue
+		}
+
+		conn.rememberCurrentTokenLocked()
+
+		_, acceptsOldToken := conn.acceptedTokenHashes[oldTokenHash]
+		if acceptsOldToken {
+			refreshedToken := newToken
+			conn.Token = &refreshedToken
+			conn.rememberTokenLocked(newToken)
+		}
+		conn.mu.Unlock()
+	}
+}
+
+func (c *Connection) rememberCurrentTokenLocked() {
+	if c.Token != nil {
+		c.rememberTokenLocked(*c.Token)
+	}
+}
+
+func (c *Connection) rememberTokenLocked(token string) {
+	if token == "" {
+		return
+	}
+
+	if c.acceptedTokenHashes == nil {
+		c.acceptedTokenHashes = make(map[[sha256.Size]byte]struct{})
+	}
+
+	c.acceptedTokenHashes[sha256.Sum256([]byte(token))] = struct{}{}
+}
+
+func (m *Multiplexer) resolveClientToken(
+	clientConn *WSConnLock,
+	clusterID string,
+	requestToken *string,
+) *string {
+	if clientConn == nil || requestToken == nil || *requestToken == "" {
+		return requestToken
+	}
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	clusterTokens := m.clientTokens[clientConn]
+
+	scope := clusterTokens[clusterID]
+	if scope == nil {
+		return requestToken
+	}
+
+	if scope.token != *requestToken {
+		requestTokenHash := sha256.Sum256([]byte(*requestToken))
+		if _, belongsToRefreshChain := scope.acceptedTokenHashes[requestTokenHash]; !belongsToRefreshChain {
+			scope.token = *requestToken
+			scope.acceptedTokenHashes[requestTokenHash] = struct{}{}
+		}
+	}
+
+	resolvedToken := scope.token
+
+	return &resolvedToken
 }
 
 // readServiceAccountToken reads the service account token from path, caching the value
@@ -375,8 +482,8 @@ func (c *Connection) safeClose() {
 	})
 }
 
-// establishClusterConnection creates a new WebSocket connection to a Kubernetes cluster.
-func (m *Multiplexer) establishClusterConnection(
+// dialClusterConnection creates a WebSocket connection without publishing it.
+func (m *Multiplexer) dialClusterConnection(
 	clusterID,
 	userID,
 	path,
@@ -424,7 +531,25 @@ func (m *Multiplexer) establishClusterConnection(
 	connection.WSConn = conn
 	connection.updateStatus(StateConnected, nil)
 
+	return connection, nil
+}
+
+// establishClusterConnection creates and publishes a new WebSocket connection.
+func (m *Multiplexer) establishClusterConnection(
+	clusterID,
+	userID,
+	path,
+	query string,
+	clientConn *WSConnLock,
+	token *string,
+) (*Connection, error) {
+	connection, err := m.dialClusterConnection(clusterID, userID, path, query, clientConn, token)
+	if err != nil {
+		return nil, err
+	}
+
 	m.mutex.Lock()
+	m.applyClientTokenScopeLocked(connection, clientConn, clusterID)
 	connKey := m.createConnectionKey(clusterID, path, userID)
 	m.connections[connKey] = connection
 	m.mutex.Unlock()
@@ -432,6 +557,57 @@ func (m *Multiplexer) establishClusterConnection(
 	go m.monitorConnection(connection)
 
 	return connection, nil
+}
+
+func (m *Multiplexer) applyClientTokenScopeLocked(
+	connection *Connection,
+	clientConn *WSConnLock,
+	clusterID string,
+) {
+	if connection.usesServiceAccountToken {
+		return
+	}
+
+	connection.mu.Lock()
+	defer connection.mu.Unlock()
+
+	if connection.Token == nil {
+		return
+	}
+
+	clusterTokens := m.clientTokens[clientConn]
+	if clusterTokens == nil {
+		clusterTokens = make(map[string]*clientTokenScope)
+		m.clientTokens[clientConn] = clusterTokens
+	}
+
+	scope := clusterTokens[clusterID]
+	if scope == nil {
+		acceptedTokenHashes := make(map[[sha256.Size]byte]struct{}, len(connection.acceptedTokenHashes))
+		for tokenHash := range connection.acceptedTokenHashes {
+			acceptedTokenHashes[tokenHash] = struct{}{}
+		}
+
+		scope = &clientTokenScope{
+			token:               *connection.Token,
+			acceptedTokenHashes: acceptedTokenHashes,
+		}
+		scope.acceptedTokenHashes[sha256.Sum256([]byte(scope.token))] = struct{}{}
+		clusterTokens[clusterID] = scope
+
+		return
+	}
+
+	latestToken := scope.token
+
+	connection.Token = &latestToken
+	if connection.acceptedTokenHashes == nil {
+		connection.acceptedTokenHashes = make(map[[sha256.Size]byte]struct{}, len(scope.acceptedTokenHashes))
+	}
+
+	for tokenHash := range scope.acceptedTokenHashes {
+		connection.acceptedTokenHashes[tokenHash] = struct{}{}
+	}
 }
 
 // getClusterConfigWithFallback attempts to get the cluster config,
@@ -491,7 +667,7 @@ func (m *Multiplexer) createConnection(
 	clientConn *WSConnLock,
 	token *string,
 ) *Connection {
-	return &Connection{
+	connection := &Connection{
 		ClusterID: clusterID,
 		UserID:    userID,
 		Path:      path,
@@ -504,6 +680,9 @@ func (m *Multiplexer) createConnection(
 		},
 		Token: token,
 	}
+	connection.rememberCurrentTokenLocked()
+
+	return connection
 }
 
 // dialWebSocket establishes a WebSocket connection.
@@ -591,13 +770,23 @@ func (m *Multiplexer) reconnect(conn *Connection) (*Connection, error) {
 		_ = conn.WSConn.Close()
 	}
 
-	newConn, err := m.establishClusterConnection(
+	conn.mu.RLock()
+
+	token := conn.Token
+	if token != nil {
+		value := *token
+		token = &value
+	}
+
+	conn.mu.RUnlock()
+
+	newConn, err := m.dialClusterConnection(
 		conn.ClusterID,
 		conn.UserID,
 		conn.Path,
 		conn.Query,
 		conn.Client,
-		conn.Token,
+		token,
 	)
 	if err != nil {
 		logger.Log(logger.LevelError, map[string]string{logFieldClusterID: conn.ClusterID}, err, "reconnecting to cluster")
@@ -606,6 +795,27 @@ func (m *Multiplexer) reconnect(conn *Connection) (*Connection, error) {
 	}
 
 	m.mutex.Lock()
+	conn.mu.RLock()
+	newConn.mu.Lock()
+
+	if !newConn.usesServiceAccountToken {
+		if conn.Token == nil {
+			newConn.Token = nil
+		} else {
+			latestToken := *conn.Token
+			newConn.Token = &latestToken
+		}
+
+		newConn.acceptedTokenHashes = make(map[[sha256.Size]byte]struct{}, len(conn.acceptedTokenHashes))
+		for tokenHash := range conn.acceptedTokenHashes {
+			newConn.acceptedTokenHashes[tokenHash] = struct{}{}
+		}
+
+		newConn.rememberCurrentTokenLocked()
+	}
+
+	newConn.mu.Unlock()
+	conn.mu.RUnlock()
 	m.connections[m.createConnectionKey(conn.ClusterID, conn.Path, conn.UserID)] = newConn
 	m.mutex.Unlock()
 
@@ -713,6 +923,8 @@ func (m *Multiplexer) closeClientConnections(clientConn *WSConnLock) {
 	var connsToClose []*Connection
 
 	m.mutex.Lock()
+	delete(m.clientTokens, clientConn)
+
 	for key, conn := range m.connections {
 		conn.mu.RLock()
 		isClient := conn.Client == clientConn
@@ -767,31 +979,37 @@ func (m *Multiplexer) readClientMessage(clientConn *websocket.Conn) (Message, bo
 // getOrCreateConnection gets an existing connection or creates a new one if it doesn't exist.
 // If a connection exists and a new token is provided, it updates the token to ensure it's fresh.
 func (m *Multiplexer) getOrCreateConnection(msg Message, clientConn *WSConnLock, token *string) (*Connection, error) {
+	token = m.resolveClientToken(clientConn, msg.ClusterID, token)
+
 	connKey := m.createConnectionKey(msg.ClusterID, msg.Path, msg.UserID)
 
 	m.mutex.RLock()
 	conn, exists := m.connections[connKey]
+
+	if exists {
+		err := m.refreshConnectionToken(conn, token)
+		m.mutex.RUnlock()
+
+		return conn, err
+	}
+
 	m.mutex.RUnlock()
 
-	if !exists {
-		var err error
+	var err error
 
-		conn, err = m.establishClusterConnection(msg.ClusterID, msg.UserID, msg.Path, msg.Query, clientConn, token)
-		if err != nil {
-			logger.Log(
-				logger.LevelError,
-				map[string]string{logFieldClusterID: msg.ClusterID, "UserID": msg.UserID},
-				err,
-				"establishing cluster connection",
-			)
+	conn, err = m.establishClusterConnection(msg.ClusterID, msg.UserID, msg.Path, msg.Query, clientConn, token)
+	if err != nil {
+		logger.Log(
+			logger.LevelError,
+			map[string]string{logFieldClusterID: msg.ClusterID, "UserID": msg.UserID},
+			err,
+			"establishing cluster connection",
+		)
 
-			return nil, err
-		}
-
-		go m.handleClusterMessages(conn, clientConn)
-	} else if err := m.refreshConnectionToken(conn, token); err != nil {
 		return nil, err
 	}
+
+	go m.handleClusterMessages(conn, clientConn)
 
 	return conn, nil
 }
@@ -808,9 +1026,18 @@ func (m *Multiplexer) refreshConnectionToken(conn *Connection, requestToken *str
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
 
-	if conn.Token == nil || *conn.Token != *requestToken {
-		conn.Token = requestToken
+	if conn.Token != nil && *conn.Token == *requestToken {
+		return nil
 	}
+
+	requestTokenHash := sha256.Sum256([]byte(*requestToken))
+	if _, belongsToRefreshChain := conn.acceptedTokenHashes[requestTokenHash]; belongsToRefreshChain {
+		return nil
+	}
+
+	updatedToken := *requestToken
+	conn.Token = &updatedToken
+	conn.rememberTokenLocked(*requestToken)
 
 	return nil
 }

--- a/backend/cmd/multiplexer_test.go
+++ b/backend/cmd/multiplexer_test.go
@@ -502,10 +502,15 @@ func TestCloseClientConnectionsClearsClientBeforeClosing(t *testing.T) {
 
 	connKey := m.createConnectionKey("test-cluster", "/api/v1/pods", "test-user")
 	m.connections[connKey] = conn
+	token := "token"
+	conn.Token = &token
+	rememberClientTokenScope(m, conn, clientConn)
+	assert.Len(t, m.clientTokens, 1)
 
 	m.closeClientConnections(clientConn)
 
 	assert.Empty(t, m.connections)
+	assert.Empty(t, m.clientTokens)
 	assert.Nil(t, conn.Client)
 	assert.Equal(t, StateClosed, conn.Status.State)
 	assert.True(t, conn.closed)
@@ -1430,6 +1435,376 @@ func TestGetOrCreateConnectionDoesNotOverwriteServiceAccountToken(t *testing.T) 
 	assert.Equal(t, conn, refreshedConn)
 	require.NotNil(t, refreshedConn.Token)
 	assert.Equal(t, serviceAccountToken, *refreshedConn.Token)
+}
+
+func TestReplaceTokenUpdatesActiveUserConnections(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+	m := NewMultiplexer(store, false)
+
+	originalToken := "original-token"
+	otherToken := "other-token"
+	refreshedToken := "refreshed-token"
+	userConnection := m.createConnection("cluster", "user", "/api/v1/pods", "watch=true", nil, &originalToken)
+	otherConnection := m.createConnection("cluster", "other", "/api/v1/services", "watch=true", nil, &otherToken)
+	serviceAccountConnection := m.createConnection("cluster", "system", "/api/v1/nodes", "watch=true", nil, &originalToken)
+	serviceAccountConnection.usesServiceAccountToken = true
+	m.connections["user"] = userConnection
+	m.connections["other"] = otherConnection
+	m.connections["system"] = serviceAccountConnection
+
+	m.ReplaceToken(originalToken, refreshedToken)
+
+	require.NotNil(t, userConnection.Token)
+	assert.Equal(t, refreshedToken, *userConnection.Token)
+	require.NotNil(t, otherConnection.Token)
+	assert.Equal(t, otherToken, *otherConnection.Token)
+	require.NotNil(t, serviceAccountConnection.Token)
+	assert.Equal(t, originalToken, *serviceAccountConnection.Token)
+}
+
+func TestReplaceTokenTracksConcurrentRefreshChain(t *testing.T) {
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+
+	originalToken := "original-token"
+	connection := m.createConnection("cluster", "user", "/api/v1/pods", "watch=true", nil, &originalToken)
+	m.connections["user"] = connection
+
+	start := make(chan struct{})
+	refreshedTokens := []string{"refreshed-a", "refreshed-b"}
+
+	var refreshes sync.WaitGroup
+	for _, refreshedToken := range refreshedTokens {
+		refreshes.Add(1)
+
+		go func(token string) {
+			defer refreshes.Done()
+
+			<-start
+
+			m.ReplaceToken(originalToken, token)
+		}(refreshedToken)
+	}
+
+	close(start)
+	refreshes.Wait()
+
+	// Both refreshes started from the original token. Whichever callback
+	// completed last controls the connection, but both results remain valid
+	// links for a subsequent refresh callback.
+	m.ReplaceToken("refreshed-a", "after-a")
+	m.ReplaceToken("refreshed-b", "after-b")
+
+	require.NotNil(t, connection.Token)
+	assert.Equal(t, "after-b", *connection.Token)
+}
+
+type reconnectRaceFixture struct {
+	m              *Multiplexer
+	connection     *Connection
+	connectionKey  string
+	dialStarted    chan string
+	allowUpgrade   chan struct{}
+	upgradeErr     chan error
+	serverDone     chan struct{}
+	allowOnce      sync.Once
+	serverDoneOnce sync.Once
+}
+
+func newReconnectRaceFixture(t *testing.T) *reconnectRaceFixture {
+	t.Helper()
+
+	fixture := &reconnectRaceFixture{
+		dialStarted:  make(chan string, 1),
+		allowUpgrade: make(chan struct{}),
+		upgradeErr:   make(chan error, 1),
+		serverDone:   make(chan struct{}),
+	}
+	server := httptest.NewServer(http.HandlerFunc(fixture.handleWebSocketDial))
+
+	t.Cleanup(func() {
+		fixture.allowOnce.Do(func() { close(fixture.allowUpgrade) })
+		fixture.serverDoneOnce.Do(func() { close(fixture.serverDone) })
+		server.Close()
+	})
+
+	store := kubeconfig.NewContextStore()
+	require.NoError(t, store.AddContext(&kubeconfig.Context{
+		Name: "test-cluster",
+		Cluster: &api.Cluster{
+			Server:                server.URL,
+			InsecureSkipTLSVerify: true,
+		},
+	}))
+
+	fixture.m = NewMultiplexer(store, false)
+	originalToken := "original-token"
+	fixture.connection = fixture.m.createConnection(
+		"test-cluster", "test-user", "/api/v1/pods", "watch=true", nil, &originalToken,
+	)
+	fixture.connectionKey = fixture.m.createConnectionKey(
+		fixture.connection.ClusterID, fixture.connection.Path, fixture.connection.UserID,
+	)
+	fixture.m.connections[fixture.connectionKey] = fixture.connection
+
+	return fixture
+}
+
+func (f *reconnectRaceFixture) handleWebSocketDial(w http.ResponseWriter, r *http.Request) {
+	f.dialStarted <- r.Header.Get("Authorization")
+
+	<-f.allowUpgrade
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+
+	ws, err := upgrader.Upgrade(w, r, nil)
+	f.upgradeErr <- err
+
+	if err != nil {
+		return
+	}
+
+	defer func() { _ = ws.Close() }()
+
+	<-f.serverDone
+}
+
+func (f *reconnectRaceFixture) releaseDial() {
+	f.allowOnce.Do(func() { close(f.allowUpgrade) })
+}
+
+type reconnectResult struct {
+	connection *Connection
+	err        error
+}
+
+func rememberClientTokenScope(m *Multiplexer, connection *Connection, clientConn *WSConnLock) {
+	connection.Client = clientConn
+
+	m.mutex.Lock()
+	m.applyClientTokenScopeLocked(connection, clientConn, connection.ClusterID)
+	m.mutex.Unlock()
+}
+
+func awaitReconnectResult(t *testing.T, result <-chan reconnectResult) reconnectResult {
+	t.Helper()
+
+	select {
+	case reconnect := <-result:
+		return reconnect
+	case <-time.After(5 * time.Second):
+		t.Fatal("connection operation did not finish")
+
+		return reconnectResult{}
+	}
+}
+
+func TestReconnectPublishesLatestRefreshedToken(t *testing.T) {
+	fixture := newReconnectRaceFixture(t)
+	refreshedToken := "refreshed-token"
+
+	result := make(chan reconnectResult, 1)
+
+	go func() {
+		newConnection, err := fixture.m.reconnect(fixture.connection)
+		result <- reconnectResult{connection: newConnection, err: err}
+	}()
+
+	select {
+	case authorization := <-fixture.dialStarted:
+		assert.Equal(t, "Bearer original-token", authorization)
+	case <-time.After(5 * time.Second):
+		t.Fatal("reconnect did not begin dialing")
+	}
+
+	fixture.m.ReplaceToken("original-token", refreshedToken)
+	fixture.releaseDial()
+
+	select {
+	case err := <-fixture.upgradeErr:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("reconnect did not complete WebSocket upgrade")
+	}
+
+	var reconnected reconnectResult
+	select {
+	case reconnected = <-result:
+		require.NoError(t, reconnected.err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("reconnect did not finish")
+	}
+
+	require.NotNil(t, reconnected.connection.Token)
+	assert.Equal(t, refreshedToken, *reconnected.connection.Token)
+	assert.Equal(t, reconnected.connection, fixture.m.connections[fixture.connectionKey])
+}
+
+func TestReconnectKeepsRefreshedTokenAfterRequestWithHandshakeToken(t *testing.T) {
+	fixture := newReconnectRaceFixture(t)
+	originalToken := "original-token"
+	refreshedToken := "refreshed-token"
+
+	fixture.m.ReplaceToken(originalToken, refreshedToken)
+
+	msg := Message{
+		ClusterID: fixture.connection.ClusterID,
+		Path:      fixture.connection.Path,
+		Query:     fixture.connection.Query,
+		UserID:    fixture.connection.UserID,
+	}
+
+	connection, err := fixture.m.getOrCreateConnection(msg, nil, &originalToken)
+	require.NoError(t, err)
+	require.NotNil(t, connection.Token)
+	assert.Equal(t, refreshedToken, *connection.Token)
+
+	result := make(chan reconnectResult, 1)
+
+	go func() {
+		newConnection, err := fixture.m.reconnect(connection)
+		result <- reconnectResult{connection: newConnection, err: err}
+	}()
+
+	select {
+	case authorization := <-fixture.dialStarted:
+		assert.Equal(t, "Bearer "+refreshedToken, authorization)
+	case <-time.After(5 * time.Second):
+		t.Fatal("reconnect did not begin dialing")
+	}
+
+	fixture.releaseDial()
+
+	select {
+	case err := <-fixture.upgradeErr:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("reconnect did not complete WebSocket upgrade")
+	}
+
+	select {
+	case reconnected := <-result:
+		require.NoError(t, reconnected.err)
+		require.NotNil(t, reconnected.connection.Token)
+		assert.Equal(t, refreshedToken, *reconnected.connection.Token)
+	case <-time.After(5 * time.Second):
+		t.Fatal("reconnect did not finish")
+	}
+}
+
+func TestReconnectUsesRefreshedTokenForNewSubscriptionOnClientWebSocket(t *testing.T) {
+	fixture := newReconnectRaceFixture(t)
+	originalToken := "original-token"
+	refreshedToken := "refreshed-token"
+
+	clientConn, clientServer := createTestWebSocketConnection()
+	defer clientServer.Close()
+
+	rememberClientTokenScope(fixture.m, fixture.connection, clientConn)
+
+	fixture.m.ReplaceToken(originalToken, refreshedToken)
+
+	newSubscriptionToken := fixture.m.resolveClientToken(
+		clientConn,
+		fixture.connection.ClusterID,
+		&originalToken,
+	)
+	require.NotNil(t, newSubscriptionToken)
+
+	newSubscription := fixture.m.createConnection(
+		fixture.connection.ClusterID,
+		fixture.connection.UserID,
+		"/api/v1/services",
+		"watch=true",
+		clientConn,
+		newSubscriptionToken,
+	)
+	newSubscriptionKey := fixture.m.createConnectionKey(
+		newSubscription.ClusterID,
+		newSubscription.Path,
+		newSubscription.UserID,
+	)
+	fixture.m.connections[newSubscriptionKey] = newSubscription
+
+	result := make(chan reconnectResult, 1)
+
+	go func() {
+		newConnection, err := fixture.m.reconnect(newSubscription)
+		result <- reconnectResult{connection: newConnection, err: err}
+	}()
+
+	select {
+	case authorization := <-fixture.dialStarted:
+		assert.Equal(t, "Bearer "+refreshedToken, authorization)
+	case <-time.After(5 * time.Second):
+		t.Fatal("reconnect did not begin dialing")
+	}
+
+	fixture.releaseDial()
+
+	select {
+	case err := <-fixture.upgradeErr:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("reconnect did not complete WebSocket upgrade")
+	}
+
+	reconnected := awaitReconnectResult(t, result)
+	require.NoError(t, reconnected.err)
+	require.NotNil(t, reconnected.connection.Token)
+	assert.Equal(t, refreshedToken, *reconnected.connection.Token)
+}
+
+func TestNewSubscriptionPublishesRefreshCompletedDuringDial(t *testing.T) {
+	fixture := newReconnectRaceFixture(t)
+	originalToken := "original-token"
+	refreshedToken := "refreshed-token"
+
+	clientConn, clientServer := createTestWebSocketConnection()
+	defer clientServer.Close()
+
+	rememberClientTokenScope(fixture.m, fixture.connection, clientConn)
+
+	requestToken := fixture.m.resolveClientToken(clientConn, fixture.connection.ClusterID, &originalToken)
+	result := make(chan reconnectResult, 1)
+
+	go func() {
+		connection, err := fixture.m.establishClusterConnection(
+			fixture.connection.ClusterID,
+			fixture.connection.UserID,
+			"/api/v1/services",
+			"watch=true",
+			clientConn,
+			requestToken,
+		)
+		result <- reconnectResult{connection: connection, err: err}
+	}()
+
+	select {
+	case authorization := <-fixture.dialStarted:
+		assert.Equal(t, "Bearer "+originalToken, authorization)
+	case <-time.After(5 * time.Second):
+		t.Fatal("new subscription did not begin dialing")
+	}
+
+	fixture.m.ReplaceToken(originalToken, refreshedToken)
+	fixture.releaseDial()
+
+	select {
+	case err := <-fixture.upgradeErr:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("new subscription did not complete WebSocket upgrade")
+	}
+
+	select {
+	case established := <-result:
+		require.NoError(t, established.err)
+		require.NotNil(t, established.connection.Token)
+		assert.Equal(t, refreshedToken, *established.connection.Token)
+		established.connection.safeClose()
+	case <-time.After(5 * time.Second):
+		t.Fatal("new subscription did not finish")
+	}
 }
 
 func TestReconnect_WithToken(t *testing.T) {

--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -594,6 +594,7 @@ type RefreshAndSetTokenParams struct {
 	OIDCValidatorIdpIssuerURL string
 	BaseURL                   string
 	SessionTTL                int
+	OnTokenRefreshed          func(oldToken, newToken string)
 }
 
 // RefreshAndSetToken refreshes an expiring token, updates the auth cookie,
@@ -644,9 +645,16 @@ func RefreshAndSetToken(params RefreshAndSetTokenParams) {
 			return
 		}
 
-		// Set refreshed token in cookie
-		SetTokenCookie(params.Writer, params.Request, params.Cluster, newTokenString, params.BaseURL, params.SessionTTL)
-
-		params.TelemetryHandler.RecordEvent(params.Span, "Token refreshed successfully")
+		completeTokenRefresh(params, newTokenString)
 	}
+}
+
+func completeTokenRefresh(params RefreshAndSetTokenParams, newToken string) {
+	SetTokenCookie(params.Writer, params.Request, params.Cluster, newToken, params.BaseURL, params.SessionTTL)
+
+	if params.OnTokenRefreshed != nil {
+		params.OnTokenRefreshed(params.Token, newToken)
+	}
+
+	params.TelemetryHandler.RecordEvent(params.Span, "Token refreshed successfully")
 }

--- a/backend/pkg/auth/auth_test.go
+++ b/backend/pkg/auth/auth_test.go
@@ -934,6 +934,8 @@ func TestRefreshAndSetToken_DefaultsToIDToken(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/clusters/"+cluster, nil)
 	rr := httptest.NewRecorder()
 
+	var replacedOldToken, replacedNewToken string
+
 	auth.RefreshAndSetToken(auth.RefreshAndSetTokenParams{
 		Ctx:              context.Background(),
 		OIDCAuthConfig:   &kubeconfig.OidcConfig{ClientID: "cid", ClientSecret: "secret", IdpIssuerURL: srv.URL},
@@ -945,6 +947,10 @@ func TestRefreshAndSetToken_DefaultsToIDToken(t *testing.T) {
 		TelemetryHandler: &telemetry.RequestHandler{},
 		OIDCIdpIssuerURL: "",
 		BaseURL:          "",
+		OnTokenRefreshed: func(oldToken, newToken string) {
+			replacedOldToken = oldToken
+			replacedNewToken = newToken
+		},
 	})
 
 	resp := rr.Result()
@@ -954,6 +960,8 @@ func TestRefreshAndSetToken_DefaultsToIDToken(t *testing.T) {
 	cookieVal, ok := findAuthCookie(resp, cluster)
 	require.True(t, ok, "expected auth cookie to be set")
 	assert.Equal(t, "NEW", cookieVal)
+	assert.Equal(t, oldToken, replacedOldToken)
+	assert.Equal(t, "NEW", replacedNewToken)
 }
 
 func TestRefreshAndSetToken_UsesAccessToken(t *testing.T) {

--- a/backend/pkg/auth/middleware.go
+++ b/backend/pkg/auth/middleware.go
@@ -47,6 +47,7 @@ type OIDCTokenRefreshConfig struct {
 	SessionTTL                   int
 	UseInCluster                 bool
 	UnsafeUseServiceAccountToken bool
+	OnTokenRefreshed             func(oldToken, newToken string)
 }
 
 // oidcMiddlewareRoute is the api.route attribute value used by the OIDC token
@@ -146,6 +147,7 @@ func NewOIDCTokenRefreshMiddleware(config OIDCTokenRefreshConfig) func(http.Hand
 				OIDCValidatorIdpIssuerURL: config.OidcValidatorIdpIssuerURL,
 				BaseURL:                   config.BaseURL,
 				SessionTTL:                config.SessionTTL,
+				OnTokenRefreshed:          config.OnTokenRefreshed,
 			})
 
 			next.ServeHTTP(w, r)

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -14,6 +14,7 @@ import (
 // WebSocketMultiplexer handles client websocket connections. Implemented in cmd to avoid circular import.
 type WebSocketMultiplexer interface {
 	HandleClientWebSocket(http.ResponseWriter, *http.Request)
+	ReplaceToken(oldToken, newToken string)
 }
 
 // HeadlampConfig holds full server config. Lives here so packages (e.g. k8cache) can import without cmd.


### PR DESCRIPTION
## Summary

Keep long-lived Kubernetes watch WebSockets aligned with successful OIDC token refreshes. Existing sockets remain connected; future upstream reconnects use the token now held by the user's Headlamp session.

## Related Issue

Fixes #7534.

Related testing context: #4057 tracks broader OIDC end-to-end coverage.

## Changes

- Notify the WebSocket multiplexer after a successful OIDC refresh.
- Replace matching user connection tokens without modifying service-account connections.
- Snapshot the current token under the connection lock before reconnecting.
- Use the refreshed token for subsequent upstream WebSocket reconnects.
- Add regression coverage for active connection token replacement.

## Steps to Test

1. Establish a Kubernetes watch WebSocket with an OIDC token.
2. Trigger Headlamp's HTTP OIDC refresh path.
3. Disconnect the upstream watch connection.
4. Verify the multiplexer reconnects with the refreshed token.

Automated checks: `npm run backend:lint`, `npm run backend:test`, and `go test -race ./pkg/auth ./cmd ./pkg/headlampconfig`.

## Notes for the Reviewer

Existing upstream sockets are not interrupted. Only reconnects use the replacement token, and service-account-backed connections are excluded.

This PR was written in part with the assistance of generative AI.
