### PR TITLE
0072: Add manifest-driven plugin command policy

### DIFF
--- a/app/app-build-manifest.json
+++ b/app/app-build-manifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./app-build-manifest.schema.json",
   "proxy-urls": ["https://artifacthub.io/*"],
   "plugins": [
     {
@@ -15,6 +16,257 @@
       "name": "prometheus",
       "archive": "https://github.com/headlamp-k8s/plugins/releases/download/prometheus-0.9.1/prometheus-0.9.1.tar.gz",
       "sha256": "06afabe42da69e8e0c5c2632acc3fee020566825d2ae71ff8e4f3dd7f78fc4ae"
+    }
+  ],
+  "$comment": "Docs for runCommands: ../docs/development/plugins/command-capabilities.md",
+  "commandSets": {
+    "minikube": [
+      { "tool": "minikube", "args": ["start"], "allowTrailingArgs": true },
+      { "tool": "minikube", "args": ["stop"], "allowTrailingArgs": true },
+      { "tool": "minikube", "args": ["delete"], "allowTrailingArgs": true },
+      { "tool": "minikube", "args": ["status"], "allowTrailingArgs": true },
+      { "tool": "minikube", "args": ["service"], "allowTrailingArgs": true },
+      { "tool": "minikube", "args": ["logs"], "allowTrailingArgs": true },
+      { "tool": "minikube", "args": ["addons"], "allowTrailingArgs": true },
+      { "tool": "minikube", "args": ["ssh"], "allowTrailingArgs": true }
+    ],
+    "minikube-local-script": [
+      {
+        "tool": "scriptjs",
+        "args": ["minikube/manage-minikube.js"],
+        "allowTrailingArgs": true
+      }
+    ],
+    "minikube-script": [
+      {
+        "tool": "scriptjs",
+        "args": ["headlamp_minikube/manage-minikube.js"],
+        "allowTrailingArgs": true
+      }
+    ],
+    "minikube-prerelease-script": [
+      {
+        "tool": "scriptjs",
+        "args": ["headlamp_minikubeprerelease/manage-minikube.js"],
+        "allowTrailingArgs": true
+      }
+    ],
+    "ai-assistant": [
+      { "tool": "gh", "args": ["auth"], "allowTrailingArgs": true },
+      { "tool": "az", "args": ["account"], "allowTrailingArgs": true },
+      { "tool": "az", "args": ["cognitiveservices"], "allowTrailingArgs": true }
+    ]
+  },
+  "runCommands": [
+    {
+      "environment": "development",
+      "pluginLocation": "development",
+      "plugins": [{ "bundleName": "minikube", "packageName": "@headlamp-k8s/minikube" }],
+      "pluginExecutables": [{ "tool": "minikube" }],
+      "commandSets": ["minikube", "minikube-local-script"]
+    },
+    {
+      "environment": "development",
+      "pluginLocation": "user",
+      "plugins": [{ "bundleName": "headlamp_minikube", "packageName": "@headlamp-k8s/minikube" }],
+      "pluginExecutables": [{ "tool": "minikube" }],
+      "commandSets": ["minikube", "minikube-script"]
+    },
+    {
+      "environment": "development",
+      "pluginLocation": "development",
+      "plugins": [{ "bundleName": "headlamp_minikube", "packageName": "@headlamp-k8s/minikube" }],
+      "pluginExecutables": [{ "tool": "minikube" }],
+      "commandSets": ["minikube", "minikube-script"]
+    },
+    {
+      "environment": "development",
+      "pluginLocation": "user",
+      "plugins": [
+        {
+          "bundleName": "headlamp_minikubeprerelease",
+          "packageName": "@headlamp-k8s/minikubeprerelease"
+        }
+      ],
+      "pluginExecutables": [{ "tool": "minikube" }],
+      "commandSets": ["minikube", "minikube-prerelease-script"]
+    },
+    {
+      "environment": "development",
+      "pluginLocation": "development",
+      "plugins": [
+        {
+          "bundleName": "headlamp_minikubeprerelease",
+          "packageName": "@headlamp-k8s/minikubeprerelease"
+        }
+      ],
+      "pluginExecutables": [{ "tool": "minikube" }],
+      "commandSets": ["minikube", "minikube-prerelease-script"]
+    },
+    {
+      "environment": "production",
+      "pluginLocation": "user",
+      "plugins": [
+        {
+          "bundleName": "headlamp_minikube",
+          "packageName": "@headlamp-k8s/minikube",
+          "artifactHubPackage": "headlamp-plugins/headlamp_minikube",
+          "artifactHubPackageId": "fbc182b5-eb90-42b7-ace8-62a7576abafd",
+          "artifactHubRepositoryId": "767e1f40-ee09-401b-b8d4-930740da5a8a"
+        }
+      ],
+      "pluginExecutables": [{ "tool": "minikube" }],
+      "commandSets": ["minikube", "minikube-script"]
+    },
+    {
+      "environment": "production",
+      "pluginLocation": "development",
+      "plugins": [
+        {
+          "bundleName": "headlamp_minikube",
+          "packageName": "@headlamp-k8s/minikube"
+        }
+      ],
+      "pluginExecutables": [{ "tool": "minikube" }],
+      "commandSets": ["minikube", "minikube-script"]
+    },
+    {
+      "environment": "production",
+      "pluginLocation": "user",
+      "plugins": [
+        {
+          "bundleName": "headlamp_minikubeprerelease",
+          "packageName": "@headlamp-k8s/minikubeprerelease",
+          "artifactHubPackage": "illumetestplugins/headlamp_minikubeprerelease",
+          "artifactHubPackageId": "eb575dd3-39f2-4dc8-ba15-0abf64a9cca4",
+          "artifactHubRepositoryId": "61e223f8-49fe-47c5-9bf8-802e8f759cab"
+        }
+      ],
+      "pluginExecutables": [{ "tool": "minikube" }],
+      "commandSets": ["minikube", "minikube-prerelease-script"]
+    },
+    {
+      "environment": "production",
+      "pluginLocation": "development",
+      "plugins": [
+        {
+          "bundleName": "headlamp_minikubeprerelease",
+          "packageName": "@headlamp-k8s/minikubeprerelease"
+        }
+      ],
+      "pluginExecutables": [{ "tool": "minikube" }],
+      "commandSets": ["minikube", "minikube-prerelease-script"]
+    },
+    {
+      "environment": "development",
+      "pluginLocation": "development",
+      "plugins": [
+        { "bundleName": "ai-assistant", "packageName": "@headlamp-k8s/ai-assistant" },
+        {
+          "bundleName": "ai-assistantprerelease",
+          "packageName": "@headlamp-k8s/ai-assistantprerelease"
+        }
+      ],
+      "commandSets": ["ai-assistant"]
+    },
+    {
+      "environment": "development",
+      "pluginLocation": "user",
+      "plugins": [
+        { "bundleName": "headlamp_ai-assistant", "packageName": "@headlamp-k8s/ai-assistant" },
+        { "bundleName": "headlamp_ai_assistant", "packageName": "@headlamp-k8s/ai-assistant" },
+        {
+          "bundleName": "headlamp_ai-assistantprerelease",
+          "packageName": "@headlamp-k8s/ai-assistantprerelease"
+        },
+        {
+          "bundleName": "headlamp_ai_assistantprerelease",
+          "packageName": "@headlamp-k8s/ai-assistantprerelease"
+        }
+      ],
+      "commandSets": ["ai-assistant"]
+    },
+    {
+      "environment": "production",
+      "pluginLocation": "user",
+      "plugins": [
+        {
+          "bundleName": "headlamp_ai-assistant",
+          "packageName": "@headlamp-k8s/ai-assistant",
+          "artifactHubPackage": "headlamp-plugins/headlamp_ai_assistant",
+          "artifactHubPackageId": "ecfd5ae3-1925-471e-8e89-aaa0f48632d2",
+          "artifactHubRepositoryId": "767e1f40-ee09-401b-b8d4-930740da5a8a"
+        },
+        {
+          "bundleName": "headlamp_ai_assistant",
+          "packageName": "@headlamp-k8s/ai-assistant",
+          "artifactHubPackage": "headlamp-plugins/headlamp_ai_assistant",
+          "artifactHubPackageId": "ecfd5ae3-1925-471e-8e89-aaa0f48632d2",
+          "artifactHubRepositoryId": "767e1f40-ee09-401b-b8d4-930740da5a8a"
+        }
+      ],
+      "commandSets": ["ai-assistant"]
+    },
+    {
+      "environment": "production",
+      "pluginLocation": "development",
+      "plugins": [
+        {
+          "bundleName": "headlamp_ai-assistant",
+          "packageName": "@headlamp-k8s/ai-assistant"
+        },
+        {
+          "bundleName": "headlamp_ai_assistant",
+          "packageName": "@headlamp-k8s/ai-assistant"
+        }
+      ],
+      "commandSets": ["ai-assistant"]
+    },
+    {
+      "environment": "production",
+      "pluginLocation": "shipped",
+      "plugins": [
+        { "bundleName": "headlamp_ai-assistant", "packageName": "@headlamp-k8s/ai-assistant" },
+        { "bundleName": "headlamp_ai_assistant", "packageName": "@headlamp-k8s/ai-assistant" },
+        {
+          "bundleName": "headlamp_ai-assistantprerelease",
+          "packageName": "@headlamp-k8s/ai-assistantprerelease"
+        },
+        {
+          "bundleName": "headlamp_ai_assistantprerelease",
+          "packageName": "@headlamp-k8s/ai-assistantprerelease"
+        }
+      ],
+      "commandSets": ["ai-assistant"]
+    },
+    {
+      "environment": "development",
+      "pluginLocation": "development",
+      "plugins": [
+        { "bundleName": "headlamp_ai-assistant", "packageName": "@headlamp-k8s/ai-assistant" },
+        { "bundleName": "headlamp_ai_assistant", "packageName": "@headlamp-k8s/ai-assistant" },
+        {
+          "bundleName": "headlamp_ai-assistantprerelease",
+          "packageName": "@headlamp-k8s/ai-assistantprerelease"
+        },
+        {
+          "bundleName": "headlamp_ai_assistantprerelease",
+          "packageName": "@headlamp-k8s/ai-assistantprerelease"
+        }
+      ],
+      "commandSets": ["ai-assistant"]
+    },
+    {
+      "environment": "development",
+      "pluginLocation": "development",
+      "plugins": [{ "bundleName": "azure-aks", "packageName": "azure-aks" }],
+      "commands": [
+        {
+          "tool": "scriptjs",
+          "args": ["azure-aks/azure-api.js"],
+          "allowTrailingArgs": true
+        }
+      ]
     }
   ],
   "legalDocuments": [

--- a/app/app-build-manifest.schema.json
+++ b/app/app-build-manifest.schema.json
@@ -1,0 +1,421 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "app-build-manifest.schema.json",
+  "title": "Headlamp Desktop app build manifest",
+  "description": "Configures product metadata, packaged plugins and resources, and runtime command policy for a Headlamp Desktop build.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON Schema used by editors to validate this manifest."
+    },
+    "$comment": {
+      "type": "string",
+      "description": "A note for people maintaining this manifest."
+    },
+    "proxy-urls": {
+      "type": "array",
+      "description": "HTTP(S) URL patterns the packaged backend may proxy. Only * wildcards are supported.",
+      "items": {
+        "type": "string",
+        "pattern": "^https?://[^/?#\\s]+(?:/[^?\\[\\]{}\\\\]*)?$"
+      }
+    },
+    "plugins": {
+      "type": "array",
+      "description": "Plugins downloaded and bundled into the desktop package.",
+      "items": { "$ref": "#/definitions/plugin" }
+    },
+    "commandSets": {
+      "type": "object",
+      "description": "Reusable named command grant arrays. A runCommands policy composes one or more with commandSets instead of repeating commands.",
+      "maxProperties": 64,
+      "propertyNames": { "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$" },
+      "additionalProperties": { "$ref": "#/definitions/commandGrantList" }
+    },
+    "product": {
+      "type": "object",
+      "description": "Product identity applied to Electron Builder and generated frontend metadata.",
+      "properties": {
+        "name": { "type": "string" },
+        "productName": { "type": "string" },
+        "version": { "type": "string" },
+        "appId": { "type": "string" },
+        "artifactName": { "type": "string" },
+        "protocols": {
+          "type": "object",
+          "properties": {
+            "schemes": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string", "minLength": 1 }
+            }
+          },
+          "required": ["schemes"],
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "resources": {
+      "type": "object",
+      "description": "Files and directories appended to Electron Builder's extraResources.",
+      "properties": {
+        "common": { "$ref": "#/definitions/resources" },
+        "linux": { "$ref": "#/definitions/resources" },
+        "mac": { "$ref": "#/definitions/resources" },
+        "win": { "$ref": "#/definitions/resources" }
+      },
+      "additionalProperties": false
+    },
+    "runCommands": {
+      "type": "array",
+      "description": "Command policies for Headlamp Desktop plugins. Each entry selects an app runtime mode, a plugin installation location, one or more exact plugin identities, and the commands those plugins may request. Production policies for plugin-manager-installed user plugins should pin Artifact Hub UUIDs; development-mode, development-location, and shipped policies should omit them. See ../docs/development/plugins/command-capabilities.md or https://headlamp.dev/docs/latest/development/plugins/command-capabilities/#product-manifest-policy.",
+      "items": { "$ref": "#/definitions/pluginCommandPolicy" }
+    },
+    "targets": {
+      "type": "object",
+      "description": "Electron Builder package targets selected per platform.",
+      "properties": {
+        "linux": { "$ref": "#/definitions/linuxTargets" },
+        "mac": { "$ref": "#/definitions/macTargets" },
+        "win": { "$ref": "#/definitions/winTargets" }
+      },
+      "additionalProperties": false
+    },
+    "platforms": {
+      "type": "object",
+      "description": "Electron Builder metadata overrides selected per platform.",
+      "properties": {
+        "linux": { "$ref": "#/definitions/platformMetadata" },
+        "mac": { "$ref": "#/definitions/platformMetadata" },
+        "win": { "$ref": "#/definitions/platformMetadata" }
+      },
+      "additionalProperties": false
+    },
+    "verify": {
+      "type": "array",
+      "description": "Packaged resources whose SHA-256 digests must be verified after packaging.",
+      "items": { "$ref": "#/definitions/verification" }
+    },
+    "legalDocuments": {
+      "type": "array",
+      "description": "Legal documents exposed by the packaged desktop application.",
+      "items": { "$ref": "#/definitions/legalDocument" }
+    }
+  },
+  "additionalProperties": true,
+  "definitions": {
+    "plugin": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "packageName": { "type": "string", "minLength": 1 },
+        "archive": { "type": "string", "format": "uri" },
+        "sha256": { "$ref": "#/definitions/sha256" },
+        "disabled": { "type": "boolean" }
+      },
+      "required": ["name"],
+      "additionalProperties": true
+    },
+    "pluginCommandPolicy": {
+      "type": "object",
+      "description": "Commands granted to exact plugin identities for one Headlamp runtime mode and one plugin installation location.",
+      "properties": {
+        "environment": {
+          "description": "Headlamp app mode in which this policy applies. This selects the running app, not where the plugin is installed.",
+          "oneOf": [
+            {
+              "const": "development",
+              "description": "Apply when Headlamp Desktop is running in development mode."
+            },
+            {
+              "const": "production",
+              "description": "Apply in a packaged production build of Headlamp Desktop."
+            }
+          ]
+        },
+        "pluginLocation": {
+          "description": "Plugin installation location that must contain the authorized bundle. This selects the plugin files, not the Headlamp app mode.",
+          "oneOf": [
+            {
+              "const": "development",
+              "description": "The operator-controlled development plugin inventory exposed under plugins/. This can contain legacy catalog installations even in production builds. Plugins here have no plugin-manager provenance receipt; policy authors trust users with write access to this inventory. See ../docs/development/plugins/command-capabilities.md or https://headlamp.dev/docs/latest/development/plugins/command-capabilities/#security-considerations."
+            },
+            {
+              "const": "user",
+              "description": "The user-installed plugin inventory exposed under user-plugins/."
+            },
+            {
+              "const": "shipped",
+              "description": "The read-only plugin inventory bundled with the desktop application and exposed under static-plugins/."
+            }
+          ]
+        },
+        "plugins": {
+          "type": "array",
+          "description": "Exact bundle directory and package.json identities sharing these grants. For production policies in the user location, add artifactHubPackage, artifactHubPackageId, and artifactHubRepositoryId. Omit Artifact Hub identity from development-mode, development-location, and shipped policies because those bundles have no plugin-manager installation receipt. See ../docs/development/plugins/command-capabilities.md or https://headlamp.dev/docs/latest/development/plugins/command-capabilities/#product-manifest-policy.",
+          "minItems": 1,
+          "maxItems": 64,
+          "items": { "$ref": "#/definitions/pluginIdentity" }
+        },
+        "pluginExecutables": {
+          "type": "array",
+          "description": "Tools supplied by these plugin bundles at the derived path bin/<tool> instead of resolved on the sanitized system PATH.",
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": { "$ref": "#/definitions/pluginExecutable" }
+        },
+        "commands": {
+          "description": "Command identifiers and argument sequences these plugins may request. Every request is matched against these entries in Electron before a process starts.",
+          "$ref": "#/definitions/commandGrantList"
+        },
+        "commandSets": {
+          "type": "array",
+          "description": "Names of reusable grant arrays in top-level commandSets, combined in order. Use this instead of commands when policies share grants.",
+          "minItems": 1,
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+          }
+        }
+      },
+      "required": ["environment", "pluginLocation", "plugins"],
+      "oneOf": [{ "required": ["commands"] }, { "required": ["commandSets"] }],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "environment": { "const": "production" },
+              "pluginLocation": { "const": "user" }
+            },
+            "required": ["environment", "pluginLocation"]
+          },
+          "then": {
+            "properties": {
+              "plugins": {
+                "items": {
+                  "required": ["artifactHubPackage"]
+                }
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": false
+    },
+    "pluginExecutable": {
+      "type": "object",
+      "description": "A plugin-owned native executable at the derived path bin/<tool>, confined to the verified bundle and integrity-checked before production execution.",
+      "properties": {
+        "tool": {
+          "type": "string",
+          "description": "Command identifier whose grants use this plugin-owned executable.",
+          "maxLength": 128,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+          "not": { "const": "scriptjs" }
+        }
+      },
+      "required": ["tool"],
+      "additionalProperties": false
+    },
+    "pluginIdentity": {
+      "type": "object",
+      "properties": {
+        "bundleName": {
+          "type": "string",
+          "description": "Bundle directory name reported by plugin discovery.",
+          "minLength": 1,
+          "pattern": "^(?!\\s)(?!.*\\s$)[^/\\\\\\u0000]+$"
+        },
+        "packageName": {
+          "type": "string",
+          "description": "Exact package name expected in the bundle's package.json.",
+          "minLength": 1,
+          "pattern": "^(?!\\s)(?!.*\\s$)[^\\u0000]+$"
+        },
+        "artifactHubPackage": {
+          "type": "string",
+          "description": "Artifact Hub repository and package names in <repository>/<package> form, for example headlamp-plugins/headlamp_minikube. Required for production policies in the plugin-manager-installed user location. Omit from development and shipped locations, which have no installation receipt. See ../docs/development/plugins/command-capabilities.md or https://headlamp.dev/docs/latest/development/plugins/command-capabilities/#product-manifest-policy.",
+          "maxLength": 257,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$"
+        },
+        "artifactHubPackageId": {
+          "type": "string",
+          "description": "Immutable package UUID pin from the package_id field returned by https://artifacthub.io/api/v1/packages/headlamp/<repository>/<package>. Recommended with artifactHubRepositoryId for production policies in the plugin-manager-installed user location; omit from development-mode, development-location, and shipped policies. See ../docs/development/plugins/command-capabilities.md or https://headlamp.dev/docs/latest/development/plugins/command-capabilities/#product-manifest-policy.",
+          "format": "uuid"
+        },
+        "artifactHubRepositoryId": {
+          "type": "string",
+          "description": "Immutable repository UUID pin from the repository.repository_id field returned by https://artifacthub.io/api/v1/packages/headlamp/<repository>/<package>. Recommended with artifactHubPackageId for production policies in the plugin-manager-installed user location; omit from development-mode, development-location, and shipped policies. See ../docs/development/plugins/command-capabilities.md or https://headlamp.dev/docs/latest/development/plugins/command-capabilities/#product-manifest-policy.",
+          "format": "uuid"
+        }
+      },
+      "required": ["bundleName", "packageName"],
+      "allOf": [
+        {
+          "if": {
+            "anyOf": [
+              { "required": ["artifactHubPackageId"] },
+              { "required": ["artifactHubRepositoryId"] }
+            ]
+          },
+          "then": {
+            "required": ["artifactHubPackage", "artifactHubPackageId", "artifactHubRepositoryId"]
+          }
+        }
+      ],
+      "additionalProperties": false
+    },
+    "commandGrant": {
+      "type": "object",
+      "properties": {
+        "tool": {
+          "type": "string",
+          "description": "Command identifier matched exactly against a plugin request. Most values name an executable, such as minikube or az. The special scriptjs value asks Headlamp to run an authorized plugin JavaScript file with Electron. Do not include a filesystem path.",
+          "maxLength": 128,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+        },
+        "args": {
+          "type": "array",
+          "description": "Ordered arguments matched after tool. They are an exact sequence unless allowTrailingArgs is true, in which case they are the required prefix.",
+          "minItems": 1,
+          "maxItems": 16,
+          "items": {
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^(?=[^\\u0000]*\\S)[^\\u0000]*$"
+          }
+        },
+        "allowTrailingArgs": {
+          "type": "boolean",
+          "description": "When false or omitted, the request must have exactly args. When true, the request may append more arguments after that required prefix.",
+          "default": false
+        }
+      },
+      "required": ["tool", "args"],
+      "additionalProperties": false
+    },
+    "commandGrantList": {
+      "type": "array",
+      "maxItems": 64,
+      "uniqueItems": true,
+      "items": { "$ref": "#/definitions/commandGrant" }
+    },
+    "resource": {
+      "type": "object",
+      "properties": {
+        "from": { "type": "string" },
+        "to": { "type": "string" },
+        "filter": { "type": "array", "items": { "type": "string" } }
+      },
+      "required": ["from"],
+      "additionalProperties": false
+    },
+    "resources": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/resource" }
+    },
+    "targetDescriptor": {
+      "type": "object",
+      "properties": {
+        "target": { "type": "string", "minLength": 1, "pattern": ".*\\S.*" },
+        "arch": { "type": "array", "minItems": 1 }
+      },
+      "required": ["target", "arch"],
+      "additionalProperties": true
+    },
+    "linuxTargets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          { "type": "string", "minLength": 1, "pattern": ".*\\S.*" },
+          {
+            "allOf": [
+              { "$ref": "#/definitions/targetDescriptor" },
+              { "properties": { "arch": { "items": { "enum": ["arm64", "armv7l", "x64"] } } } }
+            ]
+          }
+        ]
+      }
+    },
+    "macTargets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          { "type": "string", "minLength": 1, "pattern": ".*\\S.*" },
+          {
+            "allOf": [
+              { "$ref": "#/definitions/targetDescriptor" },
+              { "properties": { "arch": { "items": { "enum": ["arm64", "universal", "x64"] } } } }
+            ]
+          }
+        ]
+      }
+    },
+    "winTargets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          { "type": "string", "minLength": 1, "pattern": ".*\\S.*" },
+          {
+            "allOf": [
+              { "$ref": "#/definitions/targetDescriptor" },
+              { "properties": { "arch": { "items": { "enum": ["arm64", "ia32", "x64"] } } } }
+            ]
+          }
+        ]
+      }
+    },
+    "platformMetadata": {
+      "type": "object",
+      "properties": {
+        "appId": { "type": "string" },
+        "bundleShortVersion": { "type": "string" },
+        "bundleVersion": { "type": "string" },
+        "executableName": { "type": "string" },
+        "icon": { "type": "string" },
+        "artifactName": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "verification": {
+      "type": "object",
+      "properties": {
+        "path": { "type": "string", "minLength": 1, "pattern": ".*\\S.*" },
+        "platforms": {
+          "type": "array",
+          "items": { "enum": ["linux", "mac", "win"] }
+        },
+        "sha256": { "$ref": "#/definitions/sha256" }
+      },
+      "required": ["path", "sha256"],
+      "additionalProperties": false
+    },
+    "sha256": {
+      "type": "string",
+      "description": "Hexadecimal SHA-256 digest.",
+      "pattern": "^[A-Fa-f0-9]{64}$"
+    },
+    "legalDocument": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]{0,63}$" },
+        "title": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "file": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255,
+          "pattern": "^(?!\\.{1,2}$)[^/\\\\]+$"
+        }
+      },
+      "required": ["id", "title", "file"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/app/e2e-tests/tests/protocolScheme.spec.ts
+++ b/app/e2e-tests/tests/protocolScheme.spec.ts
@@ -67,6 +67,7 @@ test.describe('desktop protocol scheme', () => {
         ...electronEnv,
         NODE_ENV: 'development',
         ELECTRON_DEV: 'true',
+        HEADLAMP_BUILD_MANIFEST: 'app-build-manifest.json',
         ELECTRON_START_URL: pathToFileURL(path.join(appPath, '../frontend/build/index.html')).href,
         EXTERNAL_SERVER: 'true',
       },

--- a/app/electron/build-manifest.test.ts
+++ b/app/electron/build-manifest.test.ts
@@ -14,12 +14,17 @@
  * limitations under the License.
  */
 
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import { buildSync } from 'esbuild';
 import nock from 'nock';
+import { execFileSync } from 'node:child_process';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import * as tar from 'tar';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -27,17 +32,22 @@ import {
   applyBuildTargets,
   applyPlatformMetadata,
   applyProductMetadata,
+  type BuildManifest,
   DEFAULT_MANIFEST_FILE,
   loadBuildManifest,
+  productPluginCommandPolicies,
   resolveBuildManifestPath,
+  validateBuildManifest,
   verifyPackagedResources,
 } from '../scripts/build-manifest.ts';
 import {
   applyEnabledByDefault,
+  bundledPluginExecutablePaths,
   downloadFile,
   extractArchive,
   getArchiveFileName,
   pathsReferToSameFile,
+  recordBundledPluginExecutableIntegrity,
   resolveLocalPluginArchive,
   validatePluginSource,
   verifyArchiveDigest,
@@ -729,8 +739,306 @@ describe('packaged resource verification', () => {
 });
 
 describe('build manifest selection', () => {
+  it('loads with the native TypeScript type-stripping runtime', () => {
+    const moduleUrl = pathToFileURL(path.join(appPath, 'scripts/build-manifest.ts')).href;
+
+    expect(() =>
+      execFileSync(
+        process.execPath,
+        [
+          '--experimental-strip-types',
+          '--input-type=module',
+          '--eval',
+          `await import('${moduleUrl}')`,
+        ],
+        { stdio: 'pipe' }
+      )
+    ).not.toThrow();
+  });
+  it('loads from Electron-compatible bundled CommonJS', () => {
+    const outputDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-manifest-bundle-'));
+    temporaryDirectories.push(outputDirectory);
+    const outputFile = path.join(outputDirectory, 'build-manifest.cjs');
+    buildSync({
+      entryPoints: [path.join(appPath, 'scripts/build-manifest.ts')],
+      bundle: true,
+      format: 'cjs',
+      platform: 'node',
+      outfile: outputFile,
+    });
+
+    expect(() => execFileSync(process.execPath, [outputFile], { stdio: 'pipe' })).not.toThrow();
+  });
+
   it('uses Headlamp defaults when no product manifest is configured', () => {
     expect(resolveBuildManifestPath({}, '/product')).toBe(DEFAULT_MANIFEST_FILE);
+  });
+
+  it('keeps production command policies for legacy development inventory installs', () => {
+    const policies = productPluginCommandPolicies(
+      loadBuildManifest(DEFAULT_MANIFEST_FILE),
+      'production'
+    );
+    const identities = policies.map(
+      policy => `${policy.source}:${policy.bundleName}:${policy.packageName}`
+    );
+
+    expect(identities).toEqual(
+      expect.arrayContaining([
+        'development:headlamp_minikube:@headlamp-k8s/minikube',
+        'development:headlamp_minikubeprerelease:@headlamp-k8s/minikubeprerelease',
+        'user:headlamp_ai-assistant:@headlamp-k8s/ai-assistant',
+        'user:headlamp_ai_assistant:@headlamp-k8s/ai-assistant',
+        'development:headlamp_ai-assistant:@headlamp-k8s/ai-assistant',
+        'development:headlamp_ai_assistant:@headlamp-k8s/ai-assistant',
+        'shipped:headlamp_ai-assistant:@headlamp-k8s/ai-assistant',
+        'shipped:headlamp_ai_assistant:@headlamp-k8s/ai-assistant',
+        'shipped:headlamp_ai-assistantprerelease:@headlamp-k8s/ai-assistantprerelease',
+        'shipped:headlamp_ai_assistantprerelease:@headlamp-k8s/ai-assistantprerelease',
+      ])
+    );
+  });
+
+  it('pins immutable Artifact Hub IDs for every default user production policy', () => {
+    const policies = productPluginCommandPolicies(
+      loadBuildManifest(DEFAULT_MANIFEST_FILE),
+      'production'
+    ).filter(policy => policy.source === 'user');
+
+    expect(policies.length).toBeGreaterThan(0);
+    for (const policy of policies) {
+      expect(policy.artifactHub?.packageId).toMatch(/^[a-f0-9-]{36}$/i);
+      expect(policy.artifactHub?.repositoryId).toMatch(/^[a-f0-9-]{36}$/i);
+    }
+  });
+
+  it('omits Artifact Hub identity from default development-location policies', () => {
+    const policies = productPluginCommandPolicies(
+      loadBuildManifest(DEFAULT_MANIFEST_FILE),
+      'production'
+    ).filter(policy => policy.source === 'development');
+
+    expect(policies.length).toBeGreaterThan(0);
+    for (const policy of policies) {
+      expect(policy.artifactHub).toBeUndefined();
+    }
+  });
+
+  it('keeps development command policies for catalog and legacy managed installs', () => {
+    const policies = productPluginCommandPolicies(
+      loadBuildManifest(DEFAULT_MANIFEST_FILE),
+      'development'
+    );
+    const identities = policies.map(
+      policy => `${policy.source}:${policy.bundleName}:${policy.packageName}`
+    );
+
+    expect(identities).toEqual(
+      expect.arrayContaining([
+        'user:headlamp_minikube:@headlamp-k8s/minikube',
+        'development:headlamp_minikube:@headlamp-k8s/minikube',
+        'user:headlamp_minikubeprerelease:@headlamp-k8s/minikubeprerelease',
+        'development:headlamp_minikubeprerelease:@headlamp-k8s/minikubeprerelease',
+        'user:headlamp_ai-assistant:@headlamp-k8s/ai-assistant',
+        'user:headlamp_ai_assistant:@headlamp-k8s/ai-assistant',
+        'development:headlamp_ai-assistant:@headlamp-k8s/ai-assistant',
+        'development:headlamp_ai_assistant:@headlamp-k8s/ai-assistant',
+        'user:headlamp_ai-assistantprerelease:@headlamp-k8s/ai-assistantprerelease',
+        'user:headlamp_ai_assistantprerelease:@headlamp-k8s/ai-assistantprerelease',
+        'development:headlamp_ai-assistantprerelease:@headlamp-k8s/ai-assistantprerelease',
+        'development:headlamp_ai_assistantprerelease:@headlamp-k8s/ai-assistantprerelease',
+      ])
+    );
+  });
+
+  it('requires schema command arguments to contain a non-whitespace character', () => {
+    const schema = JSON.parse(
+      fs.readFileSync(path.join(appPath, 'app-build-manifest.schema.json'), 'utf8')
+    );
+    const argumentPattern = new RegExp(
+      schema.definitions.commandGrant.properties.args.items.pattern
+    );
+
+    expect(argumentPattern.test('resource group')).toBe(true);
+    expect(argumentPattern.test(' \t\n')).toBe(false);
+    expect(argumentPattern.test('list\0all')).toBe(false);
+  });
+
+  it('rejects duplicate command grants in the schema', () => {
+    const schema = JSON.parse(
+      fs.readFileSync(path.join(appPath, 'app-build-manifest.schema.json'), 'utf8')
+    );
+    const validate = addFormats(new Ajv()).compile(schema);
+    const grant = { tool: 'examplectl', args: ['list'] };
+
+    expect(
+      validate({
+        runCommands: [
+          {
+            environment: 'development',
+            pluginLocation: 'development',
+            plugins: [{ bundleName: 'example-plugin', packageName: '@example/plugin' }],
+            commands: [grant, grant],
+          },
+        ],
+      })
+    ).toBe(false);
+    expect(validate.errors).toEqual(
+      expect.arrayContaining([expect.objectContaining({ keyword: 'uniqueItems' })])
+    );
+  });
+
+  it('matches production identity and plugin executable runtime requirements', () => {
+    const schema = JSON.parse(
+      fs.readFileSync(path.join(appPath, 'app-build-manifest.schema.json'), 'utf8')
+    );
+    const validate = addFormats(new Ajv()).compile(schema);
+    const policy = {
+      environment: 'production',
+      pluginLocation: 'user',
+      plugins: [{ bundleName: 'example-plugin', packageName: '@example/plugin' }],
+      pluginExecutables: [{ tool: 'examplectl' }],
+      commands: [{ tool: 'examplectl', args: ['list'] }],
+    };
+
+    expect(validate({ runCommands: [policy] })).toBe(false);
+    expect(
+      validate({
+        runCommands: [
+          {
+            ...policy,
+            plugins: [
+              {
+                bundleName: 'example-plugin',
+                packageName: '@example/plugin',
+                artifactHubPackageId: 'fbc182b5-eb90-42b7-ace8-62a7576abafd',
+                artifactHubRepositoryId: '767e1f40-ee09-401b-b8d4-930740da5a8a',
+              },
+            ],
+          },
+        ],
+      })
+    ).toBe(false);
+    policy.plugins[0] = {
+      ...policy.plugins[0],
+      artifactHubPackage: 'headlamp-plugins/headlamp_minikube',
+    } as (typeof policy.plugins)[number];
+    expect(validate({ runCommands: [policy] })).toBe(true);
+    policy.plugins[0] = {
+      ...policy.plugins[0],
+      artifactHubPackageId: 'fbc182b5-eb90-42b7-ace8-62a7576abafd',
+      artifactHubRepositoryId: '767e1f40-ee09-401b-b8d4-930740da5a8a',
+    } as (typeof policy.plugins)[number];
+    expect(validate({ runCommands: [policy] })).toBe(true);
+    for (const bundleName of ['plugins/example-plugin', 'plugins\\example-plugin']) {
+      expect(
+        validate({
+          runCommands: [
+            {
+              ...policy,
+              plugins: [{ ...policy.plugins[0], bundleName }],
+            },
+          ],
+        })
+      ).toBe(false);
+    }
+    expect(
+      validate({
+        runCommands: [
+          {
+            ...policy,
+            pluginExecutables: [{ tool: 'examplectl', path: 'bin/examplectl' }],
+          },
+        ],
+      })
+    ).toBe(false);
+    policy.pluginExecutables[0] = { tool: 'scriptjs' };
+    expect(validate({ runCommands: [policy] })).toBe(false);
+  });
+
+  it('warns when production managed-plugin policies omit recommended UUID pins', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    validateBuildManifest({
+      runCommands: [
+        {
+          environment: 'production',
+          pluginLocation: 'user',
+          plugins: [
+            {
+              bundleName: 'example-plugin',
+              packageName: '@example/plugin',
+              artifactHubPackage: 'example-repository/example-plugin',
+            },
+          ],
+          commands: [{ tool: 'examplectl', args: ['list'] }],
+        },
+      ],
+    });
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('artifactHubPackageId'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('artifactHubRepositoryId'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('package_id'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('repository.repository_id'));
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'https://artifacthub.io/api/v1/packages/headlamp/example-repository/example-plugin'
+      )
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('docs/development/plugins/command-capabilities.md')
+    );
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('command-capabilities'));
+    warn.mockRestore();
+  });
+
+  it.each([
+    { environment: 'development', pluginLocation: 'user' },
+    { environment: 'production', pluginLocation: 'development' },
+    { environment: 'production', pluginLocation: 'shipped' },
+  ])('warns when $environment $pluginLocation policies include UUID pins', policy => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    validateBuildManifest({
+      runCommands: [
+        {
+          ...policy,
+          plugins: [
+            {
+              bundleName: 'example-plugin',
+              packageName: '@example/plugin',
+              artifactHubPackage: 'example-repository/example-plugin',
+              artifactHubPackageId: 'fbc182b5-eb90-42b7-ace8-62a7576abafd',
+              artifactHubRepositoryId: '767e1f40-ee09-401b-b8d4-930740da5a8a',
+            },
+          ],
+          commands: [{ tool: 'examplectl', args: ['list'] }],
+        },
+      ],
+    } as BuildManifest);
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('should omit'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('command-capabilities'));
+    warn.mockRestore();
+  });
+
+  it('includes UUID recommendations and documentation in schema hovers', () => {
+    const schema = JSON.parse(
+      fs.readFileSync(path.join(appPath, 'app-build-manifest.schema.json'), 'utf8')
+    );
+    const pluginIdentity = schema.definitions.pluginIdentity.properties;
+
+    for (const field of ['artifactHubPackage', 'artifactHubPackageId', 'artifactHubRepositoryId']) {
+      expect(pluginIdentity[field].description).toContain(
+        '../docs/development/plugins/command-capabilities.md'
+      );
+      expect(pluginIdentity[field].description).toContain('command-capabilities');
+      expect(pluginIdentity[field].description).toContain('https://headlamp.dev/');
+    }
+    expect(pluginIdentity.artifactHubPackageId.description).toContain('Recommended');
+    expect(pluginIdentity.artifactHubPackageId.description).toContain('omit');
   });
 
   it('resolves and loads an external product manifest', () => {
@@ -747,6 +1055,293 @@ describe('build manifest selection', () => {
 
   it('loads the default manifest when no path is supplied', () => {
     expect(loadBuildManifest()).toEqual(expect.objectContaining({ plugins: expect.any(Array) }));
+  });
+
+  it('loads plugin executables for shipped plugin identities', () => {
+    const manifest = {
+      runCommands: [
+        {
+          environment: 'production',
+          pluginLocation: 'shipped',
+          plugins: [{ bundleName: 'example-plugin', packageName: '@example/plugin' }],
+          pluginExecutables: [{ tool: 'examplectl' }],
+          commands: [{ tool: 'examplectl', args: ['project', 'list'], allowTrailingArgs: true }],
+        },
+      ],
+    };
+
+    const schema = JSON.parse(
+      fs.readFileSync(path.join(appPath, 'app-build-manifest.schema.json'), 'utf8')
+    );
+    expect(addFormats(new Ajv()).compile(schema)(manifest)).toBe(true);
+    expect(
+      productPluginCommandPolicies(
+        loadBuildManifest(temporaryFile(JSON.stringify(manifest))),
+        'production'
+      )
+    ).toEqual([
+      expect.objectContaining({
+        bundleName: 'example-plugin',
+        source: 'shipped',
+        grants: [
+          expect.objectContaining({
+            executable: { source: 'plugin', path: 'bin/examplectl' },
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it('rejects internal executable provenance in authored command grants', () => {
+    expect(() =>
+      loadBuildManifest(
+        temporaryFile(
+          JSON.stringify({
+            runCommands: [
+              {
+                environment: 'production',
+                pluginLocation: 'shipped',
+                plugins: [{ bundleName: 'example-plugin', packageName: '@example/plugin' }],
+                commands: [
+                  {
+                    tool: 'examplectl',
+                    executable: { source: 'plugin', path: 'bin/examplectl' },
+                    args: ['project', 'list'],
+                  },
+                ],
+              },
+            ],
+          })
+        )
+      )
+    ).toThrow('Invalid build manifest runCommands[0].commands');
+  });
+
+  it('selects development permissions independently of production permissions', () => {
+    const commands = [{ tool: 'examplectl', args: ['development'] }];
+    const manifest = loadBuildManifest(
+      temporaryFile(
+        JSON.stringify({
+          runCommands: [
+            {
+              environment: 'development',
+              pluginLocation: 'development',
+              plugins: [{ bundleName: 'example-plugin', packageName: '@example/plugin' }],
+              commands,
+            },
+            {
+              environment: 'production',
+              pluginLocation: 'user',
+              plugins: [
+                {
+                  bundleName: 'example_plugin',
+                  packageName: '@example/plugin',
+                  artifactHubPackage: 'example-repository/example-plugin',
+                },
+              ],
+              commands: [{ tool: 'examplectl', args: ['production'] }],
+            },
+          ],
+        })
+      )
+    );
+
+    expect(productPluginCommandPolicies(manifest, 'development')).toEqual([
+      {
+        bundleName: 'example-plugin',
+        packageName: '@example/plugin',
+        source: 'development',
+        grants: commands,
+      },
+    ]);
+    expect(productPluginCommandPolicies(manifest, 'production')).toEqual([
+      {
+        bundleName: 'example_plugin',
+        packageName: '@example/plugin',
+        source: 'user',
+        artifactHub: {
+          repository: 'example-repository',
+          package: 'example-plugin',
+        },
+        grants: [{ tool: 'examplectl', args: ['production'] }],
+      },
+    ]);
+  });
+
+  it('composes reusable command sets in declaration order', () => {
+    const commands = [
+      { tool: 'examplectl', args: ['list'], allowTrailingArgs: true },
+      { tool: 'scriptjs', args: ['example-plugin/run.js'] },
+    ];
+    const manifest = validateBuildManifest({
+      commandSets: { executable: [commands[0]], script: [commands[1]] },
+      runCommands: [
+        {
+          environment: 'development',
+          pluginLocation: 'development',
+          plugins: [{ bundleName: 'example-plugin', packageName: '@example/plugin' }],
+          commandSets: ['executable', 'script'],
+        },
+      ],
+    });
+
+    expect(productPluginCommandPolicies(manifest, 'development')[0].grants).toEqual(commands);
+  });
+
+  it.each([
+    { commandSets: ['missing'] },
+    { commandSets: ['example'], commands: [] },
+    { commandSets: [] },
+    { commandSets: ['example', 'example'] },
+    {},
+  ])('rejects an invalid command-set selection: %j', selection => {
+    expect(() =>
+      validateBuildManifest({
+        commandSets: { example: [{ tool: 'examplectl', args: ['list'] }] },
+        runCommands: [
+          {
+            environment: 'development',
+            pluginLocation: 'development',
+            plugins: [{ bundleName: 'example-plugin', packageName: '@example/plugin' }],
+            ...selection,
+          },
+        ],
+      })
+    ).toThrow(/exactly one|Invalid/);
+  });
+
+  it('rejects a malformed command set even when no policy references it', () => {
+    expect(() =>
+      validateBuildManifest({
+        commandSets: { malformed: [{ tool: 'examplectl', executable: '/tmp/examplectl' }] },
+        runCommands: [
+          {
+            environment: 'development',
+            pluginLocation: 'development',
+            plugins: [{ bundleName: 'example-plugin', packageName: '@example/plugin' }],
+            commands: [{ tool: 'examplectl', args: ['list'] }],
+          },
+        ],
+      })
+    ).toThrow('Invalid build manifest commandSets.malformed');
+  });
+
+  it('rejects production managed-plugin policy without Artifact Hub provenance', () => {
+    expect(() =>
+      loadBuildManifest(
+        temporaryFile(
+          JSON.stringify({
+            runCommands: [
+              {
+                environment: 'production',
+                pluginLocation: 'user',
+                plugins: [{ bundleName: 'example-plugin', packageName: '@example/plugin' }],
+                commands: [{ tool: 'examplectl', args: ['list'] }],
+              },
+            ],
+          })
+        )
+      )
+    ).toThrow('Missing Artifact Hub identity');
+  });
+
+  it.each([
+    { bundleName: '', packageName: '@example/plugin' },
+    { bundleName: 'example-plugin', packageName: '' },
+    { bundleName: ' example-plugin', packageName: '@example/plugin' },
+    { bundleName: 'plugins/example-plugin', packageName: '@example/plugin' },
+    { bundleName: 'plugins\\example-plugin', packageName: '@example/plugin' },
+    { bundleName: 'example-plugin', packageName: '@example/plugin\0' },
+    {
+      bundleName: 'example-plugin',
+      packageName: '@example/plugin',
+      artifactHubPackageId: 'fbc182b5-eb90-42b7-ace8-62a7576abafd',
+    },
+    {
+      bundleName: 'example-plugin',
+      packageName: '@example/plugin',
+      artifactHubPackageId: 'not-a-uuid',
+      artifactHubRepositoryId: '767e1f40-ee09-401b-b8d4-930740da5a8a',
+    },
+    {
+      bundleName: 'example-plugin',
+      packageName: '@example/plugin',
+      artifactHubPackage: 'missing-package-separator',
+    },
+    {
+      bundleName: 'example-plugin',
+      packageName: '@example/plugin',
+      artifactHubPackage: `${'r'.repeat(256)}/package`,
+    },
+  ])('rejects malformed plugin identity %#', plugin => {
+    expect(() =>
+      loadBuildManifest(
+        temporaryFile(
+          JSON.stringify({
+            runCommands: [
+              {
+                environment: 'development',
+                pluginLocation: 'development',
+                plugins: [plugin],
+                commands: [{ tool: 'examplectl', args: ['list'] }],
+              },
+            ],
+          })
+        )
+      )
+    ).toThrow();
+  });
+
+  it.each([
+    {
+      runCommands: [
+        {
+          environment: 'production',
+          pluginLocation: 'shipped',
+          plugins: [{ bundleName: 'example-plugin', packageName: '@example/plugin' }],
+          commands: [{ command: 'examplectl', args: ['list'] }],
+        },
+      ],
+    },
+    {
+      runCommands: [
+        {
+          environment: 'production',
+          pluginLocation: 'shipped',
+          plugins: [{ bundleName: 'example-plugin' }],
+          commands: [{ tool: 'examplectl', args: ['list'] }],
+        },
+      ],
+    },
+    {
+      runCommands: [
+        {
+          environment: 'production',
+          pluginLocation: 'user',
+          plugins: [{ bundleName: 'one', packageName: '@example/plugin' }],
+          commands: [{ tool: 'examplectl', args: ['one'] }],
+        },
+        {
+          environment: 'production',
+          pluginLocation: 'user',
+          plugins: [{ bundleName: 'one', packageName: '@example/plugin' }],
+          commands: [{ tool: 'examplectl', args: ['two'] }],
+        },
+      ],
+    },
+    {
+      runCommands: [
+        {
+          environment: 'production',
+          pluginLocation: 'shipped',
+          plugins: [{ bundleName: 'example-plugin', packageName: '@example/plugin' }],
+          pluginExecutables: [{ tool: 'examplectl', path: 'bin/examplectl' }],
+          commands: [{ tool: 'examplectl', args: ['list'] }],
+        },
+      ],
+    },
+  ])('rejects malformed or ambiguous product command policy', manifest => {
+    expect(() => loadBuildManifest(temporaryFile(JSON.stringify(manifest)))).toThrow();
   });
 
   it('rejects unsafe proxy URL patterns', () => {
@@ -801,6 +1396,94 @@ describe('build manifest selection', () => {
 });
 
 describe('plugin archive integrity', () => {
+  it('includes shipped plugin executables required only in development', () => {
+    const manifest = {
+      plugins: [{ name: 'example-plugin' }],
+      runCommands: [
+        {
+          environment: 'development',
+          pluginLocation: 'shipped',
+          plugins: [{ bundleName: 'example-plugin', packageName: '@example/plugin' }],
+          pluginExecutables: [{ tool: 'examplectl' }],
+          commands: [
+            {
+              tool: 'examplectl',
+              args: ['serve'],
+            },
+          ],
+        },
+      ],
+    } as BuildManifest;
+
+    expect(bundledPluginExecutablePaths(manifest)).toEqual(
+      new Map([['example-plugin', ['bin/examplectl']]])
+    );
+  });
+
+  it('copies and records only declared bundled executables', async () => {
+    const sourceDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-tar-source-'));
+    const extractionDirectory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'headlamp-plugin-extraction-')
+    );
+    const pluginRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-plugin-root-'));
+    temporaryDirectories.push(sourceDirectory, extractionDirectory, pluginRoot);
+    const sourcePlugin = path.join(sourceDirectory, 'plugin');
+    fs.mkdirSync(path.join(sourcePlugin, 'bin'), { recursive: true });
+    fs.writeFileSync(path.join(sourcePlugin, 'main.js'), 'main');
+    fs.writeFileSync(
+      path.join(sourcePlugin, 'package.json'),
+      JSON.stringify({ name: '@example/plugin' })
+    );
+    fs.writeFileSync(path.join(sourcePlugin, 'bin', 'examplectl'), 'trusted executable');
+    fs.writeFileSync(path.join(sourcePlugin, 'bin', 'undeclared'), 'not packaged');
+    const archive = path.join(sourceDirectory, 'plugin.tar.gz');
+    await tar.c({ cwd: sourceDirectory, file: archive, gzip: true }, ['plugin']);
+
+    await extractArchive('example-plugin', archive, extractionDirectory, pluginRoot, undefined, [
+      'bin/examplectl',
+    ]);
+    const bundlePath = path.join(pluginRoot, 'example-plugin');
+    await recordBundledPluginExecutableIntegrity(bundlePath, ['bin/examplectl']);
+
+    expect(fs.readFileSync(path.join(bundlePath, 'bin', 'examplectl'), 'utf8')).toBe(
+      'trusted executable'
+    );
+    expect(fs.existsSync(path.join(bundlePath, 'bin', 'undeclared'))).toBe(false);
+    expect(JSON.parse(fs.readFileSync(path.join(bundlePath, 'package.json'), 'utf8'))).toEqual(
+      expect.objectContaining({
+        headlampPluginIntegrity: {
+          version: 1,
+          executables: {
+            'bin/examplectl': crypto
+              .createHash('sha256')
+              .update('trusted executable')
+              .digest('hex'),
+          },
+        },
+      })
+    );
+  });
+
+  it('rejects a shipped plugin archive missing a declared executable', async () => {
+    const sourceDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-tar-source-'));
+    const extractionDirectory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'headlamp-plugin-extraction-')
+    );
+    temporaryDirectories.push(sourceDirectory, extractionDirectory);
+    const sourcePlugin = path.join(sourceDirectory, 'plugin');
+    fs.mkdirSync(sourcePlugin);
+    fs.writeFileSync(path.join(sourcePlugin, 'main.js'), 'main');
+    fs.writeFileSync(path.join(sourcePlugin, 'package.json'), '{}');
+    const archive = path.join(sourceDirectory, 'plugin.tar.gz');
+    await tar.c({ cwd: sourceDirectory, file: archive, gzip: true }, ['plugin']);
+
+    await expect(
+      extractArchive('example-plugin', archive, extractionDirectory, undefined, undefined, [
+        'bin/examplectl',
+      ])
+    ).rejects.toThrow();
+  });
+
   it('rejects missing and malformed plugin archives', async () => {
     const extractionDirectory = fs.mkdtempSync(
       path.join(os.tmpdir(), 'headlamp-plugin-extraction-')

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -37,6 +37,11 @@ import path from 'path';
 import url from 'url';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
+import {
+  loadBuildManifest,
+  productPluginCommandPolicies,
+  resolveBuildManifestPath,
+} from '../scripts/build-manifest';
 import { withBackendMemoryDefaults } from './backendMemory';
 import { createCertificateSetup } from './certificates';
 import { startWindowsVMDetection, waitForWindowsVMDetection } from './hardwareAcceleration';
@@ -207,10 +212,16 @@ const MAX_PORT_ATTEMPTS = Math.abs(Number(process.env.HEADLAMP_MAX_PORT_ATTEMPTS
 
 const useExternalServer = process.env.EXTERNAL_SERVER || false;
 const legalDocumentsResourcePath = getLegalDocumentsResourcePath(isDev, process.resourcesPath);
-const appBuildManifestPath = path.join(legalDocumentsResourcePath, 'app-build-manifest.json');
+const appBuildManifestPath = isDev
+  ? resolveBuildManifestPath()
+  : path.join(legalDocumentsResourcePath, 'app-build-manifest.json');
 const legalDocuments = loadLegalDocuments(appBuildManifestPath);
 const protocolScheme = readProtocolScheme(appBuildManifestPath);
 const shouldCheckForUpdates = shouldCheckForAppUpdates(appBuildManifestPath);
+const productPluginCommandPolicy = productPluginCommandPolicies(
+  loadBuildManifest(appBuildManifestPath),
+  isDev ? 'development' : 'production'
+);
 
 // make it global so that it doesn't get garbage collected
 let mainWindow: BrowserWindow | null;
@@ -506,7 +517,10 @@ class PluginManagerEventListeners {
       progress: { type: 'info', message: 'uninstalling plugin' },
     };
 
-    removeRunCmdConsent(pluginName);
+    const installedPlugin = PluginManager.list(destinationFolder)?.find(
+      plugin => plugin.pluginName === pluginName
+    );
+    removeRunCmdConsent(pluginName, installedPlugin?.folderName);
 
     PluginManager.uninstall(pluginName, destinationFolder, progress => {
       updateCache(progress);
@@ -1559,6 +1573,15 @@ function startElectron() {
       },
     });
     protocolHandler.attachToWebContents(mainWindow.webContents);
+    setupRunCmdHandlers(
+      mainWindow,
+      ipcMain,
+      productPluginCommandPolicy,
+      startUrl,
+      undefined,
+      isDev,
+      () => true
+    );
 
     applyZoom();
 
@@ -1740,7 +1763,6 @@ function startElectron() {
       applyTrayIconSetting(enabled);
     });
 
-    setupRunCmdHandlers(mainWindow, ipcMain);
     setupSecureStorageHandlers(mainWindow, startUrl);
 
     new PluginManagerEventListeners().setupEventHandlers();

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -75,7 +75,7 @@ import {
   runScript,
   setupRunCmdHandlers,
 } from './runCmd';
-import { setupSecureStorageHandlers } from './secureStorage';
+import { isTrustedDocumentUrl, setupSecureStorageHandlers } from './secureStorage';
 import { loadSettings, SETTINGS_PATH } from './settings';
 import { getShellEnv } from './shellEnv';
 import { shouldCheckForAppUpdates } from './shouldCheckForAppUpdates';
@@ -225,6 +225,15 @@ const productPluginCommandPolicy = productPluginCommandPolicies(
 
 // make it global so that it doesn't get garbage collected
 let mainWindow: BrowserWindow | null;
+
+function isFromMainWindowFrame(event: IpcMainEvent, window = mainWindow): boolean {
+  return (
+    !!window &&
+    event.sender === window.webContents &&
+    event.senderFrame === window.webContents.mainFrame &&
+    isTrustedDocumentUrl(event.senderFrame.url, startUrl)
+  );
+}
 let mcpClient: MCPClient | null = null;
 let isQuitting = false;
 let hasTray = false;
@@ -284,7 +293,7 @@ class PluginManagerEventListeners {
     };
   } = {};
 
-  constructor() {
+  constructor(private readonly window: BrowserWindow) {
     this.cache = {};
   }
 
@@ -317,6 +326,9 @@ class PluginManagerEventListeners {
    */
   setupEventHandlers() {
     ipcMain.on('plugin-manager', async (event, data) => {
+      if (!isFromMainWindowFrame(event, this.window)) {
+        return;
+      }
       let eventData: Action;
 
       try {
@@ -1394,8 +1406,11 @@ function startElectron() {
   // Default is 10, setting to 20 provides headroom for future additions
   ipcMain.setMaxListeners(20);
 
-  ipcMain.on('request-backend-token', () => {
-    mainWindow?.webContents.send('backend-token', backendToken);
+  ipcMain.on('request-backend-token', event => {
+    if (!isFromMainWindowFrame(event)) {
+      return;
+    }
+    event.sender.send('backend-token', backendToken);
   });
 
   let appVersion: string;
@@ -1569,6 +1584,7 @@ function startElectron() {
       webPreferences: {
         nodeIntegration: false,
         contextIsolation: true,
+        sandbox: true,
         preload: `${__dirname}/preload.js`,
       },
     });
@@ -1698,8 +1714,11 @@ function startElectron() {
       setMenu(mainWindow, currentMenu);
     });
 
-    ipcMain.on('appConfig', () => {
-      mainWindow?.webContents.send('appConfig', {
+    ipcMain.on('appConfig', event => {
+      if (!isFromMainWindowFrame(event, mainWindow)) {
+        return;
+      }
+      event.sender.send('appConfig', {
         checkForUpdates: shouldCheckForUpdates,
         appVersion,
         protocolScheme,
@@ -1713,14 +1732,17 @@ function startElectron() {
       readLegalDocument(legalDocumentsResourcePath, legalDocuments, id)
     );
 
-    ipcMain.on('pluginsLoaded', () => {
+    ipcMain.on('pluginsLoaded', event => {
+      if (!isFromMainWindowFrame(event, mainWindow)) {
+        return;
+      }
       loadFullMenu = true;
       console.info('Plugins are loaded. Loading full menu.');
       setMenu(mainWindow, currentMenu);
     });
 
     ipcMain.on('setMenu', (event: IpcMainEvent, menus: any) => {
-      if (!mainWindow) {
+      if (!mainWindow || !isFromMainWindowFrame(event, mainWindow)) {
         return;
       }
 
@@ -1743,21 +1765,30 @@ function startElectron() {
     });
 
     ipcMain.on('locale', (event: IpcMainEvent, newLocale: string) => {
+      if (!isFromMainWindowFrame(event, mainWindow)) {
+        return;
+      }
       if (!!newLocale && i18n.language !== newLocale) {
         i18n.changeLanguage(newLocale);
       }
     });
 
-    ipcMain.on('request-backend-port', () => {
-      mainWindow?.webContents.send('backend-port', actualPort);
+    ipcMain.on('request-backend-port', event => {
+      if (!isFromMainWindowFrame(event, mainWindow)) {
+        return;
+      }
+      event.sender.send('backend-port', actualPort);
     });
 
-    ipcMain.on('request-tray-icon', () => {
-      mainWindow?.webContents.send('tray-icon', isTrayIconEnabled());
+    ipcMain.on('request-tray-icon', event => {
+      if (!isFromMainWindowFrame(event, mainWindow)) {
+        return;
+      }
+      event.sender.send('tray-icon', isTrayIconEnabled());
     });
 
     ipcMain.on('set-tray-icon', (event: IpcMainEvent, enabled: boolean) => {
-      if (typeof enabled !== 'boolean') {
+      if (!isFromMainWindowFrame(event, mainWindow) || typeof enabled !== 'boolean') {
         return;
       }
       applyTrayIconSetting(enabled);
@@ -1765,7 +1796,7 @@ function startElectron() {
 
     setupSecureStorageHandlers(mainWindow, startUrl);
 
-    new PluginManagerEventListeners().setupEventHandlers();
+    new PluginManagerEventListeners(mainWindow).setupEventHandlers();
 
     // Handle opening plugin folder in file explorer
     ipcMain.on(
@@ -1774,6 +1805,9 @@ function startElectron() {
         event: IpcMainEvent,
         pluginInfo: { folderName: string; type: 'development' | 'user' | 'shipped' }
       ) => {
+        if (!isFromMainWindowFrame(event, mainWindow)) {
+          return;
+        }
         let folderPath: string | null = null;
 
         if (pluginInfo.type === 'user') {
@@ -1808,7 +1842,7 @@ function startElectron() {
     if (ENABLE_MCP) {
       const configPath = path.join(app.getPath('userData'), 'mcp-tools-config.json');
       const settingsPath = path.join(app.getPath('userData'), 'mcp-tools-settings.json');
-      mcpClient = new MCPClient(configPath, settingsPath, ensureCertificates);
+      mcpClient = new MCPClient(configPath, settingsPath, ensureCertificates, startUrl);
       await mcpClient.initialize();
       mcpClient.setMainWindow(mainWindow);
     }

--- a/app/electron/mcp/MCPClient.test.ts
+++ b/app/electron/mcp/MCPClient.test.ts
@@ -75,6 +75,30 @@ describe('MCPClient', () => {
     );
   });
 
+  it('accepts MCP IPC only from the trusted document in the active main frame', () => {
+    const trustedStartUrl = 'http://127.0.0.1:3000/';
+    const client = new MCPClient(cfgPath, settingsPath, undefined, trustedStartUrl);
+    const mainFrame = { url: `${trustedStartUrl}#settings` };
+    const webContents = { mainFrame };
+    client.setMainWindow({ webContents } as any);
+
+    expect(() =>
+      (client as any).assertTrustedIpcEvent({ sender: webContents, senderFrame: mainFrame })
+    ).not.toThrow();
+    expect(() =>
+      (client as any).assertTrustedIpcEvent({ sender: webContents, senderFrame: {} })
+    ).toThrow('MCP IPC request rejected');
+    expect(() =>
+      (client as any).assertTrustedIpcEvent({ sender: {}, senderFrame: mainFrame })
+    ).toThrow('MCP IPC request rejected');
+    expect(() =>
+      (client as any).assertTrustedIpcEvent({
+        sender: webContents,
+        senderFrame: { ...mainFrame, url: 'http://127.0.0.1:3000.attacker.example/' },
+      })
+    ).toThrow('MCP IPC request rejected');
+  });
+
   it('initialize is idempotent and logs exactly once', async () => {
     await client.initialize();
     await client.initialize(); // second call should be a no-op

--- a/app/electron/mcp/MCPClient.ts
+++ b/app/electron/mcp/MCPClient.ts
@@ -15,7 +15,8 @@
  */
 
 import type { DynamicStructuredTool } from '@langchain/core/dist/tools/index';
-import { type BrowserWindow, dialog, ipcMain } from 'electron';
+import { type BrowserWindow, dialog, ipcMain, type IpcMainInvokeEvent } from 'electron';
+import { isTrustedDocumentUrl } from '../secureStorage';
 import type { MultiServerMCPClient } from './MCPAdapter';
 import {
   hasClusterDependentServers,
@@ -82,11 +83,13 @@ export default class MCPClient {
    * @param configPath - Path to the persisted MCP tool configuration.
    * @param settingsPath - Path to the persisted MCP server settings.
    * @param ensureCertificates - Initializes certificate trust before networking.
+   * @param trustedStartUrl - Exact Headlamp document URL authorized to invoke MCP IPC.
    */
   constructor(
     configPath: string,
     settingsPath: string,
-    private readonly ensureCertificates: () => void = () => {}
+    private readonly ensureCertificates: () => void = () => {},
+    private readonly trustedStartUrl?: string
   ) {
     this.configPath = configPath;
     this.settingsPath = settingsPath;
@@ -626,32 +629,50 @@ export default class MCPClient {
     }
   }
 
+  private assertTrustedIpcEvent(event: IpcMainInvokeEvent): void {
+    if (
+      !this.mainWindow ||
+      event.sender !== this.mainWindow.webContents ||
+      event.senderFrame !== this.mainWindow.webContents.mainFrame ||
+      (this.trustedStartUrl !== undefined &&
+        !isTrustedDocumentUrl(event.senderFrame.url, this.trustedStartUrl))
+    ) {
+      throw new Error('MCP IPC request rejected');
+    }
+  }
+
   /**
    * Setup IPC handlers for MCP operations.
    */
   private setupIpcHandlers(): void {
-    ipcMain?.handle('mcp-execute-tool', async (event, { toolName, args, toolCallId }) =>
+    const handle = <Arguments extends unknown[], Result>(
+      channel: string,
+      handler: (...args: Arguments) => Result
+    ) => {
+      ipcMain?.handle(channel, (event, ...args: Arguments) => {
+        this.assertTrustedIpcEvent(event);
+        return handler(...args);
+      });
+    };
+
+    handle('mcp-execute-tool', ({ toolName, args, toolCallId }) =>
       this.mcpExecuteTool(toolName, args, toolCallId)
     );
-    ipcMain?.handle('mcp-get-status', async () => this.mcpGetStatus());
-    ipcMain?.handle('mcp-reset-client', async () => this.mcpResetClient());
-    ipcMain?.handle('mcp-update-config', async (event, mcpSettings: MCPSettings) =>
-      this.mcpUpdateConfig(mcpSettings)
-    );
-    ipcMain?.handle('mcp-get-config', async () => this.mcpGetConfig());
-    ipcMain?.handle('mcp-get-tools-config', async () => this.mcpGetToolsConfig());
-    ipcMain?.handle('mcp-update-tools-config', async (event, toolsConfig: MCPToolsConfig) =>
+    handle('mcp-get-status', () => this.mcpGetStatus());
+    handle('mcp-reset-client', () => this.mcpResetClient());
+    handle('mcp-update-config', (mcpSettings: MCPSettings) => this.mcpUpdateConfig(mcpSettings));
+    handle('mcp-get-config', () => this.mcpGetConfig());
+    handle('mcp-get-tools-config', () => this.mcpGetToolsConfig());
+    handle('mcp-update-tools-config', (toolsConfig: MCPToolsConfig) =>
       this.mcpUpdateToolsConfig(toolsConfig)
     );
-    ipcMain?.handle('mcp-set-tool-enabled', async (event, { serverName, toolName, enabled }) =>
+    handle('mcp-set-tool-enabled', ({ serverName, toolName, enabled }) =>
       this.mcpSetToolEnabled(serverName, toolName, enabled)
     );
-    ipcMain?.handle('mcp-get-tool-stats', async (event, { serverName, toolName }) =>
+    handle('mcp-get-tool-stats', ({ serverName, toolName }) =>
       this.mcpGetToolStats(serverName, toolName)
     );
-    ipcMain?.handle('mcp-cluster-change', async (event, { cluster }) =>
-      this.mcpClusterChange(cluster)
-    );
+    handle('mcp-cluster-change', ({ cluster }) => this.mcpClusterChange(cluster));
   }
 }
 

--- a/app/electron/package.test.ts
+++ b/app/electron/package.test.ts
@@ -36,6 +36,11 @@ const packageJson = JSON.parse(
   devDependencies: Record<string, string>;
   optionalDependencies: Record<string, string>;
 };
+const packageLock = JSON.parse(
+  fs.readFileSync(new URL('../package-lock.json', import.meta.url), 'utf8')
+) as {
+  packages: Record<string, { optionalDependencies?: Record<string, string>; resolved?: string }>;
+};
 const require = createRequire(import.meta.url);
 const { expandMsiArtifactName } = require('../windows/msi/artifact-name.js') as {
   expandMsiArtifactName: (pattern: string, options: Record<string, string>) => string;
@@ -83,14 +88,18 @@ describe('desktop package configuration', () => {
   it('derives the Linux executable name from package metadata', () => {
     expect(packageJson.build.linux.executableName).toBeUndefined();
   });
+
+  it('does not pin dependencies to private Azure registries', () => {
+    const privatePackages = Object.entries(packageLock.packages)
+      .filter(([, dependency]) => dependency.resolved?.includes('pkgs.visualstudio.com'))
+      .map(([name]) => name);
+
+    expect(privatePackages).toEqual([]);
+  });
 });
 
 describe.runIf(process.platform === 'darwin')('app package', () => {
   it('includes DMG license support for macOS packaging', () => {
-    const packageLock = JSON.parse(
-      fs.readFileSync(new URL('../package-lock.json', import.meta.url), 'utf8')
-    );
-
     expect(packageJson.optionalDependencies).toHaveProperty('dmg-license', expect.any(String));
     expect(packageLock.packages[''].optionalDependencies).toEqual(packageJson.optionalDependencies);
   });

--- a/app/electron/plugin-management.test.ts
+++ b/app/electron/plugin-management.test.ts
@@ -34,13 +34,271 @@ import {
   defaultUserPluginsDir,
   getExtraFiles,
   PluginManager,
+  preparePluginExecutable,
+  preparePluginScript,
+  recordPluginExecutableIntegrity,
+  recordPluginInstallationIntegrity,
+  removePreparedPluginExecutable,
+  removePreparedPluginScript,
+  resolveExtraFilePath,
   setAppConfigDirName,
+  verifyPluginExecutableIntegrity,
+  verifyPluginInstallationIntegrity,
 } from './plugin-management';
 
 const TEST_DATA_BASE_DIR = path.join(os.tmpdir(), 'headlamp-test-data');
 const PLUGIN_DEST_BASE_DIR = path.join(os.tmpdir(), 'headlamp-test-plugins');
 const HEADLAMP_VERSION = '0.30.0';
 const ORIGINAL_PLATFORM = process.platform;
+
+describe('plugin installation integrity', () => {
+  const temporaryDirectories: string[] = [];
+  const identity = {
+    repository: 'headlamp-plugins',
+    package: 'headlamp_minikube',
+    packageId: 'fbc182b5-eb90-42b7-ace8-62a7576abafd',
+    repositoryId: '767e1f40-ee09-401b-b8d4-930740da5a8a',
+  };
+
+  afterEach(() => {
+    for (const directory of temporaryDirectories.splice(0)) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  function fixture() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-installation-receipt-'));
+    temporaryDirectories.push(root);
+    const bundle = path.join(root, 'plugin');
+    const receiptFile = path.join(root, 'app-state', 'plugin-installation-receipts.json');
+    const script = path.join(bundle, 'manage.js');
+    fs.mkdirSync(bundle);
+    fs.writeFileSync(path.join(bundle, 'package.json'), '{"name":"@headlamp-k8s/minikube"}');
+    fs.writeFileSync(script, 'trusted');
+    return { root, bundle, receiptFile, script };
+  }
+
+  it('records installed files with the expected Artifact Hub identity', async () => {
+    const { bundle, receiptFile } = fixture();
+    await recordPluginInstallationIntegrity(bundle, identity, receiptFile);
+
+    await expect(verifyPluginInstallationIntegrity(bundle, identity, receiptFile)).resolves.toBe(
+      true
+    );
+    await expect(
+      verifyPluginInstallationIntegrity(
+        bundle,
+        {
+          repository: identity.repository,
+          package: identity.package,
+        },
+        receiptFile
+      )
+    ).resolves.toBe(true);
+    await expect(
+      verifyPluginInstallationIntegrity(
+        bundle,
+        {
+          repository: identity.repository,
+          package: 'another-package',
+        },
+        receiptFile
+      )
+    ).resolves.toBe(false);
+    await expect(
+      verifyPluginInstallationIntegrity(
+        bundle,
+        {
+          ...identity,
+          repositoryId: '61e223f8-49fe-47c5-9bf8-802e8f759cab',
+        },
+        receiptFile
+      )
+    ).resolves.toBe(false);
+    expect(JSON.parse(fs.readFileSync(receiptFile, 'utf8')).receipts[0]).toEqual(
+      expect.objectContaining({
+        ...identity,
+        inventoryPath: fs.realpathSync(path.dirname(bundle)),
+        bundleName: path.basename(bundle),
+      })
+    );
+    expect(
+      JSON.parse(fs.readFileSync(path.join(bundle, 'package.json'), 'utf8')).headlampPluginIntegrity
+    ).toBeUndefined();
+  });
+
+  it('rejects modified files and receipt-less legacy installations', async () => {
+    const { bundle, receiptFile, script } = fixture();
+
+    await expect(verifyPluginInstallationIntegrity(bundle, identity, receiptFile)).resolves.toBe(
+      false
+    );
+    await recordPluginInstallationIntegrity(bundle, identity, receiptFile);
+    fs.writeFileSync(script, 'replaced');
+    await expect(verifyPluginInstallationIntegrity(bundle, identity, receiptFile)).resolves.toBe(
+      false
+    );
+  });
+
+  it('rejects a forged package-local receipt and a copied bundle', async () => {
+    const { root, bundle, receiptFile } = fixture();
+    const packagePath = path.join(bundle, 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+    packageJson.headlampPluginIntegrity = { version: 1, installation: { ...identity, files: {} } };
+    fs.writeFileSync(packagePath, JSON.stringify(packageJson));
+
+    await expect(verifyPluginInstallationIntegrity(bundle, identity, receiptFile)).resolves.toBe(
+      false
+    );
+    await recordPluginInstallationIntegrity(bundle, identity, receiptFile);
+    const copiedBundle = path.join(root, 'other-inventory', 'plugin');
+    fs.cpSync(bundle, copiedBundle, { recursive: true });
+
+    await expect(
+      verifyPluginInstallationIntegrity(copiedBundle, identity, receiptFile)
+    ).resolves.toBe(false);
+  });
+
+  it('records a root file named __proto__ in the integrity map', async () => {
+    const { bundle, receiptFile } = fixture();
+    const specialFile = path.join(bundle, '__proto__');
+    fs.writeFileSync(specialFile, 'trusted');
+    await recordPluginInstallationIntegrity(bundle, identity, receiptFile);
+    fs.writeFileSync(specialFile, 'replaced');
+
+    await expect(verifyPluginInstallationIntegrity(bundle, identity, receiptFile)).resolves.toBe(
+      false
+    );
+  });
+
+  it('prepares immutable script bytes and removes them after use', async () => {
+    const { root, bundle, receiptFile, script } = fixture();
+    const preparedRoot = path.join(root, 'prepared');
+    await recordPluginInstallationIntegrity(bundle, identity, receiptFile);
+
+    const prepared = await preparePluginScript(
+      bundle,
+      'manage.js',
+      identity,
+      preparedRoot,
+      receiptFile
+    );
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+    fs.writeFileSync(script, 'replaced');
+    expect(fs.readFileSync(prepared.scriptPath, 'utf8')).toBe('trusted');
+    removePreparedPluginScript(prepared.scriptPath, preparedRoot);
+    expect(fs.existsSync(prepared.scriptPath)).toBe(false);
+  });
+});
+
+describe('plugin executable integrity', () => {
+  const temporaryDirectories: string[] = [];
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: ORIGINAL_PLATFORM });
+    for (const directory of temporaryDirectories.splice(0)) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  function fixture() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-executable-receipt-'));
+    temporaryDirectories.push(root);
+    const bundle = path.join(root, 'plugin');
+    const executable = path.join(bundle, 'bin', 'examplectl');
+    fs.mkdirSync(path.dirname(executable), { recursive: true });
+    fs.writeFileSync(path.join(bundle, 'package.json'), '{"name":"@example/plugin"}');
+    fs.writeFileSync(executable, 'trusted');
+    return { bundle, executable };
+  }
+
+  it('accepts installed bytes and rejects replacements', async () => {
+    const { bundle, executable } = fixture();
+    await recordPluginExecutableIntegrity(bundle, ['bin/examplectl']);
+
+    await expect(
+      verifyPluginExecutableIntegrity(bundle, 'bin/examplectl', executable)
+    ).resolves.toEqual({ ok: true });
+    fs.writeFileSync(executable, 'replaced');
+    await expect(
+      verifyPluginExecutableIntegrity(bundle, 'bin/examplectl', executable)
+    ).resolves.toEqual({ ok: false, reason: 'digest-mismatch' });
+  });
+
+  it('prepares immutable app-owned executable bytes', async () => {
+    const { bundle, executable } = fixture();
+    const preparedRoot = path.join(path.dirname(bundle), 'prepared');
+    await recordPluginExecutableIntegrity(bundle, ['bin/examplectl']);
+
+    const prepared = await preparePluginExecutable(
+      bundle,
+      'bin/examplectl',
+      executable,
+      preparedRoot
+    );
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+    fs.writeFileSync(executable, 'replaced');
+    expect(fs.readFileSync(prepared.executablePath, 'utf8')).toBe('trusted');
+    removePreparedPluginExecutable(prepared.executablePath, preparedRoot);
+    expect(fs.existsSync(prepared.executablePath)).toBe(false);
+  });
+
+  it('uses app-owned receipts for managed user-plugin executables', async () => {
+    const { bundle, executable } = fixture();
+    const preparedRoot = path.join(path.dirname(bundle), 'prepared');
+    const receiptFile = path.join(path.dirname(bundle), 'receipts.json');
+    const identity = {
+      repository: 'example-repository',
+      package: 'example-plugin',
+      packageId: '123e4567-e89b-42d3-a456-426614174000',
+      repositoryId: '123e4567-e89b-42d3-a456-426614174001',
+    };
+    await recordPluginInstallationIntegrity(bundle, identity, receiptFile);
+
+    fs.writeFileSync(executable, 'replaced');
+    await recordPluginExecutableIntegrity(bundle, ['bin/examplectl']);
+
+    await expect(
+      preparePluginExecutable(
+        bundle,
+        'bin/examplectl',
+        executable,
+        preparedRoot,
+        identity,
+        receiptFile
+      )
+    ).resolves.toEqual({ ok: false, reason: 'digest-mismatch' });
+  });
+
+  it('does not prepare modified or outside executable bytes', async () => {
+    const { bundle, executable } = fixture();
+    const preparedRoot = path.join(path.dirname(bundle), 'prepared');
+    await recordPluginExecutableIntegrity(bundle, ['bin/examplectl']);
+    fs.writeFileSync(executable, 'replaced');
+    await expect(
+      preparePluginExecutable(bundle, 'bin/examplectl', executable, preparedRoot)
+    ).resolves.toEqual({ ok: false, reason: 'digest-mismatch' });
+
+    const outsideExecutable = path.join(path.dirname(bundle), 'outside');
+    fs.writeFileSync(outsideExecutable, 'trusted');
+    await expect(
+      preparePluginExecutable(bundle, 'bin/examplectl', outsideExecutable, preparedRoot)
+    ).resolves.toEqual({ ok: false, reason: 'unavailable-executable' });
+  });
+
+  it('uses logical executable paths for Windows .exe files', async () => {
+    const { bundle, executable } = fixture();
+    fs.renameSync(executable, `${executable}.exe`);
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+
+    await recordPluginExecutableIntegrity(bundle, ['bin/examplectl']);
+    await expect(
+      verifyPluginExecutableIntegrity(bundle, 'bin/examplectl', `${executable}.exe`)
+    ).resolves.toEqual({ ok: true });
+  });
+});
 
 describe('default plugin directories', () => {
   afterEach(() => {
@@ -113,6 +371,37 @@ describe('plugin management loading', () => {
   });
 });
 
+describe('Artifact Hub package identity', () => {
+  it('preserves immutable package and repository IDs from the API', async () => {
+    nock('https://artifacthub.io')
+      .get('/api/v1/packages/headlamp/example-repo/example-plugin')
+      .reply(200, {
+        package_id: 'package-id',
+        name: 'example-plugin',
+        display_name: 'Example plugin',
+        version: '1.0.0',
+        repository: {
+          repository_id: 'repository-id',
+          name: 'example-repo',
+          user_alias: 'publisher',
+        },
+        data: {
+          'headlamp/plugin/archive-url': 'https://github.com/example/plugin/archive.tar.gz',
+          'headlamp/plugin/archive-checksum': `sha256:${'0'.repeat(64)}`,
+          'headlamp/plugin/version-compat': '>=0.22',
+          'headlamp/plugin/distro-compat': 'desktop',
+        },
+      });
+
+    const plugin = await PluginManager.fetchPluginInfo(
+      'https://artifacthub.io/packages/headlamp/example-repo/example-plugin'
+    );
+
+    expect(plugin.packageId).toBe('package-id');
+    expect(plugin.repository.repositoryId).toBe('repository-id');
+  });
+});
+
 /**
  * Creates a unique test directory for a test
  * @param basePath Base directory path
@@ -170,6 +459,9 @@ describe('PluginManager', () => {
     const minikubeBinary = platform === 'win32' ? 'minikube.exe' : 'minikube';
     const minikubePath = path.join(pluginDir, 'bin', minikubeBinary);
     expect(fs.existsSync(minikubePath)).toBe(true);
+    await expect(
+      verifyPluginExecutableIntegrity(pluginDir, 'bin/minikube', minikubePath)
+    ).resolves.toEqual({ ok: true });
 
     // Verify progress includes platform-specific download
     const platformMessages = progress.filter(
@@ -240,6 +532,60 @@ describe('PluginManager', () => {
     if (fs.existsSync(testDataDir)) {
       fs.rmSync(testDataDir, { recursive: true });
     }
+  }, 30000);
+
+  it('keeps an updated plugin when its unique backup cannot be removed', async () => {
+    const testDataDir = getUniqueTestDir(TEST_DATA_BASE_DIR, 'update-backup-data');
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'update-backup-plugins');
+    await createMinimalPluginTarball(testDataDir);
+    await createPlatformSpecificTarball(testDataDir);
+    mockArtifactHubAPI(testDataDir);
+
+    const pluginURL = 'https://artifacthub.io/packages/headlamp/test-repo/headlamp_minikube';
+    await PluginManager.install(pluginURL, pluginDestDir, HEADLAMP_VERSION, null, null);
+
+    mockArtifactHubAPI(testDataDir, '0.2.0');
+    const remove = fs.rmSync.bind(fs);
+    const removeSpy = vi.spyOn(fs, 'rmSync').mockImplementation((target, options) => {
+      if (String(target).includes('.update-backup-')) {
+        throw new Error('backup is busy');
+      }
+      return remove(target, options);
+    });
+    const renameSpy = vi.spyOn(fs, 'renameSync');
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(
+      PluginManager.update('headlamp_minikube', pluginDestDir, HEADLAMP_VERSION, null, null)
+    ).resolves.toBeUndefined();
+
+    const pluginDir = path.join(pluginDestDir, 'headlamp_minikube');
+    const packageJson = JSON.parse(fs.readFileSync(path.join(pluginDir, 'package.json'), 'utf8'));
+    const executable = path.join(
+      pluginDir,
+      'bin',
+      process.platform === 'win32' ? 'minikube.exe' : 'minikube'
+    );
+    const backupPath = renameSpy.mock.calls
+      .map(([, destination]) => String(destination))
+      .find(destination => destination.includes('.update-backup-'));
+    expect(backupPath).toMatch(/\.update-backup-[a-f0-9]{16}$/);
+    expect(path.basename(path.dirname(backupPath!))).toBe('.headlamp-plugin-updates');
+    expect(PluginManager.list(pluginDestDir)).toHaveLength(1);
+    expect(packageJson.artifacthub.version).toBe('0.2.0');
+    await expect(
+      verifyPluginExecutableIntegrity(pluginDir, 'bin/minikube', executable)
+    ).resolves.toEqual({ ok: true });
+    expect(consoleWarn).toHaveBeenCalledWith(
+      'Failed to remove plugin update backup:',
+      expect.any(Error)
+    );
+
+    removeSpy.mockRestore();
+    renameSpy.mockRestore();
+    consoleWarn.mockRestore();
+    remove(pluginDestDir, { recursive: true, force: true });
+    remove(testDataDir, { recursive: true, force: true });
   }, 30000);
 
   it('should uninstall plugin from the same directory where it was installed', async () => {
@@ -379,9 +725,13 @@ async function createPlatformSpecificTarball(testDataDir: string) {
 }
 
 /**
- * Mock the ArtifactHub API responses for testing
+ * Mock the ArtifactHub API responses for testing.
+ *
+ * @param testDataDir - Directory containing the mocked plugin archives.
+ * @param version - Artifact Hub package version returned by the mock.
+ * @param requestCount - Number of complete metadata and archive download cycles to serve.
  */
-function mockArtifactHubAPI(testDataDir: string) {
+function mockArtifactHubAPI(testDataDir: string, version = '0.1.0') {
   try {
     // Calculate checksums for the tarballs
     const pluginTarballPath = path.join(testDataDir, 'plugin-tarball.tar.gz');
@@ -413,10 +763,12 @@ function mockArtifactHubAPI(testDataDir: string) {
     nock('https://artifacthub.io')
       .get('/api/v1/packages/headlamp/test-repo/headlamp_minikube')
       .reply(200, {
+        package_id: 'fbc182b5-eb90-42b7-ace8-62a7576abafd',
         name: 'headlamp_minikube',
         display_name: 'Minikube',
-        version: '0.1.0',
+        version,
         repository: {
+          repository_id: '767e1f40-ee09-401b-b8d4-930740da5a8a',
           name: 'test-repo',
           user_alias: 'tester',
         },
@@ -428,7 +780,8 @@ function mockArtifactHubAPI(testDataDir: string) {
           'headlamp/plugin/extra-files/0/url': platformSpecificArchiveURL,
           'headlamp/plugin/extra-files/0/checksum': `sha256:${platformSpecificChecksum}`,
           'headlamp/plugin/extra-files/0/arch': `${platform}/${arch}`,
-          'headlamp/plugin/extra-files/0/output/minikube/output': 'minikube',
+          'headlamp/plugin/extra-files/0/output/minikube/output':
+            os.platform() === 'win32' ? 'minikube.exe' : 'minikube',
           'headlamp/plugin/extra-files/0/output/minikube/input':
             os.platform() === 'win32' ? 'minikube.exe' : 'minikube',
           // Add dummy entries for other platforms to ensure we only download the correct one
@@ -480,10 +833,12 @@ function mockArtifactHubAPIWithoutPlatformSpecific(testDataDir: string) {
     nock('https://artifacthub.io')
       .get('/api/v1/packages/headlamp/test-repo/headlamp_minikube')
       .reply(200, {
+        package_id: 'fbc182b5-eb90-42b7-ace8-62a7576abafd',
         name: 'headlamp_minikube',
         display_name: 'Minikube',
         version: '0.1.0',
         repository: {
+          repository_id: '767e1f40-ee09-401b-b8d4-930740da5a8a',
           name: 'test-repo',
           user_alias: 'tester',
         },
@@ -538,6 +893,15 @@ function calculateSHA256(filePath: string): string {
 }
 
 describe('getExtraFiles', () => {
+  it.each(['nested/../../outside', 'nested\\..\\..\\outside', '/outside', 'C:\\outside'])(
+    'rejects an extra-file path that escapes the bin directory: %s',
+    candidate => {
+      expect(() => resolveExtraFilePath('/plugins/example/bin', candidate, 'output')).toThrow(
+        'Invalid extra file output path'
+      );
+    }
+  );
+
   it('should extract extra-files with valid github.com/kubernetes/minikube URL', () => {
     const annotations = {
       'headlamp/plugin/extra-files/0/url':

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -24,6 +24,7 @@
  * - app/ to manage plugins.
  */
 import crypto from 'crypto';
+import { app } from 'electron';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -151,9 +152,11 @@ type ExtraFile = {
   };
 };
 export interface ArtifactHubHeadlampPkg {
+  packageId: string;
   name: string;
   display_name: string;
   repository: {
+    repositoryId: string;
     name: string;
     user_alias: string;
   };
@@ -167,6 +170,580 @@ export interface ArtifactHubHeadlampPkg {
    * @see ExtraFile
    */
   extraFiles?: Record<string, ExtraFile>;
+}
+
+/** Artifact Hub provenance expected for a managed plugin installation. */
+export interface ArtifactHubPluginIdentity {
+  /** Artifact Hub repository name recorded by the installer. */
+  repository: string;
+  /** Artifact Hub package name within the repository. */
+  package: string;
+  /** Immutable Artifact Hub package identifier, when the policy requires one. */
+  packageId?: string;
+  /** Immutable Artifact Hub repository identifier, when the policy requires one. */
+  repositoryId?: string;
+}
+
+interface PluginInstallationReceipt extends Required<ArtifactHubPluginIdentity> {
+  inventoryPath: string;
+  bundleName: string;
+  files: Record<string, string>;
+}
+
+interface PluginInstallationReceiptStore {
+  version: 1;
+  receipts: PluginInstallationReceipt[];
+}
+
+/**
+ * Package-local consistency metadata for a managed plugin.
+ *
+ * Headlamp records this after checksum-verifying and installing an Artifact Hub archive. It detects
+ * accidental corruption and changes that leave the recorded digests untouched. Because the plugin
+ * bundle contains both the files and this metadata, it does not authenticate publisher identity or
+ * resist an actor who can replace or pre-position the whole bundle and recompute the metadata.
+ */
+interface PluginPackageIntegrity {
+  version: 1;
+  executables?: Record<string, string>;
+}
+
+const PLUGIN_DATA_PATH = app?.getPath('userData') || path.join(os.tmpdir(), 'headlamp-testing');
+export const PREPARED_PLUGIN_EXECUTABLES_PATH = path.join(
+  PLUGIN_DATA_PATH,
+  'prepared-plugin-executables'
+);
+export const PREPARED_PLUGIN_SCRIPTS_PATH = path.join(PLUGIN_DATA_PATH, 'prepared-plugin-scripts');
+export const PLUGIN_INSTALLATION_RECEIPTS_PATH = path.join(
+  PLUGIN_DATA_PATH,
+  'plugin-installation-receipts.json'
+);
+
+/**
+ * Computes the SHA-256 digest of a plugin file.
+ *
+ * @param file - File to hash.
+ * @returns The lowercase hexadecimal digest.
+ */
+function hashPluginFile(file: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash('sha256');
+    const stream = fs.createReadStream(file);
+    stream.on('data', chunk => hash.update(chunk));
+    stream.on('error', reject);
+    stream.on('end', () => resolve(hash.digest('hex')));
+  });
+}
+
+/**
+ * Computes the stable digest of package.json without its self-referential integrity metadata.
+ *
+ * Excluding `headlampPluginIntegrity` allows receipts to be updated without invalidating the
+ * package digest. Consequently, this digest is a consistency check, not authentication of the
+ * package-local receipt.
+ *
+ * @param packageJson - Parsed plugin package.json.
+ * @returns The lowercase hexadecimal SHA-256 digest.
+ */
+function hashPluginPackage(packageJson: Record<string, unknown>): string {
+  const contents = { ...packageJson };
+  delete contents.headlampPluginIntegrity;
+  return crypto.createHash('sha256').update(JSON.stringify(contents)).digest('hex');
+}
+
+/**
+ * Builds a deterministic map of relative plugin file paths to SHA-256 digests.
+ *
+ * @param bundlePath - Canonical plugin bundle directory.
+ * @returns Digests for every regular file in the bundle.
+ * @throws When the bundle contains a symbolic link or non-file entry.
+ */
+async function pluginBundleFiles(bundlePath: string): Promise<Record<string, string>> {
+  const files: Record<string, string> = Object.create(null);
+
+  /** Visits one bundle directory and adds its regular files to the digest map. */
+  async function visit(directory: string): Promise<void> {
+    for (const entry of fs
+      .readdirSync(directory, { withFileTypes: true })
+      .sort((a, b) => a.name.localeCompare(b.name))) {
+      const entryPath = path.join(directory, entry.name);
+      const stat = fs.lstatSync(entryPath);
+      if (stat.isSymbolicLink() || (!stat.isDirectory() && !stat.isFile())) {
+        throw new Error(`Unsupported plugin file: ${entry.name}`);
+      }
+      if (stat.isDirectory()) {
+        await visit(entryPath);
+      } else {
+        const relativePath = path.relative(bundlePath, entryPath).split(path.sep).join('/');
+        files[relativePath] =
+          relativePath === 'package.json'
+            ? hashPluginPackage(JSON.parse(await fs.promises.readFile(entryPath, 'utf8')))
+            : await hashPluginFile(entryPath);
+      }
+    }
+  }
+  await visit(bundlePath);
+  return files;
+}
+
+/**
+ * Reads and structurally validates package-local plugin integrity metadata.
+ *
+ * This validates metadata shape only; it does not authenticate who wrote the metadata.
+ *
+ * @param bundlePath - Plugin bundle containing package.json.
+ * @returns Valid integrity metadata, or undefined when missing or malformed.
+ */
+function readPluginIntegrity(bundlePath: string): PluginPackageIntegrity | undefined {
+  try {
+    const bundle = fs.realpathSync(bundlePath);
+    const packagePath = path.join(bundle, 'package.json');
+    if (fs.lstatSync(packagePath).isSymbolicLink()) return undefined;
+    const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+    const integrity = packageJson.headlampPluginIntegrity as PluginPackageIntegrity | undefined;
+    const validFiles = (files: Record<string, string> | undefined) =>
+      files &&
+      Object.entries(files).every(([file, digest]) => file !== '' && /^[a-f0-9]{64}$/.test(digest));
+    if (integrity?.version !== 1) return undefined;
+    if (integrity.executables && !validFiles(integrity.executables)) {
+      return undefined;
+    }
+    return integrity;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Atomically updates a plugin's package.json after rejecting a symbolic-link package file.
+ *
+ * @param bundlePath - Plugin bundle containing package.json.
+ * @param update - Mutation to apply to the parsed package object.
+ */
+function updatePluginPackage(
+  bundlePath: string,
+  update: (packageJson: Record<string, unknown>) => void
+): void {
+  const bundle = fs.realpathSync(bundlePath);
+  const packagePath = path.join(bundle, 'package.json');
+  if (fs.lstatSync(packagePath).isSymbolicLink()) {
+    throw new Error('Invalid plugin package.json');
+  }
+  const packageJson: Record<string, unknown> = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+  update(packageJson);
+  const temporaryFile = `${packagePath}.${crypto.randomBytes(8).toString('hex')}.tmp`;
+  try {
+    fs.writeFileSync(temporaryFile, `${JSON.stringify(packageJson, null, 2)}\n`, { mode: 0o600 });
+    fs.renameSync(temporaryFile, packagePath);
+  } finally {
+    fs.rmSync(temporaryFile, { force: true });
+  }
+}
+
+/**
+ * Merges package-local integrity metadata without discarding another receipt category.
+ *
+ * @param bundlePath - Plugin bundle containing package.json.
+ * @param update - Installation or executable integrity fields to merge.
+ */
+function writePluginIntegrity(
+  bundlePath: string,
+  update: Partial<Omit<PluginPackageIntegrity, 'version'>>
+): void {
+  updatePluginPackage(bundlePath, packageJson => {
+    packageJson.headlampPluginIntegrity = {
+      ...readPluginIntegrity(bundlePath),
+      ...update,
+      version: 1,
+    };
+  });
+}
+
+/** Reads structurally valid installation receipts from app-owned state. */
+function readPluginInstallationReceipts(receiptFile: string): PluginInstallationReceipt[] {
+  try {
+    const store = JSON.parse(
+      fs.readFileSync(receiptFile, 'utf8')
+    ) as PluginInstallationReceiptStore;
+    if (store.version !== 1 || !Array.isArray(store.receipts)) return [];
+    return store.receipts.filter(receipt => {
+      const validFiles =
+        receipt.files &&
+        Object.entries(receipt.files).every(
+          ([file, digest]) => file !== '' && /^[a-f0-9]{64}$/.test(digest)
+        );
+      return (
+        typeof receipt.inventoryPath === 'string' &&
+        path.isAbsolute(receipt.inventoryPath) &&
+        typeof receipt.bundleName === 'string' &&
+        receipt.bundleName !== '' &&
+        typeof receipt.repository === 'string' &&
+        typeof receipt.package === 'string' &&
+        typeof receipt.packageId === 'string' &&
+        typeof receipt.repositoryId === 'string' &&
+        Boolean(validFiles)
+      );
+    });
+  } catch {
+    return [];
+  }
+}
+
+/** Atomically replaces app-owned installation receipt state. */
+function writePluginInstallationReceipts(
+  receiptFile: string,
+  receipts: PluginInstallationReceipt[]
+): void {
+  fs.mkdirSync(path.dirname(receiptFile), { recursive: true, mode: 0o700 });
+  const temporaryFile = `${receiptFile}.${crypto.randomBytes(8).toString('hex')}.tmp`;
+  try {
+    fs.writeFileSync(temporaryFile, `${JSON.stringify({ version: 1, receipts }, null, 2)}\n`, {
+      flag: 'wx',
+      mode: 0o600,
+    });
+    fs.renameSync(temporaryFile, receiptFile);
+  } finally {
+    fs.rmSync(temporaryFile, { force: true });
+  }
+}
+
+/**
+ * Reads the app-owned installation receipt for one canonical bundle and Artifact Hub identity.
+ *
+ * The canonical inventory path and bundle directory are part of the authenticated lookup key, so
+ * a receipt for one installed location cannot authorize a bundle copied or pre-positioned elsewhere.
+ *
+ * @param bundlePath - Installed plugin bundle.
+ * @param identity - Artifact Hub identity expected by the caller.
+ * @param receiptFile - App-owned receipt store.
+ * @returns The matching receipt, or undefined when it is absent, malformed, or has different IDs.
+ */
+export function readPluginInstallationReceipt(
+  bundlePath: string,
+  identity: ArtifactHubPluginIdentity,
+  receiptFile = PLUGIN_INSTALLATION_RECEIPTS_PATH
+): PluginInstallationReceipt | undefined {
+  const canonicalBundle = fs.realpathSync(bundlePath);
+  const inventoryPath = path.dirname(canonicalBundle);
+  const bundleName = path.basename(canonicalBundle);
+  const receipt = readPluginInstallationReceipts(receiptFile).find(
+    candidate => candidate.inventoryPath === inventoryPath && candidate.bundleName === bundleName
+  );
+  if (
+    !receipt ||
+    receipt.repository !== identity.repository ||
+    receipt.package !== identity.package ||
+    (identity.packageId !== undefined && receipt.packageId !== identity.packageId) ||
+    (identity.repositoryId !== undefined && receipt.repositoryId !== identity.repositoryId)
+  ) {
+    return undefined;
+  }
+  return receipt;
+}
+
+/**
+ * Records the current managed bundle contents and installer-supplied Artifact Hub identity.
+ *
+ * @param bundlePath - Installed plugin bundle.
+ * @param identity - Artifact Hub identity obtained by the installation flow.
+ * @param receiptFile - App-owned receipt store.
+ * @throws When either identity field is not a UUID.
+ */
+export async function recordPluginInstallationIntegrity(
+  bundlePath: string,
+  identity: Required<ArtifactHubPluginIdentity>,
+  receiptFile = PLUGIN_INSTALLATION_RECEIPTS_PATH
+): Promise<void> {
+  const uuid = /^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/i;
+  const name = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+  if (
+    !name.test(identity.repository) ||
+    !name.test(identity.package) ||
+    !uuid.test(identity.packageId) ||
+    !uuid.test(identity.repositoryId)
+  ) {
+    throw new Error('Invalid Artifact Hub plugin identity');
+  }
+  const canonicalBundle = fs.realpathSync(bundlePath);
+  const receipt: PluginInstallationReceipt = {
+    ...identity,
+    inventoryPath: path.dirname(canonicalBundle),
+    bundleName: path.basename(canonicalBundle),
+    files: await pluginBundleFiles(canonicalBundle),
+  };
+  const receipts = readPluginInstallationReceipts(receiptFile).filter(
+    candidate =>
+      candidate.inventoryPath !== receipt.inventoryPath ||
+      candidate.bundleName !== receipt.bundleName
+  );
+  writePluginInstallationReceipts(receiptFile, [...receipts, receipt]);
+}
+
+/**
+ * Checks a managed bundle against its app-owned receipt and expected Artifact Hub identity.
+ *
+ * Provenance decisions must never use package-local metadata: a pre-positioned bundle can rewrite
+ * both its files and `package.json`. The receipt used here is created only by Headlamp's verified
+ * install flow and stored outside plugin-controlled inventory, bound to its canonical location.
+ *
+ * @param bundlePath - Installed plugin bundle.
+ * @param identity - Artifact Hub identity expected by the caller.
+ * @param receiptFile - App-owned receipt store.
+ * @returns Whether the receipt identity and all recorded file digests match.
+ */
+export async function verifyPluginInstallationIntegrity(
+  bundlePath: string,
+  identity: ArtifactHubPluginIdentity,
+  receiptFile = PLUGIN_INSTALLATION_RECEIPTS_PATH
+): Promise<boolean> {
+  try {
+    const canonicalBundle = fs.realpathSync(bundlePath);
+    const receipt = readPluginInstallationReceipt(canonicalBundle, identity, receiptFile);
+    if (!receipt) return false;
+    const currentFiles = await pluginBundleFiles(canonicalBundle);
+    const recordedPaths = Object.keys(receipt.files);
+    return (
+      Object.keys(currentFiles).length === recordedPaths.length &&
+      recordedPaths.every(file => currentFiles[file] === receipt.files[file])
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Removes app-owned provenance for an uninstalled bundle. */
+function removePluginInstallationReceipt(
+  bundlePath: string,
+  receiptFile = PLUGIN_INSTALLATION_RECEIPTS_PATH
+): void {
+  const canonicalBundle = fs.existsSync(bundlePath)
+    ? fs.realpathSync(bundlePath)
+    : path.resolve(bundlePath);
+  const inventoryPath = path.dirname(canonicalBundle);
+  const bundleName = path.basename(canonicalBundle);
+  const receipts = readPluginInstallationReceipts(receiptFile);
+  const retained = receipts.filter(
+    receipt => receipt.inventoryPath !== inventoryPath || receipt.bundleName !== bundleName
+  );
+  if (retained.length !== receipts.length) {
+    writePluginInstallationReceipts(receiptFile, retained);
+  }
+}
+
+/**
+ * Copies a receipted plugin script into a private directory and verifies the copied bytes.
+ *
+ * @param bundlePath - Installed plugin bundle.
+ * @param scriptPath - Bundle-relative script path.
+ * @param identity - Artifact Hub identity expected by the caller.
+ * @param preparedRoot - App-managed root for one-time script copies.
+ * @returns The prepared script path, or a non-sensitive failure reason.
+ */
+export async function preparePluginScript(
+  bundlePath: string,
+  scriptPath: string,
+  identity: ArtifactHubPluginIdentity,
+  preparedRoot = PREPARED_PLUGIN_SCRIPTS_PATH,
+  receiptFile = PLUGIN_INSTALLATION_RECEIPTS_PATH
+): Promise<{ ok: true; scriptPath: string } | { ok: false; reason: string }> {
+  let preparedDirectory: string | undefined;
+  try {
+    const canonicalBundle = fs.realpathSync(bundlePath);
+    const requestedScript = path.resolve(canonicalBundle, scriptPath);
+    const canonicalScript = fs.realpathSync(requestedScript);
+    const relativeScript = path.relative(canonicalBundle, canonicalScript);
+    if (
+      relativeScript === '' ||
+      relativeScript === '..' ||
+      relativeScript.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relativeScript) ||
+      fs.lstatSync(requestedScript).isSymbolicLink()
+    ) {
+      return { ok: false, reason: 'unavailable-file' };
+    }
+    const receipt = readPluginInstallationReceipt(canonicalBundle, identity, receiptFile);
+    const digest = receipt?.files[relativeScript.split(path.sep).join('/')];
+    if (!digest) return { ok: false, reason: 'missing-receipt' };
+
+    fs.mkdirSync(preparedRoot, { recursive: true, mode: 0o700 });
+    preparedDirectory = fs.mkdtempSync(path.join(preparedRoot, 'run-'));
+    const preparedScript = path.join(preparedDirectory, path.basename(canonicalScript));
+    fs.copyFileSync(canonicalScript, preparedScript, fs.constants.COPYFILE_EXCL);
+    fs.chmodSync(preparedScript, 0o400);
+    if (digest !== (await hashPluginFile(preparedScript))) {
+      fs.rmSync(preparedDirectory, { recursive: true, force: true });
+      return { ok: false, reason: 'digest-mismatch' };
+    }
+    return { ok: true, scriptPath: preparedScript };
+  } catch {
+    if (preparedDirectory) fs.rmSync(preparedDirectory, { recursive: true, force: true });
+    return { ok: false, reason: 'unavailable-file' };
+  }
+}
+
+/**
+ * Removes a prepared script directory after validating that it belongs to the prepared root.
+ *
+ * @param scriptPath - Prepared script to remove.
+ * @param preparedRoot - App-managed root for one-time script copies.
+ * @throws When the script is not an immediate child of a prepared directory.
+ */
+export function removePreparedPluginScript(
+  scriptPath: string,
+  preparedRoot = PREPARED_PLUGIN_SCRIPTS_PATH
+): void {
+  const preparedDirectory = path.dirname(path.resolve(scriptPath));
+  if (path.dirname(preparedDirectory) !== path.resolve(preparedRoot)) {
+    throw new Error('Invalid prepared plugin script path');
+  }
+  fs.rmSync(preparedDirectory, { recursive: true, force: true });
+}
+
+/**
+ * Resolves a bundle-relative executable without allowing links or bundle escapes.
+ *
+ * @param bundlePath - Installed plugin bundle.
+ * @param executablePath - Platform-independent bundle-relative executable path.
+ * @returns Canonical bundle and executable paths plus the receipt key.
+ * @throws When the executable is unavailable, linked, or outside the bundle.
+ */
+function pluginExecutable(bundlePath: string, executablePath: string) {
+  const bundle = fs.realpathSync(bundlePath);
+  const requested = path.resolve(bundle, executablePath);
+  const platformPath =
+    process.platform === 'win32' && !fs.existsSync(requested) ? `${requested}.exe` : requested;
+  const executable = fs.realpathSync(platformPath);
+  const relative = path.relative(bundle, executable);
+  if (
+    relative === '' ||
+    relative === '..' ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative) ||
+    fs.lstatSync(platformPath).isSymbolicLink()
+  ) {
+    throw new Error(`Invalid plugin executable path: ${executablePath}`);
+  }
+  return {
+    bundle,
+    executable,
+    logicalPath: executablePath.split(path.sep).join('/'),
+  };
+}
+
+/**
+ * Records package-local digests for executables installed by the verified download flow.
+ *
+ * @param bundlePath - Installed plugin bundle.
+ * @param executablePaths - Platform-independent bundle-relative executable paths.
+ */
+export async function recordPluginExecutableIntegrity(
+  bundlePath: string,
+  executablePaths: string[]
+): Promise<void> {
+  const files: Record<string, string> = {};
+  let bundle = fs.realpathSync(bundlePath);
+  for (const executablePath of executablePaths) {
+    const resolved = pluginExecutable(bundle, executablePath);
+    bundle = resolved.bundle;
+    files[resolved.logicalPath] = await hashPluginFile(resolved.executable);
+  }
+  writePluginIntegrity(bundle, { executables: files });
+}
+
+/**
+ * Verifies that an executable resolves to the expected bundle file and matches its recorded digest.
+ *
+ * The package-local digest detects replacement that leaves the receipt unchanged; it is not proof of
+ * provenance when an actor can rewrite both the executable and its receipt.
+ *
+ * @param bundlePath - Installed plugin bundle.
+ * @param executablePath - Platform-independent bundle-relative executable path.
+ * @param absoluteExecutablePath - Absolute path selected for execution.
+ * @returns Success or a non-sensitive failure reason.
+ */
+export async function verifyPluginExecutableIntegrity(
+  bundlePath: string,
+  executablePath: string,
+  absoluteExecutablePath: string
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  try {
+    const resolved = pluginExecutable(bundlePath, executablePath);
+    if (resolved.executable !== fs.realpathSync(absoluteExecutablePath)) {
+      return { ok: false, reason: 'unavailable-executable' };
+    }
+    const digest = readPluginIntegrity(resolved.bundle)?.executables?.[resolved.logicalPath];
+    if (!digest) return { ok: false, reason: 'missing-receipt' };
+    return digest === (await hashPluginFile(resolved.executable))
+      ? { ok: true }
+      : { ok: false, reason: 'digest-mismatch' };
+  } catch {
+    return { ok: false, reason: 'unavailable-executable' };
+  }
+}
+
+/**
+ * Copies a receipted executable into a private directory and verifies the copied bytes.
+ *
+ * @param bundlePath - Installed plugin bundle.
+ * @param executablePath - Platform-independent bundle-relative executable path.
+ * @param absoluteExecutablePath - Absolute path selected for execution.
+ * @param preparedRoot - App-managed root for one-time executable copies.
+ * @param identity - Artifact Hub identity required for a managed user-plugin receipt.
+ * @param receiptFile - App-owned installation receipt store.
+ * @returns The prepared executable path, or a non-sensitive failure reason.
+ */
+export async function preparePluginExecutable(
+  bundlePath: string,
+  executablePath: string,
+  absoluteExecutablePath: string,
+  preparedRoot = PREPARED_PLUGIN_EXECUTABLES_PATH,
+  identity?: ArtifactHubPluginIdentity,
+  receiptFile = PLUGIN_INSTALLATION_RECEIPTS_PATH
+): Promise<{ ok: true; executablePath: string } | { ok: false; reason: string }> {
+  let preparedDirectory: string | undefined;
+  try {
+    const resolved = pluginExecutable(bundlePath, executablePath);
+    if (resolved.executable !== fs.realpathSync(absoluteExecutablePath)) {
+      return { ok: false, reason: 'unavailable-executable' };
+    }
+    const digest = identity
+      ? readPluginInstallationReceipt(resolved.bundle, identity, receiptFile)?.files[
+          resolved.logicalPath
+        ]
+      : readPluginIntegrity(resolved.bundle)?.executables?.[resolved.logicalPath];
+    if (!digest) return { ok: false, reason: 'missing-receipt' };
+    fs.mkdirSync(preparedRoot, { recursive: true, mode: 0o700 });
+    preparedDirectory = fs.mkdtempSync(path.join(preparedRoot, 'run-'));
+    const preparedExecutable = path.join(preparedDirectory, path.basename(resolved.executable));
+    fs.copyFileSync(resolved.executable, preparedExecutable, fs.constants.COPYFILE_EXCL);
+    fs.chmodSync(preparedExecutable, 0o500);
+    if (digest !== (await hashPluginFile(preparedExecutable))) {
+      fs.rmSync(preparedDirectory, { recursive: true, force: true });
+      return { ok: false, reason: 'digest-mismatch' };
+    }
+    return { ok: true, executablePath: preparedExecutable };
+  } catch {
+    if (preparedDirectory) fs.rmSync(preparedDirectory, { recursive: true, force: true });
+    return { ok: false, reason: 'unavailable-executable' };
+  }
+}
+
+/**
+ * Removes a prepared executable directory after validating that it belongs to the prepared root.
+ *
+ * @param executablePath - Prepared executable to remove.
+ * @param preparedRoot - App-managed root for one-time executable copies.
+ * @throws When the executable is not an immediate child of a prepared directory.
+ */
+export function removePreparedPluginExecutable(
+  executablePath: string,
+  preparedRoot = PREPARED_PLUGIN_EXECUTABLES_PATH
+): void {
+  const preparedDirectory = path.dirname(path.resolve(executablePath));
+  if (path.dirname(preparedDirectory) !== path.resolve(preparedRoot)) {
+    throw new Error('Invalid prepared plugin executable path');
+  }
+  fs.rmSync(preparedDirectory, { recursive: true, force: true });
 }
 
 /**
@@ -240,7 +817,7 @@ export class PluginManager {
     signal: AbortSignal | null = null
   ) {
     try {
-      const [name, tempFolder] = await downloadExtractArchive(
+      const [name, tempFolder, executablePaths] = await downloadExtractArchive(
         pluginData,
         headlampVersion,
         progressCallback,
@@ -254,7 +831,20 @@ export class PluginManager {
         fs.mkdirSync(destinationFolder, { recursive: true });
       }
       // move the plugin to the destination folder
-      moveDirs(tempFolder, path.join(destinationFolder, path.basename(name)));
+      const bundlePath = path.join(destinationFolder, path.basename(name));
+      moveDirs(tempFolder, bundlePath);
+      try {
+        await recordPluginExecutableIntegrity(bundlePath, executablePaths);
+        await recordPluginInstallationIntegrity(bundlePath, {
+          repository: pluginData.repository.name,
+          package: pluginData.name,
+          packageId: pluginData.packageId,
+          repositoryId: pluginData.repository.repositoryId,
+        });
+      } catch (error) {
+        fs.rmSync(bundlePath, { recursive: true, force: true });
+        throw error;
+      }
       if (progressCallback) {
         progressCallback({ type: 'success', message: 'Plugin Installed' });
       }
@@ -319,7 +909,7 @@ export class PluginManager {
       }
 
       // eslint-disable-next-line no-unused-vars
-      const [_, tempFolder] = await downloadExtractArchive(
+      const [_, tempFolder, executablePaths] = await downloadExtractArchive(
         pluginData,
         headlampVersion,
         progressCallback,
@@ -333,14 +923,32 @@ export class PluginManager {
         fs.mkdirSync(destinationFolder, { recursive: true });
       }
 
-      // remove the existing plugin folder
-      fs.rmSync(pluginDir, { recursive: true, force: true });
-
-      // create the plugin folder
-      fs.mkdirSync(pluginDir, { recursive: true });
-
-      // move the plugin to the destination folder
-      moveDirs(tempFolder, pluginDir);
+      const updateRoot = path.join(destinationFolder, '.headlamp-plugin-updates');
+      fs.mkdirSync(updateRoot, { recursive: true });
+      const backupDir = path.join(
+        updateRoot,
+        `${plugin.folderName}.update-backup-${crypto.randomBytes(8).toString('hex')}`
+      );
+      fs.renameSync(pluginDir, backupDir);
+      try {
+        moveDirs(tempFolder, pluginDir);
+        await recordPluginExecutableIntegrity(pluginDir, executablePaths);
+        await recordPluginInstallationIntegrity(pluginDir, {
+          repository: pluginData.repository.name,
+          package: pluginData.name,
+          packageId: pluginData.packageId,
+          repositoryId: pluginData.repository.repositoryId,
+        });
+      } catch (error) {
+        fs.rmSync(pluginDir, { recursive: true, force: true });
+        fs.renameSync(backupDir, pluginDir);
+        throw error;
+      }
+      try {
+        fs.rmSync(backupDir, { recursive: true, force: true });
+      } catch (error) {
+        console.warn('Failed to remove plugin update backup:', error);
+      }
       if (progressCallback) {
         progressCallback({ type: 'success', message: 'Plugin Updated' });
       }
@@ -383,6 +991,7 @@ export class PluginManager {
 
       if (fs.existsSync(pluginDir)) {
         fs.rmSync(pluginDir, { recursive: true, force: true });
+        removePluginInstallationReceipt(pluginDir);
       } else {
         throw new Error('Plugin not found');
       }
@@ -514,14 +1123,15 @@ function validateArchiveURL(archiveURL: string): boolean {
  * @param headlampVersion - The version of Headlamp for compatibility checking.
  * @param progressCallback - A callback function for reporting progress.
  * @param signal - An optional AbortSignal for cancellation.
- * @returns {Promise<[string, string]>} A promise that resolves to an array containing the plugin name and temporary folder path.
+ * @returns The plugin name, temporary bundle path, and installed executable paths.
+ * @throws When package validation, download, extraction, or executable installation fails.
  */
 async function downloadExtractArchive(
   pluginInfo: ArtifactHubHeadlampPkg,
   headlampVersion: string,
   progressCallback: ProgressCallback | null,
   signal: AbortSignal | null
-): Promise<[string, string]> {
+): Promise<[string, string, string[]]> {
   // fetch plugin metadata
   if (signal && signal.aborted) {
     throw new Error('Download cancelled');
@@ -553,10 +1163,9 @@ async function downloadExtractArchive(
   }
 
   // Create temporary folder for extraction
-  const tempDir = await fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-plugin-temp-'));
-  // Defaulting to '' should never happen if recursive is true. So this is for the type
-  // checker only.
-  const tempFolder = fs.mkdirSync(path.join(tempDir, pluginName), { recursive: true }) ?? '';
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-plugin-temp-'));
+  const tempFolder = path.join(tempDir, pluginName);
+  fs.mkdirSync(tempFolder, { recursive: true });
 
   // First, download and extract the main archive
   if (progressCallback) {
@@ -571,22 +1180,26 @@ async function downloadExtractArchive(
     signal
   );
 
-  await downloadExtraFiles(pluginInfo.extraFiles, tempFolder, progressCallback, signal);
+  const executablePaths = await downloadExtraFiles(
+    pluginInfo.extraFiles,
+    tempFolder,
+    progressCallback,
+    signal
+  );
 
-  // Add artifacthub metadata to the plugin
-  const packageJSON = JSON.parse(fs.readFileSync(`${tempFolder}/package.json`, 'utf8'));
-  packageJSON.artifacthub = {
-    name: pluginName,
-    title: pluginInfo.display_name,
-    url: `https://artifacthub.io/packages/headlamp/${pluginInfo.repository.name}/${pluginName}`,
-    version: pluginInfo.version,
-    repoName: pluginInfo.repository.name,
-    author: pluginInfo.repository.user_alias,
-  };
-  packageJSON.isManagedByHeadlampPlugin = true;
-  fs.writeFileSync(`${tempFolder}/package.json`, JSON.stringify(packageJSON, null, 2));
+  updatePluginPackage(tempFolder, packageJson => {
+    packageJson.artifacthub = {
+      name: pluginName,
+      title: pluginInfo.display_name,
+      url: `https://artifacthub.io/packages/headlamp/${pluginInfo.repository.name}/${pluginName}`,
+      version: pluginInfo.version,
+      repoName: pluginInfo.repository.name,
+      author: pluginInfo.repository.user_alias,
+    };
+    packageJson.isManagedByHeadlampPlugin = true;
+  });
 
-  return [pluginName, tempFolder];
+  return [pluginName, tempFolder, executablePaths];
 }
 
 /**
@@ -619,15 +1232,17 @@ export function getMatchingExtraFiles(extraFiles: ArtifactHubHeadlampPkg['extraF
  * @param extractFolder - Folder where files should be extracted
  * @param progressCallback - Callback for progress updates
  * @param signal - Signal for cancellation
+ * @returns Platform-independent paths for the executables placed under the bundle's `bin` folder.
+ * @throws When a matching extra file cannot be downloaded, verified, extracted, or moved.
  */
 async function downloadExtraFiles(
   extraFiles: ArtifactHubHeadlampPkg['extraFiles'],
   extractFolder: string,
   progressCallback: null | ProgressCallback,
   signal: AbortSignal | null
-): Promise<void> {
+): Promise<string[]> {
   if (!extraFiles || Object.keys(extraFiles).length === 0) {
-    return;
+    return [];
   }
   const { matchingExtraFiles, currentArchString } = getMatchingExtraFiles(extraFiles);
 
@@ -638,8 +1253,10 @@ async function downloadExtraFiles(
         message: `No extra files found for platform ${currentArchString}`,
       });
     }
-    return;
+    return [];
   }
+
+  const executablePaths = new Set<string>();
 
   // Make sure bin directory exists
   const binDir = path.join(extractFolder, 'bin');
@@ -652,6 +1269,26 @@ async function downloadExtraFiles(
     if (signal && signal.aborted) {
       throw new Error('Download cancelled');
     }
+
+    const outputMappings = Object.values(file.output).flatMap(value => {
+      if (!value.output || !value.input) {
+        return [];
+      }
+      const outputPath =
+        os.platform() === 'win32' && !value.output.endsWith('.js') && !value.output.endsWith('.exe')
+          ? `${value.output}.exe`
+          : value.output;
+      return [
+        {
+          inputFile: resolveExtraFilePath(binDir, value.input, 'input'),
+          logicalOutput:
+            os.platform() === 'win32' && value.output.endsWith('.exe')
+              ? value.output.slice(0, -'.exe'.length)
+              : value.output,
+          outputFile: resolveExtraFilePath(binDir, outputPath, 'output'),
+        },
+      ];
+    });
 
     if (progressCallback) {
       progressCallback({
@@ -683,31 +1320,18 @@ async function downloadExtraFiles(
     }
 
     // move the files to the correct output location
-    for (const value of Object.values(file.output)) {
-      if (!value.output || !value.input || value.input === value.output) {
-        continue;
-      }
-      let outputFile = path.join(binDir, value.output);
-      // If on Windows, ensure that the output file ends with .exe
-      // For example, minikube should be minikube.exe
-      // If the extra file is a .js file, we do not add .exe
-      if (os.platform() === 'win32' && !value.output.endsWith('.js')) {
-        outputFile = path.join(binDir, value.output) + '.exe';
-      }
+    for (const { inputFile, logicalOutput, outputFile } of outputMappings) {
+      if (inputFile !== outputFile) {
+        fs.copyFileSync(inputFile, outputFile);
+        fs.rmSync(inputFile);
 
-      const inputFile = path.join(binDir, value.input);
-      if (inputFile === outputFile) {
-        continue;
+        // remove the input file folder... if it's empty
+        const inputDir = path.dirname(inputFile);
+        if (inputDir !== binDir && fs.readdirSync(inputDir).length === 0) {
+          fs.rmSync(inputDir);
+        }
       }
-
-      fs.copyFileSync(inputFile, outputFile);
-      fs.rmSync(inputFile);
-
-      // remove the input file folder... if it's empty
-      const inputDir = path.dirname(inputFile);
-      if (fs.readdirSync(inputDir).length === 0) {
-        fs.rmSync(inputDir);
-      }
+      executablePaths.add(path.posix.join('bin', logicalOutput));
 
       if (progressCallback) {
         progressCallback({
@@ -724,6 +1348,7 @@ async function downloadExtraFiles(
       message: `Downloaded ${matchingExtraFiles.length} extra files for ${currentArchString}`,
     });
   }
+  return [...executablePaths];
 }
 
 /**
@@ -926,6 +1551,30 @@ function convertAnnotations(annotations: Record<string, string>): Record<string,
   return result;
 }
 
+/** Resolves an extra-file path while requiring it to remain inside the selected root. */
+export function resolveExtraFilePath(
+  rootDirectory: string,
+  relativePath: string,
+  kind: 'input' | 'output'
+): string {
+  const normalizedPath = relativePath.replace(/[\\/]/g, path.sep);
+  const root = path.resolve(rootDirectory);
+  const resolved = path.resolve(root, normalizedPath);
+  const relative = path.relative(root, resolved);
+  if (
+    relative === '' ||
+    relative === '..' ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative) ||
+    path.posix.isAbsolute(relativePath) ||
+    path.win32.isAbsolute(relativePath) ||
+    /^[A-Za-z]:/.test(relativePath)
+  ) {
+    throw new Error(`Invalid extra file ${kind} path, ${relativePath}`);
+  }
+  return resolved;
+}
+
 /**
  * Extracts the extra-files part from the converted annotations.
  * @param annotations - A record of annotations with path-style keys.
@@ -947,20 +1596,8 @@ export function getExtraFiles(
   // For example '..' in the path and starting with / or \
   for (const file of Object.values(extraFiles)) {
     for (const value of Object.values(file.output)) {
-      if (
-        value.output.startsWith('..') ||
-        value.output.startsWith('/') ||
-        value.output.startsWith('\\')
-      ) {
-        throw new Error(`Invalid extra file output path, ${value.output}`);
-      }
-      if (
-        value.input.startsWith('..') ||
-        value.input.startsWith('/') ||
-        value.input.startsWith('\\')
-      ) {
-        throw new Error(`Invalid extra file input path, ${value.input}`);
-      }
+      resolveExtraFilePath('/headlamp-extra-files', value.output, 'output');
+      resolveExtraFilePath('/headlamp-extra-files', value.input, 'input');
     }
   }
 
@@ -1026,10 +1663,15 @@ async function fetchPluginInfo(
     }
     const pkgResponse = await response.json();
     const pkg: ArtifactHubHeadlampPkg = {
+      packageId: pkgResponse.package_id,
       name: pkgResponse.name,
       display_name: pkgResponse.display_name,
       version: pkgResponse.version,
-      repository: pkgResponse.repository,
+      repository: {
+        repositoryId: pkgResponse.repository.repository_id,
+        name: pkgResponse.repository.name,
+        user_alias: pkgResponse.repository.user_alias,
+      },
       archiveURL: pkgResponse.data['headlamp/plugin/archive-url'],
       archiveChecksum: pkgResponse.data['headlamp/plugin/archive-checksum'],
       distroCompat: pkgResponse.data['headlamp/plugin/distro-compat'],

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -155,6 +155,11 @@ contextBridge.exposeInMainWorld('desktopApi', {
       ipcRenderer.invoke('secure-storage-delete', capability, key),
   },
 
+  commandCapabilities: {
+    register: (registrations: unknown[]) =>
+      ipcRenderer.invoke('register-plugin-command-capabilities', registrations),
+  },
+
   // Notify cluster change (for MCP server restart)
   notifyClusterChange: (cluster: string | null) => {
     ipcRenderer.send('cluster-changed', cluster);

--- a/app/electron/runCmd.test.ts
+++ b/app/electron/runCmd.test.ts
@@ -14,14 +14,35 @@
  * limitations under the License.
  */
 
+import crypto from 'crypto';
 import { EventEmitter } from 'events';
+import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 
-const { getShellEnvironmentMock, spawnMock, showMessageBoxSyncMock } = vi.hoisted(() => ({
+const {
+  defaultPluginsDirMock,
+  defaultUserPluginsDirMock,
+  getShellEnvironmentMock,
+  preparePluginExecutableMock,
+  preparePluginScriptMock,
+  removePreparedPluginExecutableMock,
+  removePreparedPluginScriptMock,
+  spawnMock,
+  showMessageBoxSyncMock,
+  verifyPluginInstallationIntegrityMock,
+} = vi.hoisted(() => ({
+  defaultPluginsDirMock: vi.fn(() => '/plugins/default'),
+  defaultUserPluginsDirMock: vi.fn(() => '/plugins/user'),
   getShellEnvironmentMock: vi.fn(),
+  preparePluginExecutableMock: vi.fn(),
+  preparePluginScriptMock: vi.fn(),
+  removePreparedPluginExecutableMock: vi.fn(),
+  removePreparedPluginScriptMock: vi.fn(),
   spawnMock: vi.fn(),
   showMessageBoxSyncMock: vi.fn(),
+  verifyPluginInstallationIntegrityMock: vi.fn(),
 }));
 
 vi.mock('electron', () => ({
@@ -34,8 +55,14 @@ vi.mock('child_process', () => ({
 }));
 
 vi.mock('./plugin-management', () => ({
-  defaultPluginsDir: vi.fn(() => '/plugins/default'),
-  defaultUserPluginsDir: vi.fn(() => '/plugins/user'),
+  defaultPluginsDir: defaultPluginsDirMock,
+  defaultUserPluginsDir: defaultUserPluginsDirMock,
+  PREPARED_PLUGIN_SCRIPTS_PATH: '/plugins/prepared',
+  preparePluginExecutable: preparePluginExecutableMock,
+  preparePluginScript: preparePluginScriptMock,
+  removePreparedPluginExecutable: removePreparedPluginExecutableMock,
+  removePreparedPluginScript: removePreparedPluginScriptMock,
+  verifyPluginInstallationIntegrity: verifyPluginInstallationIntegrityMock,
 }));
 
 vi.mock('./settings', () => ({
@@ -59,12 +86,349 @@ vi.mock('./main', () => ({
 import {
   addRunCmdConsent,
   checkPermissionSecret,
+  createProductCommandCapabilities,
   environmentOverrides,
   handleRunCommand,
   removeRunCmdConsent,
+  revokeRunCmdCapabilities,
   setupRunCmdHandlers,
+  systemCommandEnvironment,
   validateCommandData,
+  verifyPluginCommandPolicies,
 } from './runCmd';
+
+describe('verifyPluginCommandPolicies', () => {
+  const source = 'console.log("trusted");';
+  const sourceDigest = crypto.createHash('sha256').update(source).digest('hex');
+  const policies = [
+    {
+      bundleName: 'example-plugin',
+      packageName: '@example/plugin',
+      source: 'shipped' as const,
+      grants: [{ tool: 'examplectl', args: ['project', 'list'] }],
+    },
+  ];
+  const registrations = [
+    {
+      bundleName: 'example-plugin',
+      packageName: '@example/plugin',
+      path: 'static-plugins/example-plugin',
+      source: 'shipped',
+      type: 'shipped',
+      sourceDigest,
+    },
+  ];
+
+  it('accepts an exact package identity from a regular shipped bundle', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-command-policy-'));
+    const bundle = path.join(root, 'example-plugin');
+    fs.mkdirSync(bundle);
+    fs.writeFileSync(path.join(bundle, 'package.json'), '{"name":"@example/plugin"}');
+    fs.writeFileSync(path.join(bundle, 'main.js'), source);
+    try {
+      const result = await verifyPluginCommandPolicies(policies, registrations, {
+        development: path.join(root, 'development'),
+        user: path.join(root, 'user'),
+        shipped: root,
+      });
+      expect(result).toEqual(policies);
+    } finally {
+      fs.rmSync(root, { recursive: true });
+    }
+  });
+
+  it('rejects missing, spoofed, or escaping shipped identities', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-command-policy-'));
+    const bundle = path.join(root, 'example-plugin');
+    fs.mkdirSync(bundle);
+    fs.writeFileSync(path.join(bundle, 'package.json'), '{"name":"@attacker/plugin"}');
+    fs.writeFileSync(path.join(bundle, 'main.js'), source);
+    try {
+      const roots = {
+        development: path.join(root, 'development'),
+        user: path.join(root, 'user'),
+        shipped: root,
+      };
+      expect(await verifyPluginCommandPolicies(policies, registrations, roots)).toEqual([]);
+      expect(
+        await verifyPluginCommandPolicies(
+          [{ ...policies[0], bundleName: '../example-plugin' }],
+          registrations,
+          roots
+        )
+      ).toEqual([]);
+      expect(
+        await verifyPluginCommandPolicies(policies, registrations, {
+          ...roots,
+          shipped: path.join(root, 'missing'),
+        })
+      ).toEqual([]);
+    } finally {
+      fs.rmSync(root, { recursive: true });
+    }
+  });
+
+  it('fails closed when Electron resourcesPath is unavailable', async () => {
+    const resourcesPathDescriptor = Object.getOwnPropertyDescriptor(process, 'resourcesPath');
+    Object.defineProperty(process, 'resourcesPath', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    try {
+      expect(await verifyPluginCommandPolicies(policies, registrations)).toEqual([]);
+    } finally {
+      if (resourcesPathDescriptor) {
+        Object.defineProperty(process, 'resourcesPath', resourcesPathDescriptor);
+      } else {
+        Reflect.deleteProperty(process, 'resourcesPath');
+      }
+    }
+  });
+
+  it('requires matching app-owned Artifact Hub provenance for managed plugins', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-command-policy-'));
+    const bundle = path.join(root, 'example-plugin');
+    fs.mkdirSync(bundle);
+    fs.writeFileSync(path.join(bundle, 'package.json'), '{"name":"@example/plugin"}');
+    fs.writeFileSync(path.join(bundle, 'main.js'), source);
+    const managedPolicy = {
+      ...policies[0],
+      source: 'user' as const,
+      artifactHub: {
+        repository: 'headlamp-plugins',
+        package: 'headlamp_minikube',
+        packageId: 'fbc182b5-eb90-42b7-ace8-62a7576abafd',
+        repositoryId: '767e1f40-ee09-401b-b8d4-930740da5a8a',
+      },
+    };
+    const roots = {
+      development: path.join(root, 'development'),
+      user: root,
+      shipped: path.join(root, 'shipped'),
+    };
+    const userRegistrations = registrations.map(registration => ({
+      ...registration,
+      path: 'user-plugins/example-plugin',
+      source: 'user',
+      type: 'user',
+    }));
+    try {
+      verifyPluginInstallationIntegrityMock.mockResolvedValueOnce(false);
+      expect(await verifyPluginCommandPolicies([managedPolicy], userRegistrations, roots)).toEqual(
+        []
+      );
+      expect(verifyPluginInstallationIntegrityMock).toHaveBeenCalledWith(
+        bundle,
+        managedPolicy.artifactHub
+      );
+
+      verifyPluginInstallationIntegrityMock.mockResolvedValueOnce(true);
+      expect(await verifyPluginCommandPolicies([managedPolicy], userRegistrations, roots)).toEqual([
+        managedPolicy,
+      ]);
+    } finally {
+      fs.rmSync(root, { recursive: true });
+    }
+  });
+
+  it('rejects a capability when cached source differs from on-disk main.js', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-command-policy-'));
+    const bundle = path.join(root, 'example-plugin');
+    fs.mkdirSync(bundle);
+    fs.writeFileSync(path.join(bundle, 'package.json'), '{"name":"@example/plugin"}');
+    fs.writeFileSync(path.join(bundle, 'main.js'), 'console.log("restored");');
+    try {
+      await expect(
+        verifyPluginCommandPolicies(policies, registrations, {
+          development: path.join(root, 'development'),
+          user: path.join(root, 'user'),
+          shipped: root,
+        })
+      ).resolves.toEqual([]);
+    } finally {
+      fs.rmSync(root, { recursive: true });
+    }
+  });
+});
+
+describe('createProductCommandCapabilities', () => {
+  const sourceDigest = 'a'.repeat(64);
+  const policies = [
+    {
+      bundleName: 'example-plugin',
+      packageName: '@example/plugin',
+      source: 'shipped' as const,
+      grants: [{ tool: 'examplectl', args: ['project', 'list'], allowTrailingArgs: true }],
+    },
+  ];
+
+  it('issues an opaque capability for an exact shipped plugin identity', () => {
+    const result = createProductCommandCapabilities(
+      [
+        {
+          bundleName: 'example-plugin',
+          packageName: '@example/plugin',
+          path: 'static-plugins/example-plugin',
+          source: 'shipped',
+          type: 'shipped',
+          sourceDigest,
+        },
+      ],
+      policies,
+      7
+    );
+
+    expect(result.capabilities).toEqual([
+      {
+        bundleName: 'example-plugin',
+        packageName: '@example/plugin',
+        capability: expect.stringMatching(/^[a-f0-9]{64}$/),
+      },
+    ]);
+    expect(result.capabilityRegistry.get(result.capabilities[0].capability)).toEqual({
+      ...policies[0],
+      webContentsId: 7,
+    });
+  });
+
+  it('grants shipped AI Assistant system commands only to its exact identity', () => {
+    const aiPolicy = {
+      bundleName: 'headlamp_ai-assistant',
+      packageName: '@headlamp-k8s/ai-assistant',
+      source: 'shipped' as const,
+      grants: [{ tool: 'gh', args: ['auth'], allowTrailingArgs: true }],
+    };
+    const result = createProductCommandCapabilities(
+      [
+        {
+          bundleName: 'headlamp_ai-assistant',
+          packageName: '@headlamp-k8s/ai-assistant',
+          path: 'static-plugins/headlamp_ai-assistant',
+          source: 'shipped',
+          type: 'shipped',
+          sourceDigest,
+        },
+        {
+          bundleName: 'unrelated-plugin',
+          packageName: '@example/unrelated',
+          path: 'static-plugins/unrelated-plugin',
+          source: 'shipped',
+          type: 'shipped',
+          sourceDigest,
+        },
+      ],
+      [aiPolicy],
+      7
+    );
+
+    expect(result.capabilities).toEqual([
+      {
+        bundleName: 'headlamp_ai-assistant',
+        packageName: '@headlamp-k8s/ai-assistant',
+        capability: expect.stringMatching(/^[a-f0-9]{64}$/),
+      },
+    ]);
+    expect(result.capabilityRegistry.get(result.capabilities[0].capability)?.grants).toEqual([
+      { tool: 'gh', args: ['auth'], allowTrailingArgs: true },
+    ]);
+  });
+
+  it('issues a capability for an exact development plugin policy', () => {
+    const developmentPolicy = {
+      ...policies[0],
+      bundleName: 'example-plugin-dev',
+      source: 'development' as const,
+    };
+    const result = createProductCommandCapabilities(
+      [
+        {
+          bundleName: 'example-plugin-dev',
+          packageName: '@example/plugin',
+          path: 'plugins/example-plugin-dev',
+          source: 'development',
+          type: 'development',
+          sourceDigest,
+        },
+      ],
+      [developmentPolicy],
+      7
+    );
+
+    expect(result.capabilities).toHaveLength(1);
+    expect(result.capabilityRegistry.get(result.capabilities[0].capability)).toEqual({
+      ...developmentPolicy,
+      webContentsId: 7,
+    });
+  });
+
+  it('issues a development-source capability for a migrated user plugin', () => {
+    const developmentPolicy = {
+      ...policies[0],
+      source: 'development' as const,
+    };
+    const result = createProductCommandCapabilities(
+      [
+        {
+          bundleName: 'example-plugin',
+          packageName: '@example/plugin',
+          path: 'plugins/example-plugin',
+          source: 'development',
+          type: 'user',
+          sourceDigest,
+        },
+      ],
+      [developmentPolicy],
+      7
+    );
+
+    expect(result.capabilities).toHaveLength(1);
+  });
+
+  it.each([
+    ['user source', { source: 'user' }],
+    ['invalid type', { type: 'invalid' }],
+    ['package spoof', { packageName: '@attacker/plugin' }],
+    ['bundle path spoof', { path: 'user-plugins/example-plugin' }],
+  ])('does not issue a capability for %s', (_name, override) => {
+    const result = createProductCommandCapabilities(
+      [
+        {
+          bundleName: 'example-plugin',
+          packageName: '@example/plugin',
+          path: 'static-plugins/example-plugin',
+          source: 'shipped',
+          type: 'shipped',
+          sourceDigest,
+          ...override,
+        },
+      ],
+      policies,
+      7
+    );
+
+    expect(result.capabilities).toEqual([]);
+    expect(result.capabilityRegistry.size).toBe(0);
+  });
+
+  it('denies an ambiguous duplicate identity', () => {
+    const registration = {
+      bundleName: 'example-plugin',
+      packageName: '@example/plugin',
+      path: 'static-plugins/example-plugin',
+      source: 'shipped',
+      type: 'shipped',
+      sourceDigest,
+    };
+    const result = createProductCommandCapabilities(
+      [registration, registration, registration],
+      policies,
+      7
+    );
+
+    expect(result.capabilities).toEqual([]);
+  });
+});
 
 it('does not cache process environment changes as shell overrides', () => {
   expect(
@@ -77,6 +441,23 @@ it('does not cache process environment changes as shell overrides', () => {
 
 it('uses process.env as the default comparison environment', () => {
   expect(environmentOverrides(process.env)).toEqual({});
+});
+
+it('removes plugin-controlled directories from the system command PATH', () => {
+  expect(
+    systemCommandEnvironment(
+      {
+        PATH: ['/plugins/user/attacker/bin', '/usr/local/bin', '/plugins/shipped/tool/bin'].join(
+          path.delimiter
+        ),
+      },
+      {
+        development: '/plugins/development',
+        user: '/plugins/user',
+        shipped: '/plugins/shipped',
+      }
+    )
+  ).toEqual({ PATH: '/usr/local/bin' });
 });
 
 describe('checkPermissionSecret', () => {
@@ -299,10 +680,39 @@ describe('handleRunCommand', () => {
   let fakeEvent: any;
   let sentMessages: Array<[string, ...unknown[]]>;
 
+  const productConsentKey = (
+    source: 'development' | 'user' | 'shipped',
+    command: string,
+    args: string[]
+  ) =>
+    `run-command-consent:v2:${JSON.stringify([
+      { source, packageName: '@example/plugin', bundleName: 'example-plugin' },
+      command,
+      args,
+    ])}`;
+
   beforeEach(() => {
+    defaultPluginsDirMock.mockReturnValue('/plugins/default');
+    defaultUserPluginsDirMock.mockReturnValue('/plugins/user');
     getShellEnvironmentMock.mockReset();
     getShellEnvironmentMock.mockResolvedValue(shellEnvironment);
     spawnMock.mockReset();
+    preparePluginExecutableMock.mockReset();
+    preparePluginExecutableMock.mockImplementation(
+      async (_bundlePath: string, _executablePath: string, absoluteExecutablePath: string) => ({
+        ok: true,
+        executablePath: absoluteExecutablePath,
+      })
+    );
+    removePreparedPluginExecutableMock.mockReset();
+    preparePluginScriptMock.mockReset();
+    preparePluginScriptMock.mockResolvedValue({
+      ok: true,
+      scriptPath: '/prepared/script.js',
+    });
+    removePreparedPluginScriptMock.mockReset();
+    verifyPluginInstallationIntegrityMock.mockReset();
+    verifyPluginInstallationIntegrityMock.mockReturnValue(true);
     childEmitter = new EventEmitter();
     childEmitter.stdout = new EventEmitter();
     childEmitter.stderr = new EventEmitter();
@@ -320,6 +730,7 @@ describe('handleRunCommand', () => {
   });
 
   it('runs gh with the login-shell environment and reports child errors', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const fakeMainWindow = { id: 1 } as any;
     const permissionSecrets = { 'runCmd-gh': 99 };
 
@@ -339,14 +750,23 @@ describe('handleRunCommand', () => {
       expect.objectContaining({ env: shellEnvironment })
     );
 
-    const err = new Error('spawn error');
+    const err = Object.assign(new Error('spawn error with /private/user/path'), { code: 'EACCES' });
     childEmitter.emit('error', err);
 
-    expect(sentMessages).toContainEqual(['command-stderr', 'test-id', 'spawn error']);
+    expect(sentMessages).toContainEqual([
+      'command-stderr',
+      'test-id',
+      'spawn error with /private/user/path',
+    ]);
     expect(sentMessages).toContainEqual(['command-exit', 'test-id', -1]);
+    expect(consoleError).toHaveBeenCalledWith('Command process error', {
+      tool: 'gh',
+      reason: 'EACCES',
+    });
 
     childEmitter.emit('close', null);
     expect(sentMessages.filter(([channel]) => channel === 'command-exit')).toHaveLength(1);
+    consoleError.mockRestore();
   });
 
   it('reports exit only after stdout and stderr close', async () => {
@@ -420,8 +840,9 @@ describe('handleRunCommand', () => {
   });
 
   it('reports synchronous spawn errors without rejecting', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     spawnMock.mockImplementation(() => {
-      throw new Error('spawn failed');
+      throw Object.assign(new Error('spawn failed with /private/user/path'), { code: 'ENOENT' });
     });
     const eventData = {
       id: 'test-id',
@@ -435,8 +856,17 @@ describe('handleRunCommand', () => {
       handleRunCommand(fakeEvent, eventData, { id: 1 } as any, { 'runCmd-gh': 99 })
     ).resolves.toBeUndefined();
 
-    expect(sentMessages).toContainEqual(['command-stderr', 'test-id', 'spawn failed']);
+    expect(sentMessages).toContainEqual([
+      'command-stderr',
+      'test-id',
+      'spawn failed with /private/user/path',
+    ]);
     expect(sentMessages).toContainEqual(['command-exit', 'test-id', -1]);
+    expect(consoleError).toHaveBeenCalledWith('Failed to spawn command', {
+      tool: 'gh',
+      reason: 'ENOENT',
+    });
+    consoleError.mockRestore();
   });
 
   it('falls back to process.env when shell environment resolution fails', async () => {
@@ -494,6 +924,770 @@ describe('handleRunCommand', () => {
       // @ts-ignore Electron defines this at runtime.
       process.resourcesPath = originalResourcesPath;
     }
+  });
+
+  it('enforces a product grant before spawning with no shell', async () => {
+    const capability = 'a'.repeat(64);
+    const registry = new Map([
+      [
+        capability,
+        {
+          bundleName: 'example-plugin',
+          packageName: '@example/plugin',
+          source: 'shipped' as const,
+          grants: [{ tool: 'examplectl', args: ['project', 'list'], allowTrailingArgs: true }],
+          webContentsId: 7,
+        },
+      ],
+    ]);
+    fakeEvent.sender.id = 7;
+    const { loadSettings } = await import('./settings');
+    vi.mocked(loadSettings).mockReturnValueOnce({
+      confirmedCommands: {
+        [productConsentKey('shipped', 'examplectl', ['project', 'list'])]: true,
+      },
+    });
+
+    await handleRunCommand(
+      fakeEvent,
+      {
+        id: 'capability-id',
+        command: 'examplectl',
+        args: ['project', 'list', '--all'],
+        options: {},
+        permissionSecrets: {},
+        capability,
+      },
+      { id: 1 } as any,
+      {},
+      registry
+    );
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'examplectl',
+      ['project', 'list', '--all'],
+      expect.objectContaining({ shell: false })
+    );
+  });
+
+  it('revalidates a capability after verifying plugin executable integrity', async () => {
+    const userRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-command-bin-'));
+    const bundleRoot = path.join(userRoot, 'example-plugin');
+    const executable = path.join(bundleRoot, 'bin', 'examplectl');
+    fs.mkdirSync(path.dirname(executable), { recursive: true });
+    fs.writeFileSync(executable, '');
+    let resolveIntegrity!: (result: { ok: true; executablePath: string }) => void;
+    let markVerificationStarted!: () => void;
+    const verificationStarted = new Promise<void>(resolve => {
+      markVerificationStarted = resolve;
+    });
+    preparePluginExecutableMock.mockImplementationOnce(() => {
+      markVerificationStarted();
+      return new Promise(resolve => {
+        resolveIntegrity = resolve;
+      });
+    });
+    const capability = 'a'.repeat(64);
+    const registration = {
+      bundleName: 'example-plugin',
+      packageName: '@example/plugin',
+      source: 'user' as const,
+      artifactHub: {
+        repository: 'example-repository',
+        package: 'example-plugin',
+        packageId: '123e4567-e89b-42d3-a456-426614174000',
+        repositoryId: '123e4567-e89b-42d3-a456-426614174001',
+      },
+      grants: [
+        {
+          tool: 'examplectl',
+          executable: { source: 'plugin' as const, path: 'bin/examplectl' },
+          args: ['project', 'list'],
+        },
+      ],
+      webContentsId: 7,
+    };
+    const registry = new Map([[capability, registration]]);
+    fakeEvent.sender.id = 7;
+    const { loadSettings } = await import('./settings');
+    vi.mocked(loadSettings).mockReturnValueOnce({
+      confirmedCommands: {
+        [productConsentKey('user', 'examplectl', ['project', 'list'])]: true,
+      },
+    });
+
+    try {
+      const commandPromise = handleRunCommand(
+        fakeEvent,
+        {
+          id: 'plugin-bin-id',
+          command: 'examplectl',
+          args: ['project', 'list'],
+          options: {},
+          permissionSecrets: {},
+          capability,
+        },
+        { id: 1 } as any,
+        {},
+        registry,
+        undefined,
+        { development: '/plugins/development', user: userRoot, shipped: '/plugins/shipped' }
+      );
+      await verificationStarted;
+      expect(preparePluginExecutableMock).toHaveBeenCalledWith(
+        fs.realpathSync(bundleRoot),
+        'bin/examplectl',
+        fs.realpathSync(executable),
+        undefined,
+        registration.artifactHub
+      );
+      registry.clear();
+      resolveIntegrity({ ok: true, executablePath: '/prepared/run/examplectl' });
+      await commandPromise;
+
+      expect(spawnMock).not.toHaveBeenCalled();
+      expect(removePreparedPluginExecutableMock).toHaveBeenCalledWith('/prepared/run/examplectl');
+      expect(sentMessages).toEqual([['command-exit', 'plugin-bin-id', -2]]);
+    } finally {
+      fs.rmSync(userRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a plugin executable without a valid installation receipt', async () => {
+    const userRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-command-bin-'));
+    const executable = path.join(userRoot, 'example-plugin', 'bin', 'examplectl');
+    fs.mkdirSync(path.dirname(executable), { recursive: true });
+    fs.writeFileSync(executable, 'replaced');
+    preparePluginExecutableMock.mockResolvedValueOnce({
+      ok: false,
+      reason: 'digest-mismatch',
+    });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const capability = 'a'.repeat(64);
+    fakeEvent.sender.id = 7;
+    const { loadSettings } = await import('./settings');
+    vi.mocked(loadSettings).mockReturnValueOnce({
+      confirmedCommands: {
+        [productConsentKey('user', 'examplectl', ['project', 'list'])]: true,
+      },
+    });
+
+    await handleRunCommand(
+      fakeEvent,
+      {
+        id: 'plugin-bin-id',
+        command: 'examplectl',
+        args: ['project', 'list'],
+        options: {},
+        permissionSecrets: {},
+        capability,
+      },
+      { id: 1 } as any,
+      {},
+      new Map([
+        [
+          capability,
+          {
+            bundleName: 'example-plugin',
+            packageName: '@example/plugin',
+            source: 'user' as const,
+            artifactHub: {
+              repository: 'example-repository',
+              package: 'example-plugin',
+              packageId: '123e4567-e89b-42d3-a456-426614174000',
+              repositoryId: '123e4567-e89b-42d3-a456-426614174001',
+            },
+            grants: [
+              {
+                tool: 'examplectl',
+                executable: { source: 'plugin', path: 'bin/examplectl' },
+                args: ['project', 'list'],
+              },
+            ],
+            webContentsId: 7,
+          },
+        ],
+      ]),
+      undefined,
+      { development: '/plugins/development', user: userRoot, shipped: '/plugins/shipped' }
+    );
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(fakeEvent.sender.send).toHaveBeenCalledWith('command-exit', 'plugin-bin-id', -2);
+    expect(consoleError).toHaveBeenCalledWith('Plugin executable unavailable', {
+      tool: 'examplectl',
+      reason: 'digest-mismatch',
+      packageName: '@example/plugin',
+      bundleName: 'example-plugin',
+      source: 'user',
+    });
+    consoleError.mockRestore();
+    fs.rmSync(userRoot, { recursive: true, force: true });
+  });
+
+  it('guides users to reinstall when executable integrity metadata is missing', async () => {
+    const userRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-command-bin-'));
+    const executable = path.join(userRoot, 'example-plugin', 'bin', 'examplectl');
+    fs.mkdirSync(path.dirname(executable), { recursive: true });
+    fs.writeFileSync(executable, 'legacy');
+    preparePluginExecutableMock.mockResolvedValueOnce({
+      ok: false,
+      reason: 'missing-receipt',
+    });
+    const capability = 'a'.repeat(64);
+    fakeEvent.sender.id = 7;
+    const { loadSettings } = await import('./settings');
+    vi.mocked(loadSettings).mockReturnValueOnce({
+      confirmedCommands: {
+        [productConsentKey('user', 'examplectl', ['project', 'list'])]: true,
+      },
+    });
+
+    await handleRunCommand(
+      fakeEvent,
+      {
+        id: 'legacy-bin-id',
+        command: 'examplectl',
+        args: ['project', 'list'],
+        options: {},
+        permissionSecrets: {},
+        capability,
+      },
+      { id: 1 } as any,
+      {},
+      new Map([
+        [
+          capability,
+          {
+            bundleName: 'example-plugin',
+            packageName: '@example/plugin',
+            source: 'user' as const,
+            grants: [
+              {
+                tool: 'examplectl',
+                executable: { source: 'plugin', path: 'bin/examplectl' },
+                args: ['project', 'list'],
+              },
+            ],
+            webContentsId: 7,
+          },
+        ],
+      ]),
+      undefined,
+      { development: '/plugins/development', user: userRoot, shipped: '/plugins/shipped' }
+    );
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(fakeEvent.sender.send).toHaveBeenCalledWith(
+      'command-stderr',
+      'legacy-bin-id',
+      'Plugin executable integrity metadata is missing. Update or reinstall the plugin.'
+    );
+    expect(preparePluginExecutableMock).not.toHaveBeenCalled();
+    expect(fakeEvent.sender.send).toHaveBeenCalledWith('command-exit', 'legacy-bin-id', -2);
+    fs.rmSync(userRoot, { recursive: true, force: true });
+  });
+
+  it('runs a confined development-inventory executable without an installation receipt', async () => {
+    const developmentRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-command-bin-'));
+    const executable = path.join(developmentRoot, 'minikube', 'bin', 'minikube');
+    fs.mkdirSync(path.dirname(executable), { recursive: true });
+    fs.writeFileSync(executable, 'development');
+    const capability = 'a'.repeat(64);
+    fakeEvent.sender.id = 7;
+    try {
+      await handleRunCommand(
+        fakeEvent,
+        {
+          id: 'development-bin-id',
+          command: 'minikube',
+          args: ['start'],
+          options: {},
+          permissionSecrets: {},
+          capability,
+        },
+        { id: 1 } as any,
+        {},
+        new Map([
+          [
+            capability,
+            {
+              bundleName: 'minikube',
+              packageName: '@headlamp-k8s/minikube',
+              source: 'development' as const,
+              grants: [
+                {
+                  tool: 'minikube',
+                  executable: { source: 'plugin', path: 'bin/minikube' },
+                  args: ['start'],
+                },
+              ],
+              webContentsId: 7,
+            },
+          ],
+        ]),
+        undefined,
+        {
+          development: developmentRoot,
+          user: '/plugins/user',
+          shipped: '/plugins/shipped',
+        }
+      );
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        fs.realpathSync(executable),
+        ['start'],
+        expect.objectContaining({ shell: false })
+      );
+      expect(preparePluginExecutableMock).not.toHaveBeenCalled();
+
+      await handleRunCommand(
+        fakeEvent,
+        {
+          id: 'packaged-bin-id',
+          command: 'minikube',
+          args: ['start'],
+          options: {},
+          permissionSecrets: {},
+          capability,
+        },
+        { id: 1 } as any,
+        {},
+        new Map([
+          [
+            capability,
+            {
+              bundleName: 'minikube',
+              packageName: '@headlamp-k8s/minikube',
+              source: 'development' as const,
+              grants: [
+                {
+                  tool: 'minikube',
+                  executable: { source: 'plugin', path: 'bin/minikube' },
+                  args: ['start'],
+                },
+              ],
+              webContentsId: 7,
+            },
+          ],
+        ]),
+        undefined,
+        {
+          development: developmentRoot,
+          user: '/plugins/user',
+          shipped: '/plugins/shipped',
+        }
+      );
+      expect(preparePluginExecutableMock).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(developmentRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves a product script from its authorized plugin inventory', async () => {
+    const userRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-command-script-'));
+    const bundleRoot = path.join(userRoot, 'example-plugin');
+    fs.mkdirSync(bundleRoot);
+    fs.writeFileSync(path.join(bundleRoot, 'script.js'), '');
+    defaultUserPluginsDirMock.mockReturnValue(userRoot);
+    const capability = 'a'.repeat(64);
+    fakeEvent.sender.id = 7;
+    const { loadSettings } = await import('./settings');
+    vi.mocked(loadSettings).mockReturnValueOnce({
+      confirmedCommands: {
+        [productConsentKey('user', 'scriptjs', ['example-plugin/script.js'])]: true,
+      },
+    });
+
+    await handleRunCommand(
+      fakeEvent,
+      {
+        id: 'script-capability-id',
+        command: 'scriptjs',
+        args: ['example-plugin/script.js'],
+        options: {},
+        permissionSecrets: {},
+        capability,
+      },
+      { id: 1 } as any,
+      {},
+      new Map([
+        [
+          capability,
+          {
+            bundleName: 'example-plugin',
+            packageName: '@example/plugin',
+            source: 'user' as const,
+            artifactHub: {
+              repository: 'headlamp-plugins',
+              package: 'headlamp_minikube',
+              packageId: 'fbc182b5-eb90-42b7-ace8-62a7576abafd',
+              repositoryId: '767e1f40-ee09-401b-b8d4-930740da5a8a',
+            },
+            grants: [{ tool: 'scriptjs', args: ['example-plugin/script.js'] }],
+            webContentsId: 7,
+          },
+        ],
+      ])
+    );
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      process.execPath,
+      ['/prepared/script.js'],
+      expect.objectContaining({ shell: false })
+    );
+    expect(preparePluginScriptMock).toHaveBeenCalledWith(
+      fs.realpathSync(bundleRoot),
+      'script.js',
+      expect.objectContaining({
+        packageId: 'fbc182b5-eb90-42b7-ace8-62a7576abafd',
+        repositoryId: '767e1f40-ee09-401b-b8d4-930740da5a8a',
+      })
+    );
+    childEmitter.emit('close', 0);
+    expect(removePreparedPluginScriptMock).toHaveBeenCalledWith('/prepared/script.js');
+    fs.rmSync(userRoot, { recursive: true, force: true });
+  });
+
+  it('rejects a product script outside its authorized plugin bundle', async () => {
+    const userRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-command-script-'));
+    fs.mkdirSync(path.join(userRoot, 'example-plugin'));
+    fs.mkdirSync(path.join(userRoot, 'shadow-plugin'));
+    fs.writeFileSync(path.join(userRoot, 'shadow-plugin', 'script.js'), '');
+    defaultUserPluginsDirMock.mockReturnValue(userRoot);
+    const capability = 'a'.repeat(64);
+    fakeEvent.sender.id = 7;
+    const { loadSettings } = await import('./settings');
+    vi.mocked(loadSettings).mockReturnValueOnce({
+      confirmedCommands: {
+        [productConsentKey('user', 'scriptjs', ['shadow-plugin/script.js'])]: true,
+      },
+    });
+
+    await handleRunCommand(
+      fakeEvent,
+      {
+        id: 'script-capability-id',
+        command: 'scriptjs',
+        args: ['shadow-plugin/script.js'],
+        options: {},
+        permissionSecrets: {},
+        capability,
+      },
+      { id: 1 } as any,
+      {},
+      new Map([
+        [
+          capability,
+          {
+            bundleName: 'example-plugin',
+            packageName: '@example/plugin',
+            source: 'user' as const,
+            grants: [{ tool: 'scriptjs', args: ['shadow-plugin/script.js'] }],
+            webContentsId: 7,
+          },
+        ],
+      ])
+    );
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(sentMessages).toEqual([['command-exit', 'script-capability-id', -2]]);
+    fs.rmSync(userRoot, { recursive: true, force: true });
+  });
+
+  it('rejects a product script when its bundle is replaced by a symlink', async () => {
+    const userRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-command-script-'));
+    const externalRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-command-external-'));
+    fs.writeFileSync(path.join(externalRoot, 'script.js'), '');
+    fs.symlinkSync(
+      externalRoot,
+      path.join(userRoot, 'example-plugin'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    );
+    defaultUserPluginsDirMock.mockReturnValue(userRoot);
+    const capability = 'a'.repeat(64);
+    fakeEvent.sender.id = 7;
+    const { loadSettings } = await import('./settings');
+    vi.mocked(loadSettings).mockReturnValueOnce({
+      confirmedCommands: {
+        [productConsentKey('user', 'scriptjs', ['example-plugin/script.js'])]: true,
+      },
+    });
+
+    await handleRunCommand(
+      fakeEvent,
+      {
+        id: 'script-capability-id',
+        command: 'scriptjs',
+        args: ['example-plugin/script.js'],
+        options: {},
+        permissionSecrets: {},
+        capability,
+      },
+      { id: 1 } as any,
+      {},
+      new Map([
+        [
+          capability,
+          {
+            bundleName: 'example-plugin',
+            packageName: '@example/plugin',
+            source: 'user' as const,
+            grants: [{ tool: 'scriptjs', args: ['example-plugin/script.js'] }],
+            webContentsId: 7,
+          },
+        ],
+      ])
+    );
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(sentMessages).toEqual([['command-exit', 'script-capability-id', -2]]);
+    fs.rmSync(userRoot, { recursive: true, force: true });
+    fs.rmSync(externalRoot, { recursive: true, force: true });
+  });
+
+  it('stores product consent with an unambiguous argument-vector key', async () => {
+    const capability = 'a'.repeat(64);
+    fakeEvent.sender.id = 7;
+    showMessageBoxSyncMock.mockReturnValueOnce(0);
+    const { loadSettings, saveSettings } = await import('./settings');
+    vi.mocked(loadSettings).mockReturnValueOnce({ confirmedCommands: {} });
+    vi.mocked(saveSettings).mockClear();
+
+    await handleRunCommand(
+      fakeEvent,
+      {
+        id: 'capability-id',
+        command: 'examplectl',
+        args: ['a b'],
+        options: {},
+        permissionSecrets: {},
+        capability,
+      },
+      { id: 1 } as any,
+      {},
+      new Map([
+        [
+          capability,
+          {
+            bundleName: 'example-plugin',
+            packageName: '@example/plugin',
+            source: 'shipped' as const,
+            grants: [{ tool: 'examplectl', args: ['a b'] }],
+            webContentsId: 7,
+          },
+        ],
+      ])
+    );
+
+    expect(saveSettings).toHaveBeenCalledWith(
+      '/fake/settings.json',
+      expect.objectContaining({
+        confirmedCommands: {
+          [productConsentKey('shipped', 'examplectl', ['a b'])]: true,
+        },
+      })
+    );
+    expect(showMessageBoxSyncMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ detail: '@example/plugin@example-plugin: examplectl a b' })
+    );
+  });
+
+  it('honors legacy consent for a historically authorized plugin identity', async () => {
+    const capability = 'a'.repeat(64);
+    fakeEvent.sender.id = 7;
+    const { loadSettings } = await import('./settings');
+    vi.mocked(loadSettings).mockReturnValueOnce({ confirmedCommands: { 'gh auth': false } });
+    showMessageBoxSyncMock.mockClear();
+
+    await handleRunCommand(
+      fakeEvent,
+      {
+        id: 'legacy-consent-id',
+        command: 'gh',
+        args: ['auth', 'status'],
+        options: {},
+        permissionSecrets: {},
+        capability,
+      },
+      { id: 1 } as any,
+      {},
+      new Map([
+        [
+          capability,
+          {
+            bundleName: 'headlamp_ai-assistant',
+            packageName: '@headlamp-k8s/ai-assistant',
+            source: 'development' as const,
+            grants: [{ tool: 'gh', args: ['auth'], allowTrailingArgs: true }],
+            webContentsId: 7,
+          },
+        ],
+      ])
+    );
+
+    expect(showMessageBoxSyncMock).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(sentMessages).toEqual([['command-exit', 'legacy-consent-id', -3]]);
+  });
+
+  it('does not reuse source-less consent for a command outside the plugin history', async () => {
+    const capability = 'a'.repeat(64);
+    fakeEvent.sender.id = 7;
+    const { loadSettings } = await import('./settings');
+    vi.mocked(loadSettings).mockReturnValueOnce({ confirmedCommands: { 'gh auth': false } });
+    showMessageBoxSyncMock.mockReturnValueOnce(0);
+
+    await handleRunCommand(
+      fakeEvent,
+      {
+        id: 'cross-plugin-consent-id',
+        command: 'gh',
+        args: ['auth', 'status'],
+        options: {},
+        permissionSecrets: {},
+        capability,
+      },
+      { id: 1 } as any,
+      {},
+      new Map([
+        [
+          capability,
+          {
+            bundleName: 'headlamp_minikube',
+            packageName: '@headlamp-k8s/minikube',
+            source: 'development' as const,
+            grants: [{ tool: 'gh', args: ['auth'], allowTrailingArgs: true }],
+            webContentsId: 7,
+          },
+        ],
+      ])
+    );
+
+    expect(showMessageBoxSyncMock).toHaveBeenCalledOnce();
+    expect(spawnMock).toHaveBeenCalledOnce();
+  });
+
+  it('does not reuse source-less legacy consent for another development plugin', async () => {
+    const capability = 'a'.repeat(64);
+    fakeEvent.sender.id = 7;
+    const { loadSettings } = await import('./settings');
+    vi.mocked(loadSettings).mockReturnValueOnce({ confirmedCommands: { 'gh auth': false } });
+    showMessageBoxSyncMock.mockClear();
+    showMessageBoxSyncMock.mockReturnValueOnce(0);
+
+    await handleRunCommand(
+      fakeEvent,
+      {
+        id: 'source-consent-id',
+        command: 'gh',
+        args: ['auth', 'status'],
+        options: {},
+        permissionSecrets: {},
+        capability,
+      },
+      { id: 1 } as any,
+      {},
+      new Map([
+        [
+          capability,
+          {
+            bundleName: 'example-plugin',
+            packageName: '@example/plugin',
+            source: 'development' as const,
+            grants: [{ tool: 'gh', args: ['auth'], allowTrailingArgs: true }],
+            webContentsId: 7,
+          },
+        ],
+      ])
+    );
+
+    expect(showMessageBoxSyncMock).toHaveBeenCalledOnce();
+    expect(spawnMock).toHaveBeenCalledOnce();
+  });
+
+  it('revalidates a capability after resolving the shell environment', async () => {
+    let resolveEnvironment!: (environment: NodeJS.ProcessEnv) => void;
+    getShellEnvironmentMock.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveEnvironment = resolve;
+      })
+    );
+    const capability = 'a'.repeat(64);
+    const registration = {
+      bundleName: 'example-plugin',
+      packageName: '@example/plugin',
+      source: 'shipped' as const,
+      grants: [{ tool: 'examplectl', args: ['project', 'list'] }],
+      webContentsId: 7,
+    };
+    const registry = new Map([[capability, registration]]);
+    fakeEvent.sender.id = 7;
+    const { loadSettings } = await import('./settings');
+    vi.mocked(loadSettings).mockReturnValueOnce({
+      confirmedCommands: {
+        [productConsentKey('shipped', 'examplectl', ['project', 'list'])]: true,
+      },
+    });
+
+    const commandPromise = handleRunCommand(
+      fakeEvent,
+      {
+        id: 'capability-id',
+        command: 'examplectl',
+        args: ['project', 'list'],
+        options: {},
+        permissionSecrets: {},
+        capability,
+      },
+      { id: 1 } as any,
+      {},
+      registry
+    );
+    await Promise.resolve();
+    registry.clear();
+    resolveEnvironment(shellEnvironment);
+    await commandPromise;
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(sentMessages).toEqual([['command-exit', 'capability-id', -2]]);
+  });
+
+  it.each([
+    ['different arguments', 7, ['project', 'delete']],
+    ['different renderer', 8, ['project', 'list']],
+  ])('rejects a capability used with %s', async (_name, senderId, args) => {
+    const capability = 'a'.repeat(64);
+    fakeEvent.sender.id = senderId;
+    await handleRunCommand(
+      fakeEvent,
+      {
+        id: 'capability-id',
+        command: 'examplectl',
+        args,
+        options: {},
+        permissionSecrets: {},
+        capability,
+      },
+      { id: 1 } as any,
+      {},
+      new Map([
+        [
+          capability,
+          {
+            bundleName: 'example-plugin',
+            packageName: '@example/plugin',
+            source: 'shipped' as const,
+            grants: [{ tool: 'examplectl', args: ['project', 'list'] }],
+            webContentsId: 7,
+          },
+        ],
+      ])
+    );
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(sentMessages).toEqual([['command-exit', 'capability-id', -2]]);
   });
 
   it('initializes consent settings for a new command', async () => {
@@ -567,6 +1761,9 @@ describe('runScript', () => {
 
   it('imports the script when path is inside static .plugins dir', () =>
     testScriptImport('/resources/.plugins/my-script.js'));
+
+  it('imports the script when path is inside the app-owned prepared directory', () =>
+    testScriptImport('/plugins/prepared/run-id/my-script.js'));
 
   it('exits with error when script is outside allowed directories', async () => {
     const scriptPath = path.resolve('/not-allowed/my-script.js');
@@ -684,6 +1881,35 @@ describe('removeRunCmdConsent', () => {
     const savedSettings = vi.mocked(saveSettings).mock.calls[0][1] as any;
     expect(savedSettings.confirmedCommands[command]).toBeUndefined();
   });
+
+  it('removes v2 consent only for the uninstalled package and bundle', async () => {
+    const { loadSettings, saveSettings } = await import('./settings');
+    const removedKey = `run-command-consent:v2:${JSON.stringify([
+      {
+        source: 'user',
+        packageName: '@example/plugin',
+        bundleName: 'example-plugin',
+      },
+      'minikube',
+      ['status'],
+    ])}`;
+    const retainedKey = removedKey.replace('example-plugin', 'other-bundle');
+    vi.mocked(loadSettings).mockReturnValueOnce({
+      confirmedCommands: {
+        [removedKey]: true,
+        [retainedKey]: true,
+        'run-command-consent:v2:invalid-json': true,
+      },
+    });
+    vi.mocked(saveSettings).mockClear();
+
+    removeRunCmdConsent('@example/plugin', 'example-plugin');
+
+    const savedSettings = vi.mocked(saveSettings).mock.calls[0][1] as any;
+    expect(savedSettings.confirmedCommands[removedKey]).toBeUndefined();
+    expect(savedSettings.confirmedCommands[retainedKey]).toBe(true);
+    expect(savedSettings.confirmedCommands['run-command-consent:v2:invalid-json']).toBe(true);
+  });
 });
 
 describe('setupRunCmdHandlers', () => {
@@ -695,35 +1921,284 @@ describe('setupRunCmdHandlers', () => {
     expect(ipcMain.on).not.toHaveBeenCalled();
   });
 
-  it('sends permission secrets once per main-frame load', () => {
+  it('sends permission secrets once per trusted main-frame navigation', () => {
     const ipcHandlers = new Map<string, (...args: any[]) => void>();
-    let frameLoadHandler: (_event: unknown, isMainFrame: boolean) => void = () => {};
+    const webContentsHandlers = new Map<string, (...args: any[]) => void>();
     const send = vi.fn();
+    const mainFrame = { url: 'https://headlamp.test/' };
     const mainWindow = {
       webContents: {
-        on: vi.fn((_event: string, handler: typeof frameLoadHandler) => {
-          frameLoadHandler = handler;
+        id: 7,
+        mainFrame,
+        on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+          webContentsHandlers.set(event, handler);
         }),
         send,
       },
+      on: vi.fn(),
     } as any;
     const ipcMain = {
       on: vi.fn((channel: string, handler: (...args: any[]) => void) => {
         ipcHandlers.set(channel, handler);
       }),
+      handle: vi.fn(),
+      removeAllListeners: vi.fn(),
+      removeHandler: vi.fn(),
     } as any;
 
-    setupRunCmdHandlers(mainWindow, ipcMain);
+    setupRunCmdHandlers(mainWindow, ipcMain, [], 'https://headlamp.test/');
+    webContentsHandlers.get('did-frame-navigate')!({}, 'https://headlamp.test/', 200, 'OK', true);
     const requestSecrets = ipcHandlers.get('request-plugin-permission-secrets')!;
     requestSecrets();
     requestSecrets();
-    frameLoadHandler({}, false);
+    webContentsHandlers.get('did-frame-navigate')!({}, 'https://headlamp.test/', 200, 'OK', false);
     requestSecrets();
-    frameLoadHandler({}, true);
+    webContentsHandlers.get('did-start-navigation')!({}, 'https://headlamp.test/', false, true);
+    requestSecrets();
+    webContentsHandlers.get('did-frame-navigate')!({}, 'https://headlamp.test/', 200, 'OK', true);
     requestSecrets();
 
     expect(send).toHaveBeenCalledTimes(2);
     expect(ipcHandlers.has('run-command')).toBe(true);
+    expect(ipcMain.handle).toHaveBeenCalledWith(
+      'register-plugin-command-capabilities',
+      expect.any(Function)
+    );
+  });
+
+  it.each([
+    ['packaged default', false, false, 0],
+    ['packaged opt-in', false, true, 1],
+    ['Electron development mode', true, false, 1],
+  ])('issues development capabilities for %s', async (_name, isDevelopment, enabled, expected) => {
+    const pluginSource = 'console.log("development");';
+    const sourceDigest = crypto.createHash('sha256').update(pluginSource).digest('hex');
+    const pluginRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-development-gate-'));
+    const bundleRoot = path.join(pluginRoot, 'example-plugin');
+    fs.mkdirSync(bundleRoot);
+    fs.writeFileSync(path.join(bundleRoot, 'package.json'), '{"name":"@example/plugin"}');
+    fs.writeFileSync(path.join(bundleRoot, 'main.js'), pluginSource);
+    const invokeHandlers = new Map<string, (...args: any[]) => any>();
+    const webContents = {
+      id: 7,
+      mainFrame: { url: 'https://headlamp.test/' },
+      on: vi.fn(),
+      send: vi.fn(),
+    };
+    const mainWindow = { webContents, on: vi.fn() } as any;
+    const ipcMain = {
+      on: vi.fn(),
+      handle: vi.fn((channel: string, handler: (...args: any[]) => any) => {
+        invokeHandlers.set(channel, handler);
+      }),
+      off: vi.fn(),
+      removeHandler: vi.fn(),
+    } as any;
+
+    setupRunCmdHandlers(
+      mainWindow,
+      ipcMain,
+      [
+        {
+          bundleName: 'example-plugin',
+          packageName: '@example/plugin',
+          source: 'development',
+          grants: [{ tool: 'examplectl', args: ['project', 'list'] }],
+        },
+      ],
+      undefined,
+      { development: pluginRoot, user: pluginRoot, shipped: pluginRoot },
+      isDevelopment,
+      () => enabled
+    );
+    const capabilities = await invokeHandlers.get('register-plugin-command-capabilities')!(
+      { sender: webContents, senderFrame: webContents.mainFrame },
+      [
+        {
+          bundleName: 'example-plugin',
+          packageName: '@example/plugin',
+          path: 'plugins/example-plugin',
+          source: 'development',
+          type: 'development',
+          sourceDigest,
+        },
+      ]
+    );
+
+    expect(capabilities).toHaveLength(expected);
+    fs.rmSync(pluginRoot, { recursive: true, force: true });
+  });
+
+  it.each(['main-frame navigation', 'window close', 'explicit revocation'])(
+    'revokes capabilities on %s',
+    async lifecycle => {
+      spawnMock.mockClear();
+      const pluginSource = 'console.log("shipped");';
+      const sourceDigest = crypto.createHash('sha256').update(pluginSource).digest('hex');
+      const pluginRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-command-register-'));
+      const ipcHandlers = new Map<string, (...args: any[]) => any>();
+      const invokeHandlers = new Map<string, (...args: any[]) => any>();
+      const webContentsHandlers = new Map<string, (...args: any[]) => void>();
+      let closeHandler: () => void = () => {};
+      const sent: unknown[][] = [];
+      const mainFrame = { url: 'https://headlamp.test/' };
+      const webContents = {
+        id: 7,
+        mainFrame,
+        on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+          webContentsHandlers.set(event, handler);
+        }),
+        send: vi.fn(),
+      };
+      const mainWindow = {
+        webContents,
+        on: vi.fn((_event: string, handler: typeof closeHandler) => {
+          closeHandler = handler;
+        }),
+      } as any;
+      const ipcMain = {
+        on: vi.fn((channel: string, handler: (...args: any[]) => any) => {
+          ipcHandlers.set(channel, handler);
+        }),
+        handle: vi.fn((channel: string, handler: (...args: any[]) => any) => {
+          invokeHandlers.set(channel, handler);
+        }),
+        removeAllListeners: vi.fn(),
+        removeHandler: vi.fn(),
+      } as any;
+      setupRunCmdHandlers(
+        mainWindow,
+        ipcMain,
+        [
+          {
+            bundleName: 'example-plugin',
+            packageName: '@example/plugin',
+            source: 'shipped',
+            grants: [{ tool: 'examplectl', args: ['project', 'list'] }],
+          },
+        ],
+        'https://headlamp.test/',
+        {
+          development: pluginRoot,
+          user: pluginRoot,
+          shipped: pluginRoot,
+        }
+      );
+      webContentsHandlers.get('did-frame-navigate')!({}, 'https://headlamp.test/', 200, 'OK', true);
+      const bundleRoot = path.join(pluginRoot, 'example-plugin');
+      fs.mkdirSync(bundleRoot);
+      fs.writeFileSync(path.join(bundleRoot, 'package.json'), '{"name":"@example/plugin"}');
+      fs.writeFileSync(path.join(bundleRoot, 'main.js'), pluginSource);
+      const capabilities = await invokeHandlers.get('register-plugin-command-capabilities')!(
+        { sender: webContents, senderFrame: mainFrame },
+        [
+          {
+            bundleName: 'example-plugin',
+            packageName: '@example/plugin',
+            path: 'static-plugins/example-plugin',
+            source: 'shipped',
+            type: 'shipped',
+            sourceDigest,
+          },
+        ]
+      );
+
+      if (lifecycle === 'main-frame navigation') {
+        webContentsHandlers.get('did-start-navigation')!(
+          {},
+          'https://elsewhere.test/',
+          false,
+          true
+        );
+      } else if (lifecycle === 'window close') {
+        closeHandler();
+      } else {
+        revokeRunCmdCapabilities(ipcMain);
+      }
+      await ipcHandlers.get('run-command')!(
+        {
+          sender: { ...webContents, send: (...message: unknown[]) => sent.push(message) },
+          senderFrame: mainFrame,
+        },
+        {
+          id: 'stale-id',
+          command: 'examplectl',
+          args: ['project', 'list'],
+          options: {},
+          permissionSecrets: {},
+          capability: capabilities[0].capability,
+        }
+      );
+
+      expect(spawnMock).not.toHaveBeenCalled();
+      expect(sent).toEqual([['command-exit', 'stale-id', -2]]);
+      fs.rmSync(pluginRoot, { recursive: true, force: true });
+    }
+  );
+
+  it('rejects subframe registration and replaces an existing invoke handler', async () => {
+    const invokeHandlers = new Map<string, (...args: any[]) => any>();
+    const webContentsHandlers = new Map<string, (...args: any[]) => void>();
+    const mainFrame = { url: 'https://headlamp.test/' };
+    const webContents = {
+      id: 7,
+      mainFrame,
+      on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+        webContentsHandlers.set(event, handler);
+      }),
+      send: vi.fn(),
+    };
+    const mainWindow = { webContents, on: vi.fn() } as any;
+    const ipcMain = {
+      on: vi.fn(),
+      handle: vi.fn((channel: string, handler: (...args: any[]) => any) => {
+        if (invokeHandlers.has(channel)) {
+          throw new Error('duplicate handler');
+        }
+        invokeHandlers.set(channel, handler);
+      }),
+      off: vi.fn(),
+      removeAllListeners: vi.fn(),
+      removeHandler: vi.fn((channel: string) => invokeHandlers.delete(channel)),
+    } as any;
+    const policies = [
+      {
+        bundleName: 'example-plugin',
+        packageName: '@example/plugin',
+        source: 'shipped' as const,
+        grants: [{ tool: 'examplectl', args: ['project', 'list'] }],
+      },
+    ];
+
+    setupRunCmdHandlers(mainWindow, ipcMain, policies, 'https://headlamp.test/');
+    webContentsHandlers.get('did-frame-navigate')!({}, 'https://headlamp.test/', 200, 'OK', true);
+    const register = invokeHandlers.get('register-plugin-command-capabilities')!;
+    const registrations = [
+      {
+        bundleName: 'example-plugin',
+        packageName: '@example/plugin',
+        path: 'static-plugins/example-plugin',
+        source: 'shipped',
+        type: 'shipped',
+      },
+    ];
+
+    expect(
+      await register(
+        { sender: webContents, senderFrame: { url: 'https://headlamp.test/' } },
+        registrations
+      )
+    ).toEqual([]);
+    expect(() =>
+      setupRunCmdHandlers(mainWindow, ipcMain, policies, 'https://headlamp.test/')
+    ).not.toThrow();
+    expect(ipcMain.off).toHaveBeenCalledWith(
+      'request-plugin-permission-secrets',
+      expect.any(Function)
+    );
+    expect(ipcMain.off).toHaveBeenCalledWith('run-command', expect.any(Function));
+    expect(ipcMain.removeAllListeners).not.toHaveBeenCalled();
+    expect(ipcMain.removeHandler).toHaveBeenCalledWith('register-plugin-command-capabilities');
   });
 });
 

--- a/app/electron/runCmd.ts
+++ b/app/electron/runCmd.ts
@@ -22,7 +22,18 @@ import fs from 'node:fs';
 import { pathToFileURL } from 'node:url';
 import path from 'path';
 import i18n from './i18next.config';
-import { defaultPluginsDir, defaultUserPluginsDir } from './plugin-management';
+import {
+  defaultPluginsDir,
+  defaultUserPluginsDir,
+  PREPARED_PLUGIN_SCRIPTS_PATH,
+  preparePluginExecutable,
+  preparePluginScript,
+  removePreparedPluginExecutable,
+  removePreparedPluginScript,
+  verifyPluginInstallationIntegrity,
+} from './plugin-management';
+import { isRunCommandAllowed, RunCommandGrant } from './runCommandPolicy';
+import { isTrustedDocumentUrl } from './secureStorage';
 import { loadSettings, saveSettings, SETTINGS_PATH } from './settings';
 
 /**
@@ -42,6 +53,251 @@ interface CommandData {
   options: {};
   /** The permission secrets for the command. */
   permissionSecrets: Record<string, number>;
+  /** Opaque capability for a product-authorized plugin. */
+  capability?: string;
+}
+
+/**
+ * Product-owned command policy for a plugin identity.
+ *
+ * @example Allow a shipped plugin to list projects.
+ * ```ts
+ * const policy: ProductPluginCommandPolicy = {
+ *   bundleName: 'example-plugin',
+ *   packageName: '@example/plugin',
+ *   source: 'shipped',
+ *   grants: [{ tool: 'examplectl', args: ['project', 'list'] }],
+ * };
+ * ```
+ */
+export interface ProductPluginCommandPolicy {
+  /** Bundle directory name from the product manifest. */
+  bundleName: string;
+  /** Expected package name from the product manifest. */
+  packageName: string;
+  /** Inventory containing the authorized plugin. */
+  source: 'development' | 'user' | 'shipped';
+  /** App-owned installation provenance required for managed plugin inventories. */
+  artifactHub?: {
+    repository: string;
+    package: string;
+    packageId?: string;
+    repositoryId?: string;
+  };
+  /** Reviewed command grants for the plugin. */
+  grants: RunCommandGrant[];
+}
+
+// Keep these IPC contract interfaces in sync with frontend/src/plugin/commandCapabilities.ts.
+
+/**
+ * Plugin provenance sent to Electron before third-party code executes.
+ *
+ * @example Report a plugin discovered in the shipped inventory.
+ * ```ts
+ * const registration: PluginCommandRegistration = {
+ *   bundleName: 'example-plugin',
+ *   packageName: '@example/plugin',
+ *   path: 'static-plugins/example-plugin',
+ *   source: 'shipped',
+ *   type: 'shipped',
+ *   sourceDigest: 'dd746362bdf7510734ba74a34f15e2a6a625e7e044efb0bc38da54b7cc316084',
+ * };
+ * ```
+ */
+export interface PluginCommandRegistration {
+  /** Bundle directory reported by backend discovery. */
+  bundleName: string;
+  /** Package identity read from the plugin bundle. */
+  packageName: string;
+  /** URL path used to load the plugin. */
+  path: string;
+  /** Inventory root containing the plugin. */
+  source: string;
+  /** Plugin priority type. */
+  type: string;
+  /** SHA-256 of the exact main.js source cached by the trusted renderer. */
+  sourceDigest: string;
+}
+
+/**
+ * Command authorization issued by Electron for one verified plugin.
+ *
+ * The capability is a random 32-byte secret represented as 64 hexadecimal characters. Electron
+ * stores which plugin identity and command grants belong to that secret. The renderer includes it
+ * with each command request, allowing Electron to reject requests that have no token, use a
+ * revoked token, or request a command outside that plugin's grants.
+ *
+ * The token contains no readable plugin or permission data; plugin code must not interpret or
+ * create it.
+ *
+ * @example A capability returned by Electron for a verified plugin.
+ * ```ts
+ * const commandCapability: PluginCommandCapability = {
+ *   bundleName: 'example-plugin',
+ *   packageName: '@example/plugin',
+ *   capability: '4f8c2a917bd03e65a1c94f286e5b70d39ac214ef53d8b607c1e49a728f306db5',
+ * };
+ * ```
+ */
+export interface PluginCommandCapability {
+  /** Bundle directory bound to the capability. */
+  bundleName: string;
+  /** Package identity bound to the capability. */
+  packageName: string;
+  /** Opaque authorization token. */
+  capability: string;
+}
+
+/** Command capability state retained only by Electron's main process. */
+export interface RegisteredPluginCommandCapability extends ProductPluginCommandPolicy {
+  /** Renderer web contents that owns the capability. */
+  webContentsId: number;
+}
+
+type PluginRoots = Record<ProductPluginCommandPolicy['source'], string>;
+
+type RunCmdIpcListeners = {
+  requestPermissionSecrets: () => void;
+  revokeCapabilities: () => void;
+  runCommand: (event: IpcMainEvent, eventData: CommandDataPartial) => Promise<void>;
+};
+
+const runCmdIpcListeners = new WeakMap<Electron.IpcMain, RunCmdIpcListeners>();
+
+type PluginConsentIdentity = Pick<
+  RegisteredPluginCommandCapability,
+  'source' | 'packageName' | 'bundleName'
+>;
+
+/**
+ * Filters product command policies to plugins currently installed in their declared inventories.
+ *
+ * The product manifest expresses which plugin identities may run commands, but renderer-reported
+ * plugin provenance is untrusted. Before a capability can be issued, this function independently
+ * verifies each policy against plugin files visible to Electron's main process. It:
+ *
+ * - selects the inventory root declared by `policy.source`;
+ * - requires `policy.bundleName` to resolve inside that inventory;
+ * - rejects symbolic links for both the bundle directory and its `package.json`;
+ * - verifies the canonical bundle path remains inside the canonical inventory root; and
+ * - requires the package name in `package.json` to equal `policy.packageName` exactly.
+ *
+ * Missing inventories, absent bundles, malformed package metadata, and filesystem errors fail
+ * closed: the affected policy is omitted from the returned array rather than causing registration
+ * to throw. The function neither issues capabilities nor mutates policies. Capability registration
+ * subsequently intersects this verified result with the renderer's discovery report.
+ *
+ * Verification occurs when the trusted renderer registers plugins, not only at Electron startup.
+ * This allows an authorized development or user plugin installed after startup to become eligible
+ * after a renderer reload while still checking its files immediately before capability issuance.
+ * The development inventory is operator-controlled by threat-model definition and therefore does
+ * not require plugin-manager provenance; policies for user inventory can additionally require the
+ * installer receipt through `policy.artifactHub`.
+ *
+ * @param policies - Structurally validated policies loaded from the product manifest.
+ * @param registrations - Untrusted discovery claims including the trusted renderer's source hash.
+ * @param pluginRoots - Main-process filesystem root for each plugin inventory.
+ * @returns Policies whose installed bundle and package identity pass every verification check.
+ */
+export async function verifyPluginCommandPolicies(
+  policies: ProductPluginCommandPolicy[],
+  registrations: unknown,
+  pluginRoots: PluginRoots = defaultPluginRoots()
+): Promise<ProductPluginCommandPolicy[]> {
+  const verifiedPolicies: ProductPluginCommandPolicy[] = [];
+  const registrationList = Array.isArray(registrations) ? registrations : [];
+  for (const policy of policies) {
+    const pluginRoot = pluginRoots[policy.source];
+    let canonicalRoot: string;
+    try {
+      canonicalRoot = fs.realpathSync(pluginRoot);
+    } catch {
+      continue;
+    }
+    const bundlePath = path.resolve(pluginRoot, policy.bundleName);
+    const relativeBundlePath = path.relative(pluginRoot, bundlePath);
+    // Catalog plugins awaiting migration can have user priority while still
+    // residing in the development inventory, so validate these independently.
+    if (
+      relativeBundlePath === '' ||
+      relativeBundlePath === '..' ||
+      relativeBundlePath.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relativeBundlePath)
+    ) {
+      continue;
+    }
+
+    try {
+      const bundleStat = fs.lstatSync(bundlePath);
+      const packageFile = path.join(bundlePath, 'package.json');
+      const packageStat = fs.lstatSync(packageFile);
+      if (
+        !bundleStat.isDirectory() ||
+        bundleStat.isSymbolicLink() ||
+        !packageStat.isFile() ||
+        packageStat.isSymbolicLink()
+      ) {
+        continue;
+      }
+      const canonicalBundle = fs.realpathSync(bundlePath);
+      const relativeCanonicalBundle = path.relative(canonicalRoot, canonicalBundle);
+      if (
+        relativeCanonicalBundle === '' ||
+        relativeCanonicalBundle === '..' ||
+        relativeCanonicalBundle.startsWith(`..${path.sep}`) ||
+        path.isAbsolute(relativeCanonicalBundle)
+      ) {
+        continue;
+      }
+      const packageInfo = JSON.parse(fs.readFileSync(packageFile, 'utf8')) as unknown;
+      if (
+        typeof packageInfo !== 'object' ||
+        packageInfo === null ||
+        Array.isArray(packageInfo) ||
+        (packageInfo as { name?: unknown }).name !== policy.packageName
+      ) {
+        continue;
+      }
+      const expectedPath = `${
+        { development: 'plugins', user: 'user-plugins', shipped: 'static-plugins' }[policy.source]
+      }/${policy.bundleName}`;
+      const matchingRegistrations = registrationList.filter(candidate => {
+        if (typeof candidate !== 'object' || candidate === null || Array.isArray(candidate)) {
+          return false;
+        }
+        const registration = candidate as Partial<PluginCommandRegistration>;
+        return (
+          registration.source === policy.source &&
+          registration.bundleName === policy.bundleName &&
+          registration.packageName === policy.packageName &&
+          typeof registration.path === 'string' &&
+          registration.path.replaceAll('\\', '/') === expectedPath &&
+          /^[a-f0-9]{64}$/.test(registration.sourceDigest ?? '')
+        );
+      });
+      if (matchingRegistrations.length !== 1) continue;
+      const mainFile = path.join(bundlePath, 'main.js');
+      const mainStat = fs.lstatSync(mainFile);
+      if (mainStat.isSymbolicLink() || !mainStat.isFile()) continue;
+      const canonicalMain = fs.realpathSync(mainFile);
+      if (path.dirname(canonicalMain) !== canonicalBundle) continue;
+      const sourceDigest = crypto
+        .createHash('sha256')
+        .update(fs.readFileSync(canonicalMain, 'utf8'))
+        .digest('hex');
+      if (sourceDigest !== matchingRegistrations[0].sourceDigest) continue;
+      if (
+        policy.artifactHub === undefined ||
+        (await verifyPluginInstallationIntegrity(bundlePath, policy.artifactHub))
+      ) {
+        verifiedPolicies.push(policy);
+      }
+    } catch {
+      continue;
+    }
+  }
+  return verifiedPolicies;
 }
 
 /** Returns only values changed by shell initialization. */
@@ -86,25 +342,62 @@ function confirmCommandDialog(command: string, mainWindow: BrowserWindow): boole
  * @param args - The arguments to the command.
  * @returns true if the user has consented to running the command, false otherwise.
  */
-function checkCommandConsent(command: string, args: string[], mainWindow: BrowserWindow): boolean {
+function checkCommandConsent(
+  command: string,
+  args: string[],
+  mainWindow: BrowserWindow,
+  pluginIdentity?: PluginConsentIdentity,
+  consentArgs: string[] = args.slice(0, 1)
+): boolean {
   const settings = loadSettings(SETTINGS_PATH);
   const confirmedCommands = settings?.confirmedCommands;
 
-  // Build the consent key: command + (first arg if present)
-  let consentKey = command;
-  if (args && args.length > 0) {
-    consentKey += ' ' + args[0];
+  // Product grants use their reviewed argument prefix so saved consent cannot
+  // become broader when a request adds trailing arguments.
+  const pluginLabel = pluginIdentity
+    ? `${pluginIdentity.packageName}@${pluginIdentity.bundleName}`
+    : undefined;
+  const consentIdentity = pluginIdentity
+    ? {
+        source: pluginIdentity.source,
+        packageName: pluginIdentity.packageName,
+        bundleName: pluginIdentity.bundleName,
+      }
+    : undefined;
+  let displayCommand = pluginLabel ? `${pluginLabel}: ${command}` : command;
+  if (consentArgs.length > 0) {
+    displayCommand += ' ' + consentArgs.join(' ');
   }
+  const consentKey = pluginIdentity
+    ? `run-command-consent:v2:${JSON.stringify([consentIdentity, command, consentArgs])}`
+    : displayCommand;
+  const previousPluginConsentKey = pluginLabel
+    ? `run-command-consent:v1:${JSON.stringify([pluginLabel, command, consentArgs])}`
+    : undefined;
+  const legacyConsentKey = [command, ...args.slice(0, 1)].join(' ');
+  const legacyPluginCommands = pluginIdentity
+    ? LEGACY_CONSENT_PLUGIN_COMMANDS.get(
+        `${pluginIdentity.source}\0${pluginIdentity.packageName}\0${pluginIdentity.bundleName}`
+      )
+    : undefined;
+  const mayUseScopedLegacyConsent = !pluginIdentity || legacyPluginCommands !== undefined;
+  const mayUseSourceLessLegacyConsent =
+    !pluginIdentity || legacyPluginCommands?.has(legacyConsentKey) === true;
 
   const savedCommand: boolean | undefined = confirmedCommands
-    ? confirmedCommands[consentKey]
+    ? confirmedCommands[consentKey] ??
+      (mayUseScopedLegacyConsent && previousPluginConsentKey
+        ? confirmedCommands[previousPluginConsentKey]
+        : undefined) ??
+      (mayUseScopedLegacyConsent ? confirmedCommands[displayCommand] : undefined) ??
+      (mayUseSourceLessLegacyConsent ? confirmedCommands[legacyConsentKey] : undefined)
     : undefined;
 
   if (savedCommand === false) {
     console.error(`Invalid command: ${consentKey}, command not allowed by users choice`);
     return false;
   } else if (savedCommand === undefined) {
-    const commandChoice = confirmCommandDialog(consentKey, mainWindow);
+    const commandChoice = confirmCommandDialog(displayCommand, mainWindow);
     if (settings?.confirmedCommands === undefined) {
       settings.confirmedCommands = {};
     }
@@ -116,6 +409,123 @@ function checkCommandConsent(command: string, args: string[], mainWindow: Browse
     return commandChoice;
   }
   return true;
+}
+
+function defaultPluginRoots(): PluginRoots {
+  return {
+    development: defaultPluginsDir(),
+    user: defaultUserPluginsDir(),
+    shipped:
+      typeof process.resourcesPath === 'string'
+        ? path.join(process.resourcesPath, '.plugins')
+        : path.resolve('.plugins'),
+  };
+}
+
+function isPathWithin(root: string, candidate: string): boolean {
+  const relativePath = path.relative(path.resolve(root), path.resolve(candidate));
+  return (
+    relativePath === '' ||
+    (relativePath !== '..' &&
+      !relativePath.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relativePath))
+  );
+}
+
+/** Removes plugin-controlled directories from the executable search path. */
+export function systemCommandEnvironment(
+  environment: NodeJS.ProcessEnv,
+  pluginRoots: PluginRoots = defaultPluginRoots()
+): NodeJS.ProcessEnv {
+  const pathKey = Object.keys(environment).find(key => key.toUpperCase() === 'PATH');
+  if (!pathKey || !environment[pathKey]) {
+    return { ...environment };
+  }
+  const roots = Object.values(pluginRoots);
+  return {
+    ...environment,
+    [pathKey]: environment[pathKey]
+      .split(path.delimiter)
+      .filter(
+        directory =>
+          directory !== '' &&
+          path.isAbsolute(directory) &&
+          !roots.some(root => isPathWithin(root, directory))
+      )
+      .join(path.delimiter),
+  };
+}
+
+/** Resolved plugin executable and the canonical bundle that owns it. */
+interface ResolvedPluginExecutable {
+  /** Canonical absolute plugin bundle path. */
+  bundle: string;
+  /** Canonical absolute executable path selected for process creation. */
+  executable: string;
+}
+
+/**
+ * Resolves a declared plugin executable without allowing bundle escapes or symbolic links.
+ *
+ * @param executablePath - Platform-independent executable path relative to the bundle.
+ * @param capability - Verified plugin identity and inventory bound to the command capability.
+ * @param pluginRoots - Main-process filesystem root for each plugin inventory.
+ * @returns Canonical bundle and executable paths, or `undefined` when resolution is unsafe.
+ */
+function resolvePluginExecutable(
+  executablePath: string,
+  capability: RegisteredPluginCommandCapability,
+  pluginRoots: PluginRoots
+): ResolvedPluginExecutable | undefined {
+  const root = pluginRoots[capability.source];
+  const bundle = path.resolve(root, capability.bundleName);
+  const platformPath = executablePath.split('/').join(path.sep);
+  const names =
+    process.platform === 'win32' ? [platformPath, `${platformPath}.exe`] : [platformPath];
+  try {
+    if (fs.lstatSync(bundle).isSymbolicLink()) {
+      return undefined;
+    }
+    const canonicalRoot = fs.realpathSync(root);
+    const canonicalBundle = fs.realpathSync(bundle);
+    if (!isPathWithin(canonicalRoot, canonicalBundle)) {
+      return undefined;
+    }
+    for (const name of names) {
+      try {
+        const executable = path.resolve(bundle, name);
+        const executableStat = fs.lstatSync(executable);
+        if (!executableStat.isFile() || executableStat.isSymbolicLink()) {
+          continue;
+        }
+        const canonicalExecutable = fs.realpathSync(executable);
+        if (isPathWithin(canonicalBundle, canonicalExecutable)) {
+          return { bundle: canonicalBundle, executable: canonicalExecutable };
+        }
+      } catch {
+        continue;
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Reduces a process creation error to a non-sensitive diagnostic reason.
+ *
+ * @param error - Error thrown or emitted by `spawn`.
+ * @returns The operating-system error code, error class name, or `unknown`.
+ */
+function spawnFailureReason(error: unknown): string {
+  if (typeof error === 'object' && error !== null && 'code' in error) {
+    const code = (error as { code?: unknown }).code;
+    if (typeof code === 'string') {
+      return code;
+    }
+  }
+  return error instanceof Error ? error.name : 'unknown';
 }
 
 const COMMANDS_WITH_CONSENT = {
@@ -135,6 +545,34 @@ const COMMANDS_WITH_CONSENT = {
   headlamp_ai_assistant: ['gh auth', 'az account', 'az cognitiveservices'],
   azure_aks: ['scriptjs azure-aks/azure-api.js'],
 };
+
+const LEGACY_MINIKUBE_COMMANDS = new Set(COMMANDS_WITH_CONSENT.headlamp_minikube);
+const LEGACY_AI_ASSISTANT_COMMANDS = new Set(COMMANDS_WITH_CONSENT.headlamp_ai_assistant);
+const LEGACY_AZURE_AKS_COMMANDS = new Set(COMMANDS_WITH_CONSENT.azure_aks);
+const LEGACY_CONSENT_PLUGIN_COMMANDS = new Map<string, ReadonlySet<string>>([
+  ['development\0@headlamp-k8s/minikube\0minikube', LEGACY_MINIKUBE_COMMANDS],
+  ['development\0@headlamp-k8s/minikube\0headlamp_minikube', LEGACY_MINIKUBE_COMMANDS],
+  [
+    'development\0@headlamp-k8s/minikubeprerelease\0headlamp_minikubeprerelease',
+    LEGACY_MINIKUBE_COMMANDS,
+  ],
+  ['development\0@headlamp-k8s/ai-assistant\0ai-assistant', LEGACY_AI_ASSISTANT_COMMANDS],
+  ['development\0@headlamp-k8s/ai-assistant\0headlamp_ai-assistant', LEGACY_AI_ASSISTANT_COMMANDS],
+  ['development\0@headlamp-k8s/ai-assistant\0headlamp_ai_assistant', LEGACY_AI_ASSISTANT_COMMANDS],
+  [
+    'development\0@headlamp-k8s/ai-assistantprerelease\0ai-assistantprerelease',
+    LEGACY_AI_ASSISTANT_COMMANDS,
+  ],
+  [
+    'development\0@headlamp-k8s/ai-assistantprerelease\0headlamp_ai-assistantprerelease',
+    LEGACY_AI_ASSISTANT_COMMANDS,
+  ],
+  [
+    'development\0@headlamp-k8s/ai-assistantprerelease\0headlamp_ai_assistantprerelease',
+    LEGACY_AI_ASSISTANT_COMMANDS,
+  ],
+  ['development\0azure-aks\0azure-aks', LEGACY_AZURE_AKS_COMMANDS],
+]);
 
 /**
  * Adds the runCmd consent for the plugin.
@@ -189,8 +627,9 @@ export function addRunCmdConsent(pluginInfo: { name: string }): void {
  * Adds the runCmd consent for the plugin.
  *
  * @param pluginName The package.json name of the plugin.
+ * @param bundleName The installed bundle folder being removed.
  */
-export function removeRunCmdConsent(pluginName: string): void {
+export function removeRunCmdConsent(pluginName: string, bundleName?: string): void {
   const settings = loadSettings(SETTINGS_PATH);
   if (!settings.confirmedCommands) {
     return;
@@ -210,6 +649,22 @@ export function removeRunCmdConsent(pluginName: string): void {
   }
   for (const command of commands) {
     delete settings.confirmedCommands[command];
+  }
+  if (bundleName) {
+    const prefix = 'run-command-consent:v2:';
+    for (const consentKey of Object.keys(settings.confirmedCommands)) {
+      if (!consentKey.startsWith(prefix)) {
+        continue;
+      }
+      try {
+        const [identity] = JSON.parse(consentKey.slice(prefix.length));
+        if (identity?.packageName === pluginName && identity?.bundleName === bundleName) {
+          delete settings.confirmedCommands[consentKey];
+        }
+      } catch {
+        // Ignore malformed settings keys retained from external edits.
+      }
+    }
   }
 
   saveSettings(SETTINGS_PATH, settings);
@@ -240,10 +695,135 @@ export function checkPermissionSecret(
 }
 
 /**
+ * Creates capabilities for product policies whose reported plugin provenance matches.
+ *
+ * The renderer supplies discovery results only before plugin code executes. The
+ * main process independently requires the configured source, package identity,
+ * and expected inventory path before issuing a capability.
+ *
+ * @param registrations - Untrusted plugin discovery results from the renderer.
+ * @param policies - Validated policies loaded from the packaged product manifest.
+ * @param webContentsId - Main renderer that will own generated capabilities.
+ * @returns Public capabilities and the private token lookup used for enforcement.
+ */
+export function createProductCommandCapabilities(
+  registrations: unknown,
+  policies: ProductPluginCommandPolicy[],
+  webContentsId: number
+): {
+  capabilities: PluginCommandCapability[];
+  capabilityRegistry: Map<string, RegisteredPluginCommandCapability>;
+} {
+  const capabilities: PluginCommandCapability[] = [];
+  const capabilityRegistry = new Map<string, RegisteredPluginCommandCapability>();
+  if (!Array.isArray(registrations) || registrations.length > 256) {
+    return { capabilities, capabilityRegistry };
+  }
+
+  const registrationsByIdentity = new Map<string, PluginCommandRegistration>();
+  const ambiguousIdentities = new Set<string>();
+  for (const candidate of registrations) {
+    if (typeof candidate !== 'object' || candidate === null || Array.isArray(candidate)) {
+      continue;
+    }
+    const registration = candidate as Partial<PluginCommandRegistration>;
+    if (
+      typeof registration.bundleName !== 'string' ||
+      typeof registration.packageName !== 'string' ||
+      typeof registration.path !== 'string' ||
+      typeof registration.sourceDigest !== 'string' ||
+      !/^[a-f0-9]{64}$/.test(registration.sourceDigest) ||
+      !['development', 'user', 'shipped'].includes(registration.source ?? '') ||
+      !['development', 'user', 'shipped'].includes(registration.type ?? '')
+    ) {
+      continue;
+    }
+    const normalizedPath = registration.path.replaceAll('\\', '/');
+    const inventoryPath = {
+      development: 'plugins',
+      user: 'user-plugins',
+      shipped: 'static-plugins',
+    }[registration.source as ProductPluginCommandPolicy['source']];
+    if (normalizedPath !== `${inventoryPath}/${registration.bundleName}`) {
+      continue;
+    }
+    const identity = `${registration.source}\0${registration.bundleName}\0${registration.packageName}`;
+    if (registrationsByIdentity.has(identity) || ambiguousIdentities.has(identity)) {
+      registrationsByIdentity.delete(identity);
+      ambiguousIdentities.add(identity);
+      continue;
+    }
+    registrationsByIdentity.set(identity, registration as PluginCommandRegistration);
+  }
+
+  for (const policy of policies) {
+    const identity = `${policy.source}\0${policy.bundleName}\0${policy.packageName}`;
+    if (!registrationsByIdentity.has(identity)) {
+      continue;
+    }
+    const capability = crypto.randomBytes(32).toString('hex');
+    capabilities.push({
+      bundleName: policy.bundleName,
+      packageName: policy.packageName,
+      capability,
+    });
+    capabilityRegistry.set(capability, { ...policy, webContentsId });
+  }
+
+  return { capabilities, capabilityRegistry };
+}
+
+/**
  * Returns the path to a script in the plugins directory.
  * @param scriptName script relative to plugins folder. "headlamp-k8s-minikube/bin/manage-minikube.js"
+ * @param policy optional policy binding for capability-authorized scripts.
+ * @returns The legacy script path, a verified policy-bound path, or undefined for an unsafe path.
  */
-function getPluginsScriptPath(scriptName: string) {
+function getPluginsScriptPath(
+  scriptName: string,
+  policy?: ProductPluginCommandPolicy,
+  pluginRoots: PluginRoots = defaultPluginRoots()
+): string | undefined {
+  if (policy) {
+    const pluginRoot = pluginRoots[policy.source];
+    const bundleRoot = path.resolve(pluginRoot, policy.bundleName);
+    const scriptPath = path.resolve(pluginRoot, scriptName);
+    const relativeScriptPath = path.relative(bundleRoot, scriptPath);
+    if (
+      relativeScriptPath === '' ||
+      relativeScriptPath === '..' ||
+      relativeScriptPath.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relativeScriptPath)
+    ) {
+      return undefined;
+    }
+    try {
+      const bundleStat = fs.lstatSync(bundleRoot);
+      const scriptStat = fs.lstatSync(scriptPath);
+      const canonicalPluginRoot = fs.realpathSync(pluginRoot);
+      const canonicalBundle = fs.realpathSync(bundleRoot);
+      const canonicalScript = fs.realpathSync(scriptPath);
+      const relativeCanonicalBundle = path.relative(canonicalPluginRoot, canonicalBundle);
+      const relativeCanonicalScript = path.relative(canonicalBundle, canonicalScript);
+      if (
+        !bundleStat.isDirectory() ||
+        bundleStat.isSymbolicLink() ||
+        !scriptStat.isFile() ||
+        scriptStat.isSymbolicLink() ||
+        relativeCanonicalBundle !== policy.bundleName ||
+        relativeCanonicalScript === '' ||
+        relativeCanonicalScript === '..' ||
+        relativeCanonicalScript.startsWith(`..${path.sep}`) ||
+        path.isAbsolute(relativeCanonicalScript)
+      ) {
+        return undefined;
+      }
+      return canonicalScript;
+    } catch {
+      return undefined;
+    }
+  }
+
   const userPlugins = defaultUserPluginsDir();
   if (fs.existsSync(path.join(userPlugins, scriptName))) {
     return path.join(userPlugins, scriptName);
@@ -274,12 +854,18 @@ function getPluginsScriptPath(scriptName: string) {
  * @param mainWindow - The main browser window.
  * @param permissionSecrets - The permission secrets required for the command to run.
  *                            Checks against eventData.permissionSecrets.
+ * @param capabilityRegistry - Main-process capability policy bound to the active renderer.
+ * @param trustedStartUrl - Headlamp document URL allowed to use capabilities.
+ * @param pluginRoots - Main-process filesystem roots for plugin inventories.
  */
 export async function handleRunCommand(
   event: IpcMainEvent,
   eventData: CommandDataPartial,
   mainWindow: BrowserWindow | null,
-  permissionSecrets: Record<string, number>
+  permissionSecrets: Record<string, number>,
+  capabilityRegistry: Map<string, RegisteredPluginCommandCapability> = new Map(),
+  trustedStartUrl?: string,
+  pluginRoots: PluginRoots = defaultPluginRoots()
 ): Promise<void> {
   const commandId = typeof eventData?.id === 'string' ? eventData.id : undefined;
   const sendRejectedExit = (exitCode = -1) => {
@@ -301,25 +887,52 @@ export async function handleRunCommand(
   }
   const commandData = eventData as CommandData;
 
-  const [permissionsValid, permissionError] = checkPermissionSecret(commandData, permissionSecrets);
+  const registeredCapability = commandData.capability
+    ? capabilityRegistry.get(commandData.capability)
+    : undefined;
+  const commandFailureContext = (reason: string) => ({
+    tool: commandData.command,
+    reason,
+    ...(registeredCapability && {
+      packageName: registeredCapability.packageName,
+      bundleName: registeredCapability.bundleName,
+      source: registeredCapability.source,
+    }),
+  });
+  const isFromTrustedMainFrame = () =>
+    mainWindow !== null &&
+    (!trustedStartUrl ||
+      (event.sender === mainWindow.webContents &&
+        event.senderFrame === mainWindow.webContents.mainFrame &&
+        isTrustedDocumentUrl(event.senderFrame.url, trustedStartUrl)));
+  const capabilityGrant = registeredCapability?.grants.find(grant =>
+    isRunCommandAllowed([grant], commandData.command, commandData.args)
+  );
+  const [permissionsValid, permissionError] = commandData.capability
+    ? registeredCapability?.webContentsId === event.sender.id &&
+      capabilityGrant &&
+      isFromTrustedMainFrame()
+      ? [true, '']
+      : [false, 'Command is not authorized by product policy']
+    : checkPermissionSecret(commandData, permissionSecrets);
   if (!permissionsValid) {
     console.error(permissionError);
     sendRejectedExit(-2);
     return;
   }
 
-  if (!checkCommandConsent(commandData.command, commandData.args, mainWindow)) {
+  if (
+    !checkCommandConsent(
+      commandData.command,
+      commandData.args,
+      mainWindow,
+      registeredCapability ? registeredCapability : undefined,
+      capabilityGrant?.args
+    )
+  ) {
     sendRejectedExit(-3);
     return;
   }
-
-  // Get the command and args to run. With the correct paths for "scriptjs" commands.
-  // scriptjs commands are scripts run with the compiled app, or with "Electron" in dev mode.
-  const command = commandData.command === 'scriptjs' ? process.execPath : commandData.command;
-  const args =
-    commandData.command === 'scriptjs'
-      ? [getPluginsScriptPath(commandData.args[0]), ...commandData.args.slice(1)]
-      : commandData.args;
 
   let shellEnvironment = process.env;
   try {
@@ -329,6 +942,137 @@ export async function handleRunCommand(
     console.warn('Failed to get shell environment, using process.env:', error);
   }
 
+  // Get the command and args to run. With the correct paths for "scriptjs" commands.
+  // scriptjs commands are scripts run with the compiled app, or with "Electron" in dev mode.
+  const scriptPath =
+    commandData.command === 'scriptjs'
+      ? getPluginsScriptPath(commandData.args[0], registeredCapability, pluginRoots)
+      : undefined;
+  if (commandData.command === 'scriptjs' && !scriptPath) {
+    console.error('Command script is outside its authorized plugin bundle');
+    sendRejectedExit(-2);
+    return;
+  }
+  let preparedPluginScript: string | undefined;
+  if (commandData.command === 'scriptjs' && registeredCapability?.artifactHub) {
+    let prepared;
+    try {
+      const pluginRoot = pluginRoots[registeredCapability.source];
+      const bundlePath = fs.realpathSync(path.resolve(pluginRoot, registeredCapability.bundleName));
+      const relativeScript = path.relative(bundlePath, scriptPath as string);
+      prepared = await preparePluginScript(
+        bundlePath,
+        relativeScript,
+        registeredCapability.artifactHub
+      );
+    } catch (error) {
+      prepared = { ok: false as const, reason: spawnFailureReason(error) };
+    }
+    if (!prepared.ok) {
+      console.error('Plugin script unavailable', commandFailureContext(prepared.reason));
+      event.sender.send(
+        'command-stderr',
+        commandData.id,
+        'Plugin installation provenance is missing or invalid. Reinstall the plugin.'
+      );
+      sendRejectedExit(-2);
+      return;
+    }
+    preparedPluginScript = prepared.scriptPath;
+  }
+  const pluginExecutable =
+    registeredCapability &&
+    commandData.command !== 'scriptjs' &&
+    capabilityGrant?.executable?.source === 'plugin'
+      ? resolvePluginExecutable(capabilityGrant.executable.path, registeredCapability, pluginRoots)
+      : undefined;
+  let preparedPluginExecutable: string | undefined;
+  const removePreparedExecutable = () => {
+    if (!preparedPluginExecutable) {
+      return;
+    }
+    try {
+      removePreparedPluginExecutable(preparedPluginExecutable);
+    } catch (error) {
+      console.warn('Failed to remove prepared plugin executable', spawnFailureReason(error));
+    } finally {
+      preparedPluginExecutable = undefined;
+    }
+  };
+  const removePreparedScript = () => {
+    if (!preparedPluginScript) {
+      return;
+    }
+    try {
+      removePreparedPluginScript(preparedPluginScript);
+    } catch (error) {
+      console.warn('Failed to remove prepared plugin script', spawnFailureReason(error));
+    } finally {
+      preparedPluginScript = undefined;
+    }
+  };
+  const removePreparedFiles = () => {
+    removePreparedExecutable();
+    removePreparedScript();
+  };
+  if (capabilityGrant?.executable?.source === 'plugin') {
+    const developmentExecutable = registeredCapability?.source === 'development';
+    let failureReason: string | undefined;
+    if (!pluginExecutable) {
+      failureReason = 'missing-or-unsafe-executable';
+    } else if (!developmentExecutable) {
+      const managedIdentity =
+        registeredCapability?.source === 'user' ? registeredCapability.artifactHub : undefined;
+      if (registeredCapability?.source === 'user' && !managedIdentity) {
+        failureReason = 'missing-receipt';
+      } else {
+        const prepared = await preparePluginExecutable(
+          pluginExecutable.bundle,
+          capabilityGrant.executable.path,
+          pluginExecutable.executable,
+          undefined,
+          managedIdentity
+        );
+        if (prepared.ok) {
+          preparedPluginExecutable = prepared.executablePath;
+        } else {
+          failureReason = prepared.reason;
+        }
+      }
+    }
+    if (failureReason) {
+      console.error('Plugin executable unavailable', commandFailureContext(failureReason));
+      if (failureReason === 'missing-receipt') {
+        event.sender.send(
+          'command-stderr',
+          commandData.id,
+          'Plugin executable integrity metadata is missing. Update or reinstall the plugin.'
+        );
+      }
+      sendRejectedExit(-2);
+      return;
+    }
+  }
+  if (
+    commandData.capability &&
+    (capabilityRegistry.get(commandData.capability) !== registeredCapability ||
+      registeredCapability?.webContentsId !== event.sender.id ||
+      !isFromTrustedMainFrame())
+  ) {
+    removePreparedFiles();
+    console.error('Command capability was revoked before process creation');
+    sendRejectedExit(-2);
+    return;
+  }
+  const command =
+    commandData.command === 'scriptjs'
+      ? process.execPath
+      : preparedPluginExecutable ?? pluginExecutable?.executable ?? commandData.command;
+  const args =
+    commandData.command === 'scriptjs'
+      ? [preparedPluginScript ?? (scriptPath as string), ...commandData.args.slice(1)]
+      : commandData.args;
+
   // If the command is 'scriptjs', we pass the HEADLAMP_RUN_SCRIPT=true
   // env var so that the Headlamp or Electron process runs the script.
   let child: ChildProcessWithoutNullStreams;
@@ -337,12 +1081,16 @@ export async function handleRunCommand(
       ...commandData.options,
       shell: false,
       env: {
-        ...shellEnvironment,
+        ...(registeredCapability && commandData.command !== 'scriptjs'
+          ? systemCommandEnvironment(shellEnvironment, pluginRoots)
+          : shellEnvironment),
         ...(commandData.command === 'scriptjs' ? { HEADLAMP_RUN_SCRIPT: 'true' } : {}),
       },
     });
   } catch (error) {
+    removePreparedFiles();
     const message = error instanceof Error ? error.message : String(error);
+    console.error('Failed to spawn command', commandFailureContext(spawnFailureReason(error)));
     event.sender.send('command-stderr', commandData.id, message);
     event.sender.send('command-exit', commandData.id, -1);
     return;
@@ -366,11 +1114,14 @@ export async function handleRunCommand(
   };
 
   child.on('error', (err: Error) => {
+    removePreparedFiles();
+    console.error('Command process error', commandFailureContext(spawnFailureReason(err)));
     event.sender.send('command-stderr', commandData.id, err.message);
     sendTerminalEvent(-1);
   });
 
   child.on('close', (code: number | null) => {
+    removePreparedFiles();
     sendTerminalEvent(code);
   });
 }
@@ -385,15 +1136,22 @@ export function runScript() {
   const baseDir = path.resolve(defaultPluginsDir());
   const userPluginsDir = path.resolve(defaultUserPluginsDir());
   const staticPluginsDir = path.resolve(path.join(process.resourcesPath, '.plugins'));
+  const preparedScriptsDir = path.resolve(PREPARED_PLUGIN_SCRIPTS_PATH);
   const scriptPath = path.resolve(process.argv[1]);
 
+  const isWithin = (root: string) => {
+    const relative = path.relative(root, scriptPath);
+    return relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+  };
+
   if (
-    !scriptPath.startsWith(baseDir) &&
-    !scriptPath.startsWith(userPluginsDir) &&
-    !scriptPath.startsWith(staticPluginsDir)
+    !isWithin(baseDir) &&
+    !isWithin(userPluginsDir) &&
+    !isWithin(staticPluginsDir) &&
+    !isWithin(preparedScriptsDir)
   ) {
     console.error(
-      `Invalid script path: ${scriptPath}. Must be within ${baseDir}, ${userPluginsDir}, or ${staticPluginsDir}.`
+      `Invalid script path: ${scriptPath}. Must be within an authorized plugin script directory.`
     );
     process.exit(1);
   }
@@ -417,8 +1175,20 @@ function cryptoRandom() {
  *
  * @param mainWindow - The main browser window.
  * @param ipcMain - The IPC main instance.
+ * @param productPolicies - Validated product command policies available for registration.
+ * @param trustedStartUrl - Headlamp document URL allowed to register and use capabilities.
+ * @param pluginRoots - Optional inventory roots used to verify plugin files during registration.
+ * @param isDevelopment - Runtime mode selected by the Electron entry point.
  */
-export function setupRunCmdHandlers(mainWindow: BrowserWindow | null, ipcMain: Electron.IpcMain) {
+export function setupRunCmdHandlers(
+  mainWindow: BrowserWindow | null,
+  ipcMain: Electron.IpcMain,
+  productPolicies: ProductPluginCommandPolicy[] = [],
+  trustedStartUrl?: string,
+  pluginRoots?: Record<ProductPluginCommandPolicy['source'], string>,
+  isDevelopment = false,
+  developmentPluginsEnabled: () => boolean = () => false
+) {
   if (mainWindow === null) {
     console.error('Main window is null, cannot set up run command handlers');
     return;
@@ -428,6 +1198,19 @@ export function setupRunCmdHandlers(mainWindow: BrowserWindow | null, ipcMain: E
   // This means that if the secrets are requested before the plugins are loaded, then
   // they will not be sent until the next time the app is reloaded.
   let pluginPermissionSecretsSent = false;
+  const previousListeners = runCmdIpcListeners.get(ipcMain);
+  if (previousListeners) {
+    ipcMain.off('request-plugin-permission-secrets', previousListeners.requestPermissionSecrets);
+    ipcMain.off('run-command', previousListeners.runCommand);
+  }
+  ipcMain.removeHandler('register-plugin-command-capabilities');
+
+  let capabilityRegistrationAllowed = trustedStartUrl === undefined;
+  let capabilityRegistry = new Map<string, RegisteredPluginCommandCapability>();
+  const revokeCapabilities = () => {
+    capabilityRegistrationAllowed = false;
+    capabilityRegistry.clear();
+  };
   const permissionSecrets = {
     'runCmd-minikube': cryptoRandom(),
     'runCmd-scriptjs-minikube/manage-minikube.js': cryptoRandom(),
@@ -438,23 +1221,76 @@ export function setupRunCmdHandlers(mainWindow: BrowserWindow | null, ipcMain: E
     'runCmd-scriptjs-azure-aks/azure-api.js': cryptoRandom(),
   };
 
-  ipcMain.on('request-plugin-permission-secrets', function giveSecrets() {
+  const requestPermissionSecrets = () => {
     if (!pluginPermissionSecretsSent) {
       pluginPermissionSecretsSent = true;
       mainWindow?.webContents.send('plugin-permission-secrets', permissionSecrets);
     }
+  };
+  ipcMain.on('request-plugin-permission-secrets', requestPermissionSecrets);
+
+  ipcMain.handle('register-plugin-command-capabilities', async (event, registrations: unknown) => {
+    if (
+      event.sender !== mainWindow.webContents ||
+      (trustedStartUrl !== undefined &&
+        (event.senderFrame !== mainWindow.webContents.mainFrame ||
+          !isTrustedDocumentUrl(event.senderFrame.url, trustedStartUrl))) ||
+      !capabilityRegistrationAllowed
+    ) {
+      return [];
+    }
+    capabilityRegistrationAllowed = false;
+    const enabledPolicies = productPolicies.filter(
+      policy =>
+        policy.source !== 'development' || isDevelopment || developmentPluginsEnabled() === true
+    );
+    const result = createProductCommandCapabilities(
+      registrations,
+      await verifyPluginCommandPolicies(enabledPolicies, registrations, pluginRoots),
+      mainWindow.webContents.id
+    );
+    capabilityRegistry = result.capabilityRegistry;
+    return result.capabilities;
   });
 
-  // Only allow sending secrets again when the Electron main window reloads (not just URL changes).
-  mainWindow?.webContents.on('did-frame-finish-load', (event, isMainFrame) => {
-    if (isMainFrame) {
-      pluginPermissionSecretsSent = false;
+  mainWindow.webContents.on('did-start-navigation', (_event, _url, isInPlace, isMainFrame) => {
+    if (isMainFrame && !isInPlace) {
+      revokeCapabilities();
     }
   });
-
-  ipcMain.on('run-command', (event, eventData) =>
-    handleRunCommand(event, eventData, mainWindow, permissionSecrets)
+  mainWindow.webContents.on(
+    'did-frame-navigate',
+    (_event, url, _httpResponseCode, _httpStatusText, isMainFrame) => {
+      if (isMainFrame) {
+        pluginPermissionSecretsSent = false;
+        capabilityRegistrationAllowed =
+          trustedStartUrl === undefined || isTrustedDocumentUrl(url, trustedStartUrl);
+        capabilityRegistry.clear();
+      }
+    }
   );
+
+  mainWindow.on('closed', () => {
+    revokeCapabilities();
+  });
+
+  const runCommand = (event: IpcMainEvent, eventData: CommandDataPartial) =>
+    handleRunCommand(
+      event,
+      eventData,
+      mainWindow,
+      permissionSecrets,
+      capabilityRegistry,
+      trustedStartUrl,
+      pluginRoots ?? defaultPluginRoots()
+    );
+  ipcMain.on('run-command', runCommand);
+  runCmdIpcListeners.set(ipcMain, { requestPermissionSecrets, revokeCapabilities, runCommand });
+}
+
+/** Revokes every command capability issued by handlers registered on this IPC instance. */
+export function revokeRunCmdCapabilities(ipcMain: Electron.IpcMain): void {
+  runCmdIpcListeners.get(ipcMain)?.revokeCapabilities();
 }
 
 /**
@@ -493,9 +1329,26 @@ export function validateCommandData(eventData: CommandDataPartial): [boolean, st
     }
   }
 
+  if (eventData.args.some(argument => typeof argument !== 'string')) {
+    return [false, 'Invalid eventData.args: arguments must be strings'];
+  }
+  if (
+    eventData.capability !== undefined &&
+    (typeof eventData.capability !== 'string' || !/^[a-f0-9]{64}$/.test(eventData.capability))
+  ) {
+    return [false, 'Invalid command capability'];
+  }
+  if (
+    eventData.capability !== undefined &&
+    (Object.getPrototypeOf(eventData.options) !== Object.prototype ||
+      Reflect.ownKeys(eventData.options).length !== 0)
+  ) {
+    return [false, 'Command capabilities do not allow spawn options'];
+  }
+
   const validCommands = ['minikube', 'az', 'scriptjs', 'gh'];
 
-  if (!validCommands.includes(eventData.command)) {
+  if (eventData.capability === undefined && !validCommands.includes(eventData.command)) {
     return [
       false,
       `Invalid command: ${eventData.command}, only valid commands are: ${JSON.stringify(

--- a/app/electron/runCommandPolicy.test.ts
+++ b/app/electron/runCommandPolicy.test.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  isRunCommandAllowed,
+  matchesRunCommandGrant,
+  parseRunCommandGrants,
+} from './runCommandPolicy';
+
+describe('parseRunCommandGrants', () => {
+  it('normalizes valid grants', () => {
+    expect(
+      parseRunCommandGrants([
+        { tool: 'examplectl', args: ['project', 'list'] },
+        {
+          tool: 'kubectl',
+          args: ['get'],
+          allowTrailingArgs: true,
+        },
+      ])
+    ).toEqual([
+      { tool: 'examplectl', args: ['project', 'list'] },
+      {
+        tool: 'kubectl',
+        args: ['get'],
+        allowTrailingArgs: true,
+      },
+    ]);
+  });
+
+  it.each<unknown[]>([
+    [{ command: 'examplectl', args: ['list'] }],
+    [{ tool: 'examplectl', args: ['list'], extra: true }],
+    [
+      {
+        tool: 'examplectl',
+        executable: { source: 'plugin', path: 'bin/examplectl' },
+        args: ['list'],
+      },
+    ],
+    [{ tool: '', args: ['list'] }],
+    [{ tool: '/usr/bin/examplectl', args: ['list'] }],
+    [{ tool: 'examplectl', args: [] }],
+    [{ tool: 'examplectl', args: [''] }],
+    [{ tool: 'examplectl', args: ['  '] }],
+    [{ tool: 'examplectl', args: ['list'], allowTrailingArgs: 'yes' }],
+    [{ tool: 'examplectl', executable: true, args: ['list'] }],
+    [
+      {
+        tool: 'examplectl',
+        executable: { source: 'system', path: 'bin/examplectl' },
+        args: ['list'],
+      },
+    ],
+    [{ tool: 'examplectl', executable: { source: 'plugin' }, args: ['list'] }],
+    [
+      {
+        tool: 'examplectl',
+        executable: { source: 'plugin', path: '../examplectl' },
+        args: ['list'],
+      },
+    ],
+    [
+      {
+        tool: 'examplectl',
+        executable: { source: 'plugin', path: 'bin/other' },
+        args: ['list'],
+      },
+    ],
+  ])('rejects malformed grants: %j', grant => {
+    expect(() => parseRunCommandGrants(grant)).toThrow();
+  });
+
+  it('rejects duplicate grants', () => {
+    const grant = { tool: 'examplectl', args: ['project', 'list'] };
+    expect(() => parseRunCommandGrants([grant, grant])).toThrow('Duplicate');
+  });
+});
+
+describe('matchesRunCommandGrant', () => {
+  const exact = { tool: 'examplectl', args: ['project', 'list'] };
+  const prefix = { ...exact, allowTrailingArgs: true };
+
+  it('matches an exact tool and argument sequence', () => {
+    expect(matchesRunCommandGrant(exact, 'examplectl', ['project', 'list'])).toBe(true);
+  });
+
+  it.each<[string, string[]]>([
+    ['examplectl2', ['project', 'list']],
+    ['examplectl', ['project']],
+    ['examplectl', ['project', 'delete']],
+    ['examplectl', ['list', 'project']],
+    ['examplectl', ['project', 'list', '--all']],
+  ])('rejects an out-of-scope request', (tool, args) => {
+    expect(matchesRunCommandGrant(exact, tool, args)).toBe(false);
+  });
+
+  it('allows arguments only after an explicitly trailing prefix', () => {
+    expect(matchesRunCommandGrant(prefix, 'examplectl', ['project', 'list', '--all'])).toBe(true);
+    expect(matchesRunCommandGrant(prefix, 'examplectl', ['project', 'delete'])).toBe(false);
+  });
+});
+
+it('allows a request when one grant matches', () => {
+  expect(
+    isRunCommandAllowed(
+      [
+        { tool: 'examplectl', args: ['project', 'list'] },
+        { tool: 'examplectl', args: ['version'] },
+      ],
+      'examplectl',
+      ['version']
+    )
+  ).toBe(true);
+});

--- a/app/electron/runCommandPolicy.ts
+++ b/app/electron/runCommandPolicy.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const VALID_TOOL = /^[a-z0-9][a-z0-9._-]*$/i;
+const MAX_GRANTS = 64;
+const MAX_TOOL_LENGTH = 128;
+const MAX_ARGUMENTS = 16;
+const MAX_ARGUMENT_LENGTH = 256;
+
+/** Executable resolved only through the sanitized system search path. */
+export interface SystemRunCommandExecutable {
+  /** Trusted origin used to resolve the executable. */
+  source: 'system';
+}
+
+/** Executable intentionally supplied by the plugin bundle. */
+export interface PluginRunCommandExecutable {
+  /** Trusted origin used to resolve the executable. */
+  source: 'plugin';
+  /** Fixed platform-independent path relative to the verified plugin bundle. */
+  path: string;
+}
+
+/** Explicit executable origin attached to a normalized command grant. */
+export type RunCommandExecutable = SystemRunCommandExecutable | PluginRunCommandExecutable;
+
+/**
+ * A product-owned grant for one executable and argument sequence.
+ *
+ * @example Allow `examplectl project list` with optional trailing arguments.
+ * ```ts
+ * const grant: RunCommandGrant = {
+ *   tool: 'examplectl',
+ *   args: ['project', 'list'],
+ *   allowTrailingArgs: true,
+ * };
+ * ```
+ */
+export interface RunCommandGrant {
+  /** Canonical executable identifier. */
+  tool: string;
+  /** Executable provenance. Omitted grants resolve only on the system PATH. */
+  executable?: RunCommandExecutable;
+  /** Exact argument sequence or prefix permitted by the grant. */
+  args: string[];
+  /** Whether arguments may follow the exact declared prefix. */
+  allowTrailingArgs?: boolean;
+}
+
+/**
+ * Parses command grants from untrusted product manifest data.
+ *
+ * @param value - Candidate `commands` grant array from a top-level `runCommands` policy entry.
+ * @returns A validated, normalized copy of the grants.
+ * @throws When any grant is malformed, duplicated, or too broad.
+ */
+export function parseRunCommandGrants(value: unknown): RunCommandGrant[] {
+  if (!Array.isArray(value) || value.length > MAX_GRANTS) {
+    throw new Error(`runCommands must be an array with at most ${MAX_GRANTS} grants`);
+  }
+
+  const grants: RunCommandGrant[] = [];
+  const seen = new Set<string>();
+  for (const [index, candidate] of value.entries()) {
+    if (typeof candidate !== 'object' || candidate === null || Array.isArray(candidate)) {
+      throw new Error(`Invalid runCommands[${index}]`);
+    }
+
+    const record = candidate as Record<string, unknown>;
+    if (Object.keys(record).some(key => !['tool', 'args', 'allowTrailingArgs'].includes(key))) {
+      throw new Error(`Unknown field in runCommands[${index}]`);
+    }
+    if (
+      typeof record.tool !== 'string' ||
+      record.tool.length > MAX_TOOL_LENGTH ||
+      !VALID_TOOL.test(record.tool)
+    ) {
+      throw new Error(`Invalid tool in runCommands[${index}]`);
+    }
+    if (
+      !Array.isArray(record.args) ||
+      record.args.length === 0 ||
+      record.args.length > MAX_ARGUMENTS ||
+      record.args.some(
+        argument =>
+          typeof argument !== 'string' ||
+          argument.trim() === '' ||
+          argument.length > MAX_ARGUMENT_LENGTH ||
+          argument.includes('\0')
+      )
+    ) {
+      throw new Error(`Invalid args in runCommands[${index}]`);
+    }
+    if (record.allowTrailingArgs !== undefined && typeof record.allowTrailingArgs !== 'boolean') {
+      throw new Error(`Invalid allowTrailingArgs in runCommands[${index}]`);
+    }
+
+    const grant: RunCommandGrant = {
+      tool: record.tool,
+      args: [...record.args],
+      ...(record.allowTrailingArgs === true && { allowTrailingArgs: true }),
+    };
+    const key = JSON.stringify(grant);
+    if (seen.has(key)) {
+      throw new Error(`Duplicate runCommands[${index}]`);
+    }
+    seen.add(key);
+    grants.push(grant);
+  }
+  return grants;
+}
+
+/**
+ * Checks a request against one exact command grant.
+ *
+ * @param grant - Validated product grant.
+ * @param tool - Canonical requested executable identifier.
+ * @param args - Requested arguments.
+ * @returns Whether the request is covered by the grant.
+ */
+export function matchesRunCommandGrant(
+  grant: RunCommandGrant,
+  tool: string,
+  args: string[]
+): boolean {
+  if (grant.tool !== tool || args.length < grant.args.length) {
+    return false;
+  }
+  for (let index = 0; index < grant.args.length; index += 1) {
+    if (grant.args[index] !== args[index]) {
+      return false;
+    }
+  }
+  return grant.allowTrailingArgs === true || args.length === grant.args.length;
+}
+
+/**
+ * Checks a request against all command grants for one plugin.
+ *
+ * @param grants - Validated product grants.
+ * @param tool - Canonical requested executable identifier.
+ * @param args - Requested arguments.
+ * @returns Whether any grant covers the request.
+ */
+export function isRunCommandAllowed(
+  grants: RunCommandGrant[],
+  tool: string,
+  args: string[]
+): boolean {
+  for (const grant of grants) {
+    if (matchesRunCommandGrant(grant, tool, args)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/app/electron/secureStorage.ts
+++ b/app/electron/secureStorage.ts
@@ -277,7 +277,7 @@ function encryptionIsAvailable(): boolean {
  * @param trustedStartUrl - The URL originally loaded into the Headlamp window.
  * @returns Whether the request comes from the trusted Headlamp document.
  */
-function isTrustedDocumentUrl(documentUrl: string, trustedStartUrl: string): boolean {
+export function isTrustedDocumentUrl(documentUrl: string, trustedStartUrl: string): boolean {
   try {
     const document = new URL(documentUrl);
     const trusted = new URL(trustedStartUrl);

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -30,6 +30,8 @@
         "@types/semver": "^7.7.0",
         "@types/yargs": "^17.0.35",
         "@vitest/coverage-istanbul": "3.2.7",
+        "ajv": "^8.18.0",
+        "ajv-formats": "^3.0.1",
         "electron": "^38.8.6",
         "electron-builder": "^26.6.0",
         "esbuild": "^0.25.0",
@@ -1275,6 +1277,22 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "integrity": "sha1-B+mCx0YmFnqnoklcU4F4ktcTlJI=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "13.24.0",
       "dev": true,
@@ -1288,6 +1306,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/type-fest": {
       "version": "0.20.2",
@@ -1536,7 +1560,6 @@
     },
     "node_modules/@langchain/core": {
       "version": "1.2.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@langchain/core/-/core-1.2.7.tgz",
       "integrity": "sha1-tbjDmcD8XjNwg/fWXxdA9rve5Jg=",
       "license": "MIT",
       "dependencies": {
@@ -1554,7 +1577,6 @@
     },
     "node_modules/@langchain/langgraph": {
       "version": "1.4.9",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@langchain/langgraph/-/langgraph-1.4.9.tgz",
       "integrity": "sha1-jsbyqxIA9W3Pe55E2DjJVrI7enM=",
       "license": "MIT",
       "dependencies": {
@@ -1573,7 +1595,6 @@
     },
     "node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-checkpoint": {
       "version": "1.1.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.3.tgz",
       "integrity": "sha1-iR8vmi6Wzyqwkg+SQPmtHgqGpKs=",
       "license": "MIT",
       "engines": {
@@ -1585,7 +1606,6 @@
     },
     "node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk": {
       "version": "1.9.29",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.29.tgz",
       "integrity": "sha1-VyO9Io/hRcsNq2Pe9IWzmk7r9Vc=",
       "license": "MIT",
       "dependencies": {
@@ -1618,13 +1638,11 @@
     },
     "node_modules/@langchain/langgraph/node_modules/eventemitter3": {
       "version": "5.0.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha1-qG1mFwQzcS3egUcHrFK1JxzrH+s=",
       "license": "MIT"
     },
     "node_modules/@langchain/langgraph/node_modules/p-queue": {
       "version": "9.3.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-queue/-/p-queue-9.3.3.tgz",
       "integrity": "sha1-xeUox+s2G3uo61qUBpAvfy51/I8=",
       "license": "MIT",
       "dependencies": {
@@ -1640,7 +1658,6 @@
     },
     "node_modules/@langchain/langgraph/node_modules/p-timeout": {
       "version": "7.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-timeout/-/p-timeout-7.0.1.tgz",
       "integrity": "sha1-lWgKaqaTxTDxSsM3uL0y1Oxq5PA=",
       "license": "MIT",
       "engines": {
@@ -1796,24 +1813,6 @@
         }
       }
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-      "version": "8.18.0",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
     "node_modules/@mswjs/interceptors": {
       "version": "0.38.7",
       "license": "MIT",
@@ -1929,7 +1928,6 @@
     },
     "node_modules/@peculiar/webcrypto/node_modules/@peculiar/asn1-schema": {
       "version": "2.8.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
       "integrity": "sha1-aWmfhCWbIWFgfKv8NOUSpAI9vvk=",
       "dev": true,
       "license": "MIT",
@@ -2896,14 +2894,14 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "devOptional": true,
+      "version": "8.20.0",
+      "integrity": "sha1-MEs2Nq3Yi6fZNnYN1Q7OAG3qlfk=",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -2924,24 +2922,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.18.0",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -3080,23 +3060,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/app-builder-lib/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/app-builder-lib/node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -3167,13 +3130,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/app-builder-lib/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/app-builder-lib/node_modules/minimatch": {
       "version": "10.2.6",
@@ -4680,6 +4636,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/dmg-license/node_modules/ajv": {
+      "version": "6.15.0",
+      "integrity": "sha1-B+mCx0YmFnqnoklcU4F4ktcTlJI=",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/dmg-license/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "dev": true,
@@ -5739,6 +5717,22 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "integrity": "sha1-B+mCx0YmFnqnoklcU4F4ktcTlJI=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/find-up": {
       "version": "5.0.0",
       "dev": true,
@@ -5778,6 +5772,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/locate-path": {
       "version": "6.0.0",
@@ -6060,6 +6060,7 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
+      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
       "devOptional": true,
       "license": "MIT"
     },
@@ -6737,7 +6738,6 @@
     },
     "node_modules/hono": {
       "version": "4.13.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hono/-/hono-4.13.2.tgz",
       "integrity": "sha1-aS1ADSoOoIbj7sXHOqMgfLU/l7U=",
       "license": "MIT",
       "engines": {
@@ -7717,8 +7717,8 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "devOptional": true,
+      "version": "1.0.0",
+      "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI=",
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {
@@ -7787,7 +7787,6 @@
     },
     "node_modules/langsmith": {
       "version": "0.8.10",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/langsmith/-/langsmith-0.8.10.tgz",
       "integrity": "sha1-XYcunmiYZM0oR5+aosbUJP6P+go=",
       "license": "MIT",
       "dependencies": {
@@ -8990,7 +8989,8 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
+      "version": "2.3.1",
+      "integrity": "sha1-AnQi4vrsCyXhVJw+G9gwm5EztuU=",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -10982,6 +10982,7 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
+      "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
       "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -11852,7 +11853,6 @@
     },
     "node_modules/webcrypto-core/node_modules/@peculiar/asn1-schema": {
       "version": "2.8.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
       "integrity": "sha1-aWmfhCWbIWFgfKv8NOUSpAI9vvk=",
       "dev": true,
       "license": "MIT",

--- a/app/package.json
+++ b/app/package.json
@@ -196,6 +196,8 @@
     "@types/semver": "^7.7.0",
     "@types/yargs": "^17.0.35",
     "@vitest/coverage-istanbul": "3.2.7",
+    "ajv": "^8.18.0",
+    "ajv-formats": "^3.0.1",
     "electron": "^38.8.6",
     "electron-builder": "^26.6.0",
     "esbuild": "^0.25.0",

--- a/app/scripts/build-manifest.ts
+++ b/app/scripts/build-manifest.ts
@@ -18,6 +18,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { parseRunCommandGrants, type RunCommandGrant } from '../electron/runCommandPolicy.ts';
 import type { ProductMetadata } from './product-metadata.ts';
 import { readProductMetadata } from './product-metadata.ts';
 
@@ -32,14 +33,20 @@ export type BuildManifest = {
   /** URL glob patterns the packaged backend may proxy. */
   'proxy-urls'?: string[];
 
+  /** Reusable command grant arrays referenced by command policies. */
+  commandSets?: Record<string, RunCommandGrant[]>;
+
   /** Plugin declarations consumed by the app packaging scripts. */
-  plugins?: Array<Record<string, unknown>>;
+  plugins?: BuildPlugin[];
 
   /** Product identity fields consumed by Electron Builder. */
   product?: Record<string, unknown>;
 
   /** Common and per-platform resources copied into desktop packages. */
   resources?: Record<string, unknown>;
+
+  /** Product-owned local command policy selected for the current runtime. */
+  runCommands?: ProductPluginRunCommands[];
 
   /** Per-platform package targets consumed by Electron Builder. */
   targets?: Record<string, unknown>;
@@ -49,6 +56,74 @@ export type BuildManifest = {
 
   [key: string]: unknown;
 };
+
+/** A shipped plugin declaration owned by the product build manifest. */
+export type BuildPlugin = Record<string, unknown> & {
+  /** Bundle directory name used by plugin discovery. */
+  name?: string;
+  /** Package identity expected inside the shipped bundle. */
+  packageName?: string;
+};
+
+/** A native executable intentionally supplied by selected plugin bundles. */
+export interface ProductPluginExecutable {
+  /** Command identifier whose grants use the plugin-owned executable. */
+  tool: string;
+}
+
+/** Product command grants for one exact plugin origin and runtime environment. */
+export interface ProductPluginRunCommands {
+  /** Runtime in which this policy applies. */
+  environment: 'development' | 'production';
+  /** Inventory containing the plugin bundle. */
+  pluginLocation: 'development' | 'user' | 'shipped';
+  /** Exact bundle and package identities sharing these grants. */
+  plugins: Array<{
+    /** Bundle directory name reported by plugin discovery. */
+    bundleName: string;
+    /** Package identity read from the plugin bundle. */
+    packageName: string;
+    /** Artifact Hub repository and package names for a managed installation. */
+    artifactHubPackage?: string;
+    /** Optional immutable Artifact Hub package identifier expected for managed installations. */
+    artifactHubPackageId?: string;
+    /** Optional immutable Artifact Hub repository identifier expected for managed installations. */
+    artifactHubRepositoryId?: string;
+  }>;
+  /** Executables intentionally supplied by the selected plugin bundles. */
+  pluginExecutables?: ProductPluginExecutable[];
+  /** Local command grants enforced by the Electron main process. */
+  commands?: RunCommandGrant[];
+  /** Named command grant sets from the product manifest, combined in order. */
+  commandSets?: string[];
+}
+
+/** Validated command policy for one plugin identity and inventory. */
+export interface ProductPluginCommandPolicy {
+  /** Bundle directory name from the product manifest. */
+  bundleName: string;
+  /** Expected package name from the product manifest. */
+  packageName: string;
+  /** Inventory containing the authorized plugin. */
+  source: 'development' | 'user' | 'shipped';
+  /** App-owned installation provenance required for managed plugin inventories. */
+  artifactHub?: {
+    /** Artifact Hub repository name recorded by the installer. */
+    repository: string;
+    /** Artifact Hub package name within the repository. */
+    package: string;
+    /** Immutable Artifact Hub package identifier required by the product policy. */
+    packageId?: string;
+    /** Immutable Artifact Hub repository identifier required by the product policy. */
+    repositoryId?: string;
+  };
+  /** Reviewed command grants for the plugin. */
+  grants: RunCommandGrant[];
+}
+
+const COMMAND_POLICY_DOCS_FILE = 'docs/development/plugins/command-capabilities.md';
+const COMMAND_POLICY_DOCS_URL =
+  'https://headlamp.dev/docs/latest/development/plugins/command-capabilities/#product-manifest-policy';
 
 /** An Electron Builder target with an explicit architecture selection. */
 type BuildTargetDescriptor = {
@@ -99,7 +174,8 @@ function normalizeExtraResources(resources: unknown): unknown[] {
   return Array.isArray(resources) ? resources : [resources];
 }
 
-const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const scriptDirectory =
+  typeof __dirname === 'string' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
 export const DEFAULT_MANIFEST_FILE = path.join(scriptDirectory, '../app-build-manifest.json');
 
@@ -292,10 +368,287 @@ export function validateBuildManifest(value: unknown): BuildManifest {
     }
   }
 
-  if (manifest.plugins !== undefined && !Array.isArray(manifest.plugins)) {
-    throw new Error('Build manifest plugins must be an array');
+  if (manifest.plugins !== undefined) {
+    if (!Array.isArray(manifest.plugins)) {
+      throw new Error('Build manifest plugins must be an array');
+    }
   }
+  productPluginCommandPolicies(manifest, 'development');
+  productPluginCommandPolicies(manifest, 'production');
+  warnAboutArtifactHubUuidPins(manifest);
   return manifest;
+}
+
+function warnAboutArtifactHubUuidPins(manifest: BuildManifest): void {
+  for (const [policyIndex, policy] of (manifest.runCommands ?? []).entries()) {
+    const recommendsUuidPins =
+      policy.environment === 'production' && policy.pluginLocation === 'user';
+
+    for (const [pluginIndex, plugin] of policy.plugins.entries()) {
+      const location = `runCommands[${policyIndex}].plugins[${pluginIndex}]`;
+      const hasUuidPins = plugin.artifactHubPackageId !== undefined;
+
+      if (recommendsUuidPins && !hasUuidPins) {
+        console.warn(
+          `Build manifest warning: ${location} should pin artifactHubPackageId and ` +
+            `artifactHubRepositoryId. Request ` +
+            `https://artifacthub.io/api/v1/packages/headlamp/${plugin.artifactHubPackage}, ` +
+            `then copy package_id to artifactHubPackageId and repository.repository_id to ` +
+            `artifactHubRepositoryId. See ${COMMAND_POLICY_DOCS_FILE} or ${COMMAND_POLICY_DOCS_URL}`
+        );
+      } else if (!recommendsUuidPins && hasUuidPins) {
+        console.warn(
+          `Build manifest warning: ${location} should omit artifactHubPackageId and ` +
+            `artifactHubRepositoryId because UUID pins apply only to production policies for ` +
+            `plugin-manager-installed user plugins. See ${COMMAND_POLICY_DOCS_FILE} or ` +
+            `${COMMAND_POLICY_DOCS_URL}`
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Reads validated, product-owned command policy for plugins.
+ *
+ * @param manifest - Parsed application build manifest.
+ * @param environment - Runtime environment whose policies should be returned.
+ * @returns Validated command policies for the selected environment.
+ * @throws When a policy or plugin identity is malformed or ambiguous.
+ */
+export function productPluginCommandPolicies(
+  manifest: BuildManifest,
+  environment: 'development' | 'production'
+): ProductPluginCommandPolicy[] {
+  const policies: ProductPluginCommandPolicy[] = [];
+  const identities = new Set<string>();
+  const uuid = /^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/i;
+  const commandSets = manifest.commandSets;
+
+  if (
+    commandSets !== undefined &&
+    (typeof commandSets !== 'object' || commandSets === null || Array.isArray(commandSets))
+  ) {
+    throw new Error('Build manifest commandSets must be an object');
+  }
+  if (commandSets && Object.keys(commandSets).length > 64) {
+    throw new Error('Build manifest commandSets exceeds 64 entries');
+  }
+  for (const [name, commands] of Object.entries(commandSets ?? {})) {
+    if (
+      !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(name) ||
+      !Array.isArray(commands) ||
+      commands.some(
+        command =>
+          typeof command !== 'object' ||
+          command === null ||
+          Array.isArray(command) ||
+          Object.keys(command).some(key => !['tool', 'args', 'allowTrailingArgs'].includes(key))
+      )
+    ) {
+      throw new Error(`Invalid build manifest commandSets.${name}`);
+    }
+    parseRunCommandGrants(commands);
+  }
+
+  if (manifest.runCommands === undefined) {
+    return policies;
+  }
+  if (!Array.isArray(manifest.runCommands)) {
+    throw new Error('Build manifest runCommands must be an array');
+  }
+  for (const [index, policy] of manifest.runCommands.entries()) {
+    if (
+      typeof policy !== 'object' ||
+      policy === null ||
+      Array.isArray(policy) ||
+      Object.keys(policy).some(
+        key =>
+          ![
+            'environment',
+            'pluginLocation',
+            'plugins',
+            'pluginExecutables',
+            'commands',
+            'commandSets',
+          ].includes(key)
+      )
+    ) {
+      throw new Error(`Invalid build manifest runCommands[${index}]`);
+    }
+    if (!['development', 'production'].includes(policy.environment)) {
+      throw new Error(`Invalid build manifest runCommands[${index}].environment`);
+    }
+    if (!['development', 'user', 'shipped'].includes(policy.pluginLocation)) {
+      throw new Error(`Invalid build manifest runCommands[${index}].pluginLocation`);
+    }
+    if (
+      !Array.isArray(policy.plugins) ||
+      policy.plugins.length === 0 ||
+      policy.plugins.length > 64
+    ) {
+      throw new Error(`Invalid build manifest runCommands[${index}].plugins`);
+    }
+
+    const pluginExecutables = new Set<string>();
+    if (policy.pluginExecutables !== undefined) {
+      if (!Array.isArray(policy.pluginExecutables) || policy.pluginExecutables.length > 64) {
+        throw new Error(`Invalid build manifest runCommands[${index}].pluginExecutables`);
+      }
+      for (const [executableIndex, executable] of policy.pluginExecutables.entries()) {
+        if (
+          typeof executable !== 'object' ||
+          executable === null ||
+          Array.isArray(executable) ||
+          Object.keys(executable).some(key => key !== 'tool') ||
+          typeof executable.tool !== 'string' ||
+          executable.tool === 'scriptjs' ||
+          pluginExecutables.has(executable.tool)
+        ) {
+          throw new Error(
+            `Invalid build manifest runCommands[${index}].pluginExecutables[${executableIndex}]`
+          );
+        }
+        pluginExecutables.add(executable.tool);
+      }
+    }
+
+    const hasInlineCommands = policy.commands !== undefined;
+    const hasCommandSets = policy.commandSets !== undefined;
+    if (hasInlineCommands === hasCommandSets) {
+      throw new Error(
+        `Build manifest runCommands[${index}] must define exactly one of commands or commandSets`
+      );
+    }
+    if (
+      hasCommandSets &&
+      (!Array.isArray(policy.commandSets) ||
+        policy.commandSets.length === 0 ||
+        policy.commandSets.length > 64 ||
+        new Set(policy.commandSets).size !== policy.commandSets.length ||
+        policy.commandSets.some(
+          name =>
+            typeof name !== 'string' ||
+            !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(name) ||
+            commandSets?.[name] === undefined
+        ))
+    ) {
+      throw new Error(`Invalid build manifest runCommands[${index}].commandSets`);
+    }
+    const commands = hasCommandSets
+      ? policy.commandSets?.flatMap(name => commandSets?.[name] ?? [])
+      : policy.commands;
+    if (
+      !Array.isArray(commands) ||
+      commands.length > 64 ||
+      commands.some(
+        command =>
+          typeof command !== 'object' ||
+          command === null ||
+          Array.isArray(command) ||
+          Object.keys(command).some(key => !['tool', 'args', 'allowTrailingArgs'].includes(key))
+      )
+    ) {
+      throw new Error(`Invalid build manifest runCommands[${index}].commands`);
+    }
+    const parsedGrants = parseRunCommandGrants(commands);
+    for (const tool of pluginExecutables) {
+      if (!parsedGrants.some(grant => grant.tool === tool)) {
+        throw new Error(`Unused build manifest runCommands[${index}] plugin executable ${tool}`);
+      }
+    }
+    const grants = parsedGrants.map(grant => {
+      return pluginExecutables.has(grant.tool)
+        ? {
+            ...grant,
+            executable: { source: 'plugin' as const, path: `bin/${grant.tool}` },
+          }
+        : grant;
+    });
+    for (const [pluginIndex, plugin] of policy.plugins.entries()) {
+      if (
+        typeof plugin !== 'object' ||
+        plugin === null ||
+        Array.isArray(plugin) ||
+        Object.keys(plugin).some(
+          key =>
+            ![
+              'bundleName',
+              'packageName',
+              'artifactHubPackage',
+              'artifactHubPackageId',
+              'artifactHubRepositoryId',
+            ].includes(key)
+        ) ||
+        typeof plugin.bundleName !== 'string' ||
+        plugin.bundleName === '' ||
+        plugin.bundleName.trim() !== plugin.bundleName ||
+        plugin.bundleName.includes('\0') ||
+        plugin.bundleName.includes('/') ||
+        plugin.bundleName.includes('\\') ||
+        typeof plugin.packageName !== 'string' ||
+        plugin.packageName === '' ||
+        plugin.packageName.trim() !== plugin.packageName ||
+        plugin.packageName.includes('\0')
+      ) {
+        throw new Error(`Invalid build manifest runCommands[${index}].plugins[${pluginIndex}]`);
+      }
+      const hasArtifactHubPackageId = plugin.artifactHubPackageId !== undefined;
+      const hasArtifactHubRepositoryId = plugin.artifactHubRepositoryId !== undefined;
+      const artifactHubPackage =
+        typeof plugin.artifactHubPackage === 'string' && plugin.artifactHubPackage.length <= 257
+          ? plugin.artifactHubPackage.match(
+              /^([A-Za-z0-9][A-Za-z0-9._-]*)\/([A-Za-z0-9][A-Za-z0-9._-]*)$/
+            )
+          : undefined;
+      if (
+        (plugin.artifactHubPackage !== undefined && !artifactHubPackage) ||
+        ((hasArtifactHubPackageId || hasArtifactHubRepositoryId) && !artifactHubPackage) ||
+        hasArtifactHubPackageId !== hasArtifactHubRepositoryId ||
+        (hasArtifactHubPackageId &&
+          (!uuid.test(plugin.artifactHubPackageId ?? '') ||
+            !uuid.test(plugin.artifactHubRepositoryId ?? '')))
+      ) {
+        throw new Error(
+          `Invalid Artifact Hub identity in build manifest runCommands[${index}].plugins[${pluginIndex}]`
+        );
+      }
+      /** @see ../../docs/development/plugins/command-capabilities.md#product-manifest-policy */
+      const requiresArtifactHubIdentity =
+        policy.environment === 'production' && policy.pluginLocation === 'user';
+      if (requiresArtifactHubIdentity && !artifactHubPackage) {
+        throw new Error(
+          `Missing Artifact Hub identity in build manifest runCommands[${index}].plugins[${pluginIndex}]`
+        );
+      }
+      const identity = `${policy.environment}\0${policy.pluginLocation}\0${plugin.bundleName}\0${plugin.packageName}`;
+      if (identities.has(identity)) {
+        throw new Error(
+          `Duplicate command policy identity in build manifest runCommands[${index}]`
+        );
+      }
+      identities.add(identity);
+      if (policy.environment === environment) {
+        policies.push({
+          bundleName: plugin.bundleName,
+          packageName: plugin.packageName,
+          source: policy.pluginLocation,
+          ...(artifactHubPackage && {
+            artifactHub: {
+              repository: artifactHubPackage[1],
+              package: artifactHubPackage[2],
+              ...(hasArtifactHubPackageId && {
+                packageId: plugin.artifactHubPackageId,
+                repositoryId: plugin.artifactHubRepositoryId,
+              }),
+            },
+          }),
+          grants,
+        });
+      }
+    }
+  }
+  return policies;
 }
 
 /**

--- a/app/scripts/setup-plugins.ts
+++ b/app/scripts/setup-plugins.ts
@@ -26,8 +26,10 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import zlib from 'node:zlib';
 import * as tar from 'tar';
 import {
+  type BuildManifest,
   DEFAULT_MANIFEST_FILE,
   loadBuildManifest,
+  productPluginCommandPolicies,
   resolveBuildManifestPath,
 } from './build-manifest.ts';
 
@@ -57,12 +59,6 @@ type PluginSource = {
   enabledByDefault?: boolean;
 };
 
-/** Parsed subset of an app build manifest used during plugin setup. */
-type BuildManifest = {
-  /** Plugin archives to validate and install in declaration order. */
-  plugins?: PluginSource[];
-};
-
 export type ExtractionLimits = {
   maxEntries: number;
   maxBytes: number;
@@ -85,7 +81,9 @@ const DEFAULT_DOWNLOAD_LIMITS: DownloadLimits = {
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const PLUGIN_FOLDER = path.join(scriptDirectory, '../../.plugins');
 const MANIFEST_FILE = resolveBuildManifestPath();
-const manifest = loadBuildManifest(MANIFEST_FILE) as BuildManifest;
+const manifest = loadBuildManifest(MANIFEST_FILE) as Omit<BuildManifest, 'plugins'> & {
+  plugins?: PluginSource[];
+};
 // The reviewed in-repo manifest predates digest metadata; externally selected manifests are
 // untrusted and must pin every plugin source.
 const externalManifest = !pathsReferToSameFile(MANIFEST_FILE, DEFAULT_MANIFEST_FILE);
@@ -310,7 +308,8 @@ export async function extractArchive(
   archivePath: string,
   temporaryFolder: string = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-plugins')),
   pluginRoot: string = PLUGIN_FOLDER,
-  limits: ExtractionLimits = DEFAULT_EXTRACTION_LIMITS
+  limits: ExtractionLimits = DEFAULT_EXTRACTION_LIMITS,
+  executablePaths: string[] = []
 ): Promise<void> {
   console.log('Extracting archive', archivePath, 'to', temporaryFolder, '...');
   let entryCount = 0;
@@ -352,7 +351,9 @@ export async function extractArchive(
 
   const mainLocations = globSync(path.join(temporaryFolder, '*', 'main.js').replace(/\\/g, '/'));
   const mainLocation = mainLocations[0];
+  let packageFolder: string;
   if (mainLocation && fs.existsSync(mainLocation)) {
+    packageFolder = path.dirname(mainLocation);
     copyExtractedRegularFile(mainLocation, path.join(pluginFolder, 'main.js'), temporaryFolder);
     copyExtractedRegularFile(
       path.join(path.dirname(mainLocation), 'package.json'),
@@ -365,6 +366,7 @@ export async function extractArchive(
       temporaryFolder
     );
   } else if (fs.existsSync(path.join(temporaryFolder, 'package', 'dist'))) {
+    packageFolder = path.join(temporaryFolder, 'package');
     copyExtractedRegularFile(
       path.join(temporaryFolder, 'package', 'dist', 'main.js'),
       path.join(pluginFolder, 'main.js'),
@@ -382,6 +384,13 @@ export async function extractArchive(
     );
   } else {
     throw new Error(`Failed to find plugin content within archive: ${archivePath}`);
+  }
+  for (const executablePath of executablePaths) {
+    const source = path.join(packageFolder, executablePath);
+    const platformSource =
+      process.platform === 'win32' && !fs.existsSync(source) ? `${source}.exe` : source;
+    const destination = path.join(pluginFolder, path.relative(packageFolder, platformSource));
+    copyExtractedRegularFile(platformSource, destination, temporaryFolder);
   }
 }
 
@@ -426,7 +435,38 @@ function copyExtractedRegularFile(
   if (!fs.lstatSync(source).isFile()) {
     throw new Error(`Extracted plugin file must be a regular file: ${source}`);
   }
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
   fs.copyFileSync(realSource, destination);
+}
+
+/** Records trusted digests for declared executables in a shipped plugin bundle. */
+export async function recordBundledPluginExecutableIntegrity(
+  bundlePath: string,
+  executablePaths: string[]
+): Promise<void> {
+  if (executablePaths.length === 0) return;
+  const executables: Record<string, string> = Object.create(null);
+  for (const executablePath of executablePaths) {
+    const requested = path.join(bundlePath, executablePath);
+    const platformPath =
+      process.platform === 'win32' && !fs.existsSync(requested) ? `${requested}.exe` : requested;
+    const hash = crypto.createHash('sha256');
+    await pipeline(fs.createReadStream(platformPath), hash);
+    executables[executablePath.split(path.sep).join('/')] = hash.digest('hex');
+  }
+  const packageJsonPath = path.join(bundlePath, 'package.json');
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as Record<
+    string,
+    unknown
+  >;
+  const currentIntegrity =
+    typeof packageJson.headlampPluginIntegrity === 'object' &&
+    packageJson.headlampPluginIntegrity !== null &&
+    !Array.isArray(packageJson.headlampPluginIntegrity)
+      ? (packageJson.headlampPluginIntegrity as Record<string, unknown>)
+      : {};
+  packageJson.headlampPluginIntegrity = { ...currentIntegrity, version: 1, executables };
+  fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
 }
 
 /**
@@ -582,7 +622,8 @@ export async function fetchArchive(
   name: string,
   url: string,
   sha256: string | undefined,
-  pluginRoot: string = PLUGIN_FOLDER
+  pluginRoot: string = PLUGIN_FOLDER,
+  executablePaths: string[] = []
 ): Promise<void> {
   const archiveName = getArchiveFileName(url);
   fs.mkdirSync(pluginRoot, { recursive: true });
@@ -592,7 +633,14 @@ export async function fetchArchive(
   try {
     await downloadFile(url, archivePath);
     verifyArchiveDigest(archivePath, sha256);
-    await extractArchive(name, archivePath, temporaryFolder, pluginRoot);
+    await extractArchive(
+      name,
+      archivePath,
+      temporaryFolder,
+      pluginRoot,
+      DEFAULT_EXTRACTION_LIMITS,
+      executablePaths
+    );
   } finally {
     fs.rmSync(temporaryFolder, { recursive: true, force: true });
   }
@@ -653,6 +701,23 @@ function replacePluginFolder(stagingFolder: string): void {
   }
 }
 
+/** Collects every shipped plugin executable required by either runtime environment. */
+export function bundledPluginExecutablePaths(buildManifest: BuildManifest): Map<string, string[]> {
+  const executablePaths = new Map<string, string[]>();
+  for (const environment of ['development', 'production'] as const) {
+    for (const policy of productPluginCommandPolicies(buildManifest, environment)) {
+      if (policy.source !== 'shipped') continue;
+      const paths = policy.grants.flatMap(grant =>
+        grant.executable?.source === 'plugin' ? [grant.executable.path] : []
+      );
+      executablePaths.set(policy.bundleName, [
+        ...new Set([...(executablePaths.get(policy.bundleName) ?? []), ...paths]),
+      ]);
+    }
+  }
+  return executablePaths;
+}
+
 /**
  * Installs every plugin declared by the selected build manifest.
  *
@@ -661,12 +726,14 @@ function replacePluginFolder(stagingFolder: string): void {
 export async function main(): Promise<void> {
   const plugins = manifest.plugins ?? [];
   plugins.forEach(plugin => validatePluginSource(plugin));
+  const shippedExecutablePaths = bundledPluginExecutablePaths(manifest);
 
   const stagingFolder = fs.mkdtempSync(path.join(path.dirname(PLUGIN_FOLDER), '.plugins-stage-'));
   try {
     for (const { name, packageName, archive, file, sha256, enabledByDefault } of plugins) {
+      const executablePaths = shippedExecutablePaths.get(name) ?? [];
       if (archive) {
-        await fetchArchive(name, archive, sha256, stagingFolder);
+        await fetchArchive(name, archive, sha256, stagingFolder, executablePaths);
       }
       if (file) {
         const sourceArchive = resolveLocalPluginArchive(MANIFEST_FILE, file);
@@ -677,7 +744,9 @@ export async function main(): Promise<void> {
             name,
             privateArchive.archivePath,
             privateArchive.directory,
-            stagingFolder
+            stagingFolder,
+            DEFAULT_EXTRACTION_LIMITS,
+            executablePaths
           );
         } finally {
           fs.rmSync(privateArchive.directory, { recursive: true, force: true });
@@ -686,6 +755,7 @@ export async function main(): Promise<void> {
       const packageJsonPath = path.join(stagingFolder, name, 'package.json');
       verifyPluginIdentity(packageJsonPath, packageName);
       applyEnabledByDefault(stagingFolder, name, enabledByDefault);
+      await recordBundledPluginExecutableIntegrity(path.join(stagingFolder, name), executablePaths);
     }
     replacePluginFolder(stagingFolder);
   } finally {

--- a/docs/development/api/modules/plugin_registry.md
+++ b/docs/development/api/modules/plugin_registry.md
@@ -137,6 +137,18 @@ ___
 
 ___
 
+### PluginRunCommand
+
+Ƭ **PluginRunCommand**: (`command`: `string`, `args`: `string`[], `options`: `Record`<`string`, `never`>) => `ReturnType`<typeof `runCommand`\>
+
+Command-running function made available to a plugin authorized by the product manifest.
+
+#### Defined in
+
+[components/App/runCommand.ts](https://github.com/kubernetes-sigs/headlamp/blob/072d2509b/frontend/src/components/App/runCommand.ts)
+
+___
+
 ### PluginSettingsComponentType
 
 Ƭ **PluginSettingsComponentType**: `React.ComponentType`<[`PluginSettingsDetailsProps`](../interfaces/plugin_registry.PluginSettingsDetailsProps.md)\> \| `ReactElement` \| ``null``
@@ -1011,7 +1023,10 @@ This function uses the desktopApi.send and desktopApi.receive methods to communi
 **`example`**
 
 ```ts
-  const minikube = runCommand('minikube', ['status']);
+  import type { PluginRunCommand } from '@kinvolk/headlamp-plugin/lib';
+  declare const pluginRunCommand: PluginRunCommand;
+  const minikube = pluginRunCommand('minikube', ['status'], {});
+
   minikube.stdout.on('data', (data) => {
     console.log('stdout:', data);
   });
@@ -1027,7 +1042,7 @@ This function uses the desktopApi.send and desktopApi.receive methods to communi
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `command` | ``"minikube"`` \| ``"az"`` | The command to run. |
+| `command` | `string` | The command to run. |
 | `args` | `string`[] | An array of arguments to pass to the command. |
 | `options` | `Object` | - |
 

--- a/docs/development/plugins/command-capabilities.md
+++ b/docs/development/plugins/command-capabilities.md
@@ -1,0 +1,286 @@
+---
+title: Desktop Command Capabilities
+sidebar_label: Desktop Commands
+---
+
+# Desktop Command Policy
+
+Headlamp Desktop products can grant a known plugin permission to invoke a
+local executable. The product build manifest is the only authority for these
+grants. A plugin cannot obtain command access by changing its own package
+metadata.
+
+This API is unavailable to browser deployments. Development and user-installed
+plugins receive it only when product policy names their exact origin and
+identity.
+
+## Product Manifest Policy
+
+Declare reviewed grants in the top-level `runCommands` array in
+`app-build-manifest.json`. Keeping command policy separate from the `plugins`
+array allows a product to authorize a development or user-installed plugin
+without declaring it as a bundled plugin:
+
+```json
+{
+  "runCommands": [
+    {
+      "environment": "production",
+      "pluginLocation": "user",
+      "plugins": [
+        {
+          "bundleName": "example-plugin",
+          "packageName": "@example/plugin",
+          "artifactHubPackage": "example-repository/example-plugin"
+        }
+      ],
+      "pluginExecutables": [
+        {
+          "tool": "examplectl"
+        }
+      ],
+      "commands": [
+        {
+          "tool": "examplectl",
+          "args": ["project", "list"],
+          "allowTrailingArgs": true
+        }
+      ]
+    }
+  ]
+}
+```
+
+`environment` selects development runs or production builds. `pluginLocation`
+selects where the plugin must be installed: the `development`, `user`, or
+`shipped` inventory. Each `plugins` entry pairs a bundle directory with its
+expected `package.json` identity. All four selectors must match the discovered
+plugin and the files independently inspected by the Electron main process. Use
+separate policy entries when environments or installation locations need
+different commands.
+
+Production policies for `user` plugins must set
+`artifactHubPackage` to the Artifact Hub `<repository>/<package>` path on every
+`plugins` entry. This human-readable path identifies the package from which
+Headlamp installed the managed plugin. Requiring the readable path makes policy
+review practical: while that Artifact Hub repository exists, only its
+maintainers can publish the named package, and a compromised maintainer could
+publish a malicious update whether policy used the path or UUIDs. Headlamp
+accepts the narrower residual risk that a deleted or renamed path could later be
+reused by another publisher.
+
+Policies may additionally pin `artifactHubPackageId` and
+`artifactHubRepositoryId`. These UUIDs preserve identity if an Artifact Hub
+repository or package is renamed, deleted, or its old path is later reused.
+Providing both UUIDs is recommended for every production policy whose
+`pluginLocation` is `user`. The build logs a warning when such a policy omits
+them. When either UUID is supplied, both are required. Starting from the
+plugin's Artifact Hub page at
+`https://artifacthub.io/packages/headlamp/<repository>/<package>`, insert
+`/api/v1` before `/packages` to request its metadata. For example, the Minikube
+plugin page is
+`https://artifacthub.io/packages/headlamp/headlamp-plugins/headlamp_minikube`,
+so its metadata command is:
+
+```console
+curl https://artifacthub.io/api/v1/packages/headlamp/headlamp-plugins/headlamp_minikube \
+  | jq '{artifactHubPackageId: .package_id, artifactHubRepositoryId: .repository.repository_id}'
+```
+
+To add these optional pins, copy `package_id` to `artifactHubPackageId` and
+`repository.repository_id` to `artifactHubRepositoryId`. Use the IDs from the
+exact package page being authorized. Shipped plugins do not need an Artifact
+Hub path or UUIDs because their bytes are part of the trusted app build.
+Plugins in the `development` location do not have plugin-manager installation
+receipts, so Artifact Hub identity verification cannot work for them. They must
+omit the Artifact Hub path and UUIDs even when the app environment is
+`production`. Development-mode policies should also omit UUID pins because they
+authorize development workflows rather than a packaged production trust
+decision. The build warns when UUID pins are present in any of these policy
+types.
+
+JSON Schema Draft-07 cannot produce advisory diagnostics: a schema rule either
+accepts or rejects a value. The manifest schema therefore suggests the UUID
+fields through completion and explains these recommendations in editor hovers,
+while the build tool provides context-aware warnings without rejecting custom
+product manifests.
+
+Commands resolve from the sanitized system `PATH` by default. To execute a
+binary supplied by the plugin bundle, declare it in `pluginExecutables`. Each
+entry names one command identifier, and Headlamp derives its bundle-relative
+path as `bin/<tool>`. Headlamp never falls back between the plugin and system
+origins. A missing, invalid, or undeclared plugin executable fails closed.
+For managed-user plugins, the verified plugin-manager installation flow records
+the executable integrity metadata. For shipped plugins, the packaging flow copies
+only manifest-declared executables into the app's plugin inventory and records
+their digests before the inventory is included in the packaged application. The
+application package and its signing boundary establish provenance for these
+shipped bytes. At runtime, non-development plugin executables are verified,
+copied into an app-owned temporary directory, and rehashed before execution.
+
+Headlamp's checked-in manifest provides production managed-plugin policies only
+where Artifact Hub package paths are known. Development-only policies may also
+support local plugin workflows. A product that selects another
+manifest with `HEADLAMP_BUILD_MANIFEST` owns the complete policy and can replace
+those defaults.
+
+Each grant has these fields:
+
+- `tool` is the executable identifier, without a path.
+- `args` is a non-empty exact argument sequence or prefix. Every argument must
+  contain at least one non-whitespace character.
+- `allowTrailingArgs` defaults to `false`. Set it to `true` only when the tool
+  may receive additional arguments after the reviewed prefix.
+
+When several policies share grants, define each grant array once in the
+top-level `commandSets` object. A policy can use `commandSets` instead of inline
+`commands`; its named arrays are combined in listed order. For example:
+
+```json
+{
+  "commandSets": {
+    "examplectl-read": [{ "tool": "examplectl", "args": ["list"], "allowTrailingArgs": true }],
+    "example-plugin-script": [{ "tool": "scriptjs", "args": ["example-plugin/run.js"] }]
+  },
+  "runCommands": [
+    {
+      "environment": "development",
+      "pluginLocation": "development",
+      "plugins": [{ "bundleName": "example-plugin", "packageName": "@example/plugin" }],
+      "commandSets": ["examplectl-read", "example-plugin-script"]
+    }
+  ]
+}
+```
+
+A policy must define exactly one of `commands` or `commandSets`. Named sets do
+not broaden a policy by themselves; the expanded grants still apply only to
+that policy's exact environment, location, and plugin identities.
+
+`pluginExecutables` entries have these fields:
+
+- `tool` must match at least one command grant in the same policy. Its path is
+  always derived as `bin/<tool>`; paths and aliases cannot be authored.
+
+Unknown fields, duplicate grants, empty argument prefixes, and malformed
+values make the manifest invalid. Matching does not perform glob,
+regular expression, substring, or shell expansion.
+
+## Plugin API
+
+Headlamp injects `pluginRunCommand` only when the product manifest grants the
+verified plugin command access. The plugin passes the tool and arguments
+at invocation time:
+
+```ts
+import type { PluginRunCommand } from '@kinvolk/headlamp-plugin/lib';
+
+declare const pluginRunCommand: PluginRunCommand;
+
+const process = pluginRunCommand('examplectl', ['project', 'list', '--output', 'json'], {});
+```
+
+The empty options object is intentional. Capability-authorized plugins cannot
+supply process spawn options.
+
+## Authorization and Consent
+
+The Electron main process validates the opaque capability, renderer window,
+plugin identity, tool, and argument policy immediately before process creation.
+It stores the reviewed policy in the main process and never accepts grants from
+the renderer.
+
+Before plugin code executes, the trusted renderer hashes the exact fetched
+`main.js` source it has cached. Electron independently hashes the corresponding
+file in the verified bundle and issues a capability only when those digests
+match. The cached bytes that execute are therefore the same source Electron
+authorized, even if a writable plugin file changes during loading.
+
+Authorization and user consent are separate decisions. Consent is requested only
+after product authorization succeeds and is scoped to the plugin identity,
+canonical tool, and reviewed argument prefix. Commands are executed directly
+with `shell: false`.
+
+For a managed plugin installation, Electron writes an app-owned installation
+receipt outside plugin-controlled inventory. It records the canonical inventory
+path and bundle directory, the Artifact Hub repository and package names, their
+IDs, and the SHA-256 digest of every regular file in the bundle. Capability
+registration verifies the installed location, expected repository and package
+names, any pinned IDs, and all recorded files. Missing files, additional files,
+symbolic links, digest changes, identity mismatches, and bundles copied to
+another inventory fail closed. Package-local metadata is never used to prove
+installation provenance because a pre-positioned bundle can rewrite it.
+
+For `scriptjs`, Electron copies the receipt-matched script into a unique
+app-owned directory and launches only those staged bytes. The copy is removed
+after the child process terminates. This prevents a writable plugin bundle from
+changing the script between verification and process creation.
+
+For production execution, Electron records each downloaded executable's SHA-256
+digest in the integrity metadata after the installer has verified and placed the
+file. Electron hashes the executable again immediately before each process
+starts and rejects missing or mismatched digests. It copies matching bytes into
+a unique app-owned directory and starts the process from that verified copy, so
+replacing the plugin-bundle path after hashing cannot change what is executed.
+The copy is removed after the child process terminates. Updating a plugin
+replaces its app-owned installation receipt; uninstalling removes it.
+
+Managed plugins installed by a Headlamp release that did not record installation
+integrity metadata must be updated or reinstalled before they can receive
+production command capabilities. This includes Minikube executable and
+`scriptjs` capabilities; Headlamp does not synthesize provenance for an existing
+bundle from executable checksums alone.
+
+Electron logs executable failures with the plugin package, bundle, installation
+location, tool, and a stable reason such as `missing-receipt`,
+`digest-mismatch`, or `missing-or-unsafe-executable`. Process creation failures
+include the operating-system error code when one is available. Logs omit command
+arguments, receipt digests, capability tokens, and full filesystem paths.
+
+The development inventory permits a declared plugin executable without
+installation integrity metadata, including when a packaged app selects a
+production policy for a legacy development-inventory installation. The
+executable must still be a regular, non-symbolic-link file at the declared path
+and resolve inside the verified plugin bundle. This exception supports locally
+developed and legacy plugins such as Minikube. It does not apply to the `user`
+inventory, whose plugins must have plugin-manager installation receipts for
+production capabilities.
+
+The manifest does not have a `capabilities` wrapper. Internally, Headlamp still
+uses an opaque, short-lived capability token to avoid exposing product policy to
+plugin code or trusting a plugin identity on every invocation. Tokens are
+regenerated after a main-frame reload and revoked when the window closes. A
+token from another plugin, another window, or a previous load is rejected before
+a process is created.
+
+## Security Considerations
+
+Reviewers should treat every command grant as security-sensitive. A permitted
+executable can still read files, use credentials, access the network, or change
+the system. Use the narrowest argument prefix that supports the plugin behavior
+and avoid enabling trailing arguments unless they are required.
+
+Declaring a plugin executable additionally trusts native code installed with
+that plugin. Use system resolution unless the plugin intentionally owns and
+installs the executable.
+
+The `development` inventory is an explicit trust boundary. Headlamp assumes
+that anyone able to place or replace plugins in `defaultPluginsDir()` is an
+authorized local operator and is already trusted to supply development plugin
+code. Protecting this operator-controlled directory from a same-user process or
+from someone with equivalent filesystem permissions is outside this mechanism's
+threat model. Consequently, development-inventory policies do not require or
+attempt Artifact Hub provenance verification, because those plugins were not
+installed by the plugin manager and have no installer-authenticated receipt.
+
+This trust assumption does not bypass command policy. Electron still requires
+the product manifest to name the exact environment, development location,
+bundle directory, package name, executable origin, command, and argument
+prefix. It independently checks path containment, rejects symbolic links,
+confirms `package.json.name`, applies user consent, and confines plugin-owned
+executables before process creation. Products that do not trust the development
+inventory must omit production policies for that location or ensure the
+directory is protected according to their deployment model.
+
+This mechanism controls local command execution. It is not a JavaScript sandbox
+for plugins running in the shared renderer.

--- a/docs/development/plugins/index.md
+++ b/docs/development/plugins/index.md
@@ -34,6 +34,10 @@ Complete tutorial from installation to your first working plugin, with practical
 
 Learn the development workflow, production builds, and deployment strategies.
 
+### 🔐 [Desktop Command Capabilities](./command-capabilities.md)
+
+Configure product-owned command grants for verified plugins.
+
 ### 📖 [Common Patterns](./common-patterns.md)
 
 Ready-to-use examples for typical plugin scenarios like dashboards, resource extensions, and external integrations.

--- a/e2e-tests/tests/namespacesPage.ts
+++ b/e2e-tests/tests/namespacesPage.ts
@@ -78,8 +78,8 @@ export class NamespacesPage {
     await page.waitForLoadState('load');
     await page.fill('textarea[aria-label="yaml Code"]', yaml);
 
-    await expect(page.getByRole('button', { name: 'Apply' })).toBeVisible();
-    await page.getByRole('button', { name: 'Apply' }).click();
+    await expect(page.getByRole('button', { name: 'Apply', exact: true })).toBeVisible();
+    await page.getByRole('button', { name: 'Apply', exact: true }).click();
 
     await page.waitForSelector(`text=Applied ${name}`);
 

--- a/frontend/src/components/App/runCommand.ts
+++ b/frontend/src/components/App/runCommand.ts
@@ -28,12 +28,14 @@
  * @param permissionSecrets - Internal use. A record of permission secrets that may be required for the command.
  * @param desktopApiSend - Internal use. The function to send data to the main process.
  * @param desktopApiReceive - Internal use. The function to receive data from the main process.
+ * @param capability - Opaque product authorization for the calling plugin.
  * @returns An object with `stdout`, `stderr`, and `on` properties. You can listen for 'data' events on `stdout` and `stderr`, and 'exit' events with `on`.
  * @example
  *
  * How it can be used in a plugin:
  * ```ts
- *   declare const pluginRunCommand: typeof runCommand;
+ *   import type { PluginRunCommand } from '@kinvolk/headlamp-plugin/lib';
+ *   declare const pluginRunCommand: PluginRunCommand;
  *   const minikube = pluginRunCommand('minikube', ['status'], {});
  *
  *   minikube.stdout.on('data', (data) => {
@@ -47,8 +49,14 @@
  *   });
  * ```
  */
+export type PluginRunCommand = (
+  command: string,
+  args: string[],
+  options: Record<string, never>
+) => ReturnType<typeof runCommand>;
+
 export function runCommand(
-  command: 'minikube' | 'az' | 'scriptjs' | 'gh',
+  command: string,
   args: string[],
   options: {},
   permissionSecrets?: Record<string, number>,
@@ -60,12 +68,14 @@ export function runCommand(
       args: string[];
       options: {};
       permissionSecrets: Record<string, number>;
+      capability?: string;
     }
   ) => void,
   desktopApiReceive?: (
     channel: string,
     listener: (cmdId: string, data: string | number) => void
-  ) => (() => void) | void
+  ) => (() => void) | void,
+  capability?: string
 ): {
   stdout: { on: (event: string, listener: (chunk: any) => void) => void };
   stderr: { on: (event: string, listener: (chunk: any) => void) => void };
@@ -78,7 +88,7 @@ export function runCommand(
     // these are only optional for the pluginRunCommand
     throw new Error(
       'Do not use runCommand directly. Use pluginRunCommand via:' +
-        '  `declare const pluginRunCommand: typeof runCommand;`'
+        '  `declare const pluginRunCommand: PluginRunCommand;`'
     );
   }
 
@@ -123,7 +133,14 @@ export function runCommand(
   // We use desktopApiReceive and desktopApiSend to communicate with the main process.
   // Because other plugins may change the global window.desktopApi functions
   // to snoop on the secrets that plugins are sending.
-  desktopApiSend('run-command', { id, command, args, options, permissionSecrets });
+  desktopApiSend('run-command', {
+    id,
+    command,
+    args,
+    options,
+    permissionSecrets,
+    ...(capability && { capability }),
+  });
 
   return {
     stdout: {

--- a/frontend/src/plugin/commandCapabilities.test.ts
+++ b/frontend/src/plugin/commandCapabilities.test.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, expectTypeOf, it, vi } from 'vitest';
+import { PluginRunCommand } from '../components/App/runCommand';
+import {
+  commandCapabilityRegistration,
+  createPluginRunCommand,
+  findCommandCapability,
+  pluginSourceDigest,
+  preparePluginCommandCapabilities,
+} from './commandCapabilities';
+import { PluginInfo } from './pluginsSlice';
+
+const plugin: PluginInfo = {
+  name: '@example/plugin',
+  folderName: 'example-plugin',
+  source: 'shipped',
+  type: 'shipped',
+  description: '',
+  homepage: '',
+};
+
+describe('commandCapabilityRegistration', () => {
+  const sourceDigest = 'a'.repeat(64);
+
+  it('preserves package, bundle, path, and provenance', () => {
+    expect(
+      commandCapabilityRegistration(plugin, 'static-plugins/example-plugin', sourceDigest)
+    ).toEqual({
+      bundleName: 'example-plugin',
+      packageName: '@example/plugin',
+      path: 'static-plugins/example-plugin',
+      source: 'shipped',
+      type: 'shipped',
+      sourceDigest,
+    });
+  });
+
+  it('rejects incomplete inventory metadata', () => {
+    expect(
+      commandCapabilityRegistration({ ...plugin, source: undefined }, 'path', sourceDigest)
+    ).toBeUndefined();
+    expect(
+      commandCapabilityRegistration({ ...plugin, folderName: undefined }, 'path', sourceDigest)
+    ).toBeUndefined();
+    expect(commandCapabilityRegistration(plugin, 'path', 'invalid')).toBeUndefined();
+  });
+
+  it('hashes the exact cached source', async () => {
+    await expect(pluginSourceDigest('console.log("trusted");')).resolves.toBe(
+      'dd746362bdf7510734ba74a34f15e2a6a625e7e044efb0bc38da54b7cc316084'
+    );
+  });
+});
+
+describe('findCommandCapability', () => {
+  const capabilities = [
+    {
+      bundleName: 'example-plugin',
+      packageName: '@example/plugin',
+      capability: 'secret',
+    },
+  ];
+
+  it('matches both package and bundle identity', () => {
+    expect(findCommandCapability(capabilities, plugin)).toBe('secret');
+  });
+
+  it('does not match a spoofed package or bundle', () => {
+    expect(
+      findCommandCapability(capabilities, { ...plugin, name: '@attacker/plugin' })
+    ).toBeUndefined();
+    expect(
+      findCommandCapability(capabilities, { ...plugin, folderName: 'attacker' })
+    ).toBeUndefined();
+  });
+});
+
+describe('preparePluginCommandCapabilities', () => {
+  it('does not hash plugin sources outside Electron', async () => {
+    const sourceDigest = vi.fn();
+
+    await expect(
+      preparePluginCommandCapabilities(
+        undefined,
+        [plugin],
+        ['static-plugins/example-plugin'],
+        ['plugin source'],
+        sourceDigest
+      )
+    ).resolves.toEqual([]);
+    expect(sourceDigest).not.toHaveBeenCalled();
+  });
+
+  it('registers source-bound claims through the Electron bridge', async () => {
+    const capabilities = [
+      { bundleName: 'example-plugin', packageName: '@example/plugin', capability: 'secret' },
+    ];
+    const bridge = { register: vi.fn().mockResolvedValue(capabilities) };
+
+    await expect(
+      preparePluginCommandCapabilities(
+        bridge,
+        [plugin],
+        ['static-plugins/example-plugin'],
+        ['plugin source'],
+        vi.fn().mockResolvedValue('a'.repeat(64))
+      )
+    ).resolves.toEqual(capabilities);
+    expect(bridge.register).toHaveBeenCalledWith([
+      expect.objectContaining({
+        bundleName: 'example-plugin',
+        packageName: '@example/plugin',
+        sourceDigest: 'a'.repeat(64),
+      }),
+    ]);
+  });
+});
+
+describe('createPluginRunCommand', () => {
+  it('exposes only command, arguments, and empty options to plugins', () => {
+    expectTypeOf<PluginRunCommand>().parameters.toEqualTypeOf<
+      [command: string, args: string[], options: Record<string, never>]
+    >();
+  });
+
+  it('forwards the private capability through the captured bridge', () => {
+    const internalRunCommand = vi.fn(() => ({ stdout: {}, stderr: {}, on: vi.fn() }));
+    const send = vi.fn();
+    const receive = vi.fn();
+    const pluginRunCommand = createPluginRunCommand(
+      'secret',
+      internalRunCommand as any,
+      {},
+      send,
+      receive
+    );
+
+    pluginRunCommand?.('examplectl', ['project', 'list'], {});
+
+    expect(internalRunCommand).toHaveBeenCalledWith(
+      'examplectl',
+      ['project', 'list'],
+      {},
+      {},
+      send,
+      receive,
+      'secret'
+    );
+  });
+
+  it('does not create a bridge without a product capability', () => {
+    expect(createPluginRunCommand(undefined, vi.fn() as any, {}, vi.fn(), vi.fn())).toBeUndefined();
+  });
+});

--- a/frontend/src/plugin/commandCapabilities.ts
+++ b/frontend/src/plugin/commandCapabilities.ts
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PluginRunCommand, runCommand } from '../components/App/runCommand';
+import { PluginInfo } from './pluginsSlice';
+
+// Keep these IPC contract interfaces in sync with app/electron/runCmd.ts.
+
+/**
+ * Plugin provenance sent to Electron before third-party code executes.
+ *
+ * @example Report a plugin discovered in the shipped inventory.
+ * ```ts
+ * const registration: PluginCommandRegistration = {
+ *   bundleName: 'example-plugin',
+ *   packageName: '@example/plugin',
+ *   path: 'static-plugins/example-plugin',
+ *   source: 'shipped',
+ *   type: 'shipped',
+ *   sourceDigest: 'dd746362bdf7510734ba74a34f15e2a6a625e7e044efb0bc38da54b7cc316084',
+ * };
+ * ```
+ */
+export interface PluginCommandRegistration {
+  /** Bundle directory reported by backend discovery. */
+  bundleName: string;
+  /** Package identity read from the plugin bundle. */
+  packageName: string;
+  /** URL path used to load the plugin. */
+  path: string;
+  /** Inventory root containing the plugin. */
+  source: string;
+  /** Plugin priority type. */
+  type: string;
+  /** SHA-256 of the exact main.js source cached for execution. */
+  sourceDigest: string;
+}
+
+/**
+ * Command authorization issued by Electron for one verified plugin.
+ *
+ * The capability is a random 32-byte secret represented as 64 hexadecimal characters. Electron
+ * stores which plugin identity and command grants belong to that secret. The renderer includes it
+ * with each command request, allowing Electron to reject requests that have no token, use a
+ * revoked token, or request a command outside that plugin's grants.
+ *
+ * The token contains no readable plugin or permission data; plugin code must not interpret or
+ * create it.
+ *
+ * @example A capability returned by Electron for a verified plugin.
+ * ```ts
+ * const commandCapability: PluginCommandCapability = {
+ *   bundleName: 'example-plugin',
+ *   packageName: '@example/plugin',
+ *   capability: '4f8c2a917bd03e65a1c94f286e5b70d39ac214ef53d8b607c1e49a728f306db5',
+ * };
+ * ```
+ */
+export interface PluginCommandCapability {
+  /** Bundle directory bound to the capability. */
+  bundleName: string;
+  /** Package identity bound to the capability. */
+  packageName: string;
+  /** Opaque authorization token. */
+  capability: string;
+}
+
+interface PluginCommandCapabilitiesBridge {
+  register(registrations: PluginCommandRegistration[]): Promise<PluginCommandCapability[]>;
+}
+
+type DesktopApiSend = Parameters<typeof runCommand>[4];
+type DesktopApiReceive = Parameters<typeof runCommand>[5];
+
+/**
+ * Builds the provenance claim for a discovered plugin.
+ *
+ * @param plugin - Package metadata combined with backend inventory metadata.
+ * @param pluginPath - URL path used to load the plugin.
+ * @param sourceDigest - SHA-256 of the fetched source that will execute.
+ * @returns A registration claim, or undefined when identity metadata is incomplete.
+ */
+export function commandCapabilityRegistration(
+  plugin: PluginInfo,
+  pluginPath: string,
+  sourceDigest: string
+): PluginCommandRegistration | undefined {
+  if (
+    !plugin.folderName ||
+    !plugin.source ||
+    !plugin.type ||
+    !/^[a-f0-9]{64}$/.test(sourceDigest)
+  ) {
+    return undefined;
+  }
+  return {
+    bundleName: plugin.folderName,
+    packageName: plugin.name,
+    path: pluginPath,
+    source: plugin.source,
+    type: plugin.type,
+    sourceDigest,
+  };
+}
+
+/** Returns the SHA-256 digest of the exact JavaScript source string that will execute. */
+export async function pluginSourceDigest(source: string): Promise<string> {
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(source));
+  return Array.from(new Uint8Array(digest), byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+/** Prepares command capabilities only when the Electron preload bridge is available. */
+export async function preparePluginCommandCapabilities(
+  bridge: PluginCommandCapabilitiesBridge | undefined,
+  plugins: PluginInfo[],
+  pluginPaths: string[],
+  sources: string[],
+  sourceDigest: (source: string) => Promise<string> = pluginSourceDigest
+): Promise<PluginCommandCapability[]> {
+  if (!bridge) {
+    return [];
+  }
+  const sourceDigests = await Promise.all(sources.map(sourceDigest));
+  const registrations = plugins
+    .map((plugin, index) =>
+      commandCapabilityRegistration(plugin, pluginPaths[index], sourceDigests[index])
+    )
+    .filter(registration => registration !== undefined);
+  return bridge.register(registrations);
+}
+
+/**
+ * Finds the opaque capability bound to one exact plugin identity.
+ *
+ * @param capabilities - Capabilities returned by Electron's main process.
+ * @param plugin - Plugin package and inventory metadata.
+ * @returns The matching token, or undefined when no product grant exists.
+ */
+export function findCommandCapability(
+  capabilities: PluginCommandCapability[],
+  plugin: PluginInfo
+): string | undefined {
+  if (!plugin.folderName) {
+    return undefined;
+  }
+  for (const capability of capabilities) {
+    if (capability.bundleName === plugin.folderName && capability.packageName === plugin.name) {
+      return capability.capability;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Creates the command-running function made available to one authorized plugin.
+ * The returned function captures that plugin's capability and Headlamp's private IPC helpers,
+ * so plugin code only supplies the command, arguments, and public options. Electron checks the
+ * captured capability against the requested command before starting the process.
+ *
+ * @param capability - Opaque capability issued for the plugin identity.
+ * @param internalRunCommand - Private command function captured before plugins execute.
+ * @param permissionSecrets - Legacy secrets filtered for this plugin.
+ * @param desktopApiSend - Private preload send function.
+ * @param desktopApiReceive - Private preload receive function.
+ * @returns A scoped command function, or undefined without product authorization.
+ */
+export function createPluginRunCommand(
+  capability: string | undefined,
+  internalRunCommand: typeof runCommand,
+  permissionSecrets: Record<string, number>,
+  desktopApiSend: DesktopApiSend,
+  desktopApiReceive: DesktopApiReceive
+): PluginRunCommand | undefined {
+  if (!capability) {
+    return undefined;
+  }
+  return (command, args, options) =>
+    internalRunCommand(
+      command,
+      args,
+      options,
+      permissionSecrets,
+      desktopApiSend,
+      desktopApiReceive,
+      capability
+    );
+}

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -53,6 +53,12 @@ import * as Utils from '../lib/util';
 import { eventAction, HeadlampEventType } from '../redux/headlampEventSlice';
 import store from '../redux/stores/store';
 import * as stateless from '../stateless/index';
+import {
+  createPluginRunCommand,
+  findCommandCapability,
+  PluginCommandCapability,
+  preparePluginCommandCapabilities,
+} from './commandCapabilities';
 import { Headlamp, Plugin } from './lib';
 import { changePluginLanguage, initializePluginI18n } from './pluginI18n';
 import { useTranslation } from './pluginI18n';
@@ -583,6 +589,13 @@ export async function fetchAndExecutePlugins(
         secureStorageNamespaces.filter((namespace): namespace is string => Boolean(namespace))
       )
     : {};
+  const commandCapabilitiesBridge = window?.desktopApi?.commandCapabilities;
+  const commandCapabilities: PluginCommandCapability[] = await preparePluginCommandCapabilities(
+    commandCapabilitiesBridge,
+    packageInfosToExecute,
+    pluginPathsToExecute,
+    sourcesToExecute
+  );
 
   // Save references to the pluginRunCommand and desktopApiSend/Receive.
   // Plugins can use without worrying about modified global window.desktopApi.
@@ -647,68 +660,21 @@ export async function fetchAndExecutePlugins(
         getArgValues: (pluginName, pluginPath, allowedPermissions) => {
           const argumentNames: string[] = [];
           const argumentValues: unknown[] = [];
-          // allowedPermissions is the return value of getAllowedPermissions
-          const isPackage = identifyPackages(pluginPath, pluginName, isDevelopmentMode);
-          if (isPackage['@headlamp-k8s/minikube']) {
-            // We construct a pluginRunCommand that has private
-            //  - permission secrets
-            //  - stored desktopApiSend and desktopApiReceive functions that can't be modified
-            function pluginRunCommand(
-              command: 'minikube' | 'az' | 'scriptjs',
-              args: string[],
-              options: {}
-            ): ReturnType<typeof internalRunCommand> {
-              return internalRunCommand(
-                command,
-                args,
-                options,
-                allowedPermissions,
-                pluginDesktopApiSend,
-                pluginDesktopApiReceive
-              );
-            }
+          const commandCapability = findCommandCapability(
+            commandCapabilities,
+            packageInfosToExecute[index]
+          );
+          const productRunCommand = createPluginRunCommand(
+            commandCapability,
+            internalRunCommand,
+            allowedPermissions,
+            pluginDesktopApiSend,
+            pluginDesktopApiReceive
+          );
+          if (productRunCommand) {
             argumentNames.push('pluginRunCommand', 'pluginPath');
-            argumentValues.push(pluginRunCommand, pluginPath);
+            argumentValues.push(productRunCommand, pluginPath);
           }
-
-          if (isPackage['@headlamp-k8s/ai-assistant']) {
-            function pluginRunCommand(
-              command: 'gh' | 'az',
-              args: string[],
-              options: {}
-            ): ReturnType<typeof internalRunCommand> {
-              return internalRunCommand(
-                command,
-                args,
-                options,
-                allowedPermissions,
-                pluginDesktopApiSend,
-                pluginDesktopApiReceive
-              );
-            }
-            argumentNames.push('pluginRunCommand', 'pluginPath');
-            argumentValues.push(pluginRunCommand, pluginPath);
-          }
-
-          if (isPackage['azure-aks']) {
-            function pluginRunCommand(
-              command: 'scriptjs',
-              args: string[],
-              options: {}
-            ): ReturnType<typeof internalRunCommand> {
-              return internalRunCommand(
-                command,
-                args,
-                options,
-                allowedPermissions,
-                pluginDesktopApiSend,
-                pluginDesktopApiReceive
-              );
-            }
-            argumentNames.push('pluginRunCommand', 'pluginPath');
-            argumentValues.push(pluginRunCommand, pluginPath);
-          }
-
           const storageNamespace = secureStorageNamespaces[index];
           const storageCapability = storageNamespace
             ? secureStorageCapabilities[storageNamespace]

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -18,7 +18,7 @@ import { has } from 'lodash';
 import React, { ReactNode } from 'react';
 import { AppLogoProps, AppLogoType } from '../components/App/AppLogo';
 import { PluginManager } from '../components/App/pluginManager';
-import { runCommand } from '../components/App/runCommand';
+import { type PluginRunCommand, runCommand } from '../components/App/runCommand';
 import { setBrandingAppLogoComponent, themeSlice } from '../components/App/themeSlice';
 import { ClusterChooserProps, ClusterChooserType } from '../components/cluster/ClusterChooser';
 import {
@@ -1416,4 +1416,4 @@ export {
   ConfigStore,
 };
 
-export type { CallbackActionOptions };
+export type { CallbackActionOptions, PluginRunCommand };

--- a/plugins/headlamp-plugin/src/index.ts
+++ b/plugins/headlamp-plugin/src/index.ts
@@ -32,7 +32,12 @@ import * as Utils from './lib/util';
 import { Headlamp, Plugin } from './plugin/lib';
 import { getSupportedLocales, isLocaleSupported, useTranslation } from './plugin/pluginI18n';
 import { PluginSettingsDetailsProps } from './plugin/pluginsSlice';
-import type { CallbackActionOptions, HeadlampEvent, Relation } from './plugin/registry';
+import type {
+  CallbackActionOptions,
+  HeadlampEvent,
+  PluginRunCommand,
+  Relation,
+} from './plugin/registry';
 import Registry, {
   AppLogoProps,
   clusterAction,
@@ -161,5 +166,6 @@ export type {
   DetailsViewSectionProps,
   DefaultSidebars,
   HeadlampEvent,
+  PluginRunCommand,
   Relation,
 };


### PR DESCRIPTION
## Summary

- define strict, bounded command grants in the product build manifest
- select policy by build environment and plugin inventory source
- bind opaque capabilities to the verified plugin identity, renderer window, and main frame
- verify managed-plugin provenance and file integrity before capability issuance
- bind managed user-plugin scripts and executables to app-owned installation receipts
- stream SHA-256 hashing and stage verified scripts and executables in app-owned directories
- keep user consent separate from product authorization
- enable Electron renderer sandboxing and bind privileged stateful IPC and MCP handlers to the active trusted main frame

## Security model

The previous command path used shared `runCmd-<tool>` secrets and hard-coded package checks. A secret identified a tool, but did not bind a request to a plugin identity, installation source, argument policy, renderer frame, or verified executable bytes.

This change makes the product build manifest the command-policy authority. Plugins cannot broaden access through their own package metadata. Policies select the exact environment, inventory (`development`, `user`, or `shipped`), bundle name, package name, executable origin, and allowed argument sequence. Unknown fields, duplicate grants, empty prefixes, malformed identities, and overly broad grants fail closed.

Electron independently validates bundle containment and package identity before issuing an opaque per-window capability. Managed user plugins additionally require installer-recorded Artifact Hub identity and app-owned file digests. Authorized scripts and executables are copied to unique app-owned directories, verified, launched with `shell: false`, and removed after execution. Capabilities are revoked on navigation, reload, window close, and explicit revocation.

User consent remains a separate decision after product authorization. Legacy consent migration is limited to the historical commands of the exact known plugin identity, preventing source-less consent from crossing plugin boundaries.

## Stacked follow-up

Plugin Development Mode settings, native confirmation, packaged-app load gating, and their UI/documentation have moved to **0072b**, draft #7628. That PR is stacked on this branch and will be rebased onto `main` after this PR merges.

## Product defaults

Headlamp's checked-in manifest preserves reviewed command behavior for Minikube, AI Assistant, and Azure AKS across their supported development, managed-user, and shipped locations. Writable plugin policies require known Artifact Hub identity where applicable. Custom products selecting another manifest with `HEADLAMP_BUILD_MANIFEST` own their complete policy.

## Testing

- focused Electron command-policy, plugin-management, command-runner, build-manifest, and MCP suites: 384 tests passed
- focused frontend command-capability suite: 10 tests passed
- app TypeScript check
- final combined tree reproduced exactly by this PR plus #7628

Assisted by copilot