### PR TITLE
app: electron: Deflake VM detection worker-failure test

### DIFF
--- a/app/electron/hardwareAcceleration.test.ts
+++ b/app/electron/hardwareAcceleration.test.ts
@@ -87,7 +87,11 @@ describe('startWindowsVMDetection', () => {
       })
     );
 
-    expect(waitForWindowsVMDetection(detection)).toBe(false);
+    // Wait generously for the worker's signal: bootstrapping a worker thread
+    // can take longer than the 1s production default on slow CI runners, and
+    // this assertion needs the signal itself, not the bounded-wait fallback.
+    // A failed detection must still not be reported as a virtual machine.
+    expect(waitForWindowsVMDetection(detection, 15_000)).toBe(false);
     expect(Atomics.load(detection!.state, 0)).not.toBe(0);
   });
 });


### PR DESCRIPTION
## What this PR does

Deflakes `electron/hardwareAcceleration.test.ts > startWindowsVMDetection > signals failure when the registry executable is unavailable`, which fails intermittently on the Windows CI runners (seen on both `windows-2022` x64 and `windows-11-arm`):

```
AssertionError: expected +0 not to be +0 // Object.is equality
 ❯ electron/hardwareAcceleration.test.ts:91:51
```

The test spawns a real worker thread and waited for its signal with the production default bound of 1s (`waitForWindowsVMDetection`'s `Atomics.wait`). Bootstrapping a Node worker thread plus the failing `execFileSync` can take longer than that on a slow runner, so the shared state was still `DETECTION_PENDING` (0) when the test asserted the worker had signaled — the failed run took 1025ms, exactly the bounded wait expiring.

The fix passes an explicit generous timeout (15s) so the test waits for the signal itself. `Atomics.wait` wakes as soon as the worker notifies, so the test stays fast on healthy machines (~100ms locally). Production behavior is untouched — skipping detection after 1s at startup is intentional there.

## Testing

`npx vitest run electron/hardwareAcceleration.test.ts` — all 8 tests pass.
