### PR TITLE
frontend: HPA: Label replicas by the actual scale target kind

### DIFF
--- a/frontend/src/components/horizontalPodAutoscaler/Details.test.tsx
+++ b/frontend/src/components/horizontalPodAutoscaler/Details.test.tsx
@@ -43,12 +43,34 @@ vi.mock('../common/Resource', () => ({
   ConditionsSection: () => null,
 }));
 
+// Interpolates {{ placeholders }} like real i18next, so tests can assert on
+// the substituted value rather than just the raw translation key.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, any>) => {
+      const resolved = opts
+        ? Object.entries(opts).reduce(
+            (str, [name, value]) => str.replaceAll(`{{ ${name} }}`, String(value)),
+            key
+          )
+        : key;
+      return resolved.split('|').pop() ?? resolved;
+    },
+  }),
+}));
+
 const hpa = {
   referenceObject: { kind: 'Deployment', metadata: { name: 'web' } },
   metrics: () => [{ definition: 'cpu', value: '50%/80%' }],
-  spec: { minReplicas: 1, maxReplicas: 5 },
+  spec: { minReplicas: 1, maxReplicas: 5, scaleTargetRef: { kind: 'Deployment', name: 'web' } },
   status: { currentReplicas: 2, desiredReplicas: 3, lastScaleTime: undefined },
   jsonData: {},
+} as any;
+
+const statefulSetHpa = {
+  ...hpa,
+  referenceObject: { kind: 'StatefulSet', metadata: { name: 'db' } },
+  spec: { ...hpa.spec, scaleTargetRef: { kind: 'StatefulSet', name: 'db' } },
 } as any;
 
 describe('HpaDetails', () => {
@@ -78,9 +100,7 @@ describe('HpaDetails', () => {
     );
 
     const props = mockDetailsGrid.mock.calls[0][0];
-    const byName = Object.fromEntries(
-      props.extraInfo(hpa).map((f: any) => [String(f.name).split('|').pop(), f.value])
-    );
+    const byName = Object.fromEntries(props.extraInfo(hpa).map((f: any) => [f.name, f.value]));
 
     expect(byName['MinReplicas']).toBe(1);
     expect(byName['MaxReplicas']).toBe(5);
@@ -96,5 +116,20 @@ describe('HpaDetails', () => {
     const props = mockDetailsGrid.mock.calls[0][0];
     const lastScale = props.extraInfo(hpa).find((f: any) => f.name.includes('Last Scale Time'));
     expect(lastScale.hide).toBe(true);
+  });
+
+  it('labels the pods row with the scale target kind', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'my-hpa' }}>
+        <HpaDetails />
+      </TestContext>
+    );
+
+    const props = mockDetailsGrid.mock.calls[0][0];
+
+    expect(props.extraInfo(hpa).some((f: any) => f.name === 'Deployment pods')).toBe(true);
+    expect(props.extraInfo(statefulSetHpa).some((f: any) => f.name === 'StatefulSet pods')).toBe(
+      true
+    );
   });
 });

--- a/frontend/src/components/horizontalPodAutoscaler/Details.tsx
+++ b/frontend/src/components/horizontalPodAutoscaler/Details.tsx
@@ -66,7 +66,9 @@ export default function HpaDetails(props: { name?: string; namespace?: string; c
             value: item.spec.maxReplicas,
           },
           {
-            name: t('translation|Deployment pods'),
+            name: t('translation|{{ kind }} pods', {
+              kind: item.spec.scaleTargetRef?.kind ?? 'Deployment',
+            }),
             value: t(`translation|{{ currentReplicas }} current / {{ desiredReplicas }} desired`, {
               currentReplicas: item.status.currentReplicas,
               desiredReplicas: item.status.desiredReplicas,

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -756,7 +756,7 @@
   "(Current/Target)": "(الحالي/المستهدف)",
   "MinReplicas": "الحد الأدنى للنسخ",
   "MaxReplicas": "الحد الأقصى للنسخ",
-  "Deployment pods": "Pods النشر",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "{{ currentReplicas }} الحالي / {{ desiredReplicas }} المطلوب",
   "Last Scale Time": "",
   "Targets": "الأهداف",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -736,7 +736,7 @@
   "(Current/Target)": "(বর্তমান/লক্ষ্য)",
   "MinReplicas": "মিন্রিপ্লিকাস",
   "MaxReplicas": "ম্যাক্সরেপ্লিকাস",
-  "Deployment pods": "Deployment pod",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "{{ currentReplicas }} বর্তমান / {{ desiredReplicas }} কাঙ্ক্ষিত",
   "Last Scale Time": "সর্বশেষ Scale সময়",
   "Targets": "লক্ষ্য",

--- a/frontend/src/i18n/locales/cs/translation.json
+++ b/frontend/src/i18n/locales/cs/translation.json
@@ -746,7 +746,7 @@
   "(Current/Target)": "(Aktuální/cíl)",
   "MinReplicas": "MinReplicas",
   "MaxReplicas": "MaxReplicas",
-  "Deployment pods": "Pody nasazení",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "aktuální: {{ currentReplicas }} / požadováno: {{ desiredReplicas }}",
   "Last Scale Time": "",
   "Targets": "Cíle",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -736,7 +736,7 @@
   "(Current/Target)": "(Aktuell/Ziel)",
   "MinReplicas": "MinReplikas",
   "MaxReplicas": "MaxReplikas",
-  "Deployment pods": "Deployment-Pods",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "{{ currentReplicas }} momentan / {{ desiredReplicas }} gewünscht",
   "Last Scale Time": "",
   "Targets": "Ziele",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -736,7 +736,7 @@
   "(Current/Target)": "(Current/Target)",
   "MinReplicas": "MinReplicas",
   "MaxReplicas": "MaxReplicas",
-  "Deployment pods": "Deployment pods",
+  "{{ kind }} pods": "{{ kind }} pods",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "{{ currentReplicas }} current / {{ desiredReplicas }} desired",
   "Last Scale Time": "Last Scale Time",
   "Targets": "Targets",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -741,7 +741,7 @@
   "(Current/Target)": "(Actual/Objetivo)",
   "MinReplicas": "MinReplicas",
   "MaxReplicas": "MaxReplicas",
-  "Deployment pods": "Pods de despliegue",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "{{ currentReplicas }} actuales / {{ desiredReplicas }} deseados",
   "Last Scale Time": "",
   "Targets": "Objetivos",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -741,7 +741,7 @@
   "(Current/Target)": "(Actuel/Cible)",
   "MinReplicas": "MinRéplicas",
   "MaxReplicas": "MaxRéplicas",
-  "Deployment pods": "Pods de déploiement",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "{{ currentReplicas }} actuel / {{ desiredReplicas }} souhaité",
   "Last Scale Time": "",
   "Targets": "Cibles",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -741,7 +741,7 @@
   "(Current/Target)": "(Current/Target)",
   "MinReplicas": "MinReplicas",
   "MaxReplicas": "MaxReplicas",
-  "Deployment pods": "Deployment pods",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "{{ currentReplicas }} current / {{ desiredReplicas }} desired",
   "Last Scale Time": "",
   "Targets": "Targets",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -736,7 +736,7 @@
   "(Current/Target)": "",
   "MinReplicas": "",
   "MaxReplicas": "",
-  "Deployment pods": "",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "",
   "Last Scale Time": "",
   "Targets": "",

--- a/frontend/src/i18n/locales/hu/translation.json
+++ b/frontend/src/i18n/locales/hu/translation.json
@@ -736,7 +736,7 @@
   "(Current/Target)": "(Aktuális/Cél)",
   "MinReplicas": "MinReplicas",
   "MaxReplicas": "MaxReplicas",
-  "Deployment pods": "Üzembe helyezési podok",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "{{ currentReplicas }} aktuális/{{ desiredReplicas }} kívánt",
   "Last Scale Time": "",
   "Targets": "Tárolók",

--- a/frontend/src/i18n/locales/id/translation.json
+++ b/frontend/src/i18n/locales/id/translation.json
@@ -731,7 +731,7 @@
   "(Current/Target)": "(Saat ini/Target)",
   "MinReplicas": "MinReplicas",
   "MaxReplicas": "MaxReplicas",
-  "Deployment pods": "Pod penyebaran",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "{{ currentReplicas }} saat ini / {{ desiredReplicas }} diinginkan",
   "Last Scale Time": "",
   "Targets": "Target",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -741,7 +741,7 @@
   "(Current/Target)": "(Attuale/Obiettivo)",
   "MinReplicas": "Repliche Minime",
   "MaxReplicas": "Repliche Massime",
-  "Deployment pods": "Pod di distribuzione",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "{{ currentReplicas }} attuali / {{ desiredReplicas }} desiderate",
   "Last Scale Time": "",
   "Targets": "Obiettivi",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -731,7 +731,7 @@
   "(Current/Target)": "(現在/ターゲット)",
   "MinReplicas": "最小レプリカ",
   "MaxReplicas": "最大レプリカ",
-  "Deployment pods": "デプロイメントポッド",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "{{ currentReplicas }} 現在 / {{ desiredReplicas }} 希望",
   "Last Scale Time": "",
   "Targets": "ターゲット",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -731,7 +731,7 @@
   "(Current/Target)": "(현재/목표)",
   "MinReplicas": "최소 레플리카",
   "MaxReplicas": "최대 레플리카",
-  "Deployment pods": "배포된 포드",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "{{ currentReplicas }} 현재 / {{ desiredReplicas }} 원하는",
   "Last Scale Time": "",
   "Targets": "대상",

--- a/frontend/src/i18n/locales/nl/translation.json
+++ b/frontend/src/i18n/locales/nl/translation.json
@@ -736,7 +736,7 @@
   "(Current/Target)": "(Huidig/doel)",
   "MinReplicas": "MinReplicas",
   "MaxReplicas": "MaxReplicas",
-  "Deployment pods": "Implementatiepods",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "{{ currentReplicas }} huidig/{{ desiredReplicas }} gewenst",
   "Last Scale Time": "",
   "Targets": "Doelen",

--- a/frontend/src/i18n/locales/pl/translation.json
+++ b/frontend/src/i18n/locales/pl/translation.json
@@ -746,7 +746,7 @@
   "(Current/Target)": "Bieżąca wartość docelowa",
   "MinReplicas": "MinReplicas",
   "MaxReplicas": "MaxReplicas",
-  "Deployment pods": "Zasobniki wdrożenia",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "{{ currentReplicas }} bieżące/ {{ desiredReplicas }} żądane",
   "Last Scale Time": "",
   "Targets": "Miejsca docelowe",

--- a/frontend/src/i18n/locales/pt-br/translation.json
+++ b/frontend/src/i18n/locales/pt-br/translation.json
@@ -741,7 +741,7 @@
   "(Current/Target)": "(Actual/Objectivo)",
   "MinReplicas": "Mín. Réplicas",
   "MaxReplicas": "Máx. Réplicas",
-  "Deployment pods": "Pods de Deployment",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "{{ currentReplicas }} actual / {{ desiredReplicas }} desejadas",
   "Last Scale Time": "",
   "Targets": "Objectivos",

--- a/frontend/src/i18n/locales/pt-pt/translation.json
+++ b/frontend/src/i18n/locales/pt-pt/translation.json
@@ -741,7 +741,7 @@
   "(Current/Target)": "",
   "MinReplicas": "",
   "MaxReplicas": "",
-  "Deployment pods": "",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "",
   "Last Scale Time": "",
   "Targets": "",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -746,7 +746,7 @@
   "(Current/Target)": "(Текущий/Цель)",
   "MinReplicas": "MinReplicas",
   "MaxReplicas": "MaxReplicas",
-  "Deployment pods": "Поды Deployment",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "{{ currentReplicas }} текущих / {{ desiredReplicas }} желаемых",
   "Last Scale Time": "",
   "Targets": "Цели",

--- a/frontend/src/i18n/locales/sv/translation.json
+++ b/frontend/src/i18n/locales/sv/translation.json
@@ -736,7 +736,7 @@
   "(Current/Target)": "(Aktuellt/mål)",
   "MinReplicas": "MinReplicas",
   "MaxReplicas": "MaxReplicas",
-  "Deployment pods": "Distributionspoddar",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "{{ currentReplicas }} nuvarande/{{ desiredReplicas }} önskad",
   "Last Scale Time": "",
   "Targets": "Mål",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -736,7 +736,7 @@
   "(Current/Target)": "(தற்போதைய/டார்கெட்)",
   "MinReplicas": "மினிமம் ரெப்லிக்காக்கள்",
   "MaxReplicas": "மாக்ஸிமம் ரெப்லிக்காக்கள்",
-  "Deployment pods": "டிப்ளாய்மென்ட் பாட்கள்",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "{{ currentReplicas }} தற்போதைய / {{ desiredReplicas }} விரும்பியவை",
   "Last Scale Time": "",
   "Targets": "டார்கெட்கள்",

--- a/frontend/src/i18n/locales/tr/translation.json
+++ b/frontend/src/i18n/locales/tr/translation.json
@@ -736,7 +736,7 @@
   "(Current/Target)": "(Geçerli/Hedef)",
   "MinReplicas": "MinReplicas",
   "MaxReplicas": "MaxReplicas",
-  "Deployment pods": "Dağıtım podları",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "{{ currentReplicas }} mevcut / {{ desiredReplicas }} istenen",
   "Last Scale Time": "",
   "Targets": "Hedefler",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -736,7 +736,7 @@
   "(Current/Target)": "(موجودہ/ہدف)",
   "MinReplicas": "کم از کم ریپلیکاز",
   "MaxReplicas": "زیادہ سے زیادہ ریپلیکاز",
-  "Deployment pods": "ڈیپلائمنٹ پوڈز",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "{{ currentReplicas }} موجودہ / {{ desiredReplicas }} مطلوبہ",
   "Last Scale Time": "",
   "Targets": "اہداف",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -731,7 +731,7 @@
   "(Current/Target)": "（當前/目標）",
   "MinReplicas": "最小副本",
   "MaxReplicas": "最大副本",
-  "Deployment pods": "部署 pod",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "{{ currentReplicas }} 當前 / {{ desiredReplicas }} 期望",
   "Last Scale Time": "",
   "Targets": "目標",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -731,7 +731,7 @@
   "(Current/Target)": "（当前/目标）",
   "MinReplicas": "最小副本",
   "MaxReplicas": "最大副本",
-  "Deployment pods": "部署 pod",
+  "{{ kind }} pods": "",
   "{{ currentReplicas }} current / {{ desiredReplicas }} desired": "{{ currentReplicas }} 当前 / {{ desiredReplicas }} 期望",
   "Last Scale Time": "",
   "Targets": "目标",


### PR DESCRIPTION
## Summary

Fixes the HPA details page so the replica-count row is labeled by what the HPA is actually scaling, instead of always saying "Deployment pods".

## Related Issue

Closes #7544

## Changes

`spec.scaleTargetRef.kind` can be `Deployment`, `StatefulSet`, `ReplicaSet`, or a custom CRD — but the label was hardcoded:

```tsx
name: t('translation|Deployment pods'),
```

so an HPA scaling a StatefulSet still showed "Deployment pods: 2 current / 3 desired". Fixed by deriving the label from the actual scale target:

```tsx
name: t('translation|{{ kind }} pods', {
  kind: item.spec.scaleTargetRef?.kind ?? 'Deployment',
}),
```

(kept the `?? 'Deployment'` fallback since `referenceObject` elsewhere in this same file is accessed with optional chaining too, and it preserves prior behavior for the degenerate case where `scaleTargetRef` is somehow missing.)

## Steps to Test

1. `cd frontend && npx vitest run src/components/horizontalPodAutoscaler/Details.test.tsx` — added a test asserting the label is `"Deployment pods"` for a Deployment-scaling HPA and `"StatefulSet pods"` for a StatefulSet-scaling one; confirmed it fails on `main` and passes with the fix.
2. Manually: open the details page of an HPA whose `scaleTargetRef.kind` is `StatefulSet`, confirm the row reads "StatefulSet pods".

Ran `npx vitest run src/storybook.test.tsx -t "hpa/HpaDetailsView"` — passes; that story's fixture targets a Deployment, so no snapshot change.

## Notes for the Reviewer

Since the underlying English string genuinely changed (`"Deployment pods"` → `"{{ kind }} pods"`, not just a new key added alongside the old one), `npm run i18n` correctly reset the existing human translations for this string in other locales (German, French, Japanese, etc.) back to untranslated — those old translations were specific to "Deployment pods" and can't correctly express the new dynamic kind, so this is expected and unavoidable, not something I could preserve.

Confirmed no open issue or PR covers this before filing #7544.
