### PR TITLE
frontend: SettingsCluster: Translate the loading indicator

### DIFF
--- a/frontend/src/components/App/Settings/SettingsCluster.test.tsx
+++ b/frontend/src/components/App/Settings/SettingsCluster.test.tsx
@@ -15,9 +15,10 @@
  */
 
 import { ThemeProvider } from '@mui/material/styles';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from '../../../i18n/config';
 import { createMuiTheme } from '../../../lib/themes';
 import { TestContext } from '../../../test';
 import SettingsCluster from './SettingsCluster';
@@ -207,6 +208,14 @@ describe('SettingsCluster states and namespaces', () => {
     };
   });
 
+  // Reset the app's shared i18n instance back to English in case a test
+  // below switched languages, so later tests aren't affected. Wrapped in
+  // act() since the still-mounted component from the test re-renders when
+  // the language changes.
+  afterEach(async () => {
+    await act(() => i18n.changeLanguage('en'));
+  });
+
   it('selects the first cluster when the query is missing', () => {
     renderSettings({}, { queryCluster: null });
     expect(
@@ -219,6 +228,16 @@ describe('SettingsCluster states and namespaces', () => {
     mockState.clustersConf = {};
     renderSettings({}, { dark: true });
     expect(screen.getByText(/no clusters configured/i)).toBeInTheDocument();
+  });
+
+  it('shows a translated loading indicator while there is no cluster in the URL', async () => {
+    mockState.activeCluster = null;
+    mockState.clustersConf = {};
+
+    await i18n.changeLanguage('fr');
+    renderSettings({}, { queryCluster: null });
+
+    expect(screen.getByRole('progressbar', { name: 'Chargement' })).toBeInTheDocument();
   });
 
   it('shows an invalid-cluster message', () => {

--- a/frontend/src/components/App/Settings/SettingsCluster.tsx
+++ b/frontend/src/components/App/Settings/SettingsCluster.tsx
@@ -203,7 +203,7 @@ export default function SettingsCluster() {
 
   // If we don't have yet a cluster name from the URL, we are still loading.
   if (!clusterFromUrl) {
-    return <Loader title="Loading" />;
+    return <Loader title={t('Loading')} />;
   }
 
   if (clusters.length === 0) {


### PR DESCRIPTION
## Summary

Wraps `SettingsCluster`'s loading-state string in `t()` to match the three other identical call sites in the codebase.

## Related Issue

Closes #7552

## Changes

```tsx
if (!clusterFromUrl) {
  return <Loader title="Loading" />;
}
```

`AdvancedSearch.tsx`, `AllowedNamespacesSelectorGate.tsx`, and `ProjectDetails.tsx` (x2) all already use `Loader title={t('Loading')}` for the exact same purpose — this one call site was left as a plain string, so it doesn't translate while its siblings do.

```tsx
if (!clusterFromUrl) {
  return <Loader title={t('Loading')} />;
}
```

## Steps to Test

1. `cd frontend && npx vitest run src/components/App/Settings/SettingsCluster.test.tsx` — this branch had zero test coverage before; added a test that renders with no cluster in the URL. The test switches the app's real i18n instance to French and asserts the loading indicator's accessible name is `'Chargement'`, not the English string — an English-only assertion can't actually prove `t()` is being called, since without a real i18n instance `t('Loading')` and a hardcoded `"Loading"` render identically (caught in review). Confirmed this fails against the original hard-coded string and passes with `t('Loading')`.
2. `npx vitest run src/storybook.test.tsx -t "SettingsCluster"` — passes, no snapshot changes (none of the existing stories exercise this branch).
3. `npx vitest run --exclude "**/storybook.test.tsx"` — full unit suite (241 files / 2454 tests) passes, confirming the language switch in this test doesn't leak into any other test file.
4. Manually: switch language away from English, hit a moment where this loading state shows.

## Notes for the Reviewer

The `"Loading"` translation key already exists (used by the three other call sites), so `npm run i18n` produces no locale-file changes for this fix — confirmed with `--fail-on-update`. Confirmed no open issue or PR covers this before filing #7552.
