### PR TITLE
frontend: Add CompositePodGroup views for hierarchical gang scheduling

### DIFF
--- a/frontend/src/components/Sidebar/useSidebarItems.tsx
+++ b/frontend/src/components/Sidebar/useSidebarItems.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from 'react-i18next';
 import { getClusterAppearanceFromMeta } from '../../helpers/clusterAppearance';
 import { isElectron } from '../../helpers/isElectron';
 import { useClustersConf, useSelectedClusters } from '../../lib/k8s';
+import CompositePodGroup from '../../lib/k8s/compositePodGroup';
 import CRD from '../../lib/k8s/crd';
 import { useGatewayL4RouteAvailability } from '../../lib/k8s/gatewayL4RouteAvailability';
 import PodGroup from '../../lib/k8s/podGroup';
@@ -85,6 +86,19 @@ export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER
     queryFn: async () => {
       const enabledPerCluster = await Promise.all(
         selectedClusters.map(cluster => PodGroup.isEnabled(cluster))
+      );
+      return enabledPerCluster.some(Boolean);
+    },
+    enabled: selectedClusters.length > 0,
+  });
+
+  // CompositePodGroup needs its own feature gate on top, and unlike the flat resources
+  // it is only ever served by v1alpha3, so ask for the resource itself.
+  const { data: compositePodGroupsEnabled = false } = useQuery({
+    queryKey: ['compositePodGroupsEnabled', ...selectedClusters],
+    queryFn: async () => {
+      const enabledPerCluster = await Promise.all(
+        selectedClusters.map(cluster => CompositePodGroup.isEnabled(cluster))
       );
       return enabledPerCluster.some(Boolean);
     },
@@ -482,6 +496,14 @@ export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER
             name: 'podGroups',
             label: t('glossary|Pod Groups'),
           },
+          ...(compositePodGroupsEnabled
+            ? [
+                {
+                  name: 'compositePodGroups',
+                  label: t('glossary|Composite Pod Groups'),
+                },
+              ]
+            : []),
           {
             name: 'schedulingWorkloads',
             label: t('glossary|Workloads'),
@@ -617,6 +639,7 @@ export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER
     crdsSidebarEntries,
     gatewayKinds,
     schedulingWorkloadsEnabled,
+    compositePodGroupsEnabled,
     t,
   ]);
 

--- a/frontend/src/components/compositePodGroup/ChildGroups.test.tsx
+++ b/frontend/src/components/compositePodGroup/ChildGroups.test.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import ChildGroupsSection from './ChildGroups';
+
+const { mockCompositeList, mockPodGroupList, mockTable } = vi.hoisted(() => ({
+  mockCompositeList: vi.fn(),
+  mockPodGroupList: vi.fn(),
+  mockTable: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/compositePodGroup', () => ({
+  default: { useList: mockCompositeList },
+}));
+
+vi.mock('../../lib/k8s/podGroup', () => ({
+  default: { useList: mockPodGroupList },
+}));
+
+vi.mock('../common/SectionBox', () => ({
+  SectionBox: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../common/SimpleTable', () => ({
+  default: (props: any) => {
+    mockTable(props);
+    return null;
+  },
+}));
+
+const group = (name: string, parent?: string) => ({
+  metadata: { name, namespace: 'inference', uid: name },
+  parentCompositePodGroupName: parent,
+});
+
+const parent = group('llm-serving-root') as any;
+
+function renderSection(overrides: Partial<typeof parent> = {}) {
+  render(
+    <TestContext>
+      <ChildGroupsSection parent={{ ...parent, ...overrides }} />
+    </TestContext>
+  );
+}
+
+/** Names of the rows a table was given, by the URL segment the section reflects. */
+const rowNames = (reflectInURL: string) =>
+  mockTable.mock.calls
+    .map(([props]) => props)
+    .filter(props => props.reflectInURL === reflectInURL)
+    .flatMap(props => props.data.map((item: any) => item.metadata.name));
+
+describe('ChildGroupsSection', () => {
+  beforeEach(() => {
+    mockTable.mockReset();
+    mockCompositeList.mockReset().mockReturnValue({ items: [] });
+    mockPodGroupList.mockReset().mockReturnValue({ items: [] });
+  });
+
+  it('lists both kinds of child group', () => {
+    mockCompositeList.mockReturnValue({
+      items: [group('llm-serving-prefill', 'llm-serving-root')],
+    });
+    mockPodGroupList.mockReturnValue({ items: [group('prefill-0', 'llm-serving-root')] });
+
+    renderSection();
+
+    expect(rowNames('childCompositePodGroups')).toEqual(['llm-serving-prefill']);
+    expect(rowNames('childPodGroups')).toEqual(['prefill-0']);
+  });
+
+  it('keeps out the groups that belong to another parent', () => {
+    mockCompositeList.mockReturnValue({
+      items: [
+        group('llm-serving-prefill', 'llm-serving-root'),
+        group('other-stage', 'another-root'),
+      ],
+    });
+
+    renderSection();
+
+    expect(rowNames('childCompositePodGroups')).toEqual(['llm-serving-prefill']);
+  });
+
+  it('keeps out hierarchy roots, which have no parent at all', () => {
+    mockCompositeList.mockReturnValue({ items: [parent, group('unrelated-root')] });
+
+    renderSection();
+
+    expect(mockTable).not.toHaveBeenCalled();
+  });
+
+  it('renders no table for a kind of child the group does not have', () => {
+    mockCompositeList.mockReturnValue({
+      items: [group('llm-serving-prefill', 'llm-serving-root')],
+    });
+
+    renderSection();
+
+    expect(rowNames('childPodGroups')).toEqual([]);
+  });
+
+  it('renders nothing for a leaf composite group', () => {
+    renderSection();
+
+    expect(mockTable).not.toHaveBeenCalled();
+  });
+
+  it('tolerates a list that has not resolved yet', () => {
+    mockCompositeList.mockReturnValue({ items: null });
+    mockPodGroupList.mockReturnValue({ items: null });
+
+    expect(() => renderSection()).not.toThrow();
+  });
+
+  it('scopes both lists to the namespace and cluster of the parent', () => {
+    renderSection({ cluster: 'test-cluster' });
+
+    const expected = { namespace: 'inference', cluster: 'test-cluster' };
+    expect(mockCompositeList).toHaveBeenCalledWith(expected);
+    expect(mockPodGroupList).toHaveBeenCalledWith(expected);
+  });
+});

--- a/frontend/src/components/compositePodGroup/ChildGroups.tsx
+++ b/frontend/src/components/compositePodGroup/ChildGroups.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import CompositePodGroup from '../../lib/k8s/compositePodGroup';
+import PodGroup from '../../lib/k8s/podGroup';
+import Link from '../common/Link';
+import { SectionBox } from '../common/SectionBox';
+import SimpleTable from '../common/SimpleTable';
+import { SchedulingStatus } from '../scheduling/SchedulingStatus';
+
+/**
+ * The groups nested directly below a composite group.
+ *
+ * The API models this the other way around, as a name on the child, and there are no
+ * owner references to follow. So the children are found by listing the namespace and
+ * keeping the groups that point back at this one.
+ * @param parent - The composite group whose children to show.
+ * @returns The child composite groups and pod groups of the parent.
+ */
+function useChildGroups(parent: CompositePodGroup) {
+  const listOptions = {
+    namespace: parent.metadata.namespace,
+    cluster: parent.cluster,
+  };
+  const { items: composites } = CompositePodGroup.useList(listOptions);
+  const { items: podGroups } = PodGroup.useList(listOptions);
+
+  const isChild = (group: CompositePodGroup | PodGroup) =>
+    group.parentCompositePodGroupName === parent.metadata.name;
+
+  return {
+    childComposites: (composites ?? []).filter(isChild),
+    childPodGroups: (podGroups ?? []).filter(isChild),
+  };
+}
+
+export default function ChildGroupsSection({ parent }: { parent: CompositePodGroup }) {
+  const { t } = useTranslation(['glossary', 'translation']);
+  const { childComposites, childPodGroups } = useChildGroups(parent);
+
+  return (
+    <>
+      {childComposites.length > 0 && (
+        <SectionBox title={t('glossary|Composite Pod Groups')}>
+          <SimpleTable
+            columns={[
+              {
+                label: t('translation|Name'),
+                getter: (group: CompositePodGroup) => (
+                  <Link kubeObject={group}>{group.metadata.name}</Link>
+                ),
+              },
+              {
+                label: t('translation|Policy'),
+                getter: (group: CompositePodGroup) => group.policyKind ?? '',
+              },
+              {
+                label: t('translation|Min Group Count'),
+                getter: (group: CompositePodGroup) => group.minGroupCount ?? '',
+              },
+              {
+                label: t('translation|Status'),
+                getter: (group: CompositePodGroup) => (
+                  <SchedulingStatus condition={group.schedulingCondition} />
+                ),
+              },
+            ]}
+            data={childComposites}
+            reflectInURL="childCompositePodGroups"
+          />
+        </SectionBox>
+      )}
+      {childPodGroups.length > 0 && (
+        <SectionBox title={t('glossary|Pod Groups')}>
+          <SimpleTable
+            columns={[
+              {
+                label: t('translation|Name'),
+                getter: (group: PodGroup) => <Link kubeObject={group}>{group.metadata.name}</Link>,
+              },
+              {
+                label: t('translation|Policy'),
+                getter: (group: PodGroup) => group.policyKind ?? '',
+              },
+              {
+                label: t('translation|Min Count'),
+                getter: (group: PodGroup) => group.minCount ?? '',
+              },
+              {
+                label: t('translation|Status'),
+                getter: (group: PodGroup) => (
+                  <SchedulingStatus condition={group.schedulingCondition} />
+                ),
+              },
+            ]}
+            data={childPodGroups}
+            reflectInURL="childPodGroups"
+          />
+        </SectionBox>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/compositePodGroup/Details.stories.tsx
+++ b/frontend/src/components/compositePodGroup/Details.stories.tsx
@@ -18,18 +18,61 @@ import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import { API_BASE, TestContext } from '../../test';
 import Details from './Details';
-import { COMPOSITE_POD_GROUP_DUMMY_DATA } from './storyHelper';
+import { CHILD_POD_GROUP_DUMMY_DATA, COMPOSITE_POD_GROUP_DUMMY_DATA } from './storyHelper';
 
-const compositePodGroup = COMPOSITE_POD_GROUP_DUMMY_DATA[1];
-const name = compositePodGroup.metadata.name;
-const namespace = compositePodGroup.metadata.namespace ?? 'default';
+const [root, prefill, decode] = COMPOSITE_POD_GROUP_DUMMY_DATA;
+const namespace = root.metadata.namespace ?? 'default';
 
 const SERVED_VERSION = 'scheduling.k8s.io/v1alpha3';
-const basePath = `${API_BASE}/apis/${SERVED_VERSION}/namespaces/${namespace}/compositepodgroups`;
-const detailsUrl = `${basePath}/${name}`;
+const compositesPath = `${API_BASE}/apis/${SERVED_VERSION}/namespaces/${namespace}/compositepodgroups`;
+const podGroupsPath = (apiVersion: string) =>
+  `${API_BASE}/apis/${apiVersion}/namespaces/${namespace}/podgroups`;
 
-/** The details view also watches the collection for the object it shows. */
-const collectionWatch = http.get(basePath, () => HttpResponse.error());
+const POD_GROUP_VERSIONS = [
+  'scheduling.k8s.io/v1beta1',
+  'scheduling.k8s.io/v1alpha3',
+  'scheduling.k8s.io/v1alpha2',
+];
+
+/**
+ * A cluster on v1alpha3 does not answer for the other versions PodGroup offers. The
+ * links to the child pod groups also probe the collection itself, to find out which
+ * version to address them by.
+ */
+const podGroupVersionProbes = POD_GROUP_VERSIONS.map(apiVersion =>
+  http.get(`${API_BASE}/apis/${apiVersion}/podgroups`, () =>
+    apiVersion === SERVED_VERSION
+      ? HttpResponse.json({ kind: 'PodGroupList', items: [], metadata: {} })
+      : HttpResponse.error()
+  )
+);
+
+const otherPodGroupVersionsUnavailable = POD_GROUP_VERSIONS.filter(
+  apiVersion => apiVersion !== SERVED_VERSION
+).map(apiVersion => http.get(podGroupsPath(apiVersion), () => HttpResponse.error()));
+
+/**
+ * The details view watches the collections it needs: its own, for the object it shows
+ * and for the child composite groups, and the pod groups for the child leaves.
+ */
+const collections = [
+  http.get(compositesPath, () =>
+    HttpResponse.json({
+      kind: 'CompositePodGroupList',
+      items: COMPOSITE_POD_GROUP_DUMMY_DATA,
+      metadata: {},
+    })
+  ),
+  http.get(podGroupsPath(SERVED_VERSION), () =>
+    HttpResponse.json({
+      kind: 'PodGroupList',
+      items: CHILD_POD_GROUP_DUMMY_DATA,
+      metadata: {},
+    })
+  ),
+  ...otherPodGroupVersionsUnavailable,
+  ...podGroupVersionProbes,
+];
 
 const emptyEvents = http.get(`${API_BASE}/api/v1/namespaces/${namespace}/events`, () =>
   HttpResponse.json({
@@ -39,71 +82,72 @@ const emptyEvents = http.get(`${API_BASE}/api/v1/namespaces/${namespace}/events`
   })
 );
 
+const storyFor = (composite: (typeof COMPOSITE_POD_GROUP_DUMMY_DATA)[number]) => ({
+  msw: {
+    handlers: {
+      story: [
+        http.get(`${compositesPath}/${composite.metadata.name}`, () =>
+          HttpResponse.json(composite)
+        ),
+        ...collections,
+        emptyEvents,
+      ],
+    },
+  },
+});
+
 export default {
   title: 'CompositePodGroup/Details',
   component: Details,
   argTypes: {},
-  decorators: [
-    Story => {
-      return (
-        <TestContext routerMap={{ namespace, name }}>
-          <Story />
-        </TestContext>
-      );
-    },
-  ],
 } as Meta;
 
-const Template: StoryFn = () => {
-  return <Details />;
-};
+const Template: StoryFn<{ name: string }> = args => (
+  <TestContext routerMap={{ namespace, name: args.name }}>
+    <Details />
+  </TestContext>
+);
 
+/** A hierarchy root, whose children are the two stage groups below it. */
 export const CompositePodGroupDetails = Template.bind({});
-CompositePodGroupDetails.parameters = {
-  msw: {
-    handlers: {
-      story: [
-        http.get(detailsUrl, () => HttpResponse.json(compositePodGroup)),
-        collectionWatch,
-        emptyEvents,
-      ],
-    },
-  },
-};
+CompositePodGroupDetails.args = { name: root.metadata.name };
+CompositePodGroupDetails.parameters = storyFor(root);
 
+/** A stage group, whose children are the pod groups that hold the pods. */
+export const WithChildPodGroups = Template.bind({});
+WithChildPodGroups.args = { name: prefill.metadata.name };
+WithChildPodGroups.parameters = storyFor(prefill);
+
+/** A group whose subtree never met its scheduling requirement. */
 export const Unschedulable = Template.bind({});
-Unschedulable.parameters = {
-  msw: {
-    handlers: {
-      story: [
-        http.get(detailsUrl, () =>
-          HttpResponse.json({
-            ...COMPOSITE_POD_GROUP_DUMMY_DATA[2],
-            metadata: { ...COMPOSITE_POD_GROUP_DUMMY_DATA[2].metadata, name },
-          })
-        ),
-        collectionWatch,
-        emptyEvents,
-      ],
-    },
-  },
-};
+Unschedulable.args = { name: decode.metadata.name };
+Unschedulable.parameters = storyFor(decode);
 
 export const Loading = Template.bind({});
+Loading.args = { name: root.metadata.name };
 Loading.parameters = {
   storyshots: { disable: true },
   msw: {
     handlers: {
-      story: [http.get(detailsUrl, () => new Promise(() => {})), collectionWatch, emptyEvents],
+      story: [
+        http.get(`${compositesPath}/${root.metadata.name}`, () => new Promise(() => {})),
+        ...collections,
+        emptyEvents,
+      ],
     },
   },
 };
 
 export const Error = Template.bind({});
+Error.args = { name: root.metadata.name };
 Error.parameters = {
   msw: {
     handlers: {
-      story: [http.get(detailsUrl, () => HttpResponse.error()), collectionWatch, emptyEvents],
+      story: [
+        http.get(`${compositesPath}/${root.metadata.name}`, () => HttpResponse.error()),
+        ...collections,
+        emptyEvents,
+      ],
     },
   },
 };

--- a/frontend/src/components/compositePodGroup/Details.stories.tsx
+++ b/frontend/src/components/compositePodGroup/Details.stories.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import { http, HttpResponse } from 'msw';
+import { API_BASE, TestContext } from '../../test';
+import Details from './Details';
+import { COMPOSITE_POD_GROUP_DUMMY_DATA } from './storyHelper';
+
+const compositePodGroup = COMPOSITE_POD_GROUP_DUMMY_DATA[1];
+const name = compositePodGroup.metadata.name;
+const namespace = compositePodGroup.metadata.namespace ?? 'default';
+
+const SERVED_VERSION = 'scheduling.k8s.io/v1alpha3';
+const basePath = `${API_BASE}/apis/${SERVED_VERSION}/namespaces/${namespace}/compositepodgroups`;
+const detailsUrl = `${basePath}/${name}`;
+
+/** The details view also watches the collection for the object it shows. */
+const collectionWatch = http.get(basePath, () => HttpResponse.error());
+
+const emptyEvents = http.get(`${API_BASE}/api/v1/namespaces/${namespace}/events`, () =>
+  HttpResponse.json({
+    kind: 'EventList',
+    items: [],
+    metadata: {},
+  })
+);
+
+export default {
+  title: 'CompositePodGroup/Details',
+  component: Details,
+  argTypes: {},
+  decorators: [
+    Story => {
+      return (
+        <TestContext routerMap={{ namespace, name }}>
+          <Story />
+        </TestContext>
+      );
+    },
+  ],
+} as Meta;
+
+const Template: StoryFn = () => {
+  return <Details />;
+};
+
+export const CompositePodGroupDetails = Template.bind({});
+CompositePodGroupDetails.parameters = {
+  msw: {
+    handlers: {
+      story: [
+        http.get(detailsUrl, () => HttpResponse.json(compositePodGroup)),
+        collectionWatch,
+        emptyEvents,
+      ],
+    },
+  },
+};
+
+export const Unschedulable = Template.bind({});
+Unschedulable.parameters = {
+  msw: {
+    handlers: {
+      story: [
+        http.get(detailsUrl, () =>
+          HttpResponse.json({
+            ...COMPOSITE_POD_GROUP_DUMMY_DATA[2],
+            metadata: { ...COMPOSITE_POD_GROUP_DUMMY_DATA[2].metadata, name },
+          })
+        ),
+        collectionWatch,
+        emptyEvents,
+      ],
+    },
+  },
+};
+
+export const Loading = Template.bind({});
+Loading.parameters = {
+  storyshots: { disable: true },
+  msw: {
+    handlers: {
+      story: [http.get(detailsUrl, () => new Promise(() => {})), collectionWatch, emptyEvents],
+    },
+  },
+};
+
+export const Error = Template.bind({});
+Error.parameters = {
+  msw: {
+    handlers: {
+      story: [http.get(detailsUrl, () => HttpResponse.error()), collectionWatch, emptyEvents],
+    },
+  },
+};

--- a/frontend/src/components/compositePodGroup/Details.tsx
+++ b/frontend/src/components/compositePodGroup/Details.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import CompositePodGroup from '../../lib/k8s/compositePodGroup';
+import Link from '../common/Link';
+import { ConditionsSection, DetailsGrid } from '../common/Resource';
+
+export default function CompositePodGroupDetails(props: {
+  name?: string;
+  namespace?: string;
+  cluster?: string;
+}) {
+  const params = useParams<{ namespace: string; name: string }>();
+  const { name = params.name, namespace = params.namespace, cluster } = props;
+  const { t } = useTranslation(['glossary', 'translation']);
+
+  return (
+    <DetailsGrid
+      resourceType={CompositePodGroup}
+      name={name}
+      namespace={namespace}
+      cluster={cluster}
+      withEvents
+      extraInfo={item =>
+        item && [
+          {
+            name: t('translation|Policy'),
+            value: item.policyKind,
+            hide: !item.policyKind,
+          },
+          {
+            name: t('translation|Min Group Count'),
+            value: item.minGroupCount,
+            hide: item.minGroupCount === undefined,
+          },
+          {
+            name: t('glossary|Workload'),
+            value: item.workloadName && (
+              <Link
+                routeName="Workload"
+                params={{ namespace: item.metadata.namespace, name: item.workloadName }}
+                activeCluster={item.cluster}
+              >
+                {item.workloadName}
+              </Link>
+            ),
+            hide: !item.workloadName,
+          },
+          {
+            name: t('translation|Composite Pod Group Template Name'),
+            value: item.compositePodGroupTemplateName,
+            hide: !item.compositePodGroupTemplateName,
+          },
+          {
+            name: t('translation|Parent'),
+            value: item.parentCompositePodGroupName && (
+              <Link
+                routeName="CompositePodGroup"
+                params={{
+                  namespace: item.metadata.namespace,
+                  name: item.parentCompositePodGroupName,
+                }}
+                activeCluster={item.cluster}
+              >
+                {item.parentCompositePodGroupName}
+              </Link>
+            ),
+            hide: !item.parentCompositePodGroupName,
+          },
+          {
+            name: t('translation|Disruption Mode'),
+            value: item.disruptionMode,
+            hide: !item.disruptionMode,
+          },
+          {
+            name: t('glossary|Priority Class'),
+            value: item.spec?.priorityClassName && (
+              <Link
+                routeName="priorityClass"
+                params={{ name: item.spec.priorityClassName }}
+                activeCluster={item.cluster}
+              >
+                {item.spec.priorityClassName}
+              </Link>
+            ),
+            hide: !item.spec?.priorityClassName,
+          },
+          {
+            name: t('glossary|Priority'),
+            value: item.spec?.priority,
+            hide: item.spec?.priority === undefined,
+          },
+          {
+            name: t('translation|Preemption Policy'),
+            value: item.spec?.preemptionPolicy,
+            hide: !item.spec?.preemptionPolicy,
+          },
+          {
+            name: t('translation|Topology Keys'),
+            value: item.spec?.schedulingConstraints?.topology
+              ?.map(constraint => constraint.key)
+              .join(', '),
+            hide: !item.spec?.schedulingConstraints?.topology?.length,
+          },
+        ]
+      }
+      extraSections={item => item && [<ConditionsSection resource={item?.jsonData} />]}
+    />
+  );
+}

--- a/frontend/src/components/compositePodGroup/Details.tsx
+++ b/frontend/src/components/compositePodGroup/Details.tsx
@@ -19,6 +19,7 @@ import { useParams } from 'react-router-dom';
 import CompositePodGroup from '../../lib/k8s/compositePodGroup';
 import Link from '../common/Link';
 import { ConditionsSection, DetailsGrid } from '../common/Resource';
+import ChildGroupsSection from './ChildGroups';
 
 export default function CompositePodGroupDetails(props: {
   name?: string;
@@ -119,7 +120,18 @@ export default function CompositePodGroupDetails(props: {
           },
         ]
       }
-      extraSections={item => item && [<ConditionsSection resource={item?.jsonData} />]}
+      extraSections={item =>
+        item && [
+          {
+            id: 'headlamp.compositepodgroup-children',
+            section: <ChildGroupsSection parent={item} />,
+          },
+          {
+            id: 'headlamp.compositepodgroup-conditions',
+            section: <ConditionsSection resource={item.jsonData} />,
+          },
+        ]
+      }
     />
   );
 }

--- a/frontend/src/components/compositePodGroup/List.stories.tsx
+++ b/frontend/src/components/compositePodGroup/List.stories.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Container from '@mui/material/Container';
+import { Meta, StoryFn } from '@storybook/react';
+import { http, HttpResponse } from 'msw';
+import { API_BASE, TestContext } from '../../test';
+import List from './List';
+import { COMPOSITE_POD_GROUP_DUMMY_DATA } from './storyHelper';
+
+const SERVED_VERSION = 'scheduling.k8s.io/v1alpha3';
+
+const listUrl = `${API_BASE}/apis/${SERVED_VERSION}/compositepodgroups`;
+
+const compositePodGroupList = (items: typeof COMPOSITE_POD_GROUP_DUMMY_DATA) =>
+  HttpResponse.json({
+    kind: 'CompositePodGroupList',
+    items,
+    metadata: {},
+  });
+
+export default {
+  title: 'CompositePodGroup/List',
+  component: List,
+  argTypes: {},
+  decorators: [
+    Story => {
+      return (
+        <TestContext>
+          <Story />
+        </TestContext>
+      );
+    },
+  ],
+  parameters: {
+    msw: {
+      handlers: {
+        story: [http.get(listUrl, () => compositePodGroupList(COMPOSITE_POD_GROUP_DUMMY_DATA))],
+      },
+    },
+  },
+} as Meta;
+
+const Template: StoryFn = () => {
+  return (
+    <Container maxWidth="xl">
+      <List />
+    </Container>
+  );
+};
+
+export const CompositePodGroups = Template.bind({});
+
+export const Loading = Template.bind({});
+Loading.parameters = {
+  storyshots: { disable: true },
+  msw: {
+    handlers: {
+      story: [http.get(listUrl, () => new Promise(() => {}))],
+    },
+  },
+};
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: {
+    handlers: {
+      story: [http.get(listUrl, () => compositePodGroupList([]))],
+    },
+  },
+};
+
+export const Error = Template.bind({});
+Error.parameters = {
+  msw: {
+    handlers: {
+      story: [http.get(listUrl, () => HttpResponse.error())],
+    },
+  },
+};

--- a/frontend/src/components/compositePodGroup/List.test.tsx
+++ b/frontend/src/components/compositePodGroup/List.test.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import CompositePodGroupList from './List';
+
+const { mockListView } = vi.hoisted(() => ({
+  mockListView: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/compositePodGroup', () => ({
+  default: { kind: 'CompositePodGroup' },
+}));
+
+vi.mock('../common/Resource/ResourceListView', () => ({
+  default: (props: any) => {
+    mockListView(props);
+    return null;
+  },
+}));
+
+function renderList() {
+  render(
+    <TestContext>
+      <CompositePodGroupList />
+    </TestContext>
+  );
+  return mockListView.mock.calls[0][0];
+}
+
+const column = (props: any, id: string) => props.columns.find((c: any) => c?.id === id);
+
+describe('CompositePodGroupList', () => {
+  beforeEach(() => {
+    mockListView.mockReset();
+  });
+
+  it('renders the expected columns', () => {
+    const props = renderList();
+    const columnIds = props.columns.map((c: any) => (typeof c === 'string' ? c : c.id));
+
+    expect(columnIds).toEqual([
+      'name',
+      'namespace',
+      'cluster',
+      'policy',
+      'minGroupCount',
+      'parent',
+      'workload',
+      'status',
+      'age',
+    ]);
+  });
+
+  it('offers no create button, because the base object cannot pick an API version', () => {
+    expect(renderList().headerProps.titleSideActions).toEqual([]);
+  });
+
+  it('counts child groups rather than pods', () => {
+    const props = renderList();
+
+    expect(column(props, 'policy').getValue({ policyKind: 'Gang' })).toBe('Gang');
+    expect(column(props, 'minGroupCount').getValue({ minGroupCount: 2 })).toBe(2);
+  });
+
+  it('reads the parent and the workload from the item', () => {
+    const props = renderList();
+
+    expect(
+      column(props, 'parent').getValue({ parentCompositePodGroupName: 'llm-serving-root' })
+    ).toBe('llm-serving-root');
+    expect(column(props, 'workload').getValue({ workloadName: 'llm-serving' })).toBe('llm-serving');
+  });
+
+  it('leaves the parent empty for a hierarchy root', () => {
+    const props = renderList();
+
+    expect(column(props, 'parent').getValue({})).toBe('');
+    expect(column(props, 'minGroupCount').getValue({})).toBeNull();
+    expect(column(props, 'policy').getValue({})).toBe('');
+    expect(column(props, 'workload').getValue({})).toBe('');
+  });
+
+  it('shows the reason of the scheduling condition as the status', () => {
+    const props = renderList();
+    const status = column(props, 'status');
+    const unschedulable = {
+      schedulingCondition: {
+        type: 'CompositePodGroupInitiallyScheduled',
+        status: 'False',
+        reason: 'Unschedulable',
+      },
+    };
+
+    expect(status.getValue(unschedulable)).toBe('Unschedulable');
+
+    render(<TestContext>{status.render(unschedulable)}</TestContext>);
+    expect(screen.getByText('Unschedulable')).toBeInTheDocument();
+  });
+
+  it('falls back to a localized status when the condition has no reason', () => {
+    const props = renderList();
+    const status = column(props, 'status');
+    const scheduled = {
+      schedulingCondition: { type: 'CompositePodGroupInitiallyScheduled', status: 'True' },
+    };
+    const pending = {
+      schedulingCondition: { type: 'CompositePodGroupInitiallyScheduled', status: 'False' },
+    };
+
+    expect(status.getValue(scheduled)).toBe('translation|Scheduled');
+    expect(status.getValue(pending)).toBe('translation|Pending');
+  });
+
+  it('shows an unknown status while the group has no conditions yet', () => {
+    const props = renderList();
+    const status = column(props, 'status');
+
+    expect(status.getValue({})).toBe('translation|Unknown');
+
+    render(<TestContext>{status.render({})}</TestContext>);
+    expect(screen.getByText('translation|Unknown')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/compositePodGroup/List.tsx
+++ b/frontend/src/components/compositePodGroup/List.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import CompositePodGroup from '../../lib/k8s/compositePodGroup';
+import ResourceListView from '../common/Resource/ResourceListView';
+import { getSchedulingStatusText, SchedulingStatus } from '../scheduling/SchedulingStatus';
+
+export default function CompositePodGroupList() {
+  const { t } = useTranslation(['glossary', 'translation']);
+
+  const headerPropsNoCreateButton = { titleSideActions: [] };
+
+  return (
+    <ResourceListView
+      title={t('glossary|Composite Pod Groups')}
+      headerProps={headerPropsNoCreateButton}
+      resourceClass={CompositePodGroup}
+      columns={[
+        'name',
+        'namespace',
+        'cluster',
+        {
+          id: 'policy',
+          label: t('translation|Policy'),
+          gridTemplate: 'min-content',
+          getValue: item => item.policyKind ?? '',
+        },
+        {
+          id: 'minGroupCount',
+          label: t('translation|Min Group Count'),
+          gridTemplate: 'min-content',
+          getValue: item => item.minGroupCount ?? null,
+        },
+        {
+          id: 'parent',
+          label: t('translation|Parent'),
+          gridTemplate: 'min-content',
+          getValue: item => item.parentCompositePodGroupName ?? '',
+        },
+        {
+          id: 'workload',
+          label: t('glossary|Workload'),
+          gridTemplate: 'min-content',
+          getValue: item => item.workloadName ?? '',
+        },
+        {
+          id: 'status',
+          label: t('translation|Status'),
+          gridTemplate: 'min-content',
+          getValue: item => getSchedulingStatusText(item.schedulingCondition, t),
+          render: item => <SchedulingStatus condition={item.schedulingCondition} />,
+        },
+        'age',
+      ]}
+    />
+  );
+}

--- a/frontend/src/components/compositePodGroup/__snapshots__/Details.CompositePodGroupDetails.stories.storyshot
+++ b/frontend/src/components/compositePodGroup/__snapshots__/Details.CompositePodGroupDetails.stories.storyshot
@@ -1,0 +1,471 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-1x8tw9a"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-1j11y9k-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-y6rp3m-MuiButton-startIcon"
+        />
+        <p
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          style="padding-top: 3px;"
+        >
+          Back
+        </p>
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+        />
+      </button>
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiBox-root css-70qvj9"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
+            >
+              CompositePodGroup: llm-serving-prefill
+            </h1>
+            <div
+              class="MuiBox-root css-ldp2l3"
+            >
+              <button
+                aria-label="Copy to clipboard"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-item css-ztq4zc-MuiGrid-root"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            />
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            />
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <button
+                aria-label="Edit"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <button
+                aria-label="Delete"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <div />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              aria-busy="false"
+              aria-live="polite"
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                class="MuiBox-root css-0"
+              >
+                <dl
+                  class="MuiGrid-root MuiGrid-container css-kxuems-MuiGrid-root"
+                >
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Name
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      llm-serving-prefill
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Namespace
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                      href="/"
+                    >
+                      inference
+                    </a>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Creation
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      2022-01-01T00:00:00.000Z
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Policy
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      Gang
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Min Group Count
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    2
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Workload
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                      href="/"
+                    >
+                      llm-serving
+                    </a>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Composite Pod Group Template Name
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      prefill
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Composite Pod Group
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                      href="/"
+                    >
+                      llm-serving-root
+                    </a>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
+                  >
+                    Disruption Mode
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      All
+                    </span>
+                  </dd>
+                </dl>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+                  >
+                    Conditions
+                  </h2>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
+              <div
+                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-onzayo-MuiPaper-root-MuiTableContainer-root"
+                tabindex="0"
+              >
+                <table
+                  class="MuiTable-root css-1f5u0uu-MuiTable-root"
+                >
+                  <thead
+                    class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+                    >
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Condition
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Status
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Last Transition
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Last Update
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Reason
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 css-j24kpb-MuiTypography-root"
+                        >
+                          CompositePodGroupInitiallyScheduled
+                        </span>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        True
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <p
+                          aria-label="2022-01-01T00:00:00.000Z"
+                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
+                        >
+                          90d
+                        </p>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        -
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <p
+                          aria-label="The subtree of the composite pod group was scheduled."
+                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
+                        >
+                          Scheduled
+                        </p>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+                  >
+                    Events
+                  </h2>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              >
+                No data to be shown.
+              </div>
+              <div
+                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+              >
+                <div
+                  class="MuiBox-root css-19midj6"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+                  >
+                    No data to be shown.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/compositePodGroup/__snapshots__/Details.Error.stories.storyshot
+++ b/frontend/src/components/compositePodGroup/__snapshots__/Details.Error.stories.storyshot
@@ -1,0 +1,58 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-1x8tw9a"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-1j11y9k-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-y6rp3m-MuiButton-startIcon"
+        />
+        <p
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          style="padding-top: 3px;"
+        >
+          Back
+        </p>
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+        />
+      </button>
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        />
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+          >
+            <div
+              class="MuiBox-root css-19midj6"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-9ldkza-MuiTypography-root"
+              >
+                TypeError: Failed to fetch
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/compositePodGroup/__snapshots__/Details.Unschedulable.stories.storyshot
+++ b/frontend/src/components/compositePodGroup/__snapshots__/Details.Unschedulable.stories.storyshot
@@ -1,0 +1,461 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-1x8tw9a"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-1j11y9k-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-y6rp3m-MuiButton-startIcon"
+        />
+        <p
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          style="padding-top: 3px;"
+        >
+          Back
+        </p>
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+        />
+      </button>
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiBox-root css-70qvj9"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
+            >
+              CompositePodGroup: llm-serving-prefill
+            </h1>
+            <div
+              class="MuiBox-root css-ldp2l3"
+            >
+              <button
+                aria-label="Copy to clipboard"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-item css-ztq4zc-MuiGrid-root"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            />
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            />
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <button
+                aria-label="Edit"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <button
+                aria-label="Delete"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <div />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              aria-busy="false"
+              aria-live="polite"
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                class="MuiBox-root css-0"
+              >
+                <dl
+                  class="MuiGrid-root MuiGrid-container css-kxuems-MuiGrid-root"
+                >
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Name
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      llm-serving-prefill
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Namespace
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                      href="/"
+                    >
+                      inference
+                    </a>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Creation
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      2022-01-01T00:00:00.000Z
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Policy
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      Basic
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Workload
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                      href="/"
+                    >
+                      llm-serving
+                    </a>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Composite Pod Group Template Name
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      decode
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Parent
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                      href="/"
+                    >
+                      llm-serving-root
+                    </a>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
+                  >
+                    Disruption Mode
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      Single
+                    </span>
+                  </dd>
+                </dl>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+                  >
+                    Conditions
+                  </h2>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
+              <div
+                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-onzayo-MuiPaper-root-MuiTableContainer-root"
+                tabindex="0"
+              >
+                <table
+                  class="MuiTable-root css-1f5u0uu-MuiTable-root"
+                >
+                  <thead
+                    class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+                    >
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Condition
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Status
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Last Transition
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Last Update
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Reason
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 css-j24kpb-MuiTypography-root"
+                        >
+                          CompositePodGroupInitiallyScheduled
+                        </span>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        False
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <p
+                          aria-label="2022-01-01T00:00:00.000Z"
+                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
+                        >
+                          90d
+                        </p>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        -
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <p
+                          aria-label="No feasible placements found for the subtree."
+                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
+                        >
+                          Unschedulable
+                        </p>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+                  >
+                    Events
+                  </h2>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              >
+                No data to be shown.
+              </div>
+              <div
+                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+              >
+                <div
+                  class="MuiBox-root css-19midj6"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+                  >
+                    No data to be shown.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/compositePodGroup/__snapshots__/Details.Unschedulable.stories.storyshot
+++ b/frontend/src/components/compositePodGroup/__snapshots__/Details.Unschedulable.stories.storyshot
@@ -33,7 +33,7 @@
             <h1
               class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
             >
-              CompositePodGroup: llm-serving-prefill
+              CompositePodGroup: llm-serving-decode
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
@@ -139,7 +139,7 @@
                     <span
                       class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
                     >
-                      llm-serving-prefill
+                      llm-serving-decode
                     </span>
                   </dd>
                   <dt
@@ -248,6 +248,13 @@
             </div>
           </div>
         </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        />
       </div>
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"

--- a/frontend/src/components/compositePodGroup/__snapshots__/Details.WithChildPodGroups.stories.storyshot
+++ b/frontend/src/components/compositePodGroup/__snapshots__/Details.WithChildPodGroups.stories.storyshot
@@ -33,7 +33,7 @@
             <h1
               class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
             >
-              CompositePodGroup: llm-serving-root
+              CompositePodGroup: llm-serving-prefill
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
@@ -139,7 +139,7 @@
                     <span
                       class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
                     >
-                      llm-serving-root
+                      llm-serving-prefill
                     </span>
                   </dd>
                   <dt
@@ -221,27 +221,13 @@
                     <span
                       class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
                     >
-                      serving
+                      prefill
                     </span>
                   </dd>
                   <dt
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
                   >
-                    Disruption Mode
-                  </dt>
-                  <dd
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
-                  >
-                    <span
-                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
-                    >
-                      All
-                    </span>
-                  </dd>
-                  <dt
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
-                  >
-                    Priority Class
+                    Parent
                   </dt>
                   <dd
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
@@ -250,37 +236,13 @@
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
                       href="/"
                     >
-                      high-priority
+                      llm-serving-root
                     </a>
-                  </dd>
-                  <dt
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
-                  >
-                    Priority
-                  </dt>
-                  <dd
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
-                  >
-                    1000
-                  </dd>
-                  <dt
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
-                  >
-                    Preemption Policy
-                  </dt>
-                  <dd
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
-                  >
-                    <span
-                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
-                    >
-                      PreemptLowerPriority
-                    </span>
                   </dd>
                   <dt
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
                   >
-                    Topology Keys
+                    Disruption Mode
                   </dt>
                   <dd
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
@@ -288,7 +250,7 @@
                     <span
                       class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
                     >
-                      topology.kubernetes.io/zone
+                      All
                     </span>
                   </dd>
                 </dl>
@@ -318,7 +280,7 @@
                   <h2
                     class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
                   >
-                    Composite Pod Groups
+                    Pod Groups
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
@@ -364,7 +326,7 @@
                         class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
                         scope="col"
                       >
-                        Min Group Count
+                        Min Count
                       </th>
                       <th
                         class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
@@ -387,7 +349,7 @@
                           class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
                           href="/"
                         >
-                          llm-serving-prefill
+                          llm-serving-prefill-0
                         </a>
                       </td>
                       <td
@@ -420,24 +382,26 @@
                           class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
                           href="/"
                         >
-                          llm-serving-decode
+                          llm-serving-prefill-1
                         </a>
                       </td>
                       <td
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
                       >
-                        Basic
+                        Gang
                       </td>
                       <td
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
-                      />
+                      >
+                        2
+                      </td>
                       <td
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
                       >
                         <span
-                          class="MuiTypography-root MuiTypography-body1 css-1dablfr-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
                         >
-                          Unschedulable
+                          Scheduled
                         </span>
                       </td>
                     </tr>

--- a/frontend/src/components/compositePodGroup/__snapshots__/List.CompositePodGroups.stories.storyshot
+++ b/frontend/src/components/compositePodGroup/__snapshots__/List.CompositePodGroups.stories.storyshot
@@ -1,0 +1,1127 @@
+<body>
+  <div>
+    <div
+      class="MuiContainer-root MuiContainer-maxWidthXl css-4hqp1a-MuiContainer-root"
+    >
+      <div
+        class="MuiBox-root css-j1fy4m"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+          >
+            <div
+              class="MuiBox-root css-70qvj9"
+            >
+              <h1
+                class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
+              >
+                Composite Pod Groups
+              </h1>
+              <div
+                class="MuiBox-root css-ldp2l3"
+              />
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-item css-ztq4zc-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-1x6bjyf-MuiAutocomplete-root"
+                >
+                  <div
+                    class="MuiBox-root css-1dipl1t"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+                      style="margin-top: 0px;"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1f7ywh2-MuiFormLabel-root-MuiInputLabel-root"
+                        data-shrink="true"
+                        for="namespaces-filter"
+                        id="namespaces-filter-label"
+                      >
+                        Namespaces
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-1xjtaff-MuiInputBase-root-MuiOutlinedInput-root"
+                      >
+                        <input
+                          aria-autocomplete="both"
+                          aria-expanded="false"
+                          aria-invalid="false"
+                          autocapitalize="none"
+                          autocomplete="off"
+                          class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
+                          id="namespaces-filter"
+                          placeholder="Filter"
+                          role="combobox"
+                          spellcheck="false"
+                          type="text"
+                          value=""
+                        />
+                        <div
+                          class="MuiAutocomplete-endAdornment css-p1olib-MuiAutocomplete-endAdornment"
+                        >
+                          <button
+                            aria-label="Open"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium MuiAutocomplete-popupIndicator css-1aav1nn-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                            tabindex="-1"
+                            title="Open"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                              data-testid="ArrowDropDownIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M7 10l5 5 5-5z"
+                              />
+                            </svg>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </button>
+                        </div>
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                        >
+                          <legend
+                            class="css-sl37lx-MuiNotchedOutlined-root"
+                          >
+                            <span>
+                              Namespaces
+                            </span>
+                          </legend>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-1txv3mw"
+        >
+          <div
+            class="MuiBox-root css-8atqhb"
+          >
+            <div
+              aria-atomic="true"
+              aria-live="polite"
+              class="MuiBox-root css-ty8jgw"
+              role="status"
+            />
+            <div
+              class="MuiBox-root css-1ipmh7v"
+            >
+              <div
+                class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
+                style="min-height: 0px;"
+              >
+                <div
+                  class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
+                >
+                  <div
+                    class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
+                  >
+                    <div
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                      role="alert"
+                    >
+                      <div
+                        class="MuiAlert-message css-1pxa9xg-MuiAlert-message"
+                      >
+                        <div
+                          class="MuiStack-root css-5kul5x-MuiStack-root"
+                        >
+                          <div
+                            class="MuiBox-root css-k008qs"
+                          >
+                             
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+                style="opacity: 0; visibility: hidden;"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-18b7jph-MuiTypography-root"
+                >
+                  Drop to group by 
+                </p>
+              </div>
+              <div
+                class="MuiBox-root css-zrlv9q"
+              >
+                <span />
+                <div
+                  class="MuiBox-root css-1p0wbhh"
+                >
+                  <div
+                    class="MuiBox-root css-di3982"
+                  >
+                    <button
+                      aria-label="Show/Hide search"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                        data-testid="SearchIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                    <button
+                      aria-label="Show/Hide filters"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                        data-testid="FilterListIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                    <button
+                      aria-haspopup="menu"
+                      aria-label="Show/Hide columns"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                        data-testid="ViewColumnIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M14.67 5v14H9.33V5zm1 14H21V5h-5.33zm-7.34 0V5H3v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <table
+              class="MuiTable-root css-isyxe0-MuiTable-root"
+            >
+              <thead
+                class="MuiTableHead-root css-1tmrira-MuiTableHead-root"
+              >
+                <tr
+                  class="css-1lqh5un"
+                >
+                  <th
+                    aria-sort="none"
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-199xzek-MuiTableCell-root"
+                    colspan="1"
+                    data-index="-1"
+                    scope="col"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content-Labels MuiBox-root css-4ng264"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-bbxzxe"
+                        >
+                          <span
+                            aria-label="Toggle select all"
+                            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-3nlepf-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                            data-mui-internal-clone-element="true"
+                          >
+                            <input
+                              aria-label="Toggle select all"
+                              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                              data-indeterminate="false"
+                              type="checkbox"
+                            />
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                              data-testid="CheckBoxOutlineBlankIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              />
+                            </svg>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </span>
+                        </div>
+                      </div>
+                      <div
+                        class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                      />
+                    </div>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-pksupb-MuiTableCell-root"
+                    colspan="1"
+                    data-can-sort="true"
+                    data-index="-1"
+                    scope="col"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                        >
+                          Name
+                        </div>
+                        <span
+                          aria-label="Sort by Name ascending"
+                          class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                          data-mui-internal-clone-element="true"
+                        >
+                          <span
+                            aria-label="Sort by Name ascending"
+                            class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                            role="button"
+                            tabindex="0"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                              data-testid="SyncAltIcon"
+                              focusable="false"
+                              style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                      />
+                    </div>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1r8sxpv-MuiTableCell-root"
+                    colspan="1"
+                    data-can-sort="true"
+                    data-index="-1"
+                    scope="col"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                        >
+                          Namespace
+                        </div>
+                        <span
+                          aria-label="Sort by Namespace ascending"
+                          class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                          data-mui-internal-clone-element="true"
+                        >
+                          <span
+                            aria-label="Sort by Namespace ascending"
+                            class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                            role="button"
+                            tabindex="0"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                              data-testid="SyncAltIcon"
+                              focusable="false"
+                              style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                      />
+                    </div>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-lftrsn-MuiTableCell-root"
+                    colspan="1"
+                    data-can-sort="true"
+                    data-index="-1"
+                    scope="col"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                        >
+                          Policy
+                        </div>
+                        <span
+                          aria-label="Sort by Policy ascending"
+                          class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                          data-mui-internal-clone-element="true"
+                        >
+                          <span
+                            aria-label="Sort by Policy ascending"
+                            class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                            role="button"
+                            tabindex="0"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                              data-testid="SyncAltIcon"
+                              focusable="false"
+                              style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                      />
+                    </div>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1bfa0m6-MuiTableCell-root"
+                    colspan="1"
+                    data-can-sort="true"
+                    data-index="-1"
+                    scope="col"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                        >
+                          Min Group Count
+                        </div>
+                        <span
+                          aria-label="Sort by Min Group Count descending"
+                          class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                          data-mui-internal-clone-element="true"
+                        >
+                          <span
+                            aria-label="Sort by Min Group Count descending"
+                            class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                            role="button"
+                            tabindex="0"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                              data-testid="SyncAltIcon"
+                              focusable="false"
+                              style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                      />
+                    </div>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-g529a9-MuiTableCell-root"
+                    colspan="1"
+                    data-can-sort="true"
+                    data-index="-1"
+                    scope="col"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                        >
+                          Parent
+                        </div>
+                        <span
+                          aria-label="Sort by Parent ascending"
+                          class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                          data-mui-internal-clone-element="true"
+                        >
+                          <span
+                            aria-label="Sort by Parent ascending"
+                            class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                            role="button"
+                            tabindex="0"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                              data-testid="SyncAltIcon"
+                              focusable="false"
+                              style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                      />
+                    </div>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-45v1n3-MuiTableCell-root"
+                    colspan="1"
+                    data-can-sort="true"
+                    data-index="-1"
+                    scope="col"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                        >
+                          Workload
+                        </div>
+                        <span
+                          aria-label="Sort by Workload ascending"
+                          class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                          data-mui-internal-clone-element="true"
+                        >
+                          <span
+                            aria-label="Sort by Workload ascending"
+                            class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                            role="button"
+                            tabindex="0"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                              data-testid="SyncAltIcon"
+                              focusable="false"
+                              style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                      />
+                    </div>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-13c0hsi-MuiTableCell-root"
+                    colspan="1"
+                    data-can-sort="true"
+                    data-index="-1"
+                    scope="col"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                        >
+                          Status
+                        </div>
+                        <span
+                          aria-label="Sort by Status ascending"
+                          class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                          data-mui-internal-clone-element="true"
+                        >
+                          <span
+                            aria-label="Sort by Status ascending"
+                            class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                            role="button"
+                            tabindex="0"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                              data-testid="SyncAltIcon"
+                              focusable="false"
+                              style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                      />
+                    </div>
+                  </th>
+                  <th
+                    aria-sort="ascending"
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-7mz8xn-MuiTableCell-root"
+                    colspan="1"
+                    data-can-sort="true"
+                    data-index="-1"
+                    data-sort="asc"
+                    scope="col"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-chb057"
+                        >
+                          Age
+                        </div>
+                        <span
+                          aria-label="Sorted by Age ascending"
+                          class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                          data-mui-internal-clone-element="true"
+                        >
+                          <span
+                            aria-label="Sorted by Age ascending"
+                            class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-kfi25q-MuiButtonBase-root-MuiTableSortLabel-root"
+                            role="button"
+                            tabindex="0"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                              data-testid="ArrowDownwardIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8z"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                      />
+                    </div>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-nv4ey6-MuiTableCell-root"
+                    colspan="1"
+                    data-index="-1"
+                    scope="col"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content-Labels MuiBox-root css-4ng264"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-bbxzxe"
+                        >
+                          Actions
+                        </div>
+                      </div>
+                      <div
+                        class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                      />
+                    </div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="css-1obf64m"
+              >
+                <tr
+                  class="css-1ospngb"
+                  data-selected="false"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
+                  >
+                    <span
+                      aria-label="Toggle select row"
+                      class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-3nlepf-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <input
+                        aria-label="Toggle select row"
+                        class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                        data-indeterminate="false"
+                        type="checkbox"
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                        data-testid="CheckBoxOutlineBlankIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </span>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                      href="/"
+                    >
+                      llm-serving-root
+                    </a>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2bq9ry-MuiTableCell-root"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                      href="/"
+                    >
+                      inference
+                    </a>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1fboet4-MuiTableCell-root"
+                  >
+                    Gang
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-kmdwka-MuiTableCell-root"
+                  >
+                    2
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1vk1mz5-MuiTableCell-root"
+                  />
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-dsk3bz-MuiTableCell-root"
+                  >
+                    llm-serving
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-c9i7d5-MuiTableCell-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
+                    >
+                      Scheduled
+                    </span>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-14i1ub9-MuiTableCell-root"
+                  >
+                    <p
+                      aria-label="2022-01-01T00:00:00.000Z"
+                      class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      90d
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-hq12h3-MuiTableCell-root"
+                  >
+                    <button
+                      aria-label="Row Actions"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1cxdeyj-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </td>
+                </tr>
+                <tr
+                  class="css-1ospngb"
+                  data-selected="false"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
+                  >
+                    <span
+                      aria-label="Toggle select row"
+                      class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-3nlepf-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <input
+                        aria-label="Toggle select row"
+                        class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                        data-indeterminate="false"
+                        type="checkbox"
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                        data-testid="CheckBoxOutlineBlankIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </span>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                      href="/"
+                    >
+                      llm-serving-prefill
+                    </a>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2bq9ry-MuiTableCell-root"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                      href="/"
+                    >
+                      inference
+                    </a>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1fboet4-MuiTableCell-root"
+                  >
+                    Gang
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-kmdwka-MuiTableCell-root"
+                  >
+                    2
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1vk1mz5-MuiTableCell-root"
+                  >
+                    llm-serving-root
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-dsk3bz-MuiTableCell-root"
+                  >
+                    llm-serving
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-c9i7d5-MuiTableCell-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
+                    >
+                      Scheduled
+                    </span>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-14i1ub9-MuiTableCell-root"
+                  >
+                    <p
+                      aria-label="2022-01-01T00:00:00.000Z"
+                      class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      90d
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-hq12h3-MuiTableCell-root"
+                  >
+                    <button
+                      aria-label="Row Actions"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1cxdeyj-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </td>
+                </tr>
+                <tr
+                  class="css-1ospngb"
+                  data-selected="false"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
+                  >
+                    <span
+                      aria-label="Toggle select row"
+                      class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-3nlepf-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <input
+                        aria-label="Toggle select row"
+                        class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                        data-indeterminate="false"
+                        type="checkbox"
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                        data-testid="CheckBoxOutlineBlankIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </span>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                      href="/"
+                    >
+                      llm-serving-decode
+                    </a>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2bq9ry-MuiTableCell-root"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                      href="/"
+                    >
+                      inference
+                    </a>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1fboet4-MuiTableCell-root"
+                  >
+                    Basic
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-kmdwka-MuiTableCell-root"
+                  />
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1vk1mz5-MuiTableCell-root"
+                  >
+                    llm-serving-root
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-dsk3bz-MuiTableCell-root"
+                  >
+                    llm-serving
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-c9i7d5-MuiTableCell-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-1dablfr-MuiTypography-root"
+                    >
+                      Unschedulable
+                    </span>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-14i1ub9-MuiTableCell-root"
+                  >
+                    <p
+                      aria-label="2022-01-01T00:00:00.000Z"
+                      class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      90d
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-hq12h3-MuiTableCell-root"
+                  >
+                    <button
+                      aria-label="Row Actions"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1cxdeyj-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <div
+              class="MuiBox-root css-1bxknjp"
+            >
+              <div
+                class="MuiBox-root css-1llu0od"
+              >
+                <span />
+                <div
+                  class="MuiBox-root css-qpxlqp"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/compositePodGroup/__snapshots__/List.Empty.stories.storyshot
+++ b/frontend/src/components/compositePodGroup/__snapshots__/List.Empty.stories.storyshot
@@ -1,0 +1,150 @@
+<body>
+  <div>
+    <div
+      class="MuiContainer-root MuiContainer-maxWidthXl css-4hqp1a-MuiContainer-root"
+    >
+      <div
+        class="MuiBox-root css-j1fy4m"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+          >
+            <div
+              class="MuiBox-root css-70qvj9"
+            >
+              <h1
+                class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
+              >
+                Composite Pod Groups
+              </h1>
+              <div
+                class="MuiBox-root css-ldp2l3"
+              />
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-item css-ztq4zc-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-1x6bjyf-MuiAutocomplete-root"
+                >
+                  <div
+                    class="MuiBox-root css-1dipl1t"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+                      style="margin-top: 0px;"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1f7ywh2-MuiFormLabel-root-MuiInputLabel-root"
+                        data-shrink="true"
+                        for="namespaces-filter"
+                        id="namespaces-filter-label"
+                      >
+                        Namespaces
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-1xjtaff-MuiInputBase-root-MuiOutlinedInput-root"
+                      >
+                        <input
+                          aria-autocomplete="both"
+                          aria-expanded="false"
+                          aria-invalid="false"
+                          autocapitalize="none"
+                          autocomplete="off"
+                          class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
+                          id="namespaces-filter"
+                          placeholder="Filter"
+                          role="combobox"
+                          spellcheck="false"
+                          type="text"
+                          value=""
+                        />
+                        <div
+                          class="MuiAutocomplete-endAdornment css-p1olib-MuiAutocomplete-endAdornment"
+                        >
+                          <button
+                            aria-label="Open"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium MuiAutocomplete-popupIndicator css-1aav1nn-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                            tabindex="-1"
+                            title="Open"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                              data-testid="ArrowDropDownIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M7 10l5 5 5-5z"
+                              />
+                            </svg>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </button>
+                        </div>
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                        >
+                          <legend
+                            class="css-sl37lx-MuiNotchedOutlined-root"
+                          >
+                            <span>
+                              Namespaces
+                            </span>
+                          </legend>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-1txv3mw"
+        >
+          <div
+            class="MuiBox-root css-8atqhb"
+          >
+            <div
+              aria-atomic="true"
+              aria-live="polite"
+              class="MuiBox-root css-ty8jgw"
+              role="status"
+            >
+              No data to be shown.
+            </div>
+            <div
+              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+            >
+              <div
+                class="MuiBox-root css-19midj6"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+                >
+                  No data to be shown.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/compositePodGroup/__snapshots__/List.Error.stories.storyshot
+++ b/frontend/src/components/compositePodGroup/__snapshots__/List.Error.stories.storyshot
@@ -1,0 +1,193 @@
+<body>
+  <div>
+    <div
+      class="MuiContainer-root MuiContainer-maxWidthXl css-4hqp1a-MuiContainer-root"
+    >
+      <div
+        class="MuiBox-root css-j1fy4m"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+          >
+            <div
+              class="MuiBox-root css-70qvj9"
+            >
+              <h1
+                class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
+              >
+                Composite Pod Groups
+              </h1>
+              <div
+                class="MuiBox-root css-ldp2l3"
+              />
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-item css-ztq4zc-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-1x6bjyf-MuiAutocomplete-root"
+                >
+                  <div
+                    class="MuiBox-root css-1dipl1t"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+                      style="margin-top: 0px;"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1f7ywh2-MuiFormLabel-root-MuiInputLabel-root"
+                        data-shrink="true"
+                        for="namespaces-filter"
+                        id="namespaces-filter-label"
+                      >
+                        Namespaces
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-1xjtaff-MuiInputBase-root-MuiOutlinedInput-root"
+                      >
+                        <input
+                          aria-autocomplete="both"
+                          aria-expanded="false"
+                          aria-invalid="false"
+                          autocapitalize="none"
+                          autocomplete="off"
+                          class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
+                          id="namespaces-filter"
+                          placeholder="Filter"
+                          role="combobox"
+                          spellcheck="false"
+                          type="text"
+                          value=""
+                        />
+                        <div
+                          class="MuiAutocomplete-endAdornment css-p1olib-MuiAutocomplete-endAdornment"
+                        >
+                          <button
+                            aria-label="Open"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium MuiAutocomplete-popupIndicator css-1aav1nn-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                            tabindex="-1"
+                            title="Open"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                              data-testid="ArrowDropDownIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M7 10l5 5 5-5z"
+                              />
+                            </svg>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </button>
+                        </div>
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                        >
+                          <legend
+                            class="css-sl37lx-MuiNotchedOutlined-root"
+                          >
+                            <span>
+                              Namespaces
+                            </span>
+                          </legend>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-1txv3mw"
+        >
+          <div
+            class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard css-rme5zz-MuiPaper-root-MuiAlert-root"
+            role="alert"
+          >
+            <div
+              class="MuiAlert-icon css-1ytlwq5-MuiAlert-icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
+                data-testid="ReportProblemOutlinedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
+                />
+              </svg>
+            </div>
+            <div
+              class="MuiAlert-message css-1pxa9xg-MuiAlert-message"
+            >
+              <div
+                class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom MuiAlertTitle-root css-1mny8mx-MuiTypography-root-MuiAlertTitle-root"
+              >
+                Failed to load resources
+              </div>
+            </div>
+            <div
+              class="MuiAlert-action css-ki1hdl-MuiAlert-action"
+            >
+              <button
+                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textWarning MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorWarning MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textWarning MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorWarning MuiButton-disableElevation css-1s9cj53-MuiButtonBase-root-MuiButton-root"
+                tabindex="0"
+                type="button"
+              >
+                Show details
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-8atqhb"
+          >
+            <div
+              aria-atomic="true"
+              aria-live="polite"
+              class="MuiBox-root css-ty8jgw"
+              role="status"
+            >
+              No data to be shown.
+            </div>
+            <div
+              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+            >
+              <div
+                class="MuiBox-root css-19midj6"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+                >
+                  No data to be shown.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/compositePodGroup/storyHelper.ts
+++ b/frontend/src/components/compositePodGroup/storyHelper.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KubeCompositePodGroup } from '../../lib/k8s/compositePodGroup';
+
+const creationTimestamp = new Date('2022-01-01').toISOString();
+
+/**
+ * A disaggregated serving hierarchy: a root that gangs the prefill and decode stages
+ * together, and the two stage groups nested under it. The decode stage never met its
+ * requirement, which is the case these views exist to explain.
+ */
+export const COMPOSITE_POD_GROUP_DUMMY_DATA: KubeCompositePodGroup[] = [
+  {
+    apiVersion: 'scheduling.k8s.io/v1alpha3',
+    kind: 'CompositePodGroup',
+    metadata: {
+      name: 'llm-serving-root',
+      namespace: 'inference',
+      creationTimestamp,
+      uid: 'composite-pod-group-uid-1',
+    },
+    spec: {
+      schedulingPolicy: { gang: { minGroupCount: 2 } },
+      workloadRef: { workloadName: 'llm-serving', templateName: 'serving' },
+      schedulingConstraints: { topology: [{ key: 'topology.kubernetes.io/zone' }] },
+      disruptionMode: { all: {} },
+      priorityClassName: 'high-priority',
+      priority: 1000,
+      preemptionPolicy: 'PreemptLowerPriority',
+    },
+    status: {
+      conditions: [
+        {
+          type: 'CompositePodGroupInitiallyScheduled',
+          status: 'True',
+          reason: 'Scheduled',
+          message: 'The subtree of the composite pod group was scheduled.',
+          lastProbeTime: creationTimestamp,
+          lastTransitionTime: creationTimestamp,
+        },
+      ],
+    },
+  } as KubeCompositePodGroup,
+  {
+    apiVersion: 'scheduling.k8s.io/v1alpha3',
+    kind: 'CompositePodGroup',
+    metadata: {
+      name: 'llm-serving-prefill',
+      namespace: 'inference',
+      creationTimestamp,
+      uid: 'composite-pod-group-uid-2',
+    },
+    spec: {
+      schedulingPolicy: { gang: { minGroupCount: 2 } },
+      workloadRef: { workloadName: 'llm-serving', templateName: 'prefill' },
+      parentCompositePodGroupName: 'llm-serving-root',
+      disruptionMode: { all: {} },
+    },
+    status: {
+      conditions: [
+        {
+          type: 'CompositePodGroupInitiallyScheduled',
+          status: 'True',
+          reason: 'Scheduled',
+          message: 'The subtree of the composite pod group was scheduled.',
+          lastProbeTime: creationTimestamp,
+          lastTransitionTime: creationTimestamp,
+        },
+      ],
+    },
+  } as KubeCompositePodGroup,
+  {
+    apiVersion: 'scheduling.k8s.io/v1alpha3',
+    kind: 'CompositePodGroup',
+    metadata: {
+      name: 'llm-serving-decode',
+      namespace: 'inference',
+      creationTimestamp,
+      uid: 'composite-pod-group-uid-3',
+    },
+    spec: {
+      schedulingPolicy: { basic: {} },
+      workloadRef: { workloadName: 'llm-serving', templateName: 'decode' },
+      parentCompositePodGroupName: 'llm-serving-root',
+      disruptionMode: { single: {} },
+    },
+    status: {
+      conditions: [
+        {
+          type: 'CompositePodGroupInitiallyScheduled',
+          status: 'False',
+          reason: 'Unschedulable',
+          message: 'No feasible placements found for the subtree.',
+          lastProbeTime: creationTimestamp,
+          lastTransitionTime: creationTimestamp,
+        },
+      ],
+    },
+  } as KubeCompositePodGroup,
+];

--- a/frontend/src/components/compositePodGroup/storyHelper.ts
+++ b/frontend/src/components/compositePodGroup/storyHelper.ts
@@ -15,6 +15,7 @@
  */
 
 import type { KubeCompositePodGroup } from '../../lib/k8s/compositePodGroup';
+import type { KubePodGroup } from '../../lib/k8s/podGroup';
 
 const creationTimestamp = new Date('2022-01-01').toISOString();
 
@@ -112,3 +113,35 @@ export const COMPOSITE_POD_GROUP_DUMMY_DATA: KubeCompositePodGroup[] = [
     },
   } as KubeCompositePodGroup,
 ];
+
+/** The pod groups nested under the prefill stage of the hierarchy above. */
+export const CHILD_POD_GROUP_DUMMY_DATA: KubePodGroup[] = [0, 1].map(
+  index =>
+    ({
+      apiVersion: 'scheduling.k8s.io/v1alpha3',
+      kind: 'PodGroup',
+      metadata: {
+        name: `llm-serving-prefill-${index}`,
+        namespace: 'inference',
+        creationTimestamp,
+        uid: `pod-group-uid-${index + 1}`,
+      },
+      spec: {
+        schedulingPolicy: { gang: { minCount: 2 } },
+        workloadRef: { workloadName: 'llm-serving', templateName: 'prefill-workers' },
+        parentCompositePodGroupName: 'llm-serving-prefill',
+      },
+      status: {
+        conditions: [
+          {
+            type: 'PodGroupInitiallyScheduled',
+            status: 'True',
+            reason: 'Scheduled',
+            message: 'All pods of the group were scheduled.',
+            lastProbeTime: creationTimestamp,
+            lastTransitionTime: creationTimestamp,
+          },
+        ],
+      },
+    } as KubePodGroup)
+);

--- a/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.FoundSomeResults.stories.storyshot
+++ b/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.FoundSomeResults.stories.storyshot
@@ -74,7 +74,7 @@
         style="position: relative; height: 500px; width: 100%; overflow: auto; -webkit-overflow-scrolling: touch; will-change: transform; direction: ltr;"
       >
         <div
-          style="height: 600px; width: 100%;"
+          style="height: 650px; width: 100%;"
         >
           <li
             aria-disabled="false"
@@ -1028,6 +1028,52 @@
               <div
                 class="MuiBox-root css-72rvq0"
               >
+                C
+                <span
+                  style="font-weight: bold;"
+                >
+                  o
+                </span>
+                m
+                <span
+                  style="font-weight: bold;"
+                >
+                  po
+                </span>
+                site 
+                <span
+                  style="font-weight: bold;"
+                >
+                  Pod
+                </span>
+                 Groups
+              </div>
+            </div>
+          </li>
+          <li
+            aria-disabled="false"
+            aria-selected="false"
+            class="MuiBox-root css-iuk3p6"
+            data-option-index="10"
+            id=":mock-test-id:"
+            role="option"
+            style="position: absolute; left: 0px; top: 500px; height: 50px; width: 100%;"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-hj9wmn"
+            />
+            <div
+              class="MuiBox-root css-kznbd2"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-q1d4hg-MuiTypography-root"
+              >
+                Page
+              </span>
+              <div
+                class="MuiBox-root css-72rvq0"
+              >
                 H
                 <span
                   style="font-weight: bold;"
@@ -1054,10 +1100,10 @@
             aria-disabled="false"
             aria-selected="false"
             class="MuiBox-root css-iuk3p6"
-            data-option-index="10"
+            data-option-index="11"
             id=":mock-test-id:"
             role="option"
-            style="position: absolute; left: 0px; top: 500px; height: 50px; width: 100%;"
+            style="position: absolute; left: 0px; top: 550px; height: 50px; width: 100%;"
             tabindex="-1"
           >
             <div
@@ -1081,145 +1127,6 @@
                   pod
                 </span>
                 " with Advanced Search
-              </div>
-            </div>
-          </li>
-          <li
-            aria-disabled="false"
-            aria-selected="false"
-            class="MuiBox-root css-iuk3p6"
-            data-option-index="11"
-            id=":mock-test-id:"
-            role="option"
-            style="position: absolute; left: 0px; top: 550px; height: 50px; width: 100%;"
-            tabindex="-1"
-          >
-            <div
-              class="MuiBox-root css-hj9wmn"
-            >
-              <div
-                class="MuiBox-root css-wjpmq5"
-              >
-                <svg
-                  height="17.500378mm"
-                  id="svg13826"
-                  inkscape:version="0.91 r13725"
-                  sodipodi:docname="ns.svg"
-                  style="scale: 1.1; width: 100%; height: 100%;"
-                  viewBox="0 0 18.035334 17.500378"
-                  width="18.035334mm"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlns:cc="http://creativecommons.org/ns#"
-                  xmlns:dc="http://purl.org/dc/elements/1.1/"
-                  xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-                  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-                  xmlns:svg="http://www.w3.org/2000/svg"
-                >
-                  <defs
-                    id="defs13820"
-                  />
-                  <sodipodi:namedview
-                    bordercolor="#666666"
-                    borderopacity="1"
-                    fit-margin-bottom="0"
-                    fit-margin-left="0"
-                    fit-margin-right="0"
-                    fit-margin-top="0"
-                    id="base"
-                    inkscape:current-layer="layer1"
-                    inkscape:cx="-2.090004"
-                    inkscape:cy="23.752239"
-                    inkscape:document-units="mm"
-                    inkscape:pageopacity="0"
-                    inkscape:pageshadow="2"
-                    inkscape:window-height="775"
-                    inkscape:window-maximized="1"
-                    inkscape:window-width="1440"
-                    inkscape:window-x="0"
-                    inkscape:window-y="1"
-                    inkscape:zoom="8"
-                    pagecolor="currentcolor"
-                    showgrid="false"
-                  />
-                  <metadata
-                    id="metadata13823"
-                  >
-                    <rdf:rdf>
-                      <cc:work
-                        rdf:about=""
-                      >
-                        <dc:format>
-                          image/svg+xml
-                        </dc:format>
-                        <dc:type
-                          rdf:resource="http://purl.org/dc/dcmitype/StillImage"
-                        />
-                        <dc:title />
-                      </cc:work>
-                    </rdf:rdf>
-                  </metadata>
-                  <g
-                    id="layer1"
-                    inkscape:groupmode="layer"
-                    inkscape:label="Calque 1"
-                    transform="translate(-0.99262638,-1.174181)"
-                  >
-                    <g
-                      id="g70"
-                      transform="matrix(1.0148887,0,0,1.0148887,16.902146,-2.698726)"
-                    >
-                      <path
-                        d="m -6.8492015,4.2724668 a 1.1191255,1.1099671 0 0 0 -0.4288818,0.1085303 l -5.8524037,2.7963394 a 1.1191255,1.1099671 0 0 0 -0.605524,0.7529759 l -1.443828,6.2812846 a 1.1191255,1.1099671 0 0 0 0.151943,0.851028 1.1191255,1.1099671 0 0 0 0.06362,0.08832 l 4.0508,5.036555 a 1.1191255,1.1099671 0 0 0 0.874979,0.417654 l 6.4961011,-0.0015 a 1.1191255,1.1099671 0 0 0 0.8749788,-0.416906 L 1.3818872,15.149453 A 1.1191255,1.1099671 0 0 0 1.5981986,14.210104 L 0.15212657,7.9288154 A 1.1191255,1.1099671 0 0 0 -0.45339794,7.1758396 L -6.3065496,4.3809971 A 1.1191255,1.1099671 0 0 0 -6.8492015,4.2724668 Z"
-                        id="path3055"
-                        inkscape:connector-curvature="0"
-                        inkscape:export-filename="new.png"
-                        inkscape:export-xdpi="250.55"
-                        inkscape:export-ydpi="250.55"
-                        style="fill: transparent; fill-opacity: 1; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; stroke-opacity: 1;"
-                      />
-                      <path
-                        d="M -6.8523435,3.8176372 A 1.1814304,1.171762 0 0 0 -7.3044284,3.932904 l -6.1787426,2.9512758 a 1.1814304,1.171762 0 0 0 -0.639206,0.794891 l -1.523915,6.6308282 a 1.1814304,1.171762 0 0 0 0.160175,0.89893 1.1814304,1.171762 0 0 0 0.06736,0.09281 l 4.276094,5.317236 a 1.1814304,1.171762 0 0 0 0.92363,0.440858 l 6.8576188,-0.0015 a 1.1814304,1.171762 0 0 0 0.9236308,-0.44011 l 4.2745966,-5.317985 a 1.1814304,1.171762 0 0 0 0.228288,-0.990993 L 0.53894439,7.6775738 A 1.1814304,1.171762 0 0 0 -0.10026101,6.8834313 L -6.2790037,3.9321555 A 1.1814304,1.171762 0 0 0 -6.8523435,3.8176372 Z m 0.00299,0.4550789 a 1.1191255,1.1099671 0 0 1 0.5426517,0.1085303 l 5.85315169,2.7948425 A 1.1191255,1.1099671 0 0 1 0.15197811,7.9290648 L 1.598051,14.21035 a 1.1191255,1.1099671 0 0 1 -0.2163123,0.939348 l -4.0493032,5.037304 a 1.1191255,1.1099671 0 0 1 -0.8749789,0.416906 l -6.4961006,0.0015 a 1.1191255,1.1099671 0 0 1 -0.874979,-0.417652 l -4.0508,-5.036554 a 1.1191255,1.1099671 0 0 1 -0.06362,-0.08832 1.1191255,1.1099671 0 0 1 -0.151942,-0.851028 l 1.443827,-6.2812853 a 1.1191255,1.1099671 0 0 1 0.605524,-0.7529758 l 5.8524036,-2.7963395 a 1.1191255,1.1099671 0 0 1 0.4288819,-0.1085303 z"
-                        id="path3054-2-9"
-                        inkscape:connector-curvature="0"
-                        style="color: rgb(0, 0, 0); font-style: normal; font-variant: normal; font-weight: normal; font-stretch: normal; font-size: medium; line-height: normal; font-family: Sans; text-indent: 0; text-align: start; text-decoration: none; text-decoration-line: none; letter-spacing: normal; word-spacing: normal; text-transform: none; writing-mode: lr-tb; direction: ltr; baseline-shift: baseline; text-anchor: start; display: inline; overflow: visible; visibility: visible; fill: currentcolor; fill-opacity: 1; fill-rule: nonzero; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; marker: none; enable-background: accumulate;"
-                      />
-                    </g>
-                    <rect
-                      height="6.6900792"
-                      id="rect8790"
-                      style="opacity: 1; fill: none; fill-opacity: 1; fill-rule: nonzero; stroke: currentcolor; stroke-width: 0.40000001; stroke-linecap: butt; stroke-linejoin: round; stroke-miterlimit: 10; stroke-dasharray: 0.80000001, 0.4; stroke-dashoffset: 3.44000006; stroke-opacity: 1;"
-                      width="7.6735892"
-                      x="6.1734986"
-                      y="6.5793304"
-                    />
-                  </g>
-                </svg>
-              </div>
-            </div>
-            <div
-              class="MuiBox-root css-kznbd2"
-            >
-              <span
-                class="MuiTypography-root MuiTypography-caption css-q1d4hg-MuiTypography-root"
-              >
-                Current Namespace
-              </span>
-              <div
-                class="MuiBox-root css-72rvq0"
-              >
-                Set names
-                <span
-                  style="font-weight: bold;"
-                >
-                  p
-                </span>
-                ace: 
-                <span
-                  style="font-weight: bold;"
-                >
-                  pod
-                </span>
               </div>
             </div>
           </li>

--- a/frontend/src/components/podGroup/Details.tsx
+++ b/frontend/src/components/podGroup/Details.tsx
@@ -68,7 +68,18 @@ export default function PodGroupDetails(props: {
           },
           {
             name: t('translation|Composite Pod Group'),
-            value: item.parentCompositePodGroupName,
+            value: item.parentCompositePodGroupName && (
+              <Link
+                routeName="CompositePodGroup"
+                params={{
+                  namespace: item.metadata.namespace,
+                  name: item.parentCompositePodGroupName,
+                }}
+                activeCluster={item.cluster}
+              >
+                {item.parentCompositePodGroupName}
+              </Link>
+            ),
             hide: !item.parentCompositePodGroupName,
           },
           {

--- a/frontend/src/components/podGroup/List.tsx
+++ b/frontend/src/components/podGroup/List.tsx
@@ -16,25 +16,8 @@
 
 import { useTranslation } from 'react-i18next';
 import PodGroup from '../../lib/k8s/podGroup';
-import { StatusLabel } from '../common/Label';
 import ResourceListView from '../common/Resource/ResourceListView';
-
-/** Shows whether the group met its scheduling requirement, from its scheduling condition. */
-function SchedulingStatus({ podGroup }: { podGroup: PodGroup }) {
-  const { t } = useTranslation(['translation']);
-  const condition = podGroup.schedulingCondition;
-
-  if (!condition) {
-    return <span>{t('translation|Unknown')}</span>;
-  }
-
-  const scheduled = condition.status === 'True';
-  return (
-    <StatusLabel status={scheduled ? 'success' : 'warning'}>
-      {condition.reason || (scheduled ? t('translation|Scheduled') : t('translation|Pending'))}
-    </StatusLabel>
-  );
-}
+import { getSchedulingStatusText, SchedulingStatus } from '../scheduling/SchedulingStatus';
 
 export default function PodGroupList() {
   const { t } = useTranslation(['glossary', 'translation']);
@@ -72,18 +55,8 @@ export default function PodGroupList() {
           id: 'status',
           label: t('translation|Status'),
           gridTemplate: 'min-content',
-          getValue: item => {
-            const condition = item.schedulingCondition;
-            if (!condition) {
-              return t('translation|Unknown');
-            }
-            const scheduled = condition.status === 'True';
-            return (
-              condition.reason ||
-              (scheduled ? t('translation|Scheduled') : t('translation|Pending'))
-            );
-          },
-          render: item => <SchedulingStatus podGroup={item} />,
+          getValue: item => getSchedulingStatusText(item.schedulingCondition, t),
+          render: item => <SchedulingStatus condition={item.schedulingCondition} />,
         },
         'age',
       ]}

--- a/frontend/src/components/scheduling/SchedulingStatus.tsx
+++ b/frontend/src/components/scheduling/SchedulingStatus.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import type { KubeCondition } from '../../lib/k8s/cluster';
+import type { StatusLabelProps } from '../common/Label';
+import { StatusLabel } from '../common/Label';
+
+type Translate = (key: string) => string;
+
+/**
+ * Text of the scheduling condition of a pod group.
+ *
+ * These conditions are terminal: they report whether the group ever met its scheduling
+ * requirement, not whether its pods are running now.
+ * @param condition - The scheduling condition, when the group already has one.
+ * @param t - The translation function of the calling view.
+ * @returns The reason of the condition, or a localized fallback.
+ */
+export function getSchedulingStatusText(
+  condition: KubeCondition | undefined,
+  t: Translate
+): string {
+  if (!condition) {
+    return t('translation|Unknown');
+  }
+  if (condition.reason) {
+    return condition.reason;
+  }
+  if (condition.status === 'True') {
+    return t('translation|Scheduled');
+  }
+  return condition.status === 'False' ? t('translation|Pending') : t('translation|Unknown');
+}
+
+function getSchedulingStatusSeverity(condition: KubeCondition): StatusLabelProps['status'] {
+  if (condition.status === 'True') {
+    return 'success';
+  }
+  return condition.status === 'False' ? 'warning' : '';
+}
+
+/** Shows whether a group met its scheduling requirement, from its scheduling condition. */
+export function SchedulingStatus({ condition }: { condition: KubeCondition | undefined }) {
+  const { t } = useTranslation(['translation']);
+
+  if (!condition) {
+    return <span>{t('translation|Unknown')}</span>;
+  }
+
+  return (
+    <StatusLabel status={getSchedulingStatusSeverity(condition)}>
+      {getSchedulingStatusText(condition, t)}
+    </StatusLabel>
+  );
+}

--- a/frontend/src/components/schedulingWorkload/Details.tsx
+++ b/frontend/src/components/schedulingWorkload/Details.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import Box from '@mui/material/Box';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { getCompositeDisruptionMode } from '../../lib/k8s/compositePodGroup';
@@ -76,6 +77,31 @@ function PodGroupTemplatesSection({ templates }: { templates: PodGroupTemplate[]
   );
 }
 
+interface NestedCompositeTemplate {
+  template: CompositePodGroupTemplate;
+  depth: number;
+}
+
+/**
+ * The composite templates of a Workload in the order they nest, depth first.
+ *
+ * A composite template may hold further composite templates, up to the depth the API
+ * allows. They are part of the same Workload, so a table that only listed the outermost
+ * ones would leave most of a hierarchical workload out.
+ * @param templates - The composite templates at the current level.
+ * @param depth - How deep the current level is nested, for indenting the names.
+ * @returns One entry per template, at every level.
+ */
+function flattenCompositeTemplates(
+  templates: CompositePodGroupTemplate[],
+  depth = 0
+): NestedCompositeTemplate[] {
+  return templates.flatMap(template => [
+    { template, depth },
+    ...flattenCompositeTemplates(template.compositePodGroupTemplates ?? [], depth + 1),
+  ]);
+}
+
 /** The composite pod group templates a Workload is made of, when it has any. */
 function CompositePodGroupTemplatesSection({
   templates,
@@ -90,47 +116,51 @@ function CompositePodGroupTemplatesSection({
         columns={[
           {
             label: t('translation|Name'),
-            getter: (template: CompositePodGroupTemplate) => template.name,
+            getter: ({ template, depth }: NestedCompositeTemplate) => (
+              <Box sx={{ paddingLeft: theme => theme.spacing(depth * 2) }}>{template.name}</Box>
+            ),
           },
           {
             label: t('translation|Policy'),
-            getter: (template: CompositePodGroupTemplate) =>
+            getter: ({ template }: NestedCompositeTemplate) =>
               getSchedulingPolicyKind(template.schedulingPolicy) ?? '',
           },
           {
             label: t('translation|Min Group Count'),
-            getter: (template: CompositePodGroupTemplate) =>
+            getter: ({ template }: NestedCompositeTemplate) =>
               template.schedulingPolicy?.gang?.minGroupCount ?? '',
           },
           {
             label: t('translation|Topology Keys'),
-            getter: (template: CompositePodGroupTemplate) =>
+            getter: ({ template }: NestedCompositeTemplate) =>
               template.schedulingConstraints?.topology?.map(item => item.key).join(', ') ?? '',
           },
           {
             label: t('translation|Disruption Mode'),
-            getter: (template: CompositePodGroupTemplate) =>
+            getter: ({ template }: NestedCompositeTemplate) =>
               getCompositeDisruptionMode(template.disruptionMode) ?? '',
           },
           {
             label: t('glossary|Priority Class'),
-            getter: (template: CompositePodGroupTemplate) => template.priorityClassName ?? '',
+            getter: ({ template }: NestedCompositeTemplate) => template.priorityClassName ?? '',
           },
           {
             label: t('glossary|Priority'),
-            getter: (template: CompositePodGroupTemplate) => template.priority ?? '',
+            getter: ({ template }: NestedCompositeTemplate) => template.priority ?? '',
           },
           {
             label: t('translation|Preemption Policy'),
-            getter: (template: CompositePodGroupTemplate) => template.preemptionPolicy ?? '',
+            getter: ({ template }: NestedCompositeTemplate) => template.preemptionPolicy ?? '',
           },
           {
             label: t('translation|Pod Group Templates'),
-            getter: (template: CompositePodGroupTemplate) =>
-              template.podGroupTemplates?.length ?? 0,
+            getter: ({ template }: NestedCompositeTemplate) =>
+              template.podGroupTemplates
+                ?.map(podGroupTemplate => podGroupTemplate.name)
+                .join(', ') ?? '',
           },
         ]}
-        data={templates}
+        data={flattenCompositeTemplates(templates)}
         reflectInURL="compositePodGroupTemplates"
       />
     </SectionBox>

--- a/frontend/src/components/schedulingWorkload/Details.tsx
+++ b/frontend/src/components/schedulingWorkload/Details.tsx
@@ -16,9 +16,10 @@
 
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
+import { getCompositeDisruptionMode } from '../../lib/k8s/compositePodGroup';
 import { getDisruptionMode, getSchedulingPolicyKind } from '../../lib/k8s/podGroup';
 import type { CompositePodGroupTemplate, PodGroupTemplate } from '../../lib/k8s/schedulingWorkload';
-import Workload, { getCompositeDisruptionMode } from '../../lib/k8s/schedulingWorkload';
+import Workload from '../../lib/k8s/schedulingWorkload';
 import { DetailsGrid } from '../common/Resource';
 import { SectionBox } from '../common/SectionBox';
 import SimpleTable from '../common/SimpleTable';

--- a/frontend/src/components/schedulingWorkload/__snapshots__/Details.WorkloadDetails.stories.storyshot
+++ b/frontend/src/components/schedulingWorkload/__snapshots__/Details.WorkloadDetails.stories.storyshot
@@ -514,7 +514,11 @@
                       <td
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
                       >
-                        gang-of-gangs
+                        <div
+                          class="MuiBox-root css-1a88wtd"
+                        >
+                          gang-of-gangs
+                        </div>
                       </td>
                       <td
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
@@ -553,8 +557,92 @@
                       </td>
                       <td
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      />
+                    </tr>
+                    <tr
+                      class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
                       >
-                        1
+                        <div
+                          class="MuiBox-root css-n085mf"
+                        >
+                          prefill
+                        </div>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        Gang
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        2
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        prefill-workers
+                      </td>
+                    </tr>
+                    <tr
+                      class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <div
+                          class="MuiBox-root css-n085mf"
+                        >
+                          decode
+                        </div>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        Basic
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        Single
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        decode-workers
                       </td>
                     </tr>
                   </tbody>

--- a/frontend/src/components/schedulingWorkload/storyHelper.ts
+++ b/frontend/src/components/schedulingWorkload/storyHelper.ts
@@ -54,7 +54,23 @@ export const SCHEDULING_WORKLOAD_DUMMY_DATA: KubeSchedulingWorkload[] = [
           priorityClassName: 'high-priority',
           priority: 1000,
           preemptionPolicy: 'PreemptLowerPriority',
-          podGroupTemplates: [{ name: 'workers', schedulingPolicy: { gang: { minCount: 4 } } }],
+          compositePodGroupTemplates: [
+            {
+              name: 'prefill',
+              schedulingPolicy: { gang: { minGroupCount: 2 } },
+              podGroupTemplates: [
+                { name: 'prefill-workers', schedulingPolicy: { gang: { minCount: 2 } } },
+              ],
+            },
+            {
+              name: 'decode',
+              schedulingPolicy: { basic: {} },
+              disruptionMode: { single: {} },
+              podGroupTemplates: [
+                { name: 'decode-workers', schedulingPolicy: { gang: { minCount: 2 } } },
+              ],
+            },
+          ],
         },
       ],
     },

--- a/frontend/src/i18n/locales/ar/glossary.json
+++ b/frontend/src/i18n/locales/ar/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "ميزانية تعطّل الـ Pod",
   "Workload": "حِمل العمل",
   "Pod Groups": "مجموعات البودات",
+  "Composite Pod Groups": "",
   "Port Forwarding": "تمرير المنافذ",
   "PriorityClass": "فئة الأولوية",
   "Replica Sets": "مجموعات النسخ",

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -857,6 +857,8 @@
   "Min Count": "الحد الأدنى للعدد",
   "Pod Group Template Name": "اسم قالب مجموعة البودات",
   "Composite Pod Group": "مجموعة البودات المركّبة",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "وضع التعطيل",
   "Preemption Policy": "سياسة الاستباق",
   "Topology Keys": "مفاتيح الطوبولوجيا",

--- a/frontend/src/i18n/locales/bn/glossary.json
+++ b/frontend/src/i18n/locales/bn/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "Pod Disruption বাজেট",
   "Workload": "ওয়ার্কলোড",
   "Pod Groups": "পড গ্রুপস",
+  "Composite Pod Groups": "",
   "Port Forwarding": "পোর্ট ফরোয়ার্ডিং",
   "PriorityClass": "PriorityClass",
   "Replica Sets": "Replica সেট",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -833,6 +833,8 @@
   "Min Count": "সর্বনিম্ন সংখ্যা",
   "Pod Group Template Name": "পড গ্রুপ টেমপ্লেট নাম",
   "Composite Pod Group": "যৌগিক পড গ্রুপ",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "ডিসরাপশন মোড",
   "Preemption Policy": "Preemption নীতি",
   "Topology Keys": "টপোলজি কী",

--- a/frontend/src/i18n/locales/cs/glossary.json
+++ b/frontend/src/i18n/locales/cs/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "Rozpočet na přerušení podu",
   "Workload": "",
   "Pod Groups": "",
+  "Composite Pod Groups": "",
   "Port Forwarding": "Přesměrování portů",
   "PriorityClass": "PriorityClass",
   "Replica Sets": "Sady replik",

--- a/frontend/src/i18n/locales/cs/translation.json
+++ b/frontend/src/i18n/locales/cs/translation.json
@@ -845,6 +845,8 @@
   "Min Count": "",
   "Pod Group Template Name": "",
   "Composite Pod Group": "",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "",
   "Preemption Policy": "Zásada přerušení",
   "Topology Keys": "",

--- a/frontend/src/i18n/locales/de/glossary.json
+++ b/frontend/src/i18n/locales/de/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "Budget für Pod Disruption",
   "Workload": "Workload",
   "Pod Groups": "Pod-Gruppen",
+  "Composite Pod Groups": "",
   "Port Forwarding": "Portweiterleitung",
   "PriorityClass": "Prioritäts-Klasse",
   "Replica Sets": "Replika-Sets",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -833,6 +833,8 @@
   "Min Count": "Mindestanzahl",
   "Pod Group Template Name": "Name der Pod-Gruppen-Vorlage",
   "Composite Pod Group": "Zusammengesetzte Pod-Gruppe",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "Unterbrechungsmodus",
   "Preemption Policy": "Preemtions-Policy",
   "Topology Keys": "Topologie-Schlüssel",

--- a/frontend/src/i18n/locales/en/glossary.json
+++ b/frontend/src/i18n/locales/en/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "Pod Disruption Budget",
   "Workload": "Workload",
   "Pod Groups": "Pod Groups",
+  "Composite Pod Groups": "Composite Pod Groups",
   "Port Forwarding": "Port Forwarding",
   "PriorityClass": "PriorityClass",
   "Replica Sets": "Replica Sets",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -833,6 +833,8 @@
   "Min Count": "Min Count",
   "Pod Group Template Name": "Pod Group Template Name",
   "Composite Pod Group": "Composite Pod Group",
+  "Parent": "Parent",
+  "Composite Pod Group Template Name": "Composite Pod Group Template Name",
   "Disruption Mode": "Disruption Mode",
   "Preemption Policy": "Preemption Policy",
   "Topology Keys": "Topology Keys",

--- a/frontend/src/i18n/locales/es/glossary.json
+++ b/frontend/src/i18n/locales/es/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "Pod Disruption Budget",
   "Workload": "Carga de trabajo",
   "Pod Groups": "Grupos de Pods",
+  "Composite Pod Groups": "",
   "Port Forwarding": "Redir. de Puertos",
   "PriorityClass": "PriorityClass",
   "Replica Sets": "Replica Sets",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -839,6 +839,8 @@
   "Min Count": "Recuento mínimo",
   "Pod Group Template Name": "Nombre de la plantilla de grupo de Pods",
   "Composite Pod Group": "Grupo compuesto de Pods",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "Modo de interrupción",
   "Preemption Policy": "Política de \"Preemption\"",
   "Topology Keys": "Claves de topología",

--- a/frontend/src/i18n/locales/fr/glossary.json
+++ b/frontend/src/i18n/locales/fr/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "Pod Disruption Budget",
   "Workload": "Charge de travail",
   "Pod Groups": "Groupes de Pods",
+  "Composite Pod Groups": "",
   "Port Forwarding": "Redirection de port",
   "PriorityClass": "PriorityClass",
   "Replica Sets": "Replica Sets",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -839,6 +839,8 @@
   "Min Count": "Nombre minimum",
   "Pod Group Template Name": "Nom du modèle de groupe de Pods",
   "Composite Pod Group": "Groupe composite de Pods",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "Mode de perturbation",
   "Preemption Policy": "Politique de préemption",
   "Topology Keys": "Clés de topologie",

--- a/frontend/src/i18n/locales/he/glossary.json
+++ b/frontend/src/i18n/locales/he/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "Pod Disruption Budget",
   "Workload": "עומס עבודה",
   "Pod Groups": "קבוצות Pod",
+  "Composite Pod Groups": "",
   "Port Forwarding": "Port Forwarding",
   "PriorityClass": "PriorityClass",
   "Replica Sets": "Replica Sets",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -839,6 +839,8 @@
   "Min Count": "מספר מינימלי",
   "Pod Group Template Name": "שם תבנית קבוצת Pod",
   "Composite Pod Group": "קבוצת Pod מורכבת",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "מצב שיבוש",
   "Preemption Policy": "Preemption Policy",
   "Topology Keys": "מפתחות טופולוגיה",

--- a/frontend/src/i18n/locales/hi/glossary.json
+++ b/frontend/src/i18n/locales/hi/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "Pod डिसरप्शन बजट",
   "Workload": "वर्कलोड",
   "Pod Groups": "पॉड ग्रुप्स",
+  "Composite Pod Groups": "",
   "Port Forwarding": "पोर्ट फॉरवार्डिंग",
   "PriorityClass": "प्रायोरिटीक्लास",
   "Replica Sets": "रेप्लिका सेट्स",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -833,6 +833,8 @@
   "Min Count": "न्यूनतम संख्या",
   "Pod Group Template Name": "पॉड ग्रुप टेम्पलेट नाम",
   "Composite Pod Group": "समग्र पॉड ग्रुप",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "डिसरप्शन मोड",
   "Preemption Policy": "",
   "Topology Keys": "टोपोलॉजी कीज़",

--- a/frontend/src/i18n/locales/hu/glossary.json
+++ b/frontend/src/i18n/locales/hu/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "Podkimaradási költségkeret",
   "Workload": "",
   "Pod Groups": "",
+  "Composite Pod Groups": "",
   "Port Forwarding": "Porttovábbítás",
   "PriorityClass": "PriorityClass",
   "Replica Sets": "Replikakészletek",

--- a/frontend/src/i18n/locales/hu/translation.json
+++ b/frontend/src/i18n/locales/hu/translation.json
@@ -833,6 +833,8 @@
   "Min Count": "",
   "Pod Group Template Name": "",
   "Composite Pod Group": "",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "",
   "Preemption Policy": "Megelőzési házirend",
   "Topology Keys": "",

--- a/frontend/src/i18n/locales/id/glossary.json
+++ b/frontend/src/i18n/locales/id/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "Anggaran Gangguan Pod",
   "Workload": "",
   "Pod Groups": "",
+  "Composite Pod Groups": "",
   "Port Forwarding": "Penerusan Port",
   "PriorityClass": "PriorityClass",
   "Replica Sets": "Kumpulan Replika",

--- a/frontend/src/i18n/locales/id/translation.json
+++ b/frontend/src/i18n/locales/id/translation.json
@@ -827,6 +827,8 @@
   "Min Count": "",
   "Pod Group Template Name": "",
   "Composite Pod Group": "",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "",
   "Preemption Policy": "Kebijakan Pendahuluan",
   "Topology Keys": "",

--- a/frontend/src/i18n/locales/it/glossary.json
+++ b/frontend/src/i18n/locales/it/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "Pod Disruption Budget",
   "Workload": "Workload",
   "Pod Groups": "Gruppi di Pod",
+  "Composite Pod Groups": "",
   "Port Forwarding": "Inoltro Porta",
   "PriorityClass": "PriorityClass",
   "Replica Sets": "Replica Set",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -839,6 +839,8 @@
   "Min Count": "Conteggio minimo",
   "Pod Group Template Name": "Nome del modello di gruppo di Pod",
   "Composite Pod Group": "Gruppo composito di Pod",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "Modalità di interruzione",
   "Preemption Policy": "Politica di Preemption",
   "Topology Keys": "Chiavi di topologia",

--- a/frontend/src/i18n/locales/ja/glossary.json
+++ b/frontend/src/i18n/locales/ja/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "ポッド中断バジェット",
   "Workload": "ワークロード",
   "Pod Groups": "Podグループ",
+  "Composite Pod Groups": "",
   "Port Forwarding": "ポートフォワーディング",
   "PriorityClass": "優先度クラス",
   "Replica Sets": "レプリカセット",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -827,6 +827,8 @@
   "Min Count": "最小数",
   "Pod Group Template Name": "Podグループテンプレート名",
   "Composite Pod Group": "複合Podグループ",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "中断モード",
   "Preemption Policy": "プリエンプションポリシー",
   "Topology Keys": "トポロジーキー",

--- a/frontend/src/i18n/locales/ko/glossary.json
+++ b/frontend/src/i18n/locales/ko/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "파드 중단 예산",
   "Workload": "워크로드",
   "Pod Groups": "파드 그룹",
+  "Composite Pod Groups": "",
   "Port Forwarding": "포트 포워딩",
   "PriorityClass": "우선순위 클래스",
   "Replica Sets": "레플리카 셋",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -827,6 +827,8 @@
   "Min Count": "최소 개수",
   "Pod Group Template Name": "파드 그룹 템플릿 이름",
   "Composite Pod Group": "복합 파드 그룹",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "중단 모드",
   "Preemption Policy": "선점 정책",
   "Topology Keys": "토폴로지 키",

--- a/frontend/src/i18n/locales/nl/glossary.json
+++ b/frontend/src/i18n/locales/nl/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "Podonderbrekingsbudget",
   "Workload": "",
   "Pod Groups": "",
+  "Composite Pod Groups": "",
   "Port Forwarding": "Doorsturen van poort",
   "PriorityClass": "PriorityClass",
   "Replica Sets": "Replicasets",

--- a/frontend/src/i18n/locales/nl/translation.json
+++ b/frontend/src/i18n/locales/nl/translation.json
@@ -833,6 +833,8 @@
   "Min Count": "",
   "Pod Group Template Name": "",
   "Composite Pod Group": "",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "",
   "Preemption Policy": "Preëmptiebeleid",
   "Topology Keys": "",

--- a/frontend/src/i18n/locales/pl/glossary.json
+++ b/frontend/src/i18n/locales/pl/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "Budżet zakłóceń zasobników",
   "Workload": "",
   "Pod Groups": "",
+  "Composite Pod Groups": "",
   "Port Forwarding": "Przekierowanie portów",
   "PriorityClass": "PriorityClass",
   "Replica Sets": "Zestawy replik",

--- a/frontend/src/i18n/locales/pl/translation.json
+++ b/frontend/src/i18n/locales/pl/translation.json
@@ -845,6 +845,8 @@
   "Min Count": "",
   "Pod Group Template Name": "",
   "Composite Pod Group": "",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "",
   "Preemption Policy": "Zasady wywłaszczania",
   "Topology Keys": "",

--- a/frontend/src/i18n/locales/pt-br/glossary.json
+++ b/frontend/src/i18n/locales/pt-br/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "Pod Disruption Budget",
   "Workload": "Carga de trabalho",
   "Pod Groups": "Grupos de Pods",
+  "Composite Pod Groups": "",
   "Port Forwarding": "Port Forwarding",
   "PriorityClass": "PriorityClass",
   "Replica Sets": "Replica Sets",

--- a/frontend/src/i18n/locales/pt-br/translation.json
+++ b/frontend/src/i18n/locales/pt-br/translation.json
@@ -839,6 +839,8 @@
   "Min Count": "Contagem mínima",
   "Pod Group Template Name": "Nome do modelo de grupo de Pods",
   "Composite Pod Group": "Grupo composto de Pods",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "Modo de interrupção",
   "Preemption Policy": "Política de \"Preemption\"",
   "Topology Keys": "Chaves de topologia",

--- a/frontend/src/i18n/locales/pt-pt/glossary.json
+++ b/frontend/src/i18n/locales/pt-pt/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "Pod Disruption Budget",
   "Workload": "",
   "Pod Groups": "",
+  "Composite Pod Groups": "",
   "Port Forwarding": "Port Forwarding",
   "PriorityClass": "PriorityClass",
   "Replica Sets": "Replica Sets",

--- a/frontend/src/i18n/locales/pt-pt/translation.json
+++ b/frontend/src/i18n/locales/pt-pt/translation.json
@@ -839,6 +839,8 @@
   "Min Count": "",
   "Pod Group Template Name": "",
   "Composite Pod Group": "",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "",
   "Preemption Policy": "",
   "Topology Keys": "",

--- a/frontend/src/i18n/locales/ru/glossary.json
+++ b/frontend/src/i18n/locales/ru/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "PodDisruptionBudget",
   "Workload": "Рабочая нагрузка",
   "Pod Groups": "Группы подов",
+  "Composite Pod Groups": "",
   "Port Forwarding": "Переадресация портов",
   "PriorityClass": "Приоритетный класс",
   "Replica Sets": "ReplicaSet",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -845,6 +845,8 @@
   "Min Count": "Минимальное количество",
   "Pod Group Template Name": "Имя шаблона группы подов",
   "Composite Pod Group": "Составная группа подов",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "Режим прерывания",
   "Preemption Policy": "Политика преимущественного права",
   "Topology Keys": "Ключи топологии",

--- a/frontend/src/i18n/locales/sv/glossary.json
+++ b/frontend/src/i18n/locales/sv/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "Störningsbudget för podd",
   "Workload": "",
   "Pod Groups": "",
+  "Composite Pod Groups": "",
   "Port Forwarding": "Portvidarebefordran",
   "PriorityClass": "PriorityClass",
   "Replica Sets": "Replikuppsättningar",

--- a/frontend/src/i18n/locales/sv/translation.json
+++ b/frontend/src/i18n/locales/sv/translation.json
@@ -833,6 +833,8 @@
   "Min Count": "",
   "Pod Group Template Name": "",
   "Composite Pod Group": "",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "",
   "Preemption Policy": "Rekvireringsprincip",
   "Topology Keys": "",

--- a/frontend/src/i18n/locales/ta/glossary.json
+++ b/frontend/src/i18n/locales/ta/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "பாட் டிஸ்ரப்ஷன் பட்ஜெட்",
   "Workload": "பணிச்சுமை",
   "Pod Groups": "பாட் குழுக்கள்",
+  "Composite Pod Groups": "",
   "Port Forwarding": "போர்ட் ஃபார்வர்டிங்",
   "PriorityClass": "ப்ரயரிட்டி கிளாஸ்",
   "Replica Sets": "ரெப்ளிகா செட்ஸ்",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -833,6 +833,8 @@
   "Min Count": "குறைந்தபட்ச எண்ணிக்கை",
   "Pod Group Template Name": "பாட் குழு டெம்ப்ளேட் பெயர்",
   "Composite Pod Group": "கூட்டு பாட் குழு",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "இடையூறு பயன்முறை",
   "Preemption Policy": "ப்ரீமப்ஷன் பாலிஸி",
   "Topology Keys": "இடவியல் விசைகள்",

--- a/frontend/src/i18n/locales/tr/glossary.json
+++ b/frontend/src/i18n/locales/tr/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "Pod Kesinti Bütçesi",
   "Workload": "",
   "Pod Groups": "",
+  "Composite Pod Groups": "",
   "Port Forwarding": "Bağlantı Noktası İletme",
   "PriorityClass": "PriorityClass",
   "Replica Sets": "Çoğaltma Kümeleri",

--- a/frontend/src/i18n/locales/tr/translation.json
+++ b/frontend/src/i18n/locales/tr/translation.json
@@ -833,6 +833,8 @@
   "Min Count": "",
   "Pod Group Template Name": "",
   "Composite Pod Group": "",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "",
   "Preemption Policy": "Önalım İlkesi",
   "Topology Keys": "",

--- a/frontend/src/i18n/locales/ur/glossary.json
+++ b/frontend/src/i18n/locales/ur/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "پوڈ ڈسٹرپشن بجٹ",
   "Workload": "ورک لوڈ",
   "Pod Groups": "پوڈ گروپس",
+  "Composite Pod Groups": "",
   "Port Forwarding": "پورٹ فارورڈنگ",
   "PriorityClass": "پرائرٹی کلاس",
   "Replica Sets": "ریپلیکا سیٹس",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -833,6 +833,8 @@
   "Min Count": "کم از کم تعداد",
   "Pod Group Template Name": "پوڈ گروپ ٹیمپلیٹ کا نام",
   "Composite Pod Group": "مرکب پوڈ گروپ",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "خلل موڈ",
   "Preemption Policy": "پری ایمپشن پالیسی",
   "Topology Keys": "ٹوپولوجی کیز",

--- a/frontend/src/i18n/locales/zh-tw/glossary.json
+++ b/frontend/src/i18n/locales/zh-tw/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "Pod 中斷預算",
   "Workload": "工作負載",
   "Pod Groups": "Pod 群組",
+  "Composite Pod Groups": "",
   "Port Forwarding": "Port 轉發",
   "PriorityClass": "優先順序",
   "Replica Sets": "副本集",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -827,6 +827,8 @@
   "Min Count": "最小數量",
   "Pod Group Template Name": "Pod 群組範本名稱",
   "Composite Pod Group": "複合 Pod 群組",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "中斷模式",
   "Preemption Policy": "搶佔策略",
   "Topology Keys": "拓撲金鑰",

--- a/frontend/src/i18n/locales/zh/glossary.json
+++ b/frontend/src/i18n/locales/zh/glossary.json
@@ -207,6 +207,7 @@
   "Pod Disruption Budget": "Pod 中断预算",
   "Workload": "工作负载",
   "Pod Groups": "Pod 组",
+  "Composite Pod Groups": "",
   "Port Forwarding": "Port 转发",
   "PriorityClass": "优先顺序",
   "Replica Sets": "Replica Sets",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -827,6 +827,8 @@
   "Min Count": "最小数量",
   "Pod Group Template Name": "Pod 组模板名称",
   "Composite Pod Group": "复合 Pod 组",
+  "Parent": "",
+  "Composite Pod Group Template Name": "",
   "Disruption Mode": "中断模式",
   "Preemption Policy": "抢占策略",
   "Topology Keys": "拓扑键",

--- a/frontend/src/lib/k8s/compositePodGroup.test.ts
+++ b/frontend/src/lib/k8s/compositePodGroup.test.ts
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import App from '../../App';
+import type { KubeCompositePodGroup } from './compositePodGroup';
+import CompositePodGroup, { getCompositeDisruptionMode } from './compositePodGroup';
+
+const { mockRequest } = vi.hoisted(() => ({ mockRequest: vi.fn() }));
+
+vi.mock('./api/v1/clusterRequests', async importOriginal => ({
+  ...(await importOriginal<typeof import('./api/v1/clusterRequests')>()),
+  request: mockRequest,
+}));
+
+// cyclic imports fix
+// eslint-disable-next-line no-unused-vars
+const _dont_delete_me = App;
+
+const makeCompositePodGroup = (
+  spec: Partial<KubeCompositePodGroup['spec']>,
+  status?: KubeCompositePodGroup['status']
+) =>
+  new CompositePodGroup({
+    kind: 'CompositePodGroup',
+    apiVersion: 'scheduling.k8s.io/v1alpha3',
+    metadata: {
+      name: 'llm-serving-prefill',
+      namespace: 'inference',
+      uid: 'uid-1',
+      creationTimestamp: '2026-01-01T00:00:00Z',
+    },
+    spec: { schedulingPolicy: {}, ...spec },
+    status,
+  } as KubeCompositePodGroup);
+
+describe('getCompositeDisruptionMode', () => {
+  it('reads whichever mode the composite sets', () => {
+    expect(getCompositeDisruptionMode({ single: {} })).toBe('Single');
+    expect(getCompositeDisruptionMode({ all: {} })).toBe('All');
+  });
+
+  it('returns undefined when no mode is set', () => {
+    expect(getCompositeDisruptionMode(undefined)).toBeUndefined();
+    expect(getCompositeDisruptionMode({})).toBeUndefined();
+  });
+});
+
+describe('CompositePodGroup', () => {
+  it('is served by v1alpha3 only, unlike the flat scheduling resources', () => {
+    expect(CompositePodGroup.apiVersion).toEqual(['scheduling.k8s.io/v1alpha3']);
+  });
+
+  it('exposes the gang policy and its minimum group count', () => {
+    const composite = makeCompositePodGroup({
+      schedulingPolicy: { gang: { minGroupCount: 2 } },
+    });
+
+    expect(composite.policyKind).toBe('Gang');
+    expect(composite.minGroupCount).toBe(2);
+  });
+
+  it('has no minimum group count for the basic policy', () => {
+    const composite = makeCompositePodGroup({ schedulingPolicy: { basic: {} } });
+
+    expect(composite.policyKind).toBe('Basic');
+    expect(composite.minGroupCount).toBeUndefined();
+  });
+
+  it('reads the workload and template names from the workload reference', () => {
+    const composite = makeCompositePodGroup({
+      workloadRef: { workloadName: 'llm-serving', templateName: 'prefill' },
+    });
+
+    expect(composite.workloadName).toBe('llm-serving');
+    expect(composite.compositePodGroupTemplateName).toBe('prefill');
+  });
+
+  it('has no workload or template name when the group was not templated', () => {
+    expect(makeCompositePodGroup({}).workloadName).toBeUndefined();
+    expect(makeCompositePodGroup({}).compositePodGroupTemplateName).toBeUndefined();
+  });
+
+  it('is a hierarchy root when no parent is set', () => {
+    expect(makeCompositePodGroup({}).parentCompositePodGroupName).toBeUndefined();
+    expect(
+      makeCompositePodGroup({ parentCompositePodGroupName: 'llm-serving-serving' })
+        .parentCompositePodGroupName
+    ).toBe('llm-serving-serving');
+  });
+
+  it('normalizes the disruption mode', () => {
+    expect(makeCompositePodGroup({ disruptionMode: { single: {} } }).disruptionMode).toBe('Single');
+    expect(makeCompositePodGroup({ disruptionMode: { all: {} } }).disruptionMode).toBe('All');
+    expect(makeCompositePodGroup({}).disruptionMode).toBeUndefined();
+  });
+
+  it('picks its own scheduling condition out of the status', () => {
+    const composite = makeCompositePodGroup(
+      {},
+      {
+        conditions: [
+          { type: 'DisruptionTarget', status: 'False', lastProbeTime: '' },
+          {
+            type: 'CompositePodGroupInitiallyScheduled',
+            status: 'False',
+            reason: 'Unschedulable',
+            lastProbeTime: '',
+          },
+        ],
+      }
+    );
+
+    expect(composite.schedulingCondition?.reason).toBe('Unschedulable');
+  });
+
+  it('does not mistake the condition of a child pod group for its own', () => {
+    const composite = makeCompositePodGroup(
+      {},
+      {
+        conditions: [{ type: 'PodGroupInitiallyScheduled', status: 'True', lastProbeTime: '' }],
+      }
+    );
+
+    expect(composite.schedulingCondition).toBeUndefined();
+  });
+
+  it('has no scheduling condition when the status is empty', () => {
+    expect(makeCompositePodGroup({}).schedulingCondition).toBeUndefined();
+    expect(makeCompositePodGroup({}, { conditions: [] }).schedulingCondition).toBeUndefined();
+  });
+});
+
+describe('CompositePodGroup.isEnabled', () => {
+  beforeEach(() => {
+    mockRequest.mockReset();
+  });
+
+  it('is true when v1alpha3 serves the resource', async () => {
+    mockRequest.mockResolvedValueOnce({ resources: [{ name: 'compositepodgroups' }] });
+
+    expect(await CompositePodGroup.isEnabled('test-cluster')).toBe(true);
+    expect(mockRequest.mock.calls.map(call => call[0])).toEqual([
+      '/apis/scheduling.k8s.io/v1alpha3',
+    ]);
+  });
+
+  it('is false on a cluster that serves the flat resources but not this one', async () => {
+    mockRequest.mockResolvedValueOnce({
+      resources: [{ name: 'podgroups' }, { name: 'workloads' }],
+    });
+
+    expect(await CompositePodGroup.isEnabled('test-cluster')).toBe(false);
+  });
+
+  it('is false when v1alpha3 is not served at all', async () => {
+    mockRequest.mockRejectedValue(new Error('the server could not find the requested resource'));
+
+    expect(await CompositePodGroup.isEnabled('test-cluster')).toBe(false);
+  });
+});

--- a/frontend/src/lib/k8s/compositePodGroup.ts
+++ b/frontend/src/lib/k8s/compositePodGroup.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The CompositePodGroup resource of the scheduling.k8s.io API group. It nests pod
+ * groups and other composite groups into the hierarchy a workload controller creates
+ * from a Workload's compositePodGroupTemplates.
+ */
+
+import type { KubeCondition } from './cluster';
+import type { KubeObjectInterface } from './KubeObject';
+import { KubeObject } from './KubeObject';
+import type {
+  PodGroupDisruptionMode,
+  PodGroupSchedulingConstraints,
+  PodGroupWorkloadReference,
+} from './podGroup';
+import { getSchedulingPolicyKind, isSchedulingResourceServed } from './podGroup';
+
+/**
+ * Condition reporting whether the scheduling requirement of the whole subtree below the
+ * group has been satisfied. It is terminal: once true it stays true, even after the pods
+ * of the subtree are gone.
+ */
+export const COMPOSITE_POD_GROUP_INITIALLY_SCHEDULED_CONDITION =
+  'CompositePodGroupInitiallyScheduled';
+
+/**
+ * How the child groups of a composite group are scheduled. Mirrors
+ * PodGroupSchedulingPolicy, except that the gang policy counts child groups rather
+ * than pods.
+ */
+export interface CompositePodGroupSchedulingPolicy {
+  basic?: Record<string, never>;
+  gang?: {
+    minGroupCount: number;
+  };
+}
+
+export interface CompositePodGroupSpec {
+  schedulingPolicy: CompositePodGroupSchedulingPolicy;
+  /** The Workload and the template within it this group was created from. */
+  workloadRef: PodGroupWorkloadReference;
+  /** The composite group this one is nested in. Unset on the root of a hierarchy. */
+  parentCompositePodGroupName?: string;
+  /** Set only when the TopologyAwareWorkloadScheduling feature gate is enabled. */
+  schedulingConstraints?: PodGroupSchedulingConstraints;
+  disruptionMode?: PodGroupDisruptionMode;
+  priorityClassName?: string;
+  priority?: number;
+  /** Set only when the PodGroupPreemptionPolicy feature gate is enabled. */
+  preemptionPolicy?: 'PreemptLowerPriority' | 'Never';
+}
+
+export interface KubeCompositePodGroup extends KubeObjectInterface {
+  spec: CompositePodGroupSpec;
+  status?: {
+    conditions?: KubeCondition[];
+  };
+}
+
+/**
+ * Human readable disruption mode of a composite group. The API describes it as one of
+ * Single or All: disrupt one child group at a time, or the whole composite together.
+ * @param mode - The disruptionMode field of a composite group or template.
+ * @returns 'Single', 'All', or undefined when no mode is set.
+ */
+export function getCompositeDisruptionMode(
+  mode: PodGroupDisruptionMode | undefined
+): 'Single' | 'All' | undefined {
+  if (mode?.single) {
+    return 'Single';
+  }
+  if (mode?.all) {
+    return 'All';
+  }
+  return undefined;
+}
+
+class CompositePodGroup extends KubeObject<KubeCompositePodGroup> {
+  static kind = 'CompositePodGroup';
+  static apiName = 'compositepodgroups';
+  /**
+   * Only v1alpha3 serves this resource. v1beta1 serves the composite templates within a
+   * Workload, but not the groups they are instantiated into.
+   */
+  static apiVersion = ['scheduling.k8s.io/v1alpha3'];
+  static isNamespaced = true;
+
+  /**
+   * Whether the cluster serves this resource, which requires the CompositePodGroup
+   * feature gate to be enabled on top of the ones the flat scheduling APIs need.
+   * @param cluster - The cluster to check.
+   * @returns true when the CompositePodGroup resource is served.
+   */
+  static isEnabled(cluster: string): Promise<boolean> {
+    return isSchedulingResourceServed(
+      cluster,
+      CompositePodGroup.apiVersion,
+      CompositePodGroup.apiName
+    );
+  }
+
+  get spec() {
+    return this.jsonData.spec;
+  }
+
+  get status() {
+    return this.jsonData.status;
+  }
+
+  /** Which scheduling policy this group uses, e.g. 'Gang' or 'Basic'. */
+  get policyKind(): string | undefined {
+    return getSchedulingPolicyKind(this.spec?.schedulingPolicy);
+  }
+
+  /** Child groups that must be schedulable together, when the gang policy is used. */
+  get minGroupCount(): number | undefined {
+    return this.spec?.schedulingPolicy?.gang?.minGroupCount;
+  }
+
+  /** Name of the Workload this group was templated from, if any. */
+  get workloadName(): string | undefined {
+    return this.spec?.workloadRef?.workloadName;
+  }
+
+  /** Name of the template within the Workload this group was created from, if any. */
+  get compositePodGroupTemplateName(): string | undefined {
+    return this.spec?.workloadRef?.templateName;
+  }
+
+  /** The composite group this one is nested in, when it is not a hierarchy root. */
+  get parentCompositePodGroupName(): string | undefined {
+    return this.spec?.parentCompositePodGroupName;
+  }
+
+  /** Whether a disruption affects one child group at a time, or the whole composite. */
+  get disruptionMode(): 'Single' | 'All' | undefined {
+    return getCompositeDisruptionMode(this.spec?.disruptionMode);
+  }
+
+  get schedulingCondition(): KubeCondition | undefined {
+    return this.status?.conditions?.find(
+      condition => condition.type === COMPOSITE_POD_GROUP_INITIALLY_SCHEDULED_CONDITION
+    );
+  }
+}
+
+export default CompositePodGroup;

--- a/frontend/src/lib/k8s/index.test.ts
+++ b/frontend/src/lib/k8s/index.test.ts
@@ -313,6 +313,7 @@ const notNamespacedClasses = [
 ];
 
 const namespacedClasses = [
+  'CompositePodGroup',
   'ConfigMap',
   'ControllerRevision',
   'CronJob',

--- a/frontend/src/lib/k8s/index.ts
+++ b/frontend/src/lib/k8s/index.ts
@@ -25,6 +25,7 @@ import { ApiError } from './api/v2/ApiError';
 import { Cluster, LabelSelector, StringDict } from './cluster';
 import ClusterRole from './clusterRole';
 import ClusterRoleBinding from './clusterRoleBinding';
+import CompositePodGroup from './compositePodGroup';
 import ConfigMap from './configMap';
 import ControllerRevision from './controllerRevision';
 import CustomResourceDefinition from './crd';
@@ -87,6 +88,7 @@ export const ResourceClasses = {
   HorizontalPodAutoscaler: HPA,
   PodDisruptionBudget,
   PodGroup,
+  CompositePodGroup,
   PriorityClass,
   Ingress,
   IngressClass,
@@ -370,6 +372,7 @@ export * as node from './node';
 export * as persistentVolume from './persistentVolume';
 export * as persistentVolumeClaim from './persistentVolumeClaim';
 export * as pod from './pod';
+export * as compositePodGroup from './compositePodGroup';
 export * as podGroup from './podGroup';
 export * as schedulingWorkload from './schedulingWorkload';
 export * as replicaSet from './replicaSet';

--- a/frontend/src/lib/k8s/podGroup.ts
+++ b/frontend/src/lib/k8s/podGroup.ts
@@ -150,6 +150,35 @@ export function getDisruptionMode(
   return undefined;
 }
 
+/**
+ * Whether a cluster serves one of the scheduling.k8s.io resources.
+ *
+ * This asks for each candidate version directly instead of using apiDiscovery, because
+ * discovery only reports the first version of each group and scheduling.k8s.io also
+ * serves v1.
+ * @param cluster - The cluster to check.
+ * @param apiVersions - The group versions the resource may be served by, newest first.
+ * @param apiName - The plural name of the resource to look for.
+ * @returns true when one of the versions serves the resource.
+ */
+export async function isSchedulingResourceServed(
+  cluster: string,
+  apiVersions: string[],
+  apiName: string
+): Promise<boolean> {
+  for (const version of apiVersions) {
+    try {
+      const response = await request(`/apis/${version}`, { cluster });
+      if (response?.resources?.some((resource: { name?: string }) => resource.name === apiName)) {
+        return true;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return false;
+}
+
 class PodGroup extends KubeObject<KubePodGroup> {
   static kind = 'PodGroup';
   static apiName = 'podgroups';
@@ -163,30 +192,11 @@ class PodGroup extends KubeObject<KubePodGroup> {
   /**
    * Whether the cluster serves the workload aware scheduling APIs, which requires the
    * GenericWorkload feature gate to be enabled.
-   *
-   * This asks for each candidate version directly instead of using apiDiscovery, because
-   * discovery only reports the first version of each group and scheduling.k8s.io also
-   * serves v1.
-   *
    * @param cluster - The cluster to check.
    * @returns true when the PodGroup resource is served.
    */
-  static async isEnabled(cluster: string): Promise<boolean> {
-    for (const version of PodGroup.apiVersion) {
-      try {
-        const response = await request(`/apis/${version}`, { cluster });
-        if (
-          response?.resources?.some(
-            (resource: { name?: string }) => resource.name === PodGroup.apiName
-          )
-        ) {
-          return true;
-        }
-      } catch {
-        continue;
-      }
-    }
-    return false;
+  static isEnabled(cluster: string): Promise<boolean> {
+    return isSchedulingResourceServed(cluster, PodGroup.apiVersion, PodGroup.apiName);
   }
 
   get spec() {

--- a/frontend/src/lib/k8s/schedulingWorkload.test.ts
+++ b/frontend/src/lib/k8s/schedulingWorkload.test.ts
@@ -17,7 +17,7 @@
 import { describe, expect, it } from 'vitest';
 import App from '../../App';
 import type { KubeSchedulingWorkload } from './schedulingWorkload';
-import Workload, { getCompositeDisruptionMode } from './schedulingWorkload';
+import Workload from './schedulingWorkload';
 
 // cyclic imports fix
 // eslint-disable-next-line no-unused-vars
@@ -35,18 +35,6 @@ const makeWorkload = (spec: Partial<KubeSchedulingWorkload['spec']>) =>
     },
     spec: { podGroupTemplates: [], ...spec },
   } as KubeSchedulingWorkload);
-
-describe('getCompositeDisruptionMode', () => {
-  it('reads whichever mode the composite template sets', () => {
-    expect(getCompositeDisruptionMode({ single: {} })).toBe('Single');
-    expect(getCompositeDisruptionMode({ all: {} })).toBe('All');
-  });
-
-  it('returns undefined when no mode is set', () => {
-    expect(getCompositeDisruptionMode(undefined)).toBeUndefined();
-    expect(getCompositeDisruptionMode({})).toBeUndefined();
-  });
-});
 
 describe('Workload', () => {
   it('uses its own list route because workloads is taken by the overview page', () => {

--- a/frontend/src/lib/k8s/schedulingWorkload.ts
+++ b/frontend/src/lib/k8s/schedulingWorkload.ts
@@ -23,6 +23,7 @@
  * file names would collide on case insensitive filesystems.
  */
 
+import type { CompositePodGroupSchedulingPolicy } from './compositePodGroup';
 import type { KubeObjectInterface } from './KubeObject';
 import { KubeObject } from './KubeObject';
 import type {
@@ -31,6 +32,13 @@ import type {
   PodGroupSchedulingConstraints,
   PodGroupSchedulingPolicy,
 } from './podGroup';
+
+/**
+ * Re-exported from ./compositePodGroup, where the composite types now live. Plugins have
+ * imported these from here since they were introduced, so they stay available.
+ */
+export type { CompositePodGroupSchedulingPolicy };
+export { getCompositeDisruptionMode } from './compositePodGroup';
 
 export interface PodGroupTemplate {
   name: string;
@@ -48,18 +56,6 @@ export interface PodGroupTemplate {
 }
 
 /**
- * How the child groups of a composite template are scheduled. Mirrors
- * PodGroupSchedulingPolicy, except that the gang policy counts child groups rather
- * than pods.
- */
-export interface CompositePodGroupSchedulingPolicy {
-  basic?: Record<string, never>;
-  gang?: {
-    minGroupCount: number;
-  };
-}
-
-/**
  * A group of pod group templates scheduled together. Served by v1alpha3 and v1beta1,
  * and may nest further composite templates.
  */
@@ -74,24 +70,6 @@ export interface CompositePodGroupTemplate {
   preemptionPolicy?: 'PreemptLowerPriority' | 'Never';
   podGroupTemplates?: PodGroupTemplate[];
   compositePodGroupTemplates?: CompositePodGroupTemplate[];
-}
-
-/**
- * Human readable disruption mode of a composite template. The API describes it as one
- * of Single or All: disrupt one child group at a time, or the whole composite together.
- * @param mode - The disruptionMode field of a composite template.
- * @returns 'Single', 'All', or undefined when no mode is set.
- */
-export function getCompositeDisruptionMode(
-  mode: PodGroupDisruptionMode | undefined
-): 'Single' | 'All' | undefined {
-  if (mode?.single) {
-    return 'Single';
-  }
-  if (mode?.all) {
-    return 'All';
-  }
-  return undefined;
 }
 
 export interface WorkloadSpec {

--- a/frontend/src/lib/router/index.tsx
+++ b/frontend/src/lib/router/index.tsx
@@ -29,6 +29,8 @@ import SettingsClusters from '../../components/App/Settings/SettingsClusters';
 import AuthChooser from '../../components/authchooser';
 import Overview from '../../components/cluster/Overview';
 import { PageGrid } from '../../components/common/Resource/Resource';
+import CompositePodGroupDetails from '../../components/compositePodGroup/Details';
+import CompositePodGroupList from '../../components/compositePodGroup/List';
 import ConfigDetails from '../../components/configmap/Details';
 import ConfigMapList from '../../components/configmap/List';
 import CustomResourceDetails from '../../components/crd/CustomResourceDetails';
@@ -760,6 +762,20 @@ const defaultRoutes: { [routeName: string]: Route } = {
     name: 'Pod Group',
     sidebar: 'podGroups',
     component: () => <PodGroupDetails />,
+  },
+  compositepodgroups: {
+    path: '/compositepodgroups',
+    exact: true,
+    name: 'Composite Pod Groups',
+    sidebar: 'compositePodGroups',
+    component: () => <CompositePodGroupList />,
+  },
+  CompositePodGroup: {
+    path: '/compositepodgroups/:namespace/:name',
+    exact: true,
+    name: 'Composite Pod Group',
+    sidebar: 'compositePodGroups',
+    component: () => <CompositePodGroupDetails />,
   },
   // The 'workloads' route name is taken by the Workloads overview page, so the
   // scheduling.k8s.io Workload uses 'schedulingWorkloads' as its list route.

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -461,6 +461,7 @@
     "ResourceClasses": {
       "ClusterRole": [Function],
       "ClusterRoleBinding": [Function],
+      "CompositePodGroup": [Function],
       "ConfigMap": [Function],
       "ControllerRevision": [Function],
       "CronJob": [Function],
@@ -516,6 +517,11 @@
     },
     "clusterRoleBinding": {
       "default": [Function],
+    },
+    "compositePodGroup": {
+      "COMPOSITE_POD_GROUP_INITIALLY_SCHEDULED_CONDITION": "CompositePodGroupInitiallyScheduled",
+      "default": [Function],
+      "getCompositeDisruptionMode": [Function],
     },
     "configMap": {
       "default": [Function],
@@ -611,6 +617,7 @@
       "default": [Function],
       "getDisruptionMode": [Function],
       "getSchedulingPolicyKind": [Function],
+      "isSchedulingResourceServed": [Function],
     },
     "replicaSet": {
       "default": [Function],


### PR DESCRIPTION

## Summary

This PR adds support for `CompositePodGroup`, the third scheduling API from KEP-6012, which nests pod groups into a hierarchy. Headlamp could already show the two flat objects (`PodGroup`, `Workload`) added in #6562, but not the tree that ties them together, so a user could not tell which part of a nested workload failed to schedule.

## Related Issue

Fixes #7529

## Changes

- Added the `CompositePodGroup` resource class, modelling `spec` as served by `scheduling.k8s.io/v1alpha3`, with its own availability check
- Added list and details views, routes, and a sidebar entry in the existing Scheduling (alpha) section
- Added hierarchy navigation: a children section listing the child composite groups and pod groups, a parent link on the composite details page, and a parent link on the pod group details page
- Updated the Workload details page to show every level of nested composite templates, and to name the pod group templates instead of counting them
- Refactored the scheduling status column out of the PodGroup list so both list views share it
- Added unit tests, stories and storyshots, and translations for the two new keys across all locales

## Steps to Test

The API is alpha and off by default, so it needs a 1.37 cluster with the feature gates enabled.

1. Create the cluster:
   ```yaml
   # kind-was.yaml
   kind: Cluster
   apiVersion: kind.x-k8s.io/v1alpha4
   featureGates:
     GenericWorkload: true
     TopologyAwareWorkloadScheduling: true
     CompositePodGroup: true
   runtimeConfig:
     "scheduling.k8s.io/v1beta1": "true"
     "scheduling.k8s.io/v1alpha3": "true"
   nodes: [{role: control-plane}, {role: worker}, {role: worker}]
   ```
   ```
   kind create cluster --config kind-was.yaml --image kindest/node:v1.37.0
   ```
   Both group versions are needed: the scheduler watches `PodGroup` on `v1beta1`, while `CompositePodGroup` is only served by `v1alpha3`.
2. Apply a `Workload` with `compositePodGroupTemplates`, then the `CompositePodGroup` tree and `PodGroup` leaves it describes, and pods that reference the pod groups through `spec.schedulingGroup.podGroupName`.
3. Open **Scheduling (alpha) → Composite Pod Groups**. The entry only appears when the cluster serves the resource.
4. Open a hierarchy root: it has no Parent row, and its children are listed. Follow a child down, then follow Parent back up.
5. Open a pod group: its Composite Pod Group is now a link to the group above it.
6. Open the Workload: the composite template table shows every nesting level, indented, with the pod group templates named.
7. On a cluster without the `CompositePodGroup` feature gate, confirm the sidebar entry stays hidden.

## Screenshots

### PodGroup details 
| Before | After |
|---|---|
| <img width="1600" height="723" alt="image" src="https://github.com/user-attachments/assets/dc103669-cc50-4214-9869-5197e470b2e7" /> | <img width="1600" height="767" alt="image" src="https://github.com/user-attachments/assets/d4554ae8-94f7-4a86-990a-2d3298de9c9c" /> |

### Workload details
| Before | After |
|---|---|
| <img width="1600" height="747" alt="image" src="https://github.com/user-attachments/assets/520572ac-adc8-4bb3-b765-3ac4cb3b1dd6" /> | <img width="1600" height="785" alt="image" src="https://github.com/user-attachments/assets/7287829d-a29c-4dc2-978b-160ca692496f" /> |

### New: CompositePodGroup details
<img width="1600" height="777" alt="image" src="https://github.com/user-attachments/assets/10f910df-e14f-4411-a177-326c9fcf9bdc" />


## Notes for the Reviewer

- **`v1alpha3` only, deliberately.** `v1beta1` serves the composite templates inside a `Workload` and the parent reference on a `PodGroup`, but does not register `CompositePodGroup` itself, so this class must not fall back to the other versions the way `PodGroup` and `Workload` do.
- **The sidebar entry has its own availability check**, because a cluster can serve pod groups and workloads without serving this resource.
- **Children are found by listing the namespace and filtering on `parentCompositePodGroupName`** — the API names the parent on the child and there are no owner references to follow.
- **`CompositePodGroupInitiallyScheduled` is terminal**, so it is shown as whether the subtree ever scheduled rather than as live health. The alpha scheduler does not populate it yet, so it reads Unknown on a live cluster; the fixtures cover the Scheduled and Unschedulable cases.
- **i18n adds only two keys.** `npm run i18n` reorders every locale file, so they were inserted in place to keep the diff at one line per file.
