### PR TITLE
github: Bump ossf/scorecard-action to 2.4.4

### DIFF
--- a/.github/workflows/scorecard-analysis.yml
+++ b/.github/workflows/scorecard-analysis.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@dc50aa9510b46c811795eb24b2f1ba02a914e534 # v2.3.3
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
The Scorecard workflow failed in the CI because v2.3.3 uses a legacy GCR image that is no longer accessible. This updates it to the GHCR-backed release.