### PR TITLE
backend: Add OIDC auth URL parameters flag

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1112,12 +1112,23 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 
 		var authURL string
 
+		var authOptions []oauth2.AuthCodeOption
+
 		if config.OidcUsePKCE {
 			entry.CodeVerifier = oauth2.GenerateVerifier()
-			authURL = oauthConfig.AuthCodeURL(state, oauth2.S256ChallengeOption(entry.CodeVerifier))
-		} else {
-			authURL = oauthConfig.AuthCodeURL(state)
+			authOptions = append(authOptions, oauth2.S256ChallengeOption(entry.CodeVerifier))
 		}
+
+		if config.OidcAuthURLParameters != "" {
+			for _, param := range strings.Split(config.OidcAuthURLParameters, ",") {
+				parts := strings.SplitN(param, "=", 2)
+				if len(parts) == 2 {
+					authOptions = append(authOptions, oauth2.SetAuthURLParam(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])))
+				}
+			}
+		}
+
+		authURL = oauthConfig.AuthCodeURL(state, authOptions...)
 
 		// Store the request config keyed by state for callback handling
 		oauthMu.Lock()

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -218,6 +218,7 @@ func createHeadlampConfig(conf *config.Config) *HeadlampConfig {
 		OidcSkipTLSVerify:         conf.OidcSkipTLSVerify,
 		OidcUseAccessToken:        conf.OidcUseAccessToken,
 		OidcUsePKCE:               conf.OidcUsePKCE,
+		OidcAuthURLParameters:     conf.OidcAuthURLParameters,
 		MeUsernamePaths:           conf.MeUsernamePath,
 		MeEmailPaths:              conf.MeEmailPath,
 		MeGroupsPaths:             conf.MeGroupsPath,

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -90,6 +90,7 @@ type Config struct {
 	MeGroupsPath                 string `koanf:"me-groups-path"`
 	MeUserInfoURL                string `koanf:"me-user-info-url"`
 	OidcUsePKCE                  bool   `koanf:"oidc-use-pkce"`
+	OidcAuthURLParameters        string `koanf:"oidc-auth-url-param"`
 	ProxyAuthEnabled             bool   `koanf:"proxy-auth"`
 	ProxyAuthUsernameHeader      string `koanf:"proxy-auth-username-header"`
 	ProxyAuthGroupHeader         string `koanf:"proxy-auth-group-header"`
@@ -666,6 +667,8 @@ func addOIDCFlags(f *flag.FlagSet) {
 	f.Bool("oidc-use-access-token", false, "Setup oidc to pass through the access_token instead of the default id_token")
 	f.Bool("oidc-use-cookie", false, "Enable OIDC cookie usage even when not running in-cluster")
 	f.Bool("oidc-use-pkce", false, "Use PKCE (Proof Key for Code Exchange) for enhanced security in OIDC flow")
+	f.String("oidc-auth-url-param", "",
+		"Comma separated list of extra query parameters to send with the OIDC authorization request (format: key=value,key2=value2)")
 	f.String("me-username-path", DefaultMeUsernamePath,
 		"Comma separated JMESPath expressions used to read username from the JWT payload")
 	f.String("me-email-path", DefaultMeEmailPath,

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -29,6 +29,7 @@ type HeadlampConfig struct {
 	OidcSkipTLSVerify         bool
 	OidcCACert                string
 	OidcUsePKCE               bool
+	OidcAuthURLParameters     string
 	OidcScopes                []string
 	Cache                     cache.Cache[interface{}]
 	Multiplexer               WebSocketMultiplexer


### PR DESCRIPTION
This adds a generic `-oidc-auth-url-param` flag that accepts a comma-separated list of key=value pairs to supply extra query parameters (like `access_type=offline` and `prompt=consent`) to the OIDC authorization request.

This fixes the issue where Google OIDC requires specific parameters to provide a refresh token without hardcoding Google-specific flags into the binary.

## Summary

This PR adds a new backend configuration flag `-oidc-auth-url-param` to allow passing arbitrary extra query parameters to the OIDC authorization endpoint, without hardcoding provider-specific parameters into Headlamp.

## Related Issue

Fixes #7558

## Changes

- Added `-oidc-auth-url-param` flag definition as a string in `pkg/config/config.go`.
- Added `OidcAuthURLParameters` field to `headlampconfig.HeadlampConfig`.
- Updated `createHeadlampConfig` in `cmd/server.go` to map the parsed flag.
- Updated `OauthLogin` in `cmd/headlamp.go` to split the comma-separated flag string and dynamically append the parameters to `oauthConfig.AuthCodeURL`.

## Steps to Test

1. Start the backend with the new flag:
   ```bash
   go run ./cmd \
     -oidc-client-id="test" \
     -oidc-idp-issuer-url="https://accounts.google.com" \
     -oidc-auth-url-param="access_type=offline,prompt=consent" \
     -oidc-use-cookie
   ```
2. Start the frontend (`cd frontend && npm start`).
3. Click **"Sign In"** on the Headlamp homepage.
4. Observe the redirect URL in your browser's address bar. Verify that `&access_type=offline` and `&prompt=consent` are successfully injected into the query string.

## Screenshots (if applicable)

## Notes for the Reviewer

- Because the project uses the standard Go `flag` package (which does not support repeating flags natively like `pflag` does), this is implemented as a comma-separated string rather than a `StringSlice`.