### PR TITLE
fix: require authentication for GET /plugins endpoint

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -452,6 +452,30 @@ func addPluginDeleteRoute(config *HeadlampConfig, r *mux.Router) {
 		}
 	}).Methods("DELETE")
 }
+// isRequestAuthenticated reports whether the request carries a bearer token
+// or a session cookie for at least one known cluster.
+func (c *HeadlampConfig) isRequestAuthenticated(r *http.Request) bool {
+	if auth.BearerTokenValue(r.Header.Get("Authorization")) != "" {
+		return true
+	}
+
+	if auth.HasValidBackendToken(r) {
+	return true
+    }
+	
+	contexts, err := c.KubeConfigStore.GetContexts()
+	if err != nil {
+		return false
+	}
+
+	for _, ctx := range contexts {
+		if token, err := auth.GetTokenFromCookie(r, ctx.Name); err == nil && token != "" {
+			return true
+		}
+	}
+
+	return false
+}
 
 // addPluginListRoute registers a GET endpoint handler at "/plugins" that serves the list of available plugins.
 // It handles Telemetry, metrics collection, and plugin list caching.
@@ -474,7 +498,10 @@ func addPluginListRoute(config *HeadlampConfig, r *mux.Router) {
 		}
 
 		logger.Log(logger.LevelInfo, nil, nil, "Received GET request for plugin list")
-
+		if !config.isRequestAuthenticated(r) {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 
 		pluginsList, err := config.Cache.Get(context.Background(), plugins.PluginListKey)

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -439,6 +439,54 @@ func TestGetConfigIncludesDefaultNodeShellNamespace(t *testing.T) {
 	assert.Equal(t, "custom-ns", config.DefaultNodeShellNamespace)
 }
 
+func newTestHeadlampConfig() *HeadlampConfig {
+	return &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				KubeConfigStore: kubeconfig.NewContextStore(),
+			},
+		},
+	}
+}
+
+func TestIsRequestAuthenticatedNoCredentials(t *testing.T) {
+	c := newTestHeadlampConfig()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/plugins", nil)
+
+	assert.False(t, c.isRequestAuthenticated(req))
+}
+
+func TestIsRequestAuthenticatedBearerToken(t *testing.T) {
+	c := newTestHeadlampConfig()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/plugins", nil)
+	req.Header.Set("Authorization", "Bearer sometoken")
+
+	assert.True(t, c.isRequestAuthenticated(req))
+}
+
+func TestIsRequestAuthenticatedBackendToken(t *testing.T) {
+	c := newTestHeadlampConfig()
+
+	token := uuid.New().String()
+	require.NoError(t, os.Setenv("HEADLAMP_BACKEND_TOKEN", token))
+	defer func() { _ = os.Unsetenv("HEADLAMP_BACKEND_TOKEN") }()
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/plugins", nil)
+	req.Header.Set("X-HEADLAMP_BACKEND-TOKEN", token)
+
+	assert.True(t, c.isRequestAuthenticated(req))
+}
+
+func TestIsRequestAuthenticatedClusterCookie(t *testing.T) {
+	c := newTestHeadlampConfig()
+	require.NoError(t, c.KubeConfigStore.AddContext(&kubeconfig.Context{Name: "test-cluster"}))
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/plugins", nil)
+	req.AddCookie(&http.Cookie{Name: "headlamp-auth-test-cluster.0", Value: "sometoken"})
+
+	assert.True(t, c.isRequestAuthenticated(req))
+}
+
 //nolint:gocognit,funlen
 func TestDynamicClusters(t *testing.T) {
 	if os.Getenv("HEADLAMP_RUN_INTEGRATION_TESTS") != "true" {

--- a/backend/pkg/auth/backendtoken.go
+++ b/backend/pkg/auth/backendtoken.go
@@ -50,6 +50,21 @@ func CheckBackendToken(useInCluster bool, w http.ResponseWriter, r *http.Request
 	return nil
 }
 
+// HasValidBackendToken reports whether the request presents a token matching
+// HEADLAMP_BACKEND_TOKEN. Unlike CheckBackendToken, it makes no exception for
+// useInCluster or an unset token — it's a pure proof-of-possession check.
+func HasValidBackendToken(r *http.Request) bool {
+	backendTokenEnv := os.Getenv("HEADLAMP_BACKEND_TOKEN")
+	if backendTokenEnv == "" {
+		return false
+	}
+
+	backendTokens := r.Header.Values(backendTokenHeader)
+
+	return len(backendTokens) == 1 &&
+		subtle.ConstantTimeCompare([]byte(backendTokens[0]), []byte(backendTokenEnv)) == 1
+}
+
 // NewBackendTokenMiddleware protects API requests when the desktop app configures
 // a per-launch token and removes the private credential before forwarding.
 func NewBackendTokenMiddleware(useInCluster bool) func(http.Handler) http.Handler {

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -42,6 +42,7 @@ import * as CommonComponents from '../components/common';
 import * as ResourceMap from '../components/resourceMap';
 import { addBackstageAuthHeaders } from '../helpers/addBackstageAuthHeaders';
 import { getAppUrl } from '../helpers/getAppUrl';
+import { getHeadlampAPIHeaders } from '../helpers/getHeadlampAPIHeaders';
 import { isElectron } from '../helpers/isElectron';
 import i18next from '../i18n/config';
 import * as K8s from '../lib/k8s';
@@ -442,7 +443,7 @@ export async function fetchAndExecutePlugins(
 ) {
   const permissionSecretsPromise = permissionSecretsFromApp();
 
-  const headers = addBackstageAuthHeaders();
+  const headers = { ...getHeadlampAPIHeaders(), ...addBackstageAuthHeaders() };
 
   // Backend now returns plugin metadata with path, type, and name
   interface PluginMetadata {


### PR DESCRIPTION
## Summary

Fixes authentication handling for the `GET /plugins` endpoint.

The `/plugins` endpoint was not enforcing the same authentication boundary as other protected API requests. This change adds authentication checks while preserving the existing supported authentication mechanisms.

## Changes

### Backend

- Added `isRequestAuthenticated()` to check whether a request contains valid Headlamp authentication credentials.
- Supports authentication through:
  - Bearer token
  - Headlamp backend token
  - Per-cluster session cookie
- Protected `GET /plugins` so unauthenticated requests receive `401 Unauthorized`.

### Backend token validation

- Added `HasValidBackendToken()` to validate the `X-HEADLAMP_BACKEND_TOKEN` header.
- Uses constant-time comparison when checking the configured backend token.

### Frontend

- Updated plugin fetching to include `getHeadlampAPIHeaders()` in addition to the existing Backstage authentication headers.
- This ensures the frontend plugin request carries the authentication headers required by the newly protected `/plugins` endpoint.

### Tests

Added coverage for `isRequestAuthenticated()` with:

- No credentials
- Bearer token
- Backend token
- Per-cluster session cookie

Fixes #6869