### PR TITLE
frontend: Activity: Add unique aria-label to complementary landmark i…

### DIFF
--- a/frontend/.axe-storybook-baseline.test-a11y.json
+++ b/frontend/.axe-storybook-baseline.test-a11y.json
@@ -26,7 +26,6 @@
     "TopBar/Version Dialog": ["aria-dialog-name"],
     "AuthToken/Show Error": ["empty-heading"],
     "AuthToken/Show Actions": ["empty-heading"],
-    "Activity/Basic": ["landmark-unique"],
     "AuthChooser/Basic Auth Chooser": ["empty-heading"],
     "AuthChooser/Testing": ["empty-heading"],
     "AuthChooser/Have Clusters": ["empty-heading"],

--- a/frontend/src/components/activity/Activity.stories.tsx
+++ b/frontend/src/components/activity/Activity.stories.tsx
@@ -99,8 +99,8 @@ function setupActivities(activities: Activity[]) {
 
 export const Basic: StoryFn = () => {
   setupActivities([
-    makeActivity({ id: '1', location: 'split-left', content: 'Left' }),
-    makeActivity({ id: '2', location: 'split-right', content: 'Right' }),
+    makeActivity({ id: '1', location: 'split-left', content: 'Left', title: 'Left Activity' }),
+    makeActivity({ id: '2', location: 'split-right', content: 'Right', title: 'Right Activity' }),
   ]);
 
   return <ActivitiesRenderer />;

--- a/frontend/src/components/activity/__snapshots__/Activity.Basic.stories.storyshot
+++ b/frontend/src/components/activity/__snapshots__/Activity.Basic.stories.storyshot
@@ -11,6 +11,7 @@
         class="MuiBox-root css-11hh78l"
       />
       <div
+        aria-label="Left Activity"
         class="MuiBox-root css-3xoqkk"
         role="complementary"
       >
@@ -25,7 +26,10 @@
             />
             <p
               class="MuiTypography-root MuiTypography-body1 css-1bfo8fe-MuiTypography-root"
-            />
+              title="Left Activity"
+            >
+              Left Activity
+            </p>
             <div
               class="MuiBox-root css-1po99kh"
             />
@@ -70,6 +74,7 @@
         </div>
       </div>
       <div
+        aria-label="Right Activity"
         class="MuiBox-root css-3xoqkk"
         role="complementary"
       >
@@ -84,7 +89,10 @@
             />
             <p
               class="MuiTypography-root MuiTypography-body1 css-1bfo8fe-MuiTypography-root"
-            />
+              title="Right Activity"
+            >
+              Right Activity
+            </p>
             <div
               class="MuiBox-root css-1po99kh"
             />
@@ -156,8 +164,9 @@
               />
               <div
                 class="MuiBox-root css-r1zxuf"
+                title="Right Activity"
               >
-                Something
+                Right Activity
               </div>
             </div>
             <span
@@ -191,8 +200,9 @@
               />
               <div
                 class="MuiBox-root css-r1zxuf"
+                title="Left Activity"
               >
-                Something
+                Left Activity
               </div>
             </div>
             <span


### PR DESCRIPTION
**Summary**  
frontend: Activity: Add unique aria-label to complementary landmark in Basic story

**Related Issue**  
Fixes #7181

**Changes**  
- Added unique `title` fields to the two activities in the `Basic` story (`Activity.stories.tsx`) so they receive distinct `aria-label` values on the complementary landmarks  
- Removed the now-resolved `landmark-unique` entry from the a11y baseline file  

**Testing**  
- Ran `npm run test:a11y` with `NODE_OPTIONS="--max-old-space-size=8192"`  
- Result: 678 passing, 0 new failures, Activity/Basic violation resolved  

**Notes for Reviewer**  
- The fix adds `title: 'Left Activity'` and `title: 'Right Activity'` to the `Basic` story's `makeActivity` calls  
- These titles flow through Redux to the `Activity` component's `aria-label` prop on `role="complementary"` elements  
- Baseline entry was removed since the violation is now resolved