### PR TITLE
feat: support per-cluster plugin scoping via clusterSelector

### DIFF
--- a/backend/pkg/clusterinventory/clusterinventory.go
+++ b/backend/pkg/clusterinventory/clusterinventory.go
@@ -642,6 +642,15 @@ func clusterInventoryMetadataFromProfile(
 		Conditions: append([]metav1.Condition(nil), cp.Status.Conditions...),
 	}
 
+	if len(cp.Labels) > 0 {
+		labels := make(map[string]string, len(cp.Labels))
+		for k, v := range cp.Labels {
+			labels[k] = v
+		}
+
+		metadata.Labels = labels
+	}
+
 	if cp.Status.Version.Kubernetes != "" {
 		metadata.Version = &inventorymetadata.Version{
 			Kubernetes: cp.Status.Version.Kubernetes,

--- a/backend/pkg/clusterinventory/clusterinventory_test.go
+++ b/backend/pkg/clusterinventory/clusterinventory_test.go
@@ -448,6 +448,39 @@ func TestContextFromClusterProfilePreservesInventoryMetadata(t *testing.T) {
 	}, headlampContext.ClusterInventory.Properties)
 }
 
+func TestContextFromClusterProfileForwardsLabels(t *testing.T) {
+	runner := newTestRunner(t, Options{})
+	profileKey := "in-cluster/default/spoke-a"
+	cp := clusterProfile("spoke-a", "static-token", "https://spoke-a.example.com")
+	cp.Labels = map[string]string{
+		"tenant":      "a",
+		"has-velero":  "true",
+		"environment": "prod",
+	}
+
+	headlampContext, ok := runner.contextFromClusterProfile(profileKey, cp)
+	require.True(t, ok)
+
+	require.NotNil(t, headlampContext.ClusterInventory)
+	assert.Equal(t, map[string]string{
+		"tenant":      "a",
+		"has-velero":  "true",
+		"environment": "prod",
+	}, headlampContext.ClusterInventory.Labels)
+}
+
+func TestContextFromClusterProfileOmitsLabelsWhenNone(t *testing.T) {
+	runner := newTestRunner(t, Options{})
+	profileKey := "in-cluster/default/spoke-a"
+	cp := clusterProfile("spoke-a", "static-token", "https://spoke-a.example.com")
+
+	headlampContext, ok := runner.contextFromClusterProfile(profileKey, cp)
+	require.True(t, ok)
+
+	require.NotNil(t, headlampContext.ClusterInventory)
+	assert.Nil(t, headlampContext.ClusterInventory.Labels)
+}
+
 func TestClusterProfileDeletePrunesContextOutsideRunnerLock(t *testing.T) {
 	store := &removeLockDetectingStore{ContextStore: kubeconfig.NewContextStore()}
 	runner := newTestRunner(t, Options{

--- a/backend/pkg/clusterinventory/metadata/metadata.go
+++ b/backend/pkg/clusterinventory/metadata/metadata.go
@@ -41,7 +41,9 @@ type Property struct {
 // Metadata contains non-sensitive ClusterProfile status metadata.
 //
 // The fields mirror the non-access-provider parts of the upstream
-// [ClusterProfileStatus] shape.
+// [ClusterProfileStatus] shape, plus the ClusterProfile's Labels (an ObjectMeta field,
+// not part of Status) which Headlamp forwards so the frontend can evaluate a plugin's
+// clusterSelector against them.
 //
 // [ClusterProfileStatus]: https://pkg.go.dev/sigs.k8s.io/cluster-inventory-api/apis/v1alpha1#ClusterProfileStatus
 type Metadata struct {
@@ -49,6 +51,9 @@ type Metadata struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 	Version    *Version           `json:"version,omitempty"`
 	Properties []Property         `json:"properties,omitempty"`
+	// Labels are the ClusterProfile's labels, forwarded so plugin clusterSelector
+	// matching can be done on the frontend.
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // DeepCopy returns an independent copy of Metadata.
@@ -66,6 +71,15 @@ func (m *Metadata) DeepCopy() *Metadata {
 	if m.Version != nil {
 		version := *m.Version
 		copied.Version = &version
+	}
+
+	if m.Labels != nil {
+		labels := make(map[string]string, len(m.Labels))
+		for k, v := range m.Labels {
+			labels[k] = v
+		}
+
+		copied.Labels = labels
 	}
 
 	return copied

--- a/backend/pkg/clusterinventory/metadata/metadata_test.go
+++ b/backend/pkg/clusterinventory/metadata/metadata_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/clusterinventory/metadata"
+)
+
+func TestMetadataDeepCopyLabels(t *testing.T) {
+	original := &metadata.Metadata{
+		Profile: metadata.Profile{Namespace: "default", Name: "spoke-a", Key: "in-cluster/default/spoke-a"},
+		Labels: map[string]string{
+			"tenant": "a",
+		},
+	}
+
+	copied := original.DeepCopy()
+
+	require.NotNil(t, copied)
+	assert.Equal(t, original.Labels, copied.Labels)
+
+	// Mutating the copy must not affect the original, proving the map itself was copied
+	// rather than shared by reference.
+	copied.Labels["tenant"] = "b"
+	assert.Equal(t, "a", original.Labels["tenant"])
+
+	// And vice versa.
+	original.Labels["region"] = "us-west1"
+	_, hasRegion := copied.Labels["region"]
+	assert.False(t, hasRegion)
+}
+
+func TestMetadataDeepCopyNilLabels(t *testing.T) {
+	original := &metadata.Metadata{
+		Profile: metadata.Profile{Namespace: "default", Name: "spoke-a", Key: "in-cluster/default/spoke-a"},
+	}
+
+	copied := original.DeepCopy()
+
+	require.NotNil(t, copied)
+	assert.Nil(t, copied.Labels)
+}
+
+func TestMetadataDeepCopyNilMetadata(t *testing.T) {
+	var original *metadata.Metadata
+
+	assert.Nil(t, original.DeepCopy())
+}

--- a/frontend/src/components/App/RouteSwitcher.tsx
+++ b/frontend/src/components/App/RouteSwitcher.tsx
@@ -29,6 +29,10 @@ import { getDefaultRoutes } from '../../lib/router/getDefaultRoutes';
 import { getRoutePath } from '../../lib/router/getRoutePath';
 import { getRouteUseClusterURL } from '../../lib/router/getRouteUseClusterURL';
 import { Route as RouteType } from '../../lib/router/Route';
+import {
+  isPluginApplicable,
+  usePluginApplicabilityMap,
+} from '../../plugin/useIsPluginApplicableToCluster';
 import { useTypedSelector } from '../../redux/hooks';
 import { uiSlice } from '../../redux/uiSlice';
 import ErrorBoundary from '../common/ErrorBoundary';
@@ -41,6 +45,7 @@ export default function RouteSwitcher(props: { requiresToken: () => boolean }) {
   const routeFilters = useTypedSelector(state => state.routes.routeFilters);
   const defaultRoutes = Object.values(getDefaultRoutes()).concat(NotFoundRoute);
   const clusters = useClustersConf();
+  const pluginApplicabilityMap = usePluginApplicabilityMap();
   const filteredRoutes = Object.values(routes)
     .concat(defaultRoutes)
     .filter(
@@ -48,7 +53,9 @@ export default function RouteSwitcher(props: { requiresToken: () => boolean }) {
         !(
           routeFilters.length > 0 &&
           routeFilters.filter(f => f(route)).length !== routeFilters.length
-        ) && !route.disabled
+        ) &&
+        !route.disabled &&
+        isPluginApplicable(pluginApplicabilityMap, route.plugin)
     );
 
   return (

--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -29,7 +29,7 @@ import Typography from '@mui/material/Typography';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useQueries } from '@tanstack/react-query';
 import { has } from 'lodash';
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
@@ -38,6 +38,10 @@ import { logout } from '../../lib/auth';
 import { useCluster, useClustersConf, useSelectedClusters } from '../../lib/k8s';
 import { ClusterUserInfo, getClusterUserInfo } from '../../lib/k8s/api/v1/clusterApi';
 import { createRouteURL } from '../../lib/router/createRouteURL';
+import {
+  isPluginApplicable,
+  usePluginApplicabilityMap,
+} from '../../plugin/useIsPluginApplicableToCluster';
 import {
   AppBarAction,
   AppBarActionsProcessor,
@@ -62,8 +66,19 @@ export function useAppBarActionsProcessed() {
   const appBarActionsProcessors = useTypedSelector(
     state => state.actionButtons.appBarActionsProcessors
   );
+  const pluginApplicabilityMap = usePluginApplicabilityMap();
 
-  return { appBarActions, appBarActionsProcessors };
+  return useMemo(
+    () => ({
+      appBarActions: appBarActions.filter(action =>
+        isPluginApplicable(pluginApplicabilityMap, action.plugin)
+      ),
+      appBarActionsProcessors: appBarActionsProcessors.filter(processor =>
+        isPluginApplicable(pluginApplicabilityMap, processor.plugin)
+      ),
+    }),
+    [appBarActions, appBarActionsProcessors, pluginApplicabilityMap]
+  );
 }
 
 export function processAppBarActions(

--- a/frontend/src/components/Sidebar/sidebarSlice.ts
+++ b/frontend/src/components/Sidebar/sidebarSlice.ts
@@ -70,6 +70,12 @@ export interface SidebarEntry {
    * Custom style overrides for subheader entries.
    */
   sx?: SxProps<Theme>;
+  /**
+   * Name of the plugin that registered this entry, set automatically by
+   * `registerSidebarEntry`. `null`/`undefined` for entries not attributed to a plugin
+   * (e.g. built-in entries, or registrations made outside a plugin's synchronous load).
+   */
+  plugin?: string | null;
 }
 
 export interface SidebarState {

--- a/frontend/src/components/Sidebar/useSidebarItems.tsx
+++ b/frontend/src/components/Sidebar/useSidebarItems.tsx
@@ -26,6 +26,10 @@ import CRD from '../../lib/k8s/crd';
 import { useGatewayL4RouteAvailability } from '../../lib/k8s/gatewayL4RouteAvailability';
 import PodGroup from '../../lib/k8s/podGroup';
 import { createRouteURL } from '../../lib/router/createRouteURL';
+import {
+  isPluginApplicable,
+  usePluginApplicabilityMap,
+} from '../../plugin/useIsPluginApplicableToCluster';
 import { useTypedSelector } from '../../redux/hooks';
 import { DefaultSidebars, SidebarEntryProps, SidebarItemProps } from '.';
 import ClusterBadge from './ClusterBadge';
@@ -61,6 +65,7 @@ export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER
   const customSidebarEntries = useTypedSelector(state => state.sidebar.entries);
   const customSidebarFilters = useTypedSelector(state => state.sidebar.filters);
   const customHomeSidebarFilters = useTypedSelector(state => state.sidebar.homeFilters);
+  const pluginApplicabilityMap = usePluginApplicabilityMap();
   const shouldShowHomeItem = isElectron() || Object.keys(clusters).length !== 1;
   const selectedClusters = useSelectedClusters();
   const allClustersConf = useClustersConf();
@@ -528,8 +533,12 @@ export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER
       { name: DefaultSidebars.IN_CLUSTER, subList: inClusterItems, label: '' },
     ];
 
-    // Create a copy of all the custom entries so we don't accidentaly mutate them
-    const customEntries = _.cloneDeep(Object.values(customSidebarEntries));
+    // Create a copy of all the custom entries so we don't accidentally mutate them,
+    // excluding any plugin's entries that don't apply to the active cluster (per the
+    // plugin manifest's `headlamp.clusterSelector`).
+    const customEntries = _.cloneDeep(Object.values(customSidebarEntries)).filter(entry =>
+      isPluginApplicable(pluginApplicabilityMap, entry.plugin)
+    );
 
     // Lookup map of every sidebar entry
     const entryLookup = new Map<string, SidebarItemProps>();
@@ -609,6 +618,7 @@ export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER
     shouldShowHomeItem,
     customSidebarFilters,
     customHomeSidebarFilters,
+    pluginApplicabilityMap,
     // eslint-disable-next-line react-hooks/exhaustive-deps
     Object.keys(clusters).join(','),
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/components/common/Resource/ResourceTable.test.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.test.tsx
@@ -15,13 +15,16 @@
  */
 
 import { ThemeProvider } from '@mui/material/styles';
+import { configureStore } from '@reduxjs/toolkit';
 import { act, render } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { loadTableSettings, storeTableSettings } from '../../../helpers/tableSettings';
 import { createMuiTheme } from '../../../lib/themes';
+import reducers from '../../../redux/reducers/reducers';
 import { TestContext } from '../../../test';
 import ResourceTable from './ResourceTable';
+import { addResourceTableColumnsProcessor } from './resourceTableSlice';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
@@ -30,6 +33,23 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('../../../lib/k8s', () => ({
   useSelectedClusters: vi.fn(() => ['test-cluster']),
+}));
+
+// Column-visibility tests don't exercise plugin cluster-scoping and rely on this file's
+// narrow `lib/k8s` mock (above), which doesn't cover useCluster/useClustersConf -- so the
+// real hook can't run here. Mock it with a controllable map instead of a fixed `true`, so
+// the cluster-scoping tests below can prove a non-matching plugin's processor is actually
+// skipped, not just that the mock always lets everything through.
+const { mockApplicabilityMap } = vi.hoisted(() => ({
+  mockApplicabilityMap: new Map<string, boolean>(),
+}));
+
+vi.mock('../../../plugin/useIsPluginApplicableToCluster', () => ({
+  usePluginApplicabilityMap: () => mockApplicabilityMap,
+  isPluginApplicable: (map: Map<string, boolean>, plugin?: string | null) => {
+    if (!plugin) return true;
+    return map.get(plugin) !== false;
+  },
 }));
 
 // Capture the props passed to Table using a hoisted holder object
@@ -225,5 +245,71 @@ describe('ResourceTable Column Visibility', () => {
     );
 
     expect(lastTablePropsHolder.current.enableFacetedValues).toBe(true);
+  });
+});
+
+describe('ResourceTable cluster-scoped column processors', () => {
+  beforeEach(() => {
+    lastTablePropsHolder.current = null;
+    mockApplicabilityMap.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const columns = [
+    {
+      id: 'name',
+      label: 'Name',
+      getValue: (item: any) => item.metadata.name,
+    },
+  ];
+
+  const injectExtraColumn = ({ columns: currentColumns }: { columns: typeof columns }) => [
+    ...currentColumns,
+    { id: 'injected', label: 'Injected' },
+  ];
+
+  const renderTableWithProcessor = (pluginName: string) => {
+    const store = configureStore({ reducer: reducers });
+    store.dispatch(
+      addResourceTableColumnsProcessor({
+        id: 'test-processor',
+        processor: injectExtraColumn,
+        plugin: pluginName,
+      } as any)
+    );
+
+    const ResourceTableAny = ResourceTable as any;
+    return render(
+      <TestContext store={store}>
+        <ThemeProvider theme={theme}>
+          <ResourceTableAny id="test-table-id" columns={columns} data={mockData} />
+        </ThemeProvider>
+      </TestContext>
+    );
+  };
+
+  it('does not apply a column processor from a plugin the cluster selector excludes', () => {
+    mockApplicabilityMap.set('blocked-plugin', false);
+
+    renderTableWithProcessor('blocked-plugin');
+
+    expect(lastTablePropsHolder.current).not.toBeNull();
+    expect(lastTablePropsHolder.current.columns.some((col: any) => col.id === 'injected')).toBe(
+      false
+    );
+  });
+
+  it('applies a column processor from a plugin the cluster selector allows', () => {
+    mockApplicabilityMap.set('allowed-plugin', true);
+
+    renderTableWithProcessor('allowed-plugin');
+
+    expect(lastTablePropsHolder.current).not.toBeNull();
+    expect(lastTablePropsHolder.current.columns.some((col: any) => col.id === 'injected')).toBe(
+      true
+    );
   });
 });

--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -46,6 +46,10 @@ import { ApiError } from '../../../lib/k8s/api/v2/ApiError';
 import { KubeObject } from '../../../lib/k8s/KubeObject';
 import { KubeObjectClass } from '../../../lib/k8s/KubeObject';
 import { useFilterFunc } from '../../../lib/util';
+import {
+  isPluginApplicable,
+  usePluginApplicabilityMap,
+} from '../../../plugin/useIsPluginApplicableToCluster';
 import { DefaultHeaderAction, RowAction } from '../../../redux/actionButtonsSlice';
 import { useNamespaces } from '../../../redux/filterSlice';
 import { HeadlampEventType, useEventCallback } from '../../../redux/headlampEventSlice';
@@ -335,7 +339,15 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
   const theme = useTheme();
   const storeRowsPerPageOptions = useSettings('tableRowsPerPageOptions');
   const clusters = useSelectedClusters();
-  const tableProcessors = useTypedSelector(state => state.resourceTable.tableColumnsProcessors);
+  const pluginApplicabilityMap = usePluginApplicabilityMap();
+  const rawTableProcessors = useTypedSelector(state => state.resourceTable.tableColumnsProcessors);
+  const tableProcessors = useMemo(
+    () =>
+      rawTableProcessors.filter(processor =>
+        isPluginApplicable(pluginApplicabilityMap, processor.plugin)
+      ),
+    [rawTableProcessors, pluginApplicabilityMap]
+  );
   const defaultFilterFunc = useFilterFunc();
   const [columnVisibility, setColumnVisibility] = useState(() =>
     initColumnVisibilityState(columns, id)

--- a/frontend/src/components/common/Resource/resourceTableSlice.ts
+++ b/frontend/src/components/common/Resource/resourceTableSlice.ts
@@ -37,6 +37,12 @@ export type TableColumnsProcessor = {
     id: string;
     columns: ResourceTableProps<T>['columns'];
   }) => ResourceTableProps<T>['columns'];
+  /**
+   * Name of the plugin that registered this processor, set automatically by
+   * `registerResourceTableColumnsProcessor`. `null`/`undefined` for processors not
+   * attributed to a plugin.
+   */
+  plugin?: string | null;
 };
 
 const initialState: ResourceTableState = {

--- a/frontend/src/lib/router/Route.tsx
+++ b/frontend/src/lib/router/Route.tsx
@@ -45,4 +45,10 @@ export interface Route {
   disabled?: boolean;
   /** Render route for full width */
   isFullWidth?: boolean;
+  /**
+   * Name of the plugin that registered this route, set automatically by `registerRoute`.
+   * `null`/`undefined` for routes not attributed to a plugin (e.g. built-in routes, or
+   * registrations made outside a plugin's synchronous load).
+   */
+  plugin?: string | null;
 }

--- a/frontend/src/plugin/clusterSelector.test.ts
+++ b/frontend/src/plugin/clusterSelector.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { matchesClusterSelector } from './clusterSelector';
+
+describe('matchesClusterSelector', () => {
+  it('returns true for an undefined selector', () => {
+    expect(matchesClusterSelector(undefined, { tenant: 'a' })).toBe(true);
+  });
+
+  it('returns true for a null selector', () => {
+    expect(matchesClusterSelector(null, { tenant: 'a' })).toBe(true);
+  });
+
+  it('returns true for an empty selector', () => {
+    expect(matchesClusterSelector('', { tenant: 'a' })).toBe(true);
+  });
+
+  it('returns true for a whitespace-only selector', () => {
+    expect(matchesClusterSelector('   ', { tenant: 'a' })).toBe(true);
+  });
+
+  it('returns true when labels are undefined (permissive default)', () => {
+    expect(matchesClusterSelector('tenant=a', undefined)).toBe(true);
+  });
+
+  it('returns true when labels are null (permissive default)', () => {
+    expect(matchesClusterSelector('tenant=a', null)).toBe(true);
+  });
+
+  it('returns true for a single matching key=value pair', () => {
+    expect(matchesClusterSelector('tenant=a', { tenant: 'a' })).toBe(true);
+  });
+
+  it('returns true when all key=value pairs in a multi-key selector match', () => {
+    expect(
+      matchesClusterSelector('tenant=a,has-velero=true', { tenant: 'a', 'has-velero': 'true' })
+    ).toBe(true);
+  });
+
+  it('returns true when labels contain extra keys beyond the selector', () => {
+    expect(matchesClusterSelector('tenant=a', { tenant: 'a', environment: 'prod' })).toBe(true);
+  });
+
+  it('returns false when a selector key is missing from labels', () => {
+    expect(matchesClusterSelector('tenant=a', { environment: 'prod' })).toBe(false);
+  });
+
+  it('returns false when a selector value does not match', () => {
+    expect(matchesClusterSelector('tenant=a', { tenant: 'b' })).toBe(false);
+  });
+
+  it('returns false when only one of several key=value pairs matches', () => {
+    expect(
+      matchesClusterSelector('tenant=a,has-velero=true', { tenant: 'a', 'has-velero': 'false' })
+    ).toBe(false);
+  });
+
+  it('returns false for a non-empty selector against an empty labels object', () => {
+    expect(matchesClusterSelector('tenant=a', {})).toBe(false);
+  });
+
+  it('tolerates whitespace around keys, values, and commas', () => {
+    expect(
+      matchesClusterSelector(' tenant = a , has-velero = true ', {
+        tenant: 'a',
+        'has-velero': 'true',
+      })
+    ).toBe(true);
+  });
+
+  it('returns false for an unsupported set-based term (no "=")', () => {
+    expect(matchesClusterSelector('tenant', { tenant: 'a' })).toBe(false);
+  });
+
+  it('returns false for a selector that is only a comma, even against fully matching labels', () => {
+    expect(matchesClusterSelector(',', { tenant: 'a' })).toBe(false);
+  });
+
+  it('returns false for a trailing comma, even when the other term matches', () => {
+    expect(matchesClusterSelector('tenant=a,', { tenant: 'a' })).toBe(false);
+  });
+
+  it('returns false for a leading comma, even when the other term matches', () => {
+    expect(matchesClusterSelector(',tenant=a', { tenant: 'a' })).toBe(false);
+  });
+
+  it('returns false for a double comma between two otherwise-matching terms', () => {
+    expect(
+      matchesClusterSelector('tenant=a,,has-velero=true', { tenant: 'a', 'has-velero': 'true' })
+    ).toBe(false);
+  });
+});

--- a/frontend/src/plugin/clusterSelector.ts
+++ b/frontend/src/plugin/clusterSelector.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Evaluates a plugin's `clusterSelector` against a cluster's labels.
+ *
+ * Equality-only, comma-separated `key=value` pairs (e.g. `"tenant=a,has-velero=true"`) —
+ * the same syntax as `kubectl`'s `-l`, restricted to the equality subset. Set-based
+ * operators (`in`, `notin`, `exists`) are intentionally not supported; the backend's
+ * `clusterProfileMatchesSelector` supports the full syntax for the sync-time gate, but
+ * this frontend matcher only needs to cover the common case of showing/hiding a plugin.
+ *
+ * Permissive by design in two cases, so that adding `clusterSelector` support never
+ * breaks an existing setup:
+ * - No selector (empty/undefined): always matches — a plugin without `clusterSelector`
+ *   behaves exactly as before this feature existed.
+ * - No labels available for the cluster (`null`/`undefined`, e.g. a manually-added
+ *   kubeconfig cluster with no Cluster Inventory ClusterProfile to carry labels): always
+ *   matches, rather than hiding the plugin because Headlamp simply doesn't know the
+ *   cluster's labels.
+ *
+ * Conversely, a malformed *non-empty* selector fails closed (never matches), rather than
+ * silently ignoring the malformed part: an empty term from a stray/leading/trailing/
+ * doubled comma (e.g. `","`, `"tenant=a,"`, `"tenant=a,,has-velero=true"`) makes the whole
+ * selector invalid, even if every other term would have matched. This field controls
+ * cluster scoping, so a typo should not quietly make a selector more permissive than what
+ * was actually written.
+ *
+ * @param selector - The plugin's `clusterSelector`, e.g. `"tenant=a,has-velero=true"`.
+ * @param labels - The active cluster's labels, or `null`/`undefined` if unavailable.
+ * @returns Whether the selector matches (or is inapplicable and so treated as a match).
+ */
+export function matchesClusterSelector(
+  selector: string | undefined | null,
+  labels: Record<string, string> | undefined | null
+): boolean {
+  const trimmedSelector = (selector ?? '').trim();
+  if (!trimmedSelector) {
+    return true;
+  }
+
+  if (!labels) {
+    return true;
+  }
+
+  return trimmedSelector
+    .split(',')
+    .map(term => term.trim())
+    .every(term => {
+      // An empty term means a malformed selector (e.g. "," or a trailing/leading/double
+      // comma like "tenant=a,"). Reject it outright rather than silently dropping it —
+      // this field controls cluster scoping, so a malformed selector must fail closed
+      // (never match) instead of quietly becoming more permissive than what was written.
+      if (!term) {
+        return false;
+      }
+
+      const equalsIndex = term.indexOf('=');
+      if (equalsIndex === -1) {
+        // Not a `key=value` term (e.g. a set-based expression) — unsupported, so it
+        // can never be satisfied by this equality-only matcher.
+        return false;
+      }
+
+      const key = term.slice(0, equalsIndex).trim();
+      const value = term.slice(equalsIndex + 1).trim();
+
+      return key !== '' && labels[key] === value;
+    });
+}

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -54,6 +54,7 @@ import { eventAction, HeadlampEventType } from '../redux/headlampEventSlice';
 import store from '../redux/stores/store';
 import * as stateless from '../stateless/index';
 import { Headlamp, Plugin } from './lib';
+import { setCurrentPluginName } from './pluginContext';
 import { changePluginLanguage, initializePluginI18n } from './pluginI18n';
 import { useTranslation } from './pluginI18n';
 import { PluginInfo } from './pluginsSlice';
@@ -352,7 +353,22 @@ function runPluginInner(info: runPluginProps) {
   const values = info[6];
   const privateRunPlugin = info[7];
 
-  privateRunPlugin(source, packageName, packageVersion, handleError, PrivateFunction, args, values);
+  // Track which plugin is currently loading so registry.tsx can attribute register*
+  // calls made during this plugin's synchronous top-level execution (see pluginContext.ts).
+  setCurrentPluginName(packageName);
+  try {
+    privateRunPlugin(
+      source,
+      packageName,
+      packageVersion,
+      handleError,
+      PrivateFunction,
+      args,
+      values
+    );
+  } finally {
+    setCurrentPluginName(null);
+  }
 }
 
 const PLUGIN_LOADING_ERROR = HeadlampEventType.PLUGIN_LOADING_ERROR;

--- a/frontend/src/plugin/pluginContext.test.ts
+++ b/frontend/src/plugin/pluginContext.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { currentPluginName, setCurrentPluginName } from './pluginContext';
+
+describe('pluginContext', () => {
+  afterEach(() => {
+    setCurrentPluginName(null);
+  });
+
+  it('defaults to null', () => {
+    expect(currentPluginName).toBeNull();
+  });
+
+  it('reflects the most recent setCurrentPluginName call', () => {
+    setCurrentPluginName('my-plugin');
+    expect(currentPluginName).toBe('my-plugin');
+
+    setCurrentPluginName('another-plugin');
+    expect(currentPluginName).toBe('another-plugin');
+
+    setCurrentPluginName(null);
+    expect(currentPluginName).toBeNull();
+  });
+
+  it('is set during a synchronous plugin execution and cleared afterward, mirroring runPluginInner', () => {
+    // Mirrors the try/finally wrapping runPluginInner puts around privateRunPlugin.
+    function runSynchronously(packageName: string, fn: () => void) {
+      setCurrentPluginName(packageName);
+      try {
+        fn();
+      } finally {
+        setCurrentPluginName(null);
+      }
+    }
+
+    let observedDuringRun: string | null = null;
+    runSynchronously('my-plugin', () => {
+      observedDuringRun = currentPluginName;
+    });
+
+    expect(observedDuringRun).toBe('my-plugin');
+    expect(currentPluginName).toBeNull();
+  });
+
+  it('is cleared even if the plugin throws synchronously', () => {
+    function runSynchronously(packageName: string, fn: () => void) {
+      setCurrentPluginName(packageName);
+      try {
+        fn();
+      } finally {
+        setCurrentPluginName(null);
+      }
+    }
+
+    expect(() =>
+      runSynchronously('bad-plugin', () => {
+        throw new Error('boom');
+      })
+    ).toThrow('boom');
+
+    expect(currentPluginName).toBeNull();
+  });
+
+  it('attributes each plugin only for the duration of its own sequential run', () => {
+    function runSynchronously(packageName: string, fn: () => void) {
+      setCurrentPluginName(packageName);
+      try {
+        fn();
+      } finally {
+        setCurrentPluginName(null);
+      }
+    }
+
+    const observed: Array<string | null> = [];
+    runSynchronously('plugin-a', () => observed.push(currentPluginName));
+    observed.push(currentPluginName);
+    runSynchronously('plugin-b', () => observed.push(currentPluginName));
+    observed.push(currentPluginName);
+
+    expect(observed).toEqual(['plugin-a', null, 'plugin-b', null]);
+  });
+});

--- a/frontend/src/plugin/pluginContext.ts
+++ b/frontend/src/plugin/pluginContext.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The name of the plugin currently executing its top-level (synchronous) load code.
+ *
+ * Set by `runPluginInner` (in `plugin/index.ts`) for the duration of each plugin's
+ * synchronous execution, since plugins are run one at a time via a sequential `forEach`.
+ * Used by `registry.tsx` to attribute `register*` calls to the plugin that made them, so
+ * contributions can later be filtered by that plugin's `clusterSelector`.
+ *
+ * Only covers registrations made synchronously during load — a `register*` call made from
+ * inside an async callback (e.g. a `.then()` or `setTimeout`) after the plugin has finished
+ * loading will see this as `null` (or whichever plugin loads next), since by then execution
+ * has moved on.
+ *
+ * Lives in its own module (rather than `plugin/index.ts`) so that `registry.tsx` can read it
+ * without creating a circular import with `plugin/index.ts` (which itself imports
+ * `registry.tsx`).
+ */
+export let currentPluginName: string | null = null;
+
+/**
+ * Sets the name of the plugin currently executing its top-level load code.
+ *
+ * @param name - The plugin's package name, or `null` once it has finished loading.
+ */
+export function setCurrentPluginName(name: string | null) {
+  currentPluginName = name;
+}

--- a/frontend/src/plugin/pluginsSlice.ts
+++ b/frontend/src/plugin/pluginsSlice.ts
@@ -48,6 +48,18 @@ export interface PluginPackageHeadlampConfig {
   enabledByDefault?: boolean;
   /** Array of supported locales for i18n. */
   i18n?: string[];
+  /**
+   * Label selector (e.g. `"tenant=a,has-velero=true"`) declaring which clusters this
+   * plugin applies to. Evaluated against the active cluster's labels at render time to
+   * gate the plugin's sidebar entries, routes, appbar actions, and resource table column
+   * processors. Omit to apply the plugin to every cluster (the default, unchanged
+   * behavior). A cluster with no labels available (e.g. manually added via kubeconfig,
+   * with no Cluster Inventory ClusterProfile) always matches.
+   *
+   * @see useIsPluginApplicableToCluster
+   * @see matchesClusterSelector
+   */
+  clusterSelector?: string;
 }
 
 /**

--- a/frontend/src/plugin/registry.test.ts
+++ b/frontend/src/plugin/registry.test.ts
@@ -34,7 +34,15 @@ vi.mock('../components/resourceMap/sources/definitions/relationIds', () => ({
   BUILT_IN_RELATION_IDS: ['owner', 'owner-reversed', 'pod-configmap'],
 }));
 
-import { registerClusterEmptyState, registerResourceRelationProvider } from './registry';
+import { setCurrentPluginName } from './pluginContext';
+import {
+  registerAppBarAction,
+  registerClusterEmptyState,
+  registerResourceRelationProvider,
+  registerResourceTableColumnsProcessor,
+  registerRoute,
+  registerSidebarEntry,
+} from './registry';
 
 describe('registerResourceRelationProvider', () => {
   let warnSpy: any;
@@ -218,5 +226,93 @@ describe('registerResourceRelationProvider', () => {
     registerClusterEmptyState(emptyState);
 
     expect(activeStore.getState().clusterProvider.clusterEmptyState).toBe(emptyState);
+  });
+});
+
+describe('plugin attribution', () => {
+  beforeEach(() => {
+    activeStore = configureStore({
+      reducer: reducers,
+    });
+  });
+
+  afterEach(() => {
+    setCurrentPluginName(null);
+  });
+
+  it('stamps registerSidebarEntry with the currently executing plugin', () => {
+    setCurrentPluginName('my-plugin');
+
+    registerSidebarEntry({ parent: null, name: 'traces', label: 'Traces', url: '/traces' });
+
+    const entry = activeStore.getState().sidebar.entries['traces'];
+    expect(entry).toBeDefined();
+    expect(entry.plugin).toBe('my-plugin');
+  });
+
+  it('stamps registerSidebarEntry with null when no plugin is executing', () => {
+    setCurrentPluginName(null);
+
+    registerSidebarEntry({
+      parent: null,
+      name: 'no-plugin-entry',
+      label: 'No Plugin',
+      url: '/npe',
+    });
+
+    const entry = activeStore.getState().sidebar.entries['no-plugin-entry'];
+    expect(entry.plugin).toBeNull();
+  });
+
+  it('does not let a registered entry spoof a different plugin name', () => {
+    setCurrentPluginName('real-plugin');
+
+    // Even if a plugin-supplied field happened to carry a "plugin" key, registerSidebarEntry
+    // only forwards a fixed allowlist of fields to the store, so it can't be spoofed this way.
+    registerSidebarEntry({
+      parent: null,
+      name: 'spoofed',
+      label: 'Spoofed',
+      url: '/spoofed',
+      ...({ plugin: 'someone-elses-plugin' } as any),
+    });
+
+    const entry = activeStore.getState().sidebar.entries['spoofed'];
+    expect(entry.plugin).toBe('real-plugin');
+  });
+
+  it('stamps registerRoute with the currently executing plugin and cannot be spoofed', () => {
+    setCurrentPluginName('route-plugin');
+
+    registerRoute({
+      path: '/my-route',
+      sidebar: null,
+      component: () => null,
+      ...({ plugin: 'spoofed-plugin' } as any),
+    });
+
+    const route = activeStore.getState().routes.routes['/my-route'];
+    expect(route).toBeDefined();
+    expect(route.plugin).toBe('route-plugin');
+  });
+
+  it('stamps registerAppBarAction with the currently executing plugin', () => {
+    setCurrentPluginName('appbar-plugin');
+
+    registerAppBarAction(() => null);
+
+    const actions = activeStore.getState().actionButtons.appBarActions;
+    expect(actions).toHaveLength(1);
+    expect(actions[0].plugin).toBe('appbar-plugin');
+  });
+
+  it('stamps registerResourceTableColumnsProcessor with the currently executing plugin', () => {
+    setCurrentPluginName('table-plugin');
+
+    registerResourceTableColumnsProcessor(({ columns }) => columns);
+
+    const processors = activeStore.getState().resourceTable.tableColumnsProcessors;
+    expect(processors).toHaveLength(1);
+    expect(processors[0].plugin).toBe('table-plugin');
   });
 });

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -125,6 +125,7 @@ import { setRoute, setRouteFilter } from '../redux/routesSlice';
 import store from '../redux/stores/store';
 import { UIPanel, uiSlice } from '../redux/uiSlice';
 import { ConfigStore } from './configStore';
+import { currentPluginName } from './pluginContext';
 import {
   PluginSettingsComponentType,
   PluginSettingsDetailsProps,
@@ -344,6 +345,7 @@ export function registerSidebarEntry({
       sidebar,
       entryType,
       sx,
+      plugin: currentPluginName,
     })
   );
 }
@@ -467,7 +469,7 @@ export function registerRouteFilter(filterFunc: (entry: Route) => Route | null) 
  *
  */
 export function registerRoute(routeSpec: Route) {
-  store.dispatch(setRoute(routeSpec));
+  store.dispatch(setRoute({ ...routeSpec, plugin: currentPluginName }));
 }
 
 /**
@@ -554,7 +556,14 @@ export function registerDetailsViewHeaderActionsProcessor(
 export function registerResourceTableColumnsProcessor(
   processor: TableColumnsProcessor | TableColumnsProcessor['processor']
 ) {
-  store.dispatch(addResourceTableColumnsProcessor(processor));
+  const normalizedProcessor: TableColumnsProcessor =
+    typeof processor === 'function'
+      ? { id: `generated-id-${Date.now().toString(36)}`, processor }
+      : { ...processor };
+  normalizedProcessor.id = normalizedProcessor.id || `generated-id-${Date.now().toString(36)}`;
+  store.dispatch(
+    addResourceTableColumnsProcessor({ ...normalizedProcessor, plugin: currentPluginName })
+  );
 }
 
 function isProcessor(
@@ -597,9 +606,22 @@ export function registerAppBarAction(
   headerAction: AppBarActionType | AppBarAction | AppBarActionsProcessor | AppBarActionProcessorType
 ) {
   if (isProcessor(headerAction)) {
-    store.dispatch(setAppBarActionsProcessor(headerAction as AppBarActionsProcessor));
+    const processor: AppBarActionsProcessor =
+      typeof headerAction === 'function'
+        ? {
+            id: `generated-id-${Date.now().toString(36)}`,
+            processor: headerAction as AppBarActionProcessorType,
+          }
+        : { ...(headerAction as AppBarActionsProcessor) };
+    processor.id = processor.id || `generated-id-${Date.now().toString(36)}`;
+    store.dispatch(setAppBarActionsProcessor({ ...processor, plugin: currentPluginName }));
   }
-  store.dispatch(setAppBarAction(headerAction as AppBarAction));
+
+  const action: AppBarAction =
+    has(headerAction, 'action') || has(headerAction, 'id')
+      ? { ...(headerAction as AppBarAction) }
+      : { id: `generated-id-${Date.now().toString(36)}`, action: headerAction as AppBarActionType };
+  store.dispatch(setAppBarAction({ ...action, plugin: currentPluginName }));
 }
 
 /**

--- a/frontend/src/plugin/useIsPluginApplicableToCluster.test.tsx
+++ b/frontend/src/plugin/useIsPluginApplicableToCluster.test.tsx
@@ -1,0 +1,410 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import { renderHook } from '@testing-library/react';
+import React, { PropsWithChildren } from 'react';
+import { Provider } from 'react-redux';
+import { setConfig } from '../redux/configSlice';
+import { setPluginSettings } from './pluginsSlice';
+
+const { mockUseSelectedClusters } = vi.hoisted(() => ({
+  mockUseSelectedClusters: vi.fn(),
+}));
+
+vi.mock('../lib/k8s', () => ({
+  useSelectedClusters: mockUseSelectedClusters,
+}));
+
+// Imported after the mocks so the module under test picks up the mocked hooks.
+import reducers from '../redux/reducers/reducers';
+import {
+  isPluginApplicable,
+  useIsPluginApplicableToCluster,
+  usePluginApplicabilityMap,
+} from './useIsPluginApplicableToCluster';
+
+function makeStore() {
+  return configureStore({ reducer: reducers });
+}
+
+function wrapperFor(store: ReturnType<typeof makeStore>) {
+  return function Wrapper({ children }: PropsWithChildren<{}>) {
+    return <Provider store={store}>{children}</Provider>;
+  };
+}
+
+function clusterConfig(clusterName: string, labels?: Record<string, string>) {
+  return {
+    name: clusterName,
+    auth_type: '',
+    ...(labels !== undefined ? { meta_data: { clusterInventory: { labels } } } : {}),
+  };
+}
+
+/** Dispatches a real setConfig, exercising the actual configSlice reducer/state shape
+ * rather than mocking useClustersConf's return value -- this hook now reads
+ * state.config.clusters directly (see useIsPluginApplicableToCluster.ts) specifically so
+ * that fresh label data reaches it, so tests should go through the real slice too. */
+function setClusters(
+  store: ReturnType<typeof makeStore>,
+  clusters: Record<string, ReturnType<typeof clusterConfig>>
+) {
+  store.dispatch(setConfig({ clusters }));
+}
+
+describe('useIsPluginApplicableToCluster', () => {
+  beforeEach(() => {
+    mockUseSelectedClusters.mockReturnValue(['test-cluster']);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns true for a plugin with no clusterSelector', () => {
+    const store = makeStore();
+    setClusters(store, { 'test-cluster': clusterConfig('test-cluster', { tenant: 'a' }) });
+    store.dispatch(
+      setPluginSettings([
+        {
+          name: 'my-plugin',
+          description: '',
+          homepage: '',
+          headlamp: {},
+        } as any,
+      ])
+    );
+
+    const { result } = renderHook(() => useIsPluginApplicableToCluster('my-plugin'), {
+      wrapper: wrapperFor(store),
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns true when the selector matches the active cluster labels', () => {
+    const store = makeStore();
+    setClusters(store, { 'test-cluster': clusterConfig('test-cluster', { tenant: 'a' }) });
+    store.dispatch(
+      setPluginSettings([
+        {
+          name: 'my-plugin',
+          description: '',
+          homepage: '',
+          headlamp: { clusterSelector: 'tenant=a' },
+        } as any,
+      ])
+    );
+
+    const { result } = renderHook(() => useIsPluginApplicableToCluster('my-plugin'), {
+      wrapper: wrapperFor(store),
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when the selector does not match the active cluster labels', () => {
+    const store = makeStore();
+    setClusters(store, { 'test-cluster': clusterConfig('test-cluster', { tenant: 'a' }) });
+    store.dispatch(
+      setPluginSettings([
+        {
+          name: 'my-plugin',
+          description: '',
+          homepage: '',
+          headlamp: { clusterSelector: 'tenant=b' },
+        } as any,
+      ])
+    );
+
+    const { result } = renderHook(() => useIsPluginApplicableToCluster('my-plugin'), {
+      wrapper: wrapperFor(store),
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true (permissive) when the active cluster has no labels', () => {
+    const store = makeStore();
+    setClusters(store, { 'test-cluster': clusterConfig('test-cluster') });
+    store.dispatch(
+      setPluginSettings([
+        {
+          name: 'my-plugin',
+          description: '',
+          homepage: '',
+          headlamp: { clusterSelector: 'tenant=a' },
+        } as any,
+      ])
+    );
+
+    const { result } = renderHook(() => useIsPluginApplicableToCluster('my-plugin'), {
+      wrapper: wrapperFor(store),
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns true (permissive) when no cluster is selected', () => {
+    mockUseSelectedClusters.mockReturnValue([]);
+
+    const store = makeStore();
+    store.dispatch(
+      setPluginSettings([
+        {
+          name: 'my-plugin',
+          description: '',
+          homepage: '',
+          headlamp: { clusterSelector: 'tenant=a' },
+        } as any,
+      ])
+    );
+
+    const { result } = renderHook(() => useIsPluginApplicableToCluster('my-plugin'), {
+      wrapper: wrapperFor(store),
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns true for a null plugin name (unattributed contribution)', () => {
+    const store = makeStore();
+    setClusters(store, { 'test-cluster': clusterConfig('test-cluster', { tenant: 'a' }) });
+    store.dispatch(
+      setPluginSettings([
+        {
+          name: 'my-plugin',
+          description: '',
+          homepage: '',
+          headlamp: { clusterSelector: 'tenant=b' },
+        } as any,
+      ])
+    );
+
+    const { result } = renderHook(() => useIsPluginApplicableToCluster(null), {
+      wrapper: wrapperFor(store),
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns true for an undefined plugin name', () => {
+    const store = makeStore();
+
+    const { result } = renderHook(() => useIsPluginApplicableToCluster(undefined), {
+      wrapper: wrapperFor(store),
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns true for a plugin name absent from pluginSettings', () => {
+    const store = makeStore();
+
+    const { result } = renderHook(() => useIsPluginApplicableToCluster('unknown-plugin'), {
+      wrapper: wrapperFor(store),
+    });
+
+    expect(result.current).toBe(true);
+  });
+});
+
+describe('usePluginApplicabilityMap', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('maps each plugin to its applicability to the active cluster', () => {
+    mockUseSelectedClusters.mockReturnValue(['test-cluster']);
+    const store = makeStore();
+    setClusters(store, { 'test-cluster': clusterConfig('test-cluster', { tenant: 'a' }) });
+    store.dispatch(
+      setPluginSettings([
+        {
+          name: 'matching-plugin',
+          description: '',
+          homepage: '',
+          headlamp: { clusterSelector: 'tenant=a' },
+        } as any,
+        {
+          name: 'non-matching-plugin',
+          description: '',
+          homepage: '',
+          headlamp: { clusterSelector: 'tenant=b' },
+        } as any,
+        {
+          name: 'unscoped-plugin',
+          description: '',
+          homepage: '',
+        } as any,
+      ])
+    );
+
+    const { result } = renderHook(() => usePluginApplicabilityMap(), {
+      wrapper: wrapperFor(store),
+    });
+
+    expect(result.current.get('matching-plugin')).toBe(true);
+    expect(result.current.get('non-matching-plugin')).toBe(false);
+    expect(result.current.get('unscoped-plugin')).toBe(true);
+  });
+
+  it('ignores an overridden (isLoaded: false) variant of a plugin name', () => {
+    // pluginSettings can hold multiple entries for the same name once
+    // applyPluginPriority runs (dev/user/shipped variants) -- only the loaded one
+    // should determine that plugin's applicability.
+    mockUseSelectedClusters.mockReturnValue(['test-cluster']);
+    const store = makeStore();
+    setClusters(store, { 'test-cluster': clusterConfig('test-cluster', { tenant: 'a' }) });
+    store.dispatch(
+      setPluginSettings([
+        {
+          name: 'my-plugin',
+          description: '',
+          homepage: '',
+          type: 'shipped',
+          isLoaded: false,
+          overriddenBy: 'user',
+          headlamp: { clusterSelector: 'tenant=b' },
+        } as any,
+        {
+          name: 'my-plugin',
+          description: '',
+          homepage: '',
+          type: 'user',
+          isLoaded: true,
+          headlamp: { clusterSelector: 'tenant=a' },
+        } as any,
+      ])
+    );
+
+    const { result } = renderHook(() => usePluginApplicabilityMap(), {
+      wrapper: wrapperFor(store),
+    });
+
+    // Only the loaded ('user') variant's selector should apply; if the overridden
+    // ('shipped') entry were allowed to win, this would be false instead.
+    expect(result.current.get('my-plugin')).toBe(true);
+  });
+
+  describe('multi-cluster (aggregate) pages', () => {
+    beforeEach(() => {
+      mockUseSelectedClusters.mockReturnValue(['cluster-a', 'cluster-b']);
+    });
+
+    it('applies (union) when the selector matches at least one selected cluster', () => {
+      const store = makeStore();
+      setClusters(store, {
+        'cluster-a': clusterConfig('cluster-a', { tenant: 'a' }),
+        'cluster-b': clusterConfig('cluster-b', { tenant: 'b' }),
+      });
+      store.dispatch(
+        setPluginSettings([
+          {
+            name: 'my-plugin',
+            description: '',
+            homepage: '',
+            headlamp: { clusterSelector: 'tenant=a' },
+          } as any,
+        ])
+      );
+
+      const { result } = renderHook(() => usePluginApplicabilityMap(), {
+        wrapper: wrapperFor(store),
+      });
+
+      expect(result.current.get('my-plugin')).toBe(true);
+    });
+
+    it('does not apply when the selector matches neither selected cluster', () => {
+      const store = makeStore();
+      setClusters(store, {
+        'cluster-a': clusterConfig('cluster-a', { tenant: 'a' }),
+        'cluster-b': clusterConfig('cluster-b', { tenant: 'b' }),
+      });
+      store.dispatch(
+        setPluginSettings([
+          {
+            name: 'my-plugin',
+            description: '',
+            homepage: '',
+            headlamp: { clusterSelector: 'tenant=c' },
+          } as any,
+        ])
+      );
+
+      const { result } = renderHook(() => usePluginApplicabilityMap(), {
+        wrapper: wrapperFor(store),
+      });
+
+      expect(result.current.get('my-plugin')).toBe(false);
+    });
+
+    it('applies (permissive) when one selected cluster has no labels, even if the other does not match', () => {
+      const store = makeStore();
+      setClusters(store, {
+        'cluster-a': clusterConfig('cluster-a'), // no labels at all
+        'cluster-b': clusterConfig('cluster-b', { tenant: 'b' }),
+      });
+      store.dispatch(
+        setPluginSettings([
+          {
+            name: 'my-plugin',
+            description: '',
+            homepage: '',
+            headlamp: { clusterSelector: 'tenant=z' },
+          } as any,
+        ])
+      );
+
+      const { result } = renderHook(() => usePluginApplicabilityMap(), {
+        wrapper: wrapperFor(store),
+      });
+
+      // cluster-a has no labels -> permissive match for it -> union is true, even
+      // though cluster-b's labels don't match the selector.
+      expect(result.current.get('my-plugin')).toBe(true);
+    });
+  });
+});
+
+describe('isPluginApplicable', () => {
+  const map = new Map([
+    ['matching-plugin', true],
+    ['non-matching-plugin', false],
+  ]);
+
+  it('returns true for a null plugin name', () => {
+    expect(isPluginApplicable(map, null)).toBe(true);
+  });
+
+  it('returns true for an undefined plugin name', () => {
+    expect(isPluginApplicable(map, undefined)).toBe(true);
+  });
+
+  it('returns true for a plugin name absent from the map', () => {
+    expect(isPluginApplicable(map, 'unknown-plugin')).toBe(true);
+  });
+
+  it('returns true for a plugin mapped to true', () => {
+    expect(isPluginApplicable(map, 'matching-plugin')).toBe(true);
+  });
+
+  it('returns false for a plugin mapped to false', () => {
+    expect(isPluginApplicable(map, 'non-matching-plugin')).toBe(false);
+  });
+});

--- a/frontend/src/plugin/useIsPluginApplicableToCluster.ts
+++ b/frontend/src/plugin/useIsPluginApplicableToCluster.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo } from 'react';
+import { useSelectedClusters } from '../lib/k8s';
+import { useTypedSelector } from '../redux/hooks';
+import { matchesClusterSelector } from './clusterSelector';
+
+type ClusterLabels = Record<string, string> | undefined;
+type LabeledClusterConfig = {
+  meta_data?: { clusterInventory?: { labels?: Record<string, string> } };
+};
+
+/**
+ * Reads Cluster Inventory labels for every currently *selected* cluster (plural: an
+ * aggregate/multi-cluster URL like `/c/a+b/...` can have more than one).
+ *
+ * Reads `state.config.clusters`/`statelessClusters` directly rather than going through
+ * `useClustersConf()`, which memoizes its return value only on the set of cluster-name
+ * keys (see `lib/k8s/index.ts`). A ClusterProfile's labels can change without any cluster
+ * being added or removed — Layout.tsx polls and dispatches fresh config on an interval —
+ * so that memo would keep returning the old labels for an existing cluster until some
+ * unrelated change (or a reload) happened to bust it. Selecting the raw slices here
+ * instead means this hook naturally re-renders whenever Redux actually gets new data for
+ * a selected cluster.
+ *
+ * `allClusters` is deliberately not consulted: nothing in the app ever dispatches into it
+ * (only `setConfig`/`setStatelessConfig` exist, writing `clusters`/`statelessClusters`
+ * respectively), so it is always empty in practice.
+ *
+ * Only clusters discovered via Cluster Inventory (ClusterProfile CRDs) carry labels
+ * today — manually-added kubeconfig clusters have no ClusterProfile to source them from,
+ * so this returns `undefined` for those, which `matchesClusterSelector` treats
+ * permissively (always matches).
+ */
+function useSelectedClusterLabelSets(): ClusterLabels[] {
+  const selectedClusters = useSelectedClusters();
+  const clusters = useTypedSelector(state => state.config.clusters);
+  const statelessClusters = useTypedSelector(state => state.config.statelessClusters);
+
+  return useMemo(
+    () =>
+      selectedClusters.map(clusterName => {
+        const clusterConf = (statelessClusters?.[clusterName] ?? clusters?.[clusterName]) as
+          | LabeledClusterConfig
+          | undefined;
+
+        return clusterConf?.meta_data?.clusterInventory?.labels;
+      }),
+    // selectedClusters is re-derived (and can get a new array identity) on every render
+    // that doesn't actually change which clusters are selected; join() keeps the memo
+    // keyed on the clusters themselves rather than that array's identity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedClusters.join(','), clusters, statelessClusters]
+  );
+}
+
+/**
+ * Computes, for every known plugin, whether it applies to the currently selected
+ * cluster(s).
+ *
+ * Reads all plugin `clusterSelector`s and the selected clusters' labels once, rather than
+ * once per contribution — sidebar entries, routes, appbar actions, and table column
+ * processors are rendered from arrays, and React hooks can't be called per-item inside a
+ * loop. Consumption points should use this (or {@link useIsPluginApplicableToCluster} for
+ * a single plugin) instead of evaluating `clusterSelector` themselves.
+ *
+ * Multi-cluster (aggregate) pages use union semantics: a plugin applies if its selector
+ * matches *any* selected cluster. This matches the rest of the feature's permissive
+ * defaults (no selector, or an unlabeled cluster, both always match) — an aggregate view
+ * mixing matching and non-matching clusters still shows the plugin, rather than requiring
+ * every selected cluster to match and surprising a plugin author whose selector matches
+ * the cluster they actually care about. The tradeoff: on an aggregate page, a table
+ * column processor gated to cluster A still runs over the whole table, including rows
+ * from non-matching cluster B — union chooses to show potentially-irrelevant processing
+ * over hiding a plugin the user does want on the page.
+ *
+ * @returns A map of plugin name to whether it applies to the selected cluster(s). A
+ *          plugin absent from the map (e.g. an unattributed contribution's `null` plugin
+ *          name) should be treated as applicable — see {@link useIsPluginApplicableToCluster}.
+ */
+export function usePluginApplicabilityMap(): Map<string, boolean> {
+  // Optional chaining: some test and Storybook stores preload only the slices a given
+  // story touches, so `plugins`/`pluginSettings` may be absent there even though the real
+  // app store always has them (see pluginsSlice's initialState). Left as `undefined`
+  // (rather than defaulted here) to keep this selector's return value referentially
+  // stable across renders; the fallback is applied inside the memo below instead.
+  const pluginSettings = useTypedSelector(state => state.plugins?.pluginSettings);
+  const labelSets = useSelectedClusterLabelSets();
+
+  return useMemo(() => {
+    const map = new Map<string, boolean>();
+    for (const plugin of pluginSettings ?? []) {
+      // pluginSettings can hold multiple entries for the same name (dev/user/shipped
+      // variants) once applyPluginPriority runs; only the one it picked (isLoaded !==
+      // false) actually executes, so an overridden variant's clusterSelector must not
+      // overwrite the loaded one's entry in the map.
+      if (plugin.isLoaded === false) {
+        continue;
+      }
+
+      const selector = plugin.headlamp?.clusterSelector;
+      // No selected cluster at all (e.g. a cluster-agnostic page): fall through to
+      // matchesClusterSelector's own no-labels permissive default, same as any other
+      // "we don't know this cluster's labels" case.
+      const applies =
+        labelSets.length === 0
+          ? matchesClusterSelector(selector, undefined)
+          : labelSets.some(labels => matchesClusterSelector(selector, labels));
+
+      map.set(plugin.name, applies);
+    }
+    return map;
+  }, [pluginSettings, labelSets]);
+}
+
+/**
+ * Whether a plugin's UI contributions should be shown on the active cluster, given a
+ * `usePluginApplicabilityMap()` result.
+ *
+ * Plain function (not a hook) so it's safe to call once per item inside `.filter()`/
+ * `.map()` over a list of contributions (sidebar entries, routes, appbar actions, table
+ * column processors) — computing the applicability map is the hook call, done once per
+ * render; checking an individual contribution against it is not.
+ *
+ * Returns `true` (show it) when:
+ * - `pluginName` is `null`/`undefined` — an unattributed contribution (e.g. registered
+ *   outside a plugin's synchronous load, or by the deprecated `Registry` class) is shown
+ *   rather than hidden, since there is no plugin config to gate it by.
+ * - The plugin has no `clusterSelector`, or the active cluster has no labels available —
+ *   see {@link matchesClusterSelector} for the exact permissive rules.
+ * - `pluginName` doesn't match any known plugin (defensive default).
+ *
+ * @param applicabilityMap - Result of {@link usePluginApplicabilityMap}.
+ * @param pluginName - The contribution's `plugin` field.
+ */
+export function isPluginApplicable(
+  applicabilityMap: Map<string, boolean>,
+  pluginName: string | null | undefined
+): boolean {
+  if (!pluginName) {
+    return true;
+  }
+
+  return applicabilityMap.get(pluginName) ?? true;
+}
+
+/**
+ * Whether a single, statically-known plugin's UI contributions should be shown on the
+ * active cluster, per its `headlamp.clusterSelector` manifest field.
+ *
+ * For a contribution list rendered in a loop, use {@link usePluginApplicabilityMap} +
+ * {@link isPluginApplicable} instead — calling this hook once per item in a loop would
+ * violate the rules of hooks (and needlessly recompute the map each time).
+ *
+ * @param pluginName - The plugin's package name, or `null`/`undefined`.
+ */
+export function useIsPluginApplicableToCluster(pluginName: string | null | undefined): boolean {
+  const applicabilityMap = usePluginApplicabilityMap();
+
+  return isPluginApplicable(applicabilityMap, pluginName);
+}

--- a/frontend/src/redux/actionButtonsSlice.ts
+++ b/frontend/src/redux/actionButtonsSlice.ts
@@ -39,6 +39,11 @@ export type RowAction = {
 export type AppBarAction = {
   id: string;
   action?: AppBarActionType;
+  /**
+   * Name of the plugin that registered this action, set automatically by
+   * `registerAppBarAction`. `null`/`undefined` for actions not attributed to a plugin.
+   */
+  plugin?: string | null;
 };
 
 export enum DefaultHeaderAction {
@@ -80,6 +85,11 @@ export type AppBarActionProcessorType = (info: AppBarActionsProcessorArgs) => Ap
 export type AppBarActionsProcessor = {
   id: string;
   processor: AppBarActionProcessorType;
+  /**
+   * Name of the plugin that registered this processor, set automatically by
+   * `registerAppBarAction`. `null`/`undefined` for processors not attributed to a plugin.
+   */
+  plugin?: string | null;
 };
 
 export interface HeaderActionState {


### PR DESCRIPTION
## What this PR does

Adds per-cluster plugin scoping via an optional `clusterSelector` field in the plugin manifest. Plugins can declare which clusters they apply to using label-selector syntax:

```json
{
  "headlamp": {
    "clusterSelector": "tenant=a,has-velero=true"
  }
}
```

The framework evaluates this against the active cluster's labels at render time and suppresses the plugin's UI contributions on non-matching clusters. Plugins without `clusterSelector` behave exactly as today — no breaking changes.

Resolves #7525

## How it works

**Plugin attribution** — a module-level `currentPluginName` is set during each plugin's synchronous load. Every `register*` call (sidebar entries, routes, appbar actions, resource table column processors) stamps the owning plugin's name on the dispatched payload. Anti-spoofing: the stamp is applied after the user-provided field spread, so a plugin cannot claim another plugin's name.

Known limitation: this only attributes registrations made during a plugin's synchronous top-level load (the normal case for existing plugins). A `register*` call made from an async callback after load, or from the deprecated `Registry` class's `initialize()` path, is left unattributed (`plugin: null`) and is therefore always shown — permissive rather than silently hidden.

**Cluster label forwarding** — `clusterInventoryMetadataFromProfile` now copies `cp.Labels` into `inventorymetadata.Metadata`, following the existing `Conditions`/`Properties` pattern. Labels arrive on the frontend at `cluster.meta_data.clusterInventory.labels` with no new endpoint.

**Selector matching + render gating** — an equality-only label matcher evaluates the plugin's `clusterSelector` against the active cluster's labels. `usePluginApplicabilityMap()` builds a batch lookup consumed at four render-gating points: sidebar entries, routes, appbar actions, and resource table column processors.

Detail view sections, header actions, and glances already receive a `KubeObject` (`resource`/`node.kubeObject`) carrying `.cluster` and can self-gate without framework changes. Map sources (`registerMapSource`) are hook-based (`useData()`), so they can call `useCluster()`/`useSelectedClusters()` themselves — also self-gateable, just via a different mechanism.

**Permissive default** — a cluster with no labels (manually added via kubeconfig, no ClusterProfile) always matches. This avoids breaking existing setups where cluster inventory isn't used.

## What's NOT changed

- Plugin loading — plugins still load once at app init, no dynamic loading/unloading
- Backend plugin serving — stays flat/filesystem-based
- `register*` function signatures — unchanged for plugin authors
- Existing plugins — zero breaking changes

## Testing

Unit tests cover all new pieces: plugin attribution + anti-spoofing, the selector matcher, the applicability hook, and backend label forwarding + DeepCopy independence.

Fixing regressions the new code caused in the existing suite required two changes: `ResourceTable.test.tsx` got a mock for the new hook module (its existing `lib/k8s` mock didn't cover `useCluster`/`useClustersConf`), and `usePluginApplicabilityMap` was made defensive against a missing `pluginSettings` slice, since several Storybook mock stores don't preload it.

If you run the full frontend suite, you may see unrelated failures in `GraphSources.test.tsx` / `GraphView > HungSourceRepro` and a handful of timeouts (`SettingsCluster`, `EditorDialog`, `LogsButton`, `ColorPicker`) — confirmed pre-existing by running the same tests against a clean `main` checkout; unrelated to this branch.

Not yet validated end-to-end in a running Headlamp instance with a real plugin and real ClusterProfile labels — happy to do that if helpful during review.