### PR TITLE
fix(backend/serviceproxy): preserve URIPrefix base path and guard against prefix escape

### DIFF
--- a/backend/pkg/serviceproxy/connection.go
+++ b/backend/pkg/serviceproxy/connection.go
@@ -45,14 +45,32 @@ func (c *Connection) Get(ctx context.Context, requestURI string, w http.Response
 
 	if rel.Path != "" {
 		cleaned := path.Clean(rel.Path)
-		if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		if cleaned == ".." || strings.HasPrefix(cleaned, "../") || rel.Path == ".." || strings.HasPrefix(rel.Path, "../") {
 			return fmt.Errorf("request uri must not traverse above base path")
 		}
-
-		rel.Path = cleaned
 	}
 
-	fullURL := base.ResolveReference(rel)
+	baseClean := path.Clean("/" + strings.TrimPrefix(base.Path, "/"))
+	if baseClean == "/" {
+		baseClean = ""
+	}
+
+	var relClean string
+	if rel.Path != "" {
+		relClean = path.Clean("/" + strings.TrimPrefix(rel.Path, "/"))
+	}
+
+	combinedPath := path.Clean(baseClean + relClean)
+	if baseClean != "" && combinedPath != baseClean && !strings.HasPrefix(combinedPath, baseClean+"/") {
+		return fmt.Errorf("request uri must not traverse above base path")
+	}
+
+	fullURL := &url.URL{
+		Scheme:   base.Scheme,
+		Host:     base.Host,
+		Path:     combinedPath,
+		RawQuery: rel.RawQuery,
+	}
 
 	return HTTPGetStream(ctx, fullURL.String(), w)
 }

--- a/backend/pkg/serviceproxy/connection_test.go
+++ b/backend/pkg/serviceproxy/connection_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -98,6 +99,20 @@ var getTests = []struct {
 		wantBody:   []byte("Hello, World!"),
 		wantErr:    false,
 	},
+	{
+		name:       "prefixed URI preserves base path",
+		uri:        "http://example.com/api/v1/proxy",
+		requestURI: "/status",
+		wantBody:   []byte("Hello, World!"),
+		wantErr:    false,
+	},
+	{
+		name:       "prefixed URI with traversal preserves prefix",
+		uri:        "http://example.com/api/v1/proxy",
+		requestURI: "/../status",
+		wantBody:   []byte("Hello, World!"),
+		wantErr:    false,
+	},
 }
 
 func TestGet(t *testing.T) {
@@ -107,6 +122,9 @@ func TestGet(t *testing.T) {
 
 			if tt.wantBody != nil {
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if strings.Contains(tt.uri, "/api/v1/proxy") && !strings.HasPrefix(r.URL.Path, "/api/v1/proxy") {
+						t.Errorf("Expected path prefix /api/v1/proxy, got %s", r.URL.Path)
+					}
 					_, err := w.Write(tt.wantBody)
 					if err != nil {
 						t.Fatal(err)
@@ -114,7 +132,11 @@ func TestGet(t *testing.T) {
 				}))
 				defer ts.Close()
 
-				conn.URI = ts.URL
+				if strings.Contains(tt.uri, "/api/v1/proxy") {
+					conn.URI = ts.URL + "/api/v1/proxy"
+				} else {
+					conn.URI = ts.URL
+				}
 			}
 
 			w := httptest.NewRecorder()


### PR DESCRIPTION
### What this PR does
Ensures that `serviceproxy.Connection.Get` preserves the configured `proxyService.URIPrefix` base path and prevents relative paths with leading slashes or parent segments from escaping above the base prefix.

### Details
1. When `c.URI` contains a path prefix (e.g. `http://service:8080/api/v1/proxy`), `base.ResolveReference(rel)` with an absolute path previously resolved against the host root, dropping the base path prefix.
2. `combinedPath` joins `baseClean` and `relClean`, verifying that the resulting path remains scoped within `baseClean`.
3. Adds unit tests in `pkg/serviceproxy/connection_test.go` verifying prefix preservation and traversal protection.