### PR TITLE
frontend: k8s: Keep the list resource version on a watch error

### DIFF
--- a/frontend/src/lib/k8s/api/v2/KubeList.test.ts
+++ b/frontend/src/lib/k8s/api/v2/KubeList.test.ts
@@ -173,3 +173,112 @@ describe('KubeList.applyUpdate', () => {
     consoleErrorSpy.mockRestore();
   });
 });
+
+// A watch ERROR delivers a `Status`, whose metadata carries neither a uid nor a
+// resourceVersion. The list's resourceVersion is what the next watch is started from
+// (`useKubeObjectList` builds the watch URL out of it), so blanking it sends
+// `resourceVersion=undefined` to the API server and the list stops updating.
+describe('KubeList.applyUpdate on events that carry no resource', () => {
+  const itemClass = MockKubeObject as unknown as KubeObjectClass;
+  const listAtVersion7: KubeList<any> = {
+    kind: 'MockKubeList',
+    apiVersion: 'v1',
+    items: [
+      { apiVersion: 'v1', kind: 'MockKubeObject', metadata: { uid: '1', resourceVersion: '7' } },
+    ],
+    metadata: { resourceVersion: '7' },
+  };
+
+  // What the API server actually sends for a watch that fell behind.
+  const expiredStatus = {
+    kind: 'Status',
+    apiVersion: 'v1',
+    metadata: {},
+    status: 'Failure',
+    message: 'too old resource version: 100 (200)',
+    reason: 'Expired',
+    code: 410,
+  } as any;
+
+  it('keeps the resource version when a watch reports an error', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = KubeList.applyUpdate(
+      listAtVersion7,
+      { type: 'ERROR', object: expiredStatus },
+      itemClass,
+      cluster
+    );
+
+    expect(result.metadata.resourceVersion).toBe('7');
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('returns the same list on an error, so nothing downstream re-renders', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = KubeList.applyUpdate(
+      listAtVersion7,
+      { type: 'ERROR', object: expiredStatus },
+      itemClass,
+      cluster
+    );
+
+    expect(result).toBe(listAtVersion7);
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('keeps the resource version on an unrecognised event type', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = KubeList.applyUpdate(
+      listAtVersion7,
+      { type: 'BOOKMARK' as any, object: expiredStatus },
+      itemClass,
+      cluster
+    );
+
+    expect(result.metadata.resourceVersion).toBe('7');
+    consoleErrorSpy.mockRestore();
+  });
+
+  // The multiplexer builds its own ERROR event and stamps resourceVersion '0' on it, which
+  // the staleness guard above already rejects. Pin that too, so the two transports keep
+  // agreeing about what an error does to the list.
+  it('keeps the resource version for a multiplexer-shaped error event', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = KubeList.applyUpdate(
+      listAtVersion7,
+      {
+        type: 'ERROR',
+        object: {
+          kind: 'Status',
+          status: 'Failure',
+          message: 'websocket closed',
+          metadata: { uid: 'key:ERROR:websocket closed', resourceVersion: '0' },
+        } as any,
+      },
+      itemClass,
+      cluster
+    );
+
+    expect(result.metadata.resourceVersion).toBe('7');
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('keeps the resource version when an applied event carries none', () => {
+    const result = KubeList.applyUpdate(
+      listAtVersion7,
+      {
+        type: 'ADDED',
+        object: { apiVersion: 'v1', kind: 'MockKubeObject', metadata: { uid: '2' } } as any,
+      },
+      itemClass,
+      cluster
+    );
+
+    expect(result.metadata.resourceVersion).toBe('7');
+    expect(result.items).toHaveLength(2);
+  });
+});

--- a/frontend/src/lib/k8s/api/v2/KubeList.ts
+++ b/frontend/src/lib/k8s/api/v2/KubeList.ts
@@ -80,17 +80,27 @@ export const KubeList = {
         }
         break;
       case 'ERROR':
+        // A watch ERROR carries a `Status`, not a resource, so it has no uid to match
+        // and no resourceVersion to adopt. Returning the list unchanged keeps the
+        // version we last saw: adopting the absent one would send the next watch a
+        // literal `resourceVersion=undefined`, which the API server rejects, and the
+        // list would stop receiving updates.
         console.error('Error in update', update);
-        break;
+        return list;
       default:
+        // Same reasoning for a type we do not recognise: nothing was applied, so
+        // nothing about the list has moved on.
         console.error('Unknown update type', update);
+        return list;
     }
 
     return {
       ...list,
       metadata: {
         ...list.metadata,
-        resourceVersion: update.object.metadata.resourceVersion!,
+        // Keep the version we already had when an event arrives without one, so a
+        // malformed message cannot blank the value the next watch is started from.
+        resourceVersion: update.object.metadata.resourceVersion ?? list.metadata.resourceVersion,
       },
       items: newItems,
     };


### PR DESCRIPTION
A watch `ERROR` event delivers a `Status`, whose metadata carries neither a uid nor a
resourceVersion. `KubeList.applyUpdate` treated it like any other event and copied that
absent version onto the list.

`useKubeObjectList` builds the watch URL out of the list's resourceVersion:

```ts
return lists.map(({ cluster, namespace, resourceVersion }) => {
  const url = makeUrl([KubeObjectEndpoint.toUrl(endpoint!, namespace)], {
    ...stableWatchQueryParams,
    watch: 1,
    resourceVersion,
  });
```

`makeUrl` puts that object through `URLSearchParams`, which renders an undefined value as
the string `undefined`:

```
> new URLSearchParams({ watch: 1, resourceVersion: undefined }).toString()
'watch=1&resourceVersion=undefined'
```

So after one error the next watch asks for `resourceVersion=undefined`, the API server
rejects it, and that list stops receiving live updates. A `410 Expired` reaches this, and
that is how a watch which has fallen behind is reported.

This is the direct websocket path, which is the one a default build uses:
`getWebsocketMultiplexerEnabled()` returns `import.meta.env.REACT_APP_ENABLE_WEBSOCKET_MULTIPLEXER === 'true'`,
and nothing in the repo sets it to `true`. The only script that sets it at all,
`start-without-multiplexer`, sets it to `false`. The multiplexer path is already safe, because
it builds its own error event and stamps `resourceVersion: '0'` on it, which the staleness
guard rejects. Worth mentioning separately: the doc comment on that function says it
defaults to true, and the implementation defaults to false.

`ERROR` and unrecognised event types now return the list unchanged, since neither applied
anything. Returning the same reference also drops the re-render they caused through
`setQueryData`. An applied event arriving without a resourceVersion keeps the version the
list already had.

Four tests fail against the previous code, three with `expected undefined to be '7'`:
the version survives an error, the same list object comes back, an unrecognised type
behaves the same, and an applied event with no version leaves the version alone. A fifth
pins the multiplexer-shaped error event, which passed before and should keep passing.
