### PR TITLE
refactor: rename Params interface to Options in clusterRequests

### DIFF
--- a/frontend/src/lib/k8s/api/v1/clusterRequests.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterRequests.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-// @todo: Params is a confusing name for options, because params are also query params.
-
 import type { OpPatch } from 'json-patch';
 import { addBackstageAuthHeaders } from '../../../../helpers/addBackstageAuthHeaders';
 import { isDebugVerbose } from '../../../../helpers/debugVerbose';
@@ -36,7 +34,7 @@ import type { QueryParameters } from './queryParameters';
 /**
  * Options for the request.
  */
-export interface RequestParams extends RequestInit {
+export interface RequestOptions extends RequestInit {
   /** Number of milliseconds to wait for a response. */
   timeout?: number;
   /** Is the request expected to receive JSON data? */
@@ -63,7 +61,7 @@ export interface ClusterRequest {
 /**
  * The options for `clusterRequest`.
  */
-export interface ClusterRequestParams extends RequestParams {
+export interface ClusterRequestOptions extends RequestOptions {
   cluster?: string | null;
   autoLogoutOnAuthError?: boolean;
 }
@@ -95,7 +93,7 @@ export function getClusterAuthType(cluster: string): string {
  */
 export async function request(
   path: string,
-  params: RequestParams = {},
+  params: RequestOptions = {},
   autoLogoutOnAuthError: boolean = true,
   useCluster: boolean = true,
   queryParams?: QueryParameters
@@ -123,7 +121,7 @@ export async function request(
  */
 export async function clusterRequest(
   path: string,
-  params: ClusterRequestParams = {},
+  params: ClusterRequestOptions = {},
   queryParams?: QueryParameters
 ): Promise<any> {
   interface RequestHeaders {
@@ -248,7 +246,7 @@ export function post(
   url: string,
   json: JSON | object | KubeObjectInterface,
   autoLogoutOnAuthError: boolean = true,
-  options: ClusterRequestParams = {}
+  options: ClusterRequestOptions = {}
 ) {
   const { cluster: clusterName, ...requestOptions } = options;
   const body = JSON.stringify(json);
@@ -267,7 +265,7 @@ export function patch(
   url: string,
   json: any,
   autoLogoutOnAuthError = true,
-  options: ClusterRequestParams = {}
+  options: ClusterRequestOptions = {}
 ) {
   const { cluster: clusterName, ...requestOptions } = options;
   const body = JSON.stringify(json);
@@ -298,7 +296,7 @@ export function jsonPatch(
   url: string,
   operations: OpPatch[],
   autoLogoutOnAuthError = true,
-  options: ClusterRequestParams = {}
+  options: ClusterRequestOptions = {}
 ) {
   const { cluster: clusterName, ...requestOptions } = options;
   const body = JSON.stringify(operations);
@@ -318,7 +316,7 @@ export function put(
   url: string,
   json: Partial<KubeObjectInterface>,
   autoLogoutOnAuthError = true,
-  requestOptions: ClusterRequestParams = {}
+  requestOptions: ClusterRequestOptions = {}
 ) {
   const body = JSON.stringify(json);
   const { cluster: clusterName, ...restOptions } = requestOptions;
@@ -333,7 +331,7 @@ export function put(
   return clusterRequest(url, opts);
 }
 
-export function remove(url: string, requestOptions: ClusterRequestParams = {}) {
+export function remove(url: string, requestOptions: ClusterRequestOptions = {}) {
   const { cluster: clusterName, ...restOptions } = requestOptions;
   const cluster = clusterName || getCluster() || '';
   const opts = { method: 'DELETE', headers: JSON_HEADERS, cluster, ...restOptions };

--- a/frontend/src/lib/k8s/apiProxy/index.ts
+++ b/frontend/src/lib/k8s/apiProxy/index.ts
@@ -49,8 +49,8 @@ export {
   remove,
   request,
   type ClusterRequest,
-  type ClusterRequestParams,
-  type RequestParams,
+  type ClusterRequestOptions,
+  type RequestOptions,
 } from '../api/v1/clusterRequests';
 
 // Streaming API functions


### PR DESCRIPTION
Summary
This PR renames the confusing Params interfaces in clusterRequests.ts to Options to clarify their purpose, as params are often confused with URL query parameters.

Related Issue
Fixes #7571

Changes
- Renamed RequestParams to RequestOptions in frontend/src/lib/k8s/api/v1/clusterRequests.ts and updated exports.
- Renamed ClusterRequestParams to ClusterRequestOptions in the same file.
- Removed the tech debt TODO comment related to this naming issue.
- Updated the re-exports in frontend/src/lib/k8s/apiProxy/index.ts.

Steps to Test
1. Review the changes to ensure all references to the old interface names are updated.
2. Run make frontend-test to verify that no typings or usages are broken.

Notes for the Reviewer
This is a straightforward tech debt / intermediate refactoring task. All tests and lint checks have been run and are passing.
