### PR TITLE
frontend: podGroup: Move the scheduling status into its own component

### DIFF
--- a/frontend/src/components/podGroup/List.tsx
+++ b/frontend/src/components/podGroup/List.tsx
@@ -16,25 +16,8 @@
 
 import { useTranslation } from 'react-i18next';
 import PodGroup from '../../lib/k8s/podGroup';
-import { StatusLabel } from '../common/Label';
 import ResourceListView from '../common/Resource/ResourceListView';
-
-/** Shows whether the group met its scheduling requirement, from its scheduling condition. */
-function SchedulingStatus({ podGroup }: { podGroup: PodGroup }) {
-  const { t } = useTranslation(['translation']);
-  const condition = podGroup.schedulingCondition;
-
-  if (!condition) {
-    return <span>{t('translation|Unknown')}</span>;
-  }
-
-  const scheduled = condition.status === 'True';
-  return (
-    <StatusLabel status={scheduled ? 'success' : 'warning'}>
-      {condition.reason || (scheduled ? t('translation|Scheduled') : t('translation|Pending'))}
-    </StatusLabel>
-  );
-}
+import { getSchedulingStatusText, SchedulingStatus } from '../scheduling/SchedulingStatus';
 
 export default function PodGroupList() {
   const { t } = useTranslation(['glossary', 'translation']);
@@ -72,18 +55,8 @@ export default function PodGroupList() {
           id: 'status',
           label: t('translation|Status'),
           gridTemplate: 'min-content',
-          getValue: item => {
-            const condition = item.schedulingCondition;
-            if (!condition) {
-              return t('translation|Unknown');
-            }
-            const scheduled = condition.status === 'True';
-            return (
-              condition.reason ||
-              (scheduled ? t('translation|Scheduled') : t('translation|Pending'))
-            );
-          },
-          render: item => <SchedulingStatus podGroup={item} />,
+          getValue: item => getSchedulingStatusText(item.schedulingCondition, t),
+          render: item => <SchedulingStatus condition={item.schedulingCondition} />,
         },
         'age',
       ]}

--- a/frontend/src/components/scheduling/SchedulingStatus.tsx
+++ b/frontend/src/components/scheduling/SchedulingStatus.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import type { KubeCondition } from '../../lib/k8s/cluster';
+import type { StatusLabelProps } from '../common/Label';
+import { StatusLabel } from '../common/Label';
+
+type Translate = (key: string) => string;
+
+/**
+ * Text of the scheduling condition of a pod group.
+ *
+ * These conditions are terminal: they report whether the group ever met its scheduling
+ * requirement, not whether its pods are running now.
+ * @param condition - The scheduling condition, when the group already has one.
+ * @param t - The translation function of the calling view.
+ * @returns The reason of the condition, or a localized fallback.
+ */
+export function getSchedulingStatusText(
+  condition: KubeCondition | undefined,
+  t: Translate
+): string {
+  if (!condition) {
+    return t('translation|Unknown');
+  }
+  if (condition.reason) {
+    return condition.reason;
+  }
+  if (condition.status === 'True') {
+    return t('translation|Scheduled');
+  }
+  return condition.status === 'False' ? t('translation|Pending') : t('translation|Unknown');
+}
+
+function getSchedulingStatusSeverity(condition: KubeCondition): StatusLabelProps['status'] {
+  if (condition.status === 'True') {
+    return 'success';
+  }
+  return condition.status === 'False' ? 'warning' : '';
+}
+
+/** Shows whether a group met its scheduling requirement, from its scheduling condition. */
+export function SchedulingStatus({ condition }: { condition: KubeCondition | undefined }) {
+  const { t } = useTranslation(['translation']);
+
+  if (!condition) {
+    return <span>{t('translation|Unknown')}</span>;
+  }
+
+  return (
+    <StatusLabel status={getSchedulingStatusSeverity(condition)}>
+      {getSchedulingStatusText(condition, t)}
+    </StatusLabel>
+  );
+}


### PR DESCRIPTION
## Summary

Moves the PodGroup scheduling status rendering into a shared `SchedulingStatus` component, and fixes an `Unknown` scheduling condition being reported as Pending.

## Related Issue

Part of [#7529](https://github.com/kubernetes-sigs/headlamp/issues/7529) . Split out of #7542  at review request, so that the refactor of the existing PodGroup view lands separately from the new CompositePodGroup work.

## Changes

- Added `frontend/src/components/scheduling/SchedulingStatus.tsx`, holding the status text helper and the label
- Updated `podGroup/List.tsx` to use it instead of rendering the status inline
- Fixed a condition with `status: "Unknown"` reading as Pending; it now reads as Unknown, and its label stays neutral instead of warning
- The label now takes the condition rather than the group, so it does not have to know which resource the condition came from

## Steps to Test

1. On a 1.34+ cluster with the WorkloadAwareScheduling feature gate enabled,  navigate to Scheduling -> Pod Groups.
2. Check the Scheduling column: a scheduled group reads its condition reason or Scheduled, an unscheduled one Pending, and    a group whose condition is Unknown or absent reads Unknown with a neutral label.
3. `cd frontend && npm test -- src/components/podGroup`


## Notes for the Reviewer

- Pure refactor apart from the Unknown handling; no new strings, no API changes.
- The component lives under `components/scheduling/` rather than `components/podGroup/`
  because it takes a condition, not a resource.
