### PR TITLE
Fix the auth screen's back button looping back to itself

### DIFF
--- a/frontend/src/components/App/Home/index.tsx
+++ b/frontend/src/components/App/Home/index.tsx
@@ -19,7 +19,7 @@ import { Box, Tab, Tabs, Typography } from '@mui/material';
 import { isEqual } from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { setupBackstageMessageReceiver } from '../../../helpers/backstageMessageReceiver';
 import { useAutoConnectClusters } from '../../../helpers/clusterAutoConnect';
 import { isBackstage } from '../../../helpers/isBackstage';
@@ -39,9 +39,13 @@ import RecentClusters from './RecentClusters';
 
 export default function Home() {
   const history = useHistory();
+  const location = useLocation();
   const clusters = useClustersConf();
+  // Arriving from the auth screen means the user asked to leave the cluster, so
+  // sending them back into it would just return them to the screen they left.
+  const { fromAuthChooser = false } = (location.state || {}) as { fromAuthChooser?: boolean };
 
-  if (!isElectron() && clusters && Object.keys(clusters).length === 1) {
+  if (!isElectron() && !fromAuthChooser && clusters && Object.keys(clusters).length === 1) {
     history.push(createRouteURL('cluster', { cluster: Object.keys(clusters)[0] }));
     return null;
   }

--- a/frontend/src/components/authchooser/AuthChooser.test.tsx
+++ b/frontend/src/components/authchooser/AuthChooser.test.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { SnackbarProvider } from 'notistack';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Route, useLocation } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMuiTheme } from '../../lib/themes';
+import store from '../../redux/stores/store';
+import AuthChooser from '.';
+
+const { clusters, testAuthMock } = vi.hoisted(() => ({
+  clusters: {} as { [name: string]: any },
+  testAuthMock: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s', () => ({
+  useClustersConf: () => clusters,
+}));
+
+// getCluster() reads the browser URL rather than the router, which MemoryRouter
+// does not touch.
+vi.mock('../../lib/cluster', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../lib/cluster')>()),
+  getCluster: () => 'main',
+}));
+
+vi.mock('../../lib/k8s/api/v1/clusterApi', () => ({
+  testAuth: testAuthMock,
+}));
+
+function LocationDisplay() {
+  const location = useLocation();
+  return (
+    <div
+      data-testid="location"
+      data-pathname={location.pathname}
+      data-from-auth-chooser={String(
+        !!(location.state as { fromAuthChooser?: boolean } | undefined)?.fromAuthChooser
+      )}
+    />
+  );
+}
+
+/**
+ * Renders the auth chooser for a cluster whose auth check has just failed, which is
+ * the state the dialog is left in when a cluster's connection or token goes away.
+ *
+ * The location is reported from outside the cluster route, so it survives the
+ * navigation the back button triggers.
+ */
+async function renderFailedAuthChooser() {
+  testAuthMock.mockRejectedValue(Object.assign(new Error('Bad Gateway'), { status: 502 }));
+
+  render(
+    <ThemeProvider theme={createMuiTheme({ name: 'light', base: 'light' })}>
+      <Provider store={store}>
+        <SnackbarProvider>
+          <MemoryRouter initialEntries={['/c/main']}>
+            <Route path="/c/:cluster">
+              <AuthChooser />
+            </Route>
+            <LocationDisplay />
+          </MemoryRouter>
+        </SnackbarProvider>
+      </Provider>
+    </ThemeProvider>
+  );
+
+  // The back button only appears once the auth check has settled.
+  await waitFor(() => expect(screen.getByRole('button', { name: /back/i })).toBeVisible());
+}
+
+describe('AuthChooser', () => {
+  beforeEach(() => {
+    for (const name of Object.keys(clusters)) {
+      delete clusters[name];
+    }
+  });
+
+  it('leaves for the chooser rather than going back into the failing cluster', async () => {
+    clusters.main = { name: 'main', auth_type: '' };
+    clusters.other = { name: 'other', auth_type: '' };
+
+    await renderFailedAuthChooser();
+    fireEvent.click(screen.getByRole('button', { name: /back/i }));
+
+    // goBack() used to leave us on the cluster page, which re-runs the auth check
+    // and lands straight back here.
+    expect(screen.getByTestId('location').dataset.pathname).toBe('/');
+  });
+
+  it('tells the chooser not to send a lone cluster straight back', async () => {
+    clusters.main = { name: 'main', auth_type: '' };
+
+    await renderFailedAuthChooser();
+    fireEvent.click(screen.getByRole('button', { name: /back/i }));
+
+    const location = screen.getByTestId('location');
+    expect(location.dataset.pathname).toBe('/');
+    expect(location.dataset.fromAuthChooser).toBe('true');
+  });
+});

--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -231,7 +231,14 @@ function AuthChooser({ children }: AuthChooserProps) {
         history.replace(from);
       }}
       handleBackButtonPress={() => {
-        numClusters > 1 ? history.goBack() : history.push('/');
+        // Both of these led straight back here: going back re-entered the cluster
+        // whose auth had just failed, and '/' bounced a lone cluster back in, so
+        // the only way out was to exhaust the history. Leave for the chooser
+        // instead, and tell it not to send a lone cluster back.
+        history.push({
+          pathname: createRouteURL('chooser'),
+          state: { fromAuthChooser: true },
+        });
       }}
       handleTokenAuth={() => {
         const tokenRoute = getRoute('token');


### PR DESCRIPTION
## Summary

Nothing is actually stacking — `history.length` never moves. The auth screen's Back button is the only way off it, and both of its branches led straight back: with more than one cluster `goBack()` returns to the cluster page, which re-runs the auth check, fails, and redirects here again; with one cluster `'/'` reaches Home, which in the browser build pushes back into the only cluster there is. So you press Back until the history runs out and get dumped wherever it lands, which is what @segevfiner saw.

Back now goes to the cluster chooser, and carries a flag so Home doesn't send a lone cluster back in.

## Related Issue

Fixes #7327

## Changes

- `authchooser`: Back pushes the chooser route with `fromAuthChooser` state, instead of `goBack()` / `'/'`
- `App/Home`: skips the single-cluster auto-redirect when that state is set
- Added `AuthChooser.test.tsx` covering both branches

## Steps to Test

1. `cd frontend && npx vitest run src/components/authchooser` — both tests fail without the fix
2. With two or more clusters, break auth on one (stop the cluster, or expire the token), open it, and press Back on the auth screen. Should land on the cluster list, once
3. Same with a single cluster in the browser build — previously `'/'` bounced straight back in

I ran 1 and reproduced 2 and 3 locally in both the browser build and the desktop app.

## Notes for the Reviewer

- @illume you okayed this approach on the issue. Kept it to `handleBackButtonPress` as discussed, rather than moving the auth screen off being a route.
- The Home guard is needed because `Home` redirects into the cluster when there is exactly one and we're not in Electron — without it the single-cluster case still loops.
- Doesn't touch why auth fails in the first place, only the escape hatch. The related question of a 404 being treated as "needs a token" is #7154 / #7328.
