### PR TITLE
Add Windows publisher metadata to the executables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ node_modules
 plugins/headlamp-plugin/headlamp-myfancy/
 plugins/examples/*/dist/
 .DS_Store
+
+# Generated Windows VERSIONINFO resources (see backend-versioninfo).
+backend/cmd/*.syso

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,19 @@ EMBED_BINARY_NAME := headlamp_app
 # Get version and app name from app/package.json
 APP_VERSION ?= $(shell node -p "require('./app/package.json').version" 2>/dev/null || echo "unknown")
 APP_NAME ?= $(shell node -p "require('./app/package.json').productName" 2>/dev/null || echo "Headlamp")
+# Windows reads a binary's publisher details from a VERSIONINFO resource, and
+# only a plain x.y.z can fill its numeric fields, so fall back to zeros for
+# release candidates and for the "unknown" APP_VERSION above.
+APP_VERSION_NUM ?= $(shell node -p "((require('./app/package.json').version||'').match(/^[0-9]+[.][0-9]+[.][0-9]+/)||['0.0.0'])[0]" 2>/dev/null || echo "0.0.0")
+VERSIONINFO_VERSION := v1.4.1
+VERSIONINFO_FLAGS := -platform-specific \
+	-file-version "$(APP_VERSION)" -product-version "$(APP_VERSION)" \
+	-ver-major $(word 1,$(subst ., ,$(APP_VERSION_NUM))) \
+	-ver-minor $(word 2,$(subst ., ,$(APP_VERSION_NUM))) \
+	-ver-patch $(word 3,$(subst ., ,$(APP_VERSION_NUM))) -ver-build 0 \
+	-product-ver-major $(word 1,$(subst ., ,$(APP_VERSION_NUM))) \
+	-product-ver-minor $(word 2,$(subst ., ,$(APP_VERSION_NUM))) \
+	-product-ver-patch $(word 3,$(subst ., ,$(APP_VERSION_NUM))) -product-ver-build 0
 # Build flags with version and app name
 BUILD_VERSION_FLAGS := -trimpath -ldflags="-s -w -X github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig.Version=$(APP_VERSION) -X 'github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig.AppName=$(APP_NAME)'"
 # embed build flags
@@ -64,6 +77,20 @@ ifeq ($(UNIXSHELL), true)
 else
 	powershell -Command "$$env:GOBIN='$(CURDIR)/backend/tools'; go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2"
 endif
+
+# Go emits no VERSIONINFO of its own, which leaves headlamp-server.exe with no
+# product name, description or company for allowlisting rules to key on. Build
+# the resource for every architecture up front: the _windows_<arch> filename
+# suffixes keep the linker from touching it anywhere but Windows, so the
+# non-Windows and cross-compiled builds below stay unaffected.
+.PHONY: backend-versioninfo
+# The generator has to build for the host even while the surrounding build is
+# cross-compiling, so clear the target settings for this recipe alone. Make
+# exports these itself, which keeps the recipe free of shell-specific syntax.
+backend-versioninfo: export GOOS :=
+backend-versioninfo: export GOARCH :=
+backend-versioninfo:
+	cd backend/cmd && go run github.com/josephspurrier/goversioninfo/cmd/goversioninfo@$(VERSIONINFO_VERSION) $(VERSIONINFO_FLAGS) versioninfo.json
 
 backend-lint: tools/golangci-lint
 ifeq ($(UNIXSHELL), true)
@@ -120,11 +147,11 @@ app-i18n-check: app/node_modules/.package-lock.json
 	cd app && npm run i18n-check
 
 .PHONY: backend
-backend:
+backend: backend-versioninfo
 	cd backend && go build $(BUILD_VERSION_FLAGS) -o ./headlamp-server${SERVER_EXE_EXT} ./cmd
 
 .PHONY: backend-embed
-backend-embed:
+backend-embed: backend-versioninfo
 	REACT_APP_HEADLAMP_SIDEBAR_DEFAULT_OPEN=false $(MAKE) frontend-build
 	$(MAKE) backend-embed-prepare
 	cd backend && go build $(EMBED_BUILD_FLAGS) -o ./headlamp-server${SERVER_EXE_EXT} ./cmd
@@ -182,17 +209,17 @@ backend-embed-windows:
 	$(MAKE) backend-embed-windows-386 VERSION=$(VERSION)
 	@echo "✓ Completed all Windows builds for version $(VERSION)"
 
-backend-embed-windows-arm64:
+backend-embed-windows-arm64: backend-versioninfo
 	@echo "Building for windows/arm64 with version $(VERSION)..."
 	cd backend && CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build $(EMBED_BUILD_FLAGS) -o dist/$(EMBED_BINARY_NAME)_$(VERSION)_windows_arm64.exe ./cmd
 	@echo "✓ Built: $(EMBED_BINARY_NAME)_$(VERSION)_windows_arm64.exe"
 
-backend-embed-windows-amd64:
+backend-embed-windows-amd64: backend-versioninfo
 	@echo "Building for windows/amd64 with version $(VERSION)..."
 	cd backend && CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build $(EMBED_BUILD_FLAGS) -o dist/$(EMBED_BINARY_NAME)_$(VERSION)_windows_amd64.exe ./cmd
 	@echo "✓ Built: $(EMBED_BINARY_NAME)_$(VERSION)_windows_amd64.exe"
 
-backend-embed-windows-386:
+backend-embed-windows-386: backend-versioninfo
 	@echo "Building for windows/386 with version $(VERSION)..."
 	cd backend && CGO_ENABLED=0 GOOS=windows GOARCH=386 go build $(EMBED_BUILD_FLAGS) -o dist/$(EMBED_BINARY_NAME)_$(VERSION)_windows_386.exe ./cmd
 	@echo "✓ Built: $(EMBED_BINARY_NAME)_$(VERSION)_windows_386.exe"

--- a/app/package.json
+++ b/app/package.json
@@ -36,6 +36,7 @@
   },
   "build": {
     "appId": "com.microsoft.Headlamp",
+    "copyright": "Copyright The Kubernetes Authors",
     "beforeBuild": "./scripts/build-backend.js",
     "afterPack": "./scripts/after-pack.js",
     "asar": false,

--- a/app/scripts/verify-build-windows.ps1
+++ b/app/scripts/verify-build-windows.ps1
@@ -65,6 +65,19 @@ function Test-BackendBinary {
     exit 1
   }
   Write-Host "[PASS] Backend binary is working" -ForegroundColor Green
+
+  # Zero-trust allowlisting keys on these fields, and Go emits no VERSIONINFO
+  # unless the build links in a resource, so an empty one here means the
+  # generated .syso went missing rather than that a value was mistyped.
+  $info = (Get-Item $backendPath).VersionInfo
+  foreach ($field in @("CompanyName", "FileDescription", "ProductName")) {
+    if (-not $info.$field) {
+      Write-Host "[FAIL] Backend is missing $field in its version resource" -ForegroundColor Red
+      exit 1
+    }
+    Write-Host "Backend ${field}: $($info.$field)"
+  }
+  Write-Host "[PASS] Backend version resource is populated" -ForegroundColor Green
   return $true
 }
 

--- a/backend/cmd/versioninfo.json
+++ b/backend/cmd/versioninfo.json
@@ -1,0 +1,35 @@
+{
+	"FixedFileInfo": {
+		"FileVersion": {
+			"Major": 0,
+			"Minor": 0,
+			"Patch": 0,
+			"Build": 0
+		},
+		"ProductVersion": {
+			"Major": 0,
+			"Minor": 0,
+			"Patch": 0,
+			"Build": 0
+		},
+		"FileFlagsMask": "3f",
+		"FileFlags ": "00",
+		"FileOS": "040004",
+		"FileType": "01",
+		"FileSubType": "00"
+	},
+	"StringFileInfo": {
+		"CompanyName": "The Kubernetes Authors",
+		"FileDescription": "Headlamp Server",
+		"InternalName": "headlamp-server",
+		"LegalCopyright": "Copyright The Kubernetes Authors",
+		"OriginalFilename": "headlamp-server.exe",
+		"ProductName": "Headlamp"
+	},
+	"VarFileInfo": {
+		"Translation": {
+			"LangID": "0409",
+			"CharsetID": "04B0"
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`headlamp-server.exe` is a Go binary and Go emits no VERSIONINFO resource, so it
ships with no product name, file description or company name. There's nothing in
the file for a zero-trust allowlist to key on except the path or hash, which is
why the rules break on every update.

This generates that resource with `goversioninfo` before the server is linked,
and sets the copyright on the electron-builder side, which was the only
publisher field missing there. Signing is untouched.

## Related Issue

Fixes #7517

## Changes

- Added `backend/cmd/versioninfo.json` and a `backend-versioninfo` Make target
  that runs `goversioninfo`; `backend`, `backend-embed` and
  `backend-embed-windows-*` depend on it
- Added `copyright` to the build block in `app/package.json`
- `verify-build-windows.ps1` now fails if the backend's CompanyName,
  FileDescription or ProductName is empty

## Steps to Test

1. On Windows: `make backend` (to cross-build from macOS/Linux instead:
   `GOOS=windows GOARCH=amd64 OS=Windows_NT make backend` — `OS=Windows_NT` is
   only needed off-Windows, for the `.exe` suffix). Then check
   `(Get-Item .\backend\headlamp-server.exe).VersionInfo | Format-List *`
   (the `Format-List *` is needed - PowerShell's default view for VersionInfo
   shows only the version numbers and hides the string fields)
2. Repeat for `386`, `arm` and `arm64` to confirm each still links
3. `make backend` on Linux/macOS — unaffected, the `_windows_<arch>` filename
   suffixes keep the linker away from the resource

I ran 1-3 cross-building from macOS and confirmed the fields land in the exe's
`.rsrc` section. @benrose258 has since confirmed them on Windows and his
security team signed off against their allowlisting tooling. The packaged app
side (the `copyright` field from `app/package.json`) is still untested.

## Notes for the Reviewer

- **CompanyName needs your call.** I used "The Kubernetes Authors" per the
  license headers, but `appId` says `com.microsoft.Headlamp` and `author.name`
  says `Kinvolk`. `author.name` is what electron-builder puts in CompanyName for
  `Headlamp.exe`, so right now the server and the app disagree. I left `author`
  alone since changing it also moves the deb maintainer.
- goversioninfo is pinned at v1.4.1 via `go run pkg@version` — nothing new to
  install, no `go.mod` change.



