### PR TITLE
frontend: storage: Fix VolumeList story rendering the wrong component

### DIFF
--- a/frontend/src/components/storage/VolumeList.stories.tsx
+++ b/frontend/src/components/storage/VolumeList.stories.tsx
@@ -17,8 +17,8 @@
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import { API_BASE, TestContext } from '../../test';
-import ListView from './ClassList';
 import { BASE_PV } from './storyHelper';
+import ListView from './VolumeList';
 
 export default {
   title: 'PersistentVolume/ListView',
@@ -44,7 +44,7 @@ Items.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get(`${API_BASE}/apis/storage.k8s.io/v1/storageclasses`, () =>
+        http.get(`${API_BASE}/api/v1/persistentvolumes`, () =>
           HttpResponse.json({
             kind: 'PersistentVolumeList',
             items: [BASE_PV],

--- a/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
@@ -15,13 +15,13 @@
             <h1
               class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
             >
-              Storage Classes
+              Persistent Volumes
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
             >
               <button
-                aria-label="Create StorageClass"
+                aria-label="Create PersistentVolume"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"
                 tabindex="0"
@@ -173,7 +173,7 @@
             </div>
           </div>
           <table
-            class="MuiTable-root css-t7kba7-MuiTable-root"
+            class="MuiTable-root css-u509nh-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-1tmrira-MuiTableHead-root"
@@ -287,7 +287,7 @@
                 </th>
                 <th
                   aria-sort="none"
-                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ie7snh-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-cbjriw-MuiTableCell-root"
                   colspan="1"
                   data-can-sort="true"
                   data-index="-1"
@@ -302,15 +302,15 @@
                       <div
                         class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
                       >
-                        Provisioner
+                        Class Name
                       </div>
                       <span
-                        aria-label="Sort by Provisioner ascending"
+                        aria-label="Sort by Class Name ascending"
                         class="MuiBadge-root css-1c32n2y-MuiBadge-root"
                         data-mui-internal-clone-element="true"
                       >
                         <span
-                          aria-label="Sort by Provisioner ascending"
+                          aria-label="Sort by Class Name ascending"
                           class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
                           role="button"
                           tabindex="0"
@@ -342,7 +342,7 @@
                 </th>
                 <th
                   aria-sort="none"
-                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1019980-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ishh8b-MuiTableCell-root"
                   colspan="1"
                   data-can-sort="true"
                   data-index="-1"
@@ -357,15 +357,70 @@
                       <div
                         class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
                       >
-                        Default
+                        Capacity
                       </div>
                       <span
-                        aria-label="Sort by Default ascending"
+                        aria-label="Sort by Capacity ascending"
                         class="MuiBadge-root css-1c32n2y-MuiBadge-root"
                         data-mui-internal-clone-element="true"
                       >
                         <span
-                          aria-label="Sort by Default ascending"
+                          aria-label="Sort by Capacity ascending"
+                          class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                          role="button"
+                          tabindex="0"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                            data-testid="SyncAltIcon"
+                            focusable="false"
+                            style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                        >
+                          0
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                    />
+                  </div>
+                </th>
+                <th
+                  aria-sort="none"
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-19s9d07-MuiTableCell-root"
+                  colspan="1"
+                  data-can-sort="true"
+                  data-index="-1"
+                  scope="col"
+                >
+                  <div
+                    class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                      >
+                        Access Modes
+                      </div>
+                      <span
+                        aria-label="Sort by Access Modes ascending"
+                        class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                        data-mui-internal-clone-element="true"
+                      >
+                        <span
+                          aria-label="Sort by Access Modes ascending"
                           class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
                           role="button"
                           tabindex="0"
@@ -452,7 +507,7 @@
                 </th>
                 <th
                   aria-sort="none"
-                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-u8eg21-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qa28sw-MuiTableCell-root"
                   colspan="1"
                   data-can-sort="true"
                   data-index="-1"
@@ -467,15 +522,15 @@
                       <div
                         class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
                       >
-                        Volume Binding Mode
+                        Claim
                       </div>
                       <span
-                        aria-label="Sort by Volume Binding Mode ascending"
+                        aria-label="Sort by Claim ascending"
                         class="MuiBadge-root css-1c32n2y-MuiBadge-root"
                         data-mui-internal-clone-element="true"
                       >
                         <span
-                          aria-label="Sort by Volume Binding Mode ascending"
+                          aria-label="Sort by Claim ascending"
                           class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
                           role="button"
                           tabindex="0"
@@ -507,7 +562,7 @@
                 </th>
                 <th
                   aria-sort="none"
-                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-78qi2x-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-13c0hsi-MuiTableCell-root"
                   colspan="1"
                   data-can-sort="true"
                   data-index="-1"
@@ -520,17 +575,17 @@
                       class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
                     >
                       <div
-                        class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-1t5kuvk"
+                        class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
                       >
-                        Allow Volume Expansion
+                        Status
                       </div>
                       <span
-                        aria-label="Sort by Allow Volume Expansion ascending"
+                        aria-label="Sort by Status ascending"
                         class="MuiBadge-root css-1c32n2y-MuiBadge-root"
                         data-mui-internal-clone-element="true"
                       >
                         <span
-                          aria-label="Sort by Allow Volume Expansion ascending"
+                          aria-label="Sort by Status ascending"
                           class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
                           role="button"
                           tabindex="0"
@@ -689,20 +744,48 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ilsbxl-MuiTableCell-root"
-                />
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-12mnx8z-MuiTableCell-root"
+                >
+                  <a
+                    aria-label="default"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    data-mui-internal-clone-element="true"
+                    href="/"
+                  >
+                    default
+                  </a>
+                </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-12j49la-MuiTableCell-root"
-                />
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1l0ciqb-MuiTableCell-root"
+                >
+                  8Gi
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1idyspx-MuiTableCell-root"
+                >
+                  <span
+                    aria-label="ReadWriteOnce"
+                    class=""
+                    data-mui-internal-clone-element="true"
+                  >
+                    ReadWriteOnce
+                  </span>
+                </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-10q82xd-MuiTableCell-root"
                 />
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-ade44f-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-11nzp2p-MuiTableCell-root"
                 />
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-xt8srx-MuiTableCell-root"
-                />
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1n4xkg0-MuiTableCell-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
+                  >
+                    Bound
+                  </span>
+                </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-14i1ub9-MuiTableCell-root"
                 >


### PR DESCRIPTION
## What

`VolumeList.stories.tsx` imported `ListView` from `./ClassList` and served its
fixtures from the `storageclasses` endpoint. The story titled
`PersistentVolume/ListView` therefore rendered the **StorageClass** list, not
the PersistentVolume list.

The committed storyshot confirms it — it recorded a `Storage Classes` heading:

```
-                  Storage Classes
+                  Persistent Volumes
```

So `VolumeList` had no story coverage at all, despite appearing to have some.

## Change

Import `VolumeList` and serve fixtures from `/api/v1/persistentvolumes`, so the
story exercises the component it names. Storyshot regenerated.

Four source lines; the rest of the diff is the regenerated snapshot.

## Testing

`npx vitest run src/storybook.test.tsx -t "PersistentVolume/ListView"` passes,
and the regenerated snapshot now shows the PersistentVolume table.

Split out of #7263 so each change is reviewable on its own, per the
atomic-commit guideline.