### PR TITLE
Add secondaryContrastText colors to built-in dark themes

### DIFF
--- a/frontend/src/components/App/defaultAppThemes.ts
+++ b/frontend/src/components/App/defaultAppThemes.ts
@@ -42,6 +42,7 @@ export const darkTheme: AppTheme = {
   base: 'dark',
   primary: '#ffffff',
   secondary: '#1b1a19',
+  secondaryContrastText: '#faf9f8',
   text: {
     primary: '#faf9f8',
   },
@@ -98,6 +99,7 @@ export const lightsOutTheme: AppTheme = {
   base: 'dark',
   primary: '#1f6feb',
   secondary: '#212830',
+  secondaryContrastText: '#f0f6fc',
   text: {
     primary: '#f0f6fc',
   },


### PR DESCRIPTION
## Summary

I noticed that our secondary buttons in the built-in Dark themes don't have sufficient contrast, making them hard to see. 

We see this surface in a few elements in dark mode, for instance in the project creation popups (See cancel button): 
<img width="50%" height="auto" alt="image" src="https://github.com/user-attachments/assets/822076f4-642c-45fb-897d-e8d47ede635f" /><img width="50%" height="auto" alt="image" src="https://github.com/user-attachments/assets/f1ecf399-b601-4720-b3bc-55ee4d4df0a6" />


This is because we explicitly defined a secondary color for the background, but none for the button text-  which left it to use headlmap's default, which is a dark text color (for the default light secondary button with it's light background).

This PR adds `secondaryContrast` to `darkTheme` & `lightsOutTheme` that match their existing `text -> primary` color to ensure adequate contrast.

**Fixed:**
<img  width="50%" height="auto" alt="image" src="https://github.com/user-attachments/assets/87ee0c55-a4c5-40cb-a905-85268c55fd91" /> <img width="49%" height="auto" alt="image" src="https://github.com/user-attachments/assets/cbe7974c-28bb-45dc-8f2e-309166920c9f" />
