### PR TITLE
frontend: clusterRequest: Serialize first contact per cluster

### DIFF
--- a/frontend/src/helpers/clusterConnectQueue.test.ts
+++ b/frontend/src/helpers/clusterConnectQueue.test.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { resetClusterConnectQueue, withClusterConnectSlot } from './clusterConnectQueue';
+
+/** A promise plus the handles needed to settle it from the test body. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('withClusterConnectSlot', () => {
+  beforeEach(() => {
+    resetClusterConnectQueue();
+  });
+
+  it('does not start a second cluster while the first has not answered', async () => {
+    const first = deferred<string>();
+    const started: string[] = [];
+
+    const a = withClusterConnectSlot('cluster-a', () => {
+      started.push('a');
+      return first.promise;
+    });
+    const b = withClusterConnectSlot('cluster-b', () => {
+      started.push('b');
+      return Promise.resolve('b');
+    });
+
+    // Give the queue a chance to run anything it should not have run yet.
+    await Promise.resolve();
+    expect(started).toEqual(['a']);
+
+    first.resolve('a');
+    await expect(a).resolves.toBe('a');
+    await expect(b).resolves.toBe('b');
+    expect(started).toEqual(['a', 'b']);
+  });
+
+  it('lets the next cluster through when the first one fails', async () => {
+    const first = deferred<string>();
+    const started: string[] = [];
+
+    const a = withClusterConnectSlot('cluster-a', () => {
+      started.push('a');
+      return first.promise;
+    });
+    const b = withClusterConnectSlot('cluster-b', () => {
+      started.push('b');
+      return Promise.resolve('b');
+    });
+
+    first.reject(new Error('login failed'));
+
+    await expect(a).rejects.toThrow('login failed');
+    await expect(b).resolves.toBe('b');
+    expect(started).toEqual(['a', 'b']);
+  });
+
+  it('runs later requests for an already contacted cluster immediately', async () => {
+    await withClusterConnectSlot('cluster-a', () => Promise.resolve('first'));
+
+    const blocker = deferred<string>();
+    // cluster-b holds the queue; cluster-a must not be stuck behind it.
+    withClusterConnectSlot('cluster-b', () => blocker.promise);
+
+    let ran = false;
+    const again = withClusterConnectSlot('cluster-a', () => {
+      ran = true;
+      return Promise.resolve('again');
+    });
+
+    expect(ran).toBe(true);
+    await expect(again).resolves.toBe('again');
+
+    blocker.resolve('b');
+  });
+
+  it('marks a cluster as contacted even when its first request failed', async () => {
+    await expect(
+      withClusterConnectSlot('cluster-a', () => Promise.reject(new Error('nope')))
+    ).rejects.toThrow('nope');
+
+    const blocker = deferred<string>();
+    withClusterConnectSlot('cluster-b', () => blocker.promise);
+
+    let ran = false;
+    await withClusterConnectSlot('cluster-a', () => {
+      ran = true;
+      return Promise.resolve('again');
+    });
+
+    expect(ran).toBe(true);
+
+    blocker.resolve('b');
+  });
+
+  it('does not queue requests that have no cluster', async () => {
+    const blocker = deferred<string>();
+    withClusterConnectSlot('cluster-a', () => blocker.promise);
+
+    let ran = false;
+    const config = withClusterConnectSlot('', () => {
+      ran = true;
+      return Promise.resolve('config');
+    });
+
+    expect(ran).toBe(true);
+    await expect(config).resolves.toBe('config');
+
+    blocker.resolve('a');
+  });
+
+  it('admits queued clusters in the order they were requested', async () => {
+    const blocker = deferred<string>();
+    const started: string[] = [];
+
+    const a = withClusterConnectSlot('cluster-a', () => {
+      started.push('a');
+      return blocker.promise;
+    });
+    const b = withClusterConnectSlot('cluster-b', () => {
+      started.push('b');
+      return Promise.resolve('b');
+    });
+    const c = withClusterConnectSlot('cluster-c', () => {
+      started.push('c');
+      return Promise.resolve('c');
+    });
+
+    blocker.resolve('a');
+    await Promise.all([a, b, c]);
+
+    expect(started).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/frontend/src/helpers/clusterConnectQueue.ts
+++ b/frontend/src/helpers/clusterConnectQueue.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Clusters whose first request has already settled. Requests for these clusters
+ * are never queued.
+ */
+const contactedClusters = new Set<string>();
+
+/**
+ * The tail of the queue of first requests. Each new first request chains onto
+ * it, which is what makes admission first-in-first-out.
+ */
+let queueTail: Promise<unknown> = Promise.resolve();
+
+/**
+ * Runs a cluster request, letting only one cluster make its *first* contact at
+ * a time.
+ *
+ * The backend only answers a `/clusters/<name>/...` request once the kubeconfig
+ * `exec` credential plugin for that cluster has finished. Such plugins (SSO
+ * helpers like kubelogin, gcloud or aws) typically open a browser and bind a
+ * fixed localhost redirect port, so running several at once makes the port
+ * binds collide and every login fail. Ordering the first request per cluster
+ * orders the plugin invocations, which keeps at most one interactive login
+ * running.
+ *
+ * Only the first request per cluster is queued: once a cluster has answered
+ * once its credentials are cached in the backend, so later requests run
+ * immediately and in parallel as before.
+ *
+ * @param cluster - Name of the cluster, or empty for non-cluster requests.
+ * @param run - Performs the request. Called immediately when no slot is needed.
+ *
+ * @returns Whatever `run` resolves or rejects with.
+ */
+export function withClusterConnectSlot<T>(
+  cluster: string | null | undefined,
+  run: () => Promise<T>
+): Promise<T> {
+  if (!cluster || contactedClusters.has(cluster)) {
+    return run();
+  }
+
+  // The cluster is marked as contacted once the request settles, not once it
+  // succeeds: a cluster whose login fails must release the queue instead of
+  // holding up every other cluster.
+  const slot = queueTail.then(() =>
+    run().finally(() => {
+      contactedClusters.add(cluster);
+    })
+  );
+
+  // Swallow the rejection for the queue itself, so a failing request cannot
+  // reject the slot of whichever cluster comes next.
+  queueTail = slot.catch(() => {});
+
+  return slot;
+}
+
+/**
+ * Clears the queue and the set of contacted clusters.
+ *
+ * Only meant for tests, since the state above lives for as long as the page.
+ */
+export function resetClusterConnectQueue() {
+  contactedClusters.clear();
+  queueTail = Promise.resolve();
+}

--- a/frontend/src/lib/k8s/api/v1/clusterRequests.test.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterRequests.test.ts
@@ -16,6 +16,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { addBackstageAuthHeaders } from '../../../../helpers/addBackstageAuthHeaders';
+import { resetClusterConnectQueue } from '../../../../helpers/clusterConnectQueue';
 import { setBackendToken } from '../../../../helpers/getHeadlampAPIHeaders';
 import { isBackstage } from '../../../../helpers/isBackstage';
 import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
@@ -45,6 +46,7 @@ vi.mock('../../../auth', () => ({
 describe('clusterRequest transports', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetClusterConnectQueue();
     vi.stubGlobal('fetch', vi.fn());
     setBackendToken('desktop-token');
     vi.mocked(isBackstage).mockReturnValue(false);
@@ -132,5 +134,76 @@ describe('clusterRequest transports', () => {
       status: 408,
       message: expect.stringContaining('Request timed-out'),
     });
+  });
+
+  it('does not contact two clusters at once on their first request', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    (fetch as Mock).mockImplementation(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise(resolve => setTimeout(resolve, 10));
+      inFlight -= 1;
+      return new Response(JSON.stringify({}), { status: 200 });
+    });
+
+    await Promise.all([
+      clusterRequest('/version', { cluster: 'cluster-a' }),
+      clusterRequest('/version', { cluster: 'cluster-b' }),
+    ]);
+
+    expect(maxInFlight).toBe(1);
+    expect((fetch as Mock).mock.calls).toHaveLength(2);
+  });
+
+  it('contacts a cluster in parallel once it has answered once', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    (fetch as Mock).mockImplementation(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise(resolve => setTimeout(resolve, 10));
+      inFlight -= 1;
+      return new Response(JSON.stringify({}), { status: 200 });
+    });
+
+    await clusterRequest('/version', { cluster: 'cluster-a' });
+    maxInFlight = 0;
+
+    await Promise.all([
+      clusterRequest('/version', { cluster: 'cluster-a' }),
+      clusterRequest('/api/v1/pods', { cluster: 'cluster-a' }),
+    ]);
+
+    expect(maxInFlight).toBe(2);
+  });
+
+  it('starts the request timeout only once the cluster has a queue slot', async () => {
+    // cluster-a holds the queue for longer than cluster-b's timeout. If the
+    // abort timer started before the slot was granted, cluster-b would time out
+    // while it was still only waiting.
+    (fetch as Mock).mockImplementation(
+      (url: string, init: RequestInit) =>
+        new Promise((resolve, reject) => {
+          const delay = String(url).includes('cluster-a') ? 60 : 5;
+          const timer = setTimeout(
+            () => resolve(new Response(JSON.stringify({}), { status: 200 })),
+            delay
+          );
+          init.signal?.addEventListener('abort', () => {
+            clearTimeout(timer);
+            const abortError = new Error('aborted');
+            abortError.name = 'AbortError';
+            reject(abortError);
+          });
+        })
+    );
+
+    const results = Promise.all([
+      clusterRequest('/version', { cluster: 'cluster-a' }),
+      clusterRequest('/version', { cluster: 'cluster-b', timeout: 40 }),
+    ]);
+
+    await expect(results).resolves.toHaveLength(2);
   });
 });

--- a/frontend/src/lib/k8s/api/v1/clusterRequests.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterRequests.ts
@@ -18,6 +18,7 @@
 
 import type { OpPatch } from 'json-patch';
 import { addBackstageAuthHeaders } from '../../../../helpers/addBackstageAuthHeaders';
+import { withClusterConnectSlot } from '../../../../helpers/clusterConnectQueue';
 import { isDebugVerbose } from '../../../../helpers/debugVerbose';
 import { getAppUrl } from '../../../../helpers/getAppUrl';
 import { getHeadlampAPIHeaders } from '../../../../helpers/getHeadlampAPIHeaders';
@@ -163,13 +164,9 @@ export async function clusterRequest(
     fullPath = combinePath(`/${CLUSTERS_PREFIX}/${cluster}`, path);
   }
 
-  const controller = new AbortController();
-  const id = setTimeout(() => controller.abort(), timeout);
-
   let url = combinePath(getAppUrl(), fullPath);
   url += asQuery(queryParams);
   const requestData = {
-    signal: controller.signal,
     credentials: 'include' as RequestCredentials,
     ...opts,
   };
@@ -178,15 +175,24 @@ export async function clusterRequest(
   }
   let response: Response = new Response(undefined, { status: 502, statusText: 'Unreachable' });
   try {
-    response = await fetch(url, requestData);
+    response = await withClusterConnectSlot(cluster, async () => {
+      // The abort timer is started here, and not before the slot is granted, so
+      // that time spent waiting for another cluster's first contact is not
+      // counted against this request's timeout.
+      const controller = new AbortController();
+      const id = setTimeout(() => controller.abort(), timeout);
+      try {
+        return await fetch(url, { signal: controller.signal, ...requestData });
+      } finally {
+        clearTimeout(id);
+      }
+    });
   } catch (err) {
     if (err instanceof Error) {
       if (err.name === 'AbortError') {
         response = new Response(undefined, { status: 408, statusText: 'Request timed-out' });
       }
     }
-  } finally {
-    clearTimeout(id);
   }
 
   // The backend signals through this header that it wants a reload.

--- a/frontend/src/lib/k8s/api/v2/fetch.test.ts
+++ b/frontend/src/lib/k8s/api/v2/fetch.test.ts
@@ -16,6 +16,7 @@
 
 import nock from 'nock';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import { resetClusterConnectQueue } from '../../../../helpers/clusterConnectQueue';
 import { setBackendToken } from '../../../../helpers/getHeadlampAPIHeaders';
 import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
 import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
@@ -52,6 +53,7 @@ describe('clusterFetch', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    resetClusterConnectQueue();
     setBackendToken('desktop-token');
     (findKubeconfigByClusterName as Mock).mockResolvedValue(kubeconfig);
     (getUserIdFromLocalStorage as Mock).mockReturnValue(userID);
@@ -114,5 +116,19 @@ describe('clusterFetch', () => {
     nock(BASE_HTTP_URL).get(`/clusters/${clusterName}${testUrl}`).reply(500);
 
     await expect(clusterFetch(testUrl, { cluster: clusterName })).rejects.toThrow('Unreachable');
+  });
+
+  it('does not contact two clusters at once on their first request', async () => {
+    // Without serialization the undelayed cluster-b would answer first.
+    nock(BASE_HTTP_URL).get(`/clusters/cluster-a${testUrl}`).delay(50).reply(200, mockResponse);
+    nock(BASE_HTTP_URL).get(`/clusters/cluster-b${testUrl}`).reply(200, mockResponse);
+
+    const settled: string[] = [];
+    await Promise.all([
+      clusterFetch(testUrl, { cluster: 'cluster-a' }).then(() => settled.push('cluster-a')),
+      clusterFetch(testUrl, { cluster: 'cluster-b' }).then(() => settled.push('cluster-b')),
+    ]);
+
+    expect(settled).toEqual(['cluster-a', 'cluster-b']);
   });
 });

--- a/frontend/src/lib/k8s/api/v2/fetch.ts
+++ b/frontend/src/lib/k8s/api/v2/fetch.ts
@@ -15,6 +15,7 @@
  */
 
 import { addBackstageAuthHeaders } from '../../../../helpers/addBackstageAuthHeaders';
+import { withClusterConnectSlot } from '../../../../helpers/clusterConnectQueue';
 import { getAppUrl } from '../../../../helpers/getAppUrl';
 import { getHeadlampAPIHeaders } from '../../../../helpers/getHeadlampAPIHeaders';
 import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
@@ -97,7 +98,9 @@ export async function clusterFetch(url: string | URL, init: RequestInit & { clus
   const urlParts = init.cluster ? ['clusters', init.cluster, url] : [url];
 
   try {
-    const response = await backendFetch(makeUrl(urlParts), init);
+    const response = await withClusterConnectSlot(init.cluster, () =>
+      backendFetch(makeUrl(urlParts), init)
+    );
 
     return response;
   } catch (e) {


### PR DESCRIPTION
## Summary

Headlamp contacts several clusters at once on startup. For kubeconfig contexts
that use `exec:` credential plugins (kubelogin/oidc-login, gcloud, aws sso),
each contact makes the backend fork the plugin, which opens a browser **and**
binds a fixed localhost redirect port. Running several at once makes the port
binds collide, the browser posts the callback to the wrong plugin's server, and
every login fails.

This PR serializes the *first* request made to each cluster, so at most one
interactive credential plugin runs at a time. Steady-state traffic is
unaffected and stays fully parallel.

## Related Issue

Fixes #7593

## Changes

- Added `frontend/src/helpers/clusterConnectQueue.ts` — a small FIFO admission
  gate that queues only the first request per cluster. Once a cluster has
  answered once, its later requests return through a synchronous fast path with
  no added overhead.
- Wired it into `clusterRequest` (v1) and `clusterFetch` (v2). These are the
  only two places in the frontend that build a `/clusters/<name>/...` URL, so
  this covers the home view, the always-mounted notification bell, deep-linked
  multi-cluster URLs, `ProjectList` and API discovery.
- Moved the v1 `AbortController` timer inside the gate, so a queued request does
  not burn its timeout budget while waiting for another cluster.
- Added unit tests for the queue plus regression tests on both request paths.

No backend changes, no new dependencies, no configuration or settings.

## Steps to Test

1. Create a kubeconfig with two contexts whose `exec:` command is a script that
   appends `START <ts>` / `END <ts>` to a log file and sleeps a few seconds
   (standing in for an SSO helper that binds a fixed redirect port).
2. Make sure both clusters are in the recently-used list so the home view
   connects to them, then load Headlamp.
3. Inspect the log. Before this change the two `START` lines interleave; after
   it, each `START`/`END` pair is nested — the second plugin only runs once the
   first has finished.

## Screenshots (if applicable)

N/A — no visual change.

## Notes for the Reviewer

- **Why not fix this in the backend?** The plugin invocation is `cmd.Run()` in
  `backend/pkg/exec/exec.go`, guarded by `Authenticator.mu`. That mutex only
  serializes clusters whose exec config is byte-identical, because `cacheKey`
  hashes the whole `ExecConfig` — different clusters get different
  `Authenticator` instances and run concurrently. That granularity comes from
  upstream client-go, and Headlamp's vendored copy is only wired in on Windows
  (`kubeconfig.go`, `makeTransportFor`), so a gate there would be dead code on
  Linux/macOS unless the `GOOS` guard were dropped — and it would still miss
  `multiplexer.go`, which calls `rest.TLSConfigFor` directly. I opted for the
  smaller client-side change; happy to revisit if you'd prefer it in Go.
- **No timeout cap on the queue, deliberately.** `clusterFetch` has no request
  timeout, so a first contact that hangs will delay other clusters' first
  contact. Any cap short enough to help there would be shorter than a real
  interactive SSO login and would reintroduce the bug, so I left it out rather
  than guess at a value.
- **Websockets are not gated.** They never eagerly fork the plugin
  (`transport.TLSConfigFor` only installs a lazy `GetClientCertificate`
  callback), and they are opened after the gated HTTP request that supplies
  their `resourceVersion`.
- This builds on 007d953b7, which limited the home view to recently-used
  clusters. That reduced the fan-out but did not serialize it, so 2–3 plugins
  could still race.
- **Local test note:** 388 storyshots fail in my environment both with and
  without this change (MUI 5.18.0 resolved against the committed snapshots).
  Verified by running the suite on a clean `main` — identical 389/323/712
  counts. Unrelated to this PR.
