### PR TITLE
fix: decode Base64 secret values with js-base64 to support UTF-8 characters

### DIFF
--- a/frontend/src/components/common/Resource/EnvironmentVariables.test.ts
+++ b/frontend/src/components/common/Resource/EnvironmentVariables.test.ts
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Base64 } from 'js-base64';
+import { describe, expect, it, vi } from 'vitest';
+import { KubeContainer } from '../../../lib/k8s/cluster';
+import { KubePod } from '../../../lib/k8s/pod';
+
+const { MockKubeObject } = vi.hoisted(() => {
+  class MockKubeObject {
+    jsonData: any;
+    static kind = '';
+    constructor(data: any) {
+      this.jsonData = data;
+    }
+  }
+  return { MockKubeObject };
+});
+
+vi.mock('../../../lib/k8s/KubeObject', () => ({ KubeObject: MockKubeObject }));
+vi.mock('../../../lib/k8s/deployment', () => ({ default: class extends MockKubeObject {} }));
+vi.mock('../../../lib/k8s/replicaSet', () => ({ default: class extends MockKubeObject {} }));
+vi.mock('../../../lib/k8s/statefulSet', () => ({ default: class extends MockKubeObject {} }));
+vi.mock('../../../lib/k8s/daemonSet', () => ({ default: class extends MockKubeObject {} }));
+vi.mock('../../../lib/k8s/job', () => ({ default: class extends MockKubeObject {} }));
+vi.mock('../../../lib/k8s/pod', () => ({ default: class extends MockKubeObject {} }));
+
+import { buildEnvironmentVariables, extractEnvVarReferences } from './Resource';
+
+describe('buildEnvironmentVariables', () => {
+  const dummyPod = {
+    metadata: {
+      name: 'test-pod',
+      namespace: 'default',
+      creationTimestamp: '2025-01-01T00:00:00Z',
+    },
+  } as unknown as KubePod;
+
+  const dummyContainer: KubeContainer = {
+    name: 'test-container',
+    image: 'nginx',
+    imagePullPolicy: 'IfNotPresent',
+  };
+
+  it('correctly decodes secrets with multibyte UTF-8 data for secretKeyRef', () => {
+    const utf8SecretValue = 'pässwörd_🚀_日本語_العربية';
+    const base64Encoded = Base64.encode(utf8SecretValue);
+
+    const container: KubeContainer = {
+      ...dummyContainer,
+      env: [
+        {
+          name: 'UTF8_SECRET_KEY',
+          valueFrom: {
+            secretKeyRef: {
+              name: 'my-utf8-secret',
+              key: 'API_KEY',
+            },
+          },
+        },
+      ],
+    };
+
+    const references = extractEnvVarReferences(container);
+
+    const fetchedSecrets = new Map([
+      [
+        'my-utf8-secret',
+        {
+          resource: {
+            metadata: { creationTimestamp: '2025-01-01T00:00:00Z' },
+            data: {
+              API_KEY: base64Encoded,
+            },
+          } as any,
+          error: null,
+        },
+      ],
+    ]);
+
+    const fetchedConfigMaps = new Map();
+
+    const variables = buildEnvironmentVariables(
+      references,
+      fetchedSecrets,
+      fetchedConfigMaps,
+      dummyPod,
+      container,
+      '2025-01-01T00:00:00Z'
+    );
+
+    expect(variables).toHaveLength(1);
+    expect(variables[0]).toEqual({
+      key: 'UTF8_SECRET_KEY',
+      value: utf8SecretValue,
+      from: expect.anything(),
+      isError: false,
+      isSecret: true,
+      isOutOfSync: false,
+    });
+  });
+
+  it('correctly decodes secrets with multibyte UTF-8 data for secretRef (envFrom)', () => {
+    const utf8SecretValue1 = 'token_with_accent_éèà';
+    const utf8SecretValue2 = 'emoji_secret_🔑✨';
+
+    const container: KubeContainer = {
+      ...dummyContainer,
+      envFrom: [
+        {
+          secretRef: {
+            name: 'app-secrets',
+          },
+          prefix: 'APP_',
+        },
+      ],
+    };
+
+    const references = extractEnvVarReferences(container);
+
+    const fetchedSecrets = new Map([
+      [
+        'app-secrets',
+        {
+          resource: {
+            metadata: { creationTimestamp: '2025-01-01T00:00:00Z' },
+            data: {
+              SECRET_ONE: Base64.encode(utf8SecretValue1),
+              SECRET_TWO: Base64.encode(utf8SecretValue2),
+            },
+          } as any,
+          error: null,
+        },
+      ],
+    ]);
+
+    const fetchedConfigMaps = new Map();
+
+    const variables = buildEnvironmentVariables(
+      references,
+      fetchedSecrets,
+      fetchedConfigMaps,
+      dummyPod,
+      container,
+      '2025-01-01T00:00:00Z'
+    );
+
+    expect(variables).toHaveLength(2);
+    expect(variables.find(v => v.key === 'APP_SECRET_ONE')?.value).toBe(utf8SecretValue1);
+    expect(variables.find(v => v.key === 'APP_SECRET_TWO')?.value).toBe(utf8SecretValue2);
+  });
+});

--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -754,7 +754,7 @@ interface FetchedResource {
  * Extracts all environment variable references from a container spec.
  * This is a pure function with no hooks.
  */
-function extractEnvVarReferences(container: KubeContainer): EnvVarReference[] {
+export function extractEnvVarReferences(container: KubeContainer): EnvVarReference[] {
   const refs: EnvVarReference[] = [];
 
   // Process env variables
@@ -868,7 +868,7 @@ function ConfigMapFetcher(props: {
  * Builds environment variables from references and fetched resources.
  * This is a pure function with no hooks.
  */
-function buildEnvironmentVariables(
+export function buildEnvironmentVariables(
   references: EnvVarReference[],
   fetchedSecrets: Map<string, FetchedResource>,
   fetchedConfigMaps: Map<string, FetchedResource>,
@@ -912,7 +912,7 @@ function buildEnvironmentVariables(
           });
         } else if (secret) {
           const secretData = (secret as any).data || {};
-          const value = secretData[ref.key!] ? atob(secretData[ref.key!]) : '';
+          const value = secretData[ref.key!] ? Base64.decode(secretData[ref.key!]) : '';
           variables.set(ref.name, {
             value,
             from: secret,
@@ -971,7 +971,7 @@ function buildEnvironmentVariables(
           const outOfSync = isOutOfSync(secret.metadata?.creationTimestamp);
           Object.entries(secretData).forEach(([key, value]) => {
             variables.set(`${prefix}${key}`, {
-              value: atob(value as string),
+              value: value ? Base64.decode(value as string) : '',
               from: secret,
               isError: false,
               isSecret: true,


### PR DESCRIPTION
## Summary

Fixes a crash in the Pod/container environment variables panel when Secret values
contain non-ASCII characters, such as emojis, CJK, Arabic, or accented Latin characters.

The issue was caused by using the native browser `atob()` function to decode
Kubernetes Secret data. `atob()` decodes Base64 into a Latin-1 binary string
rather than interpreting the result as UTF-8, so any Secret value containing
multi-byte characters is either silently corrupted or causes a `DOMException`,
preventing the environment variables panel from rendering correctly.

This PR replaces both `atob()` calls in `buildEnvironmentVariables` with
`Base64.decode()` from the existing `js-base64` dependency, which correctly
decodes Base64-encoded UTF-8 values into proper JavaScript strings.

## Related Issue

Fixes #7596 

## Changes

* `frontend/src/components/common/Resource/Resource.tsx`

  * Replaced the `atob()` calls used when resolving:

    * `env[].valueFrom.secretKeyRef`
    * `envFrom[].secretRef`
  * Uses `Base64.decode()` to correctly decode UTF-8 Secret values.
  * Added a null guard for empty Secret values.
  * Exported `extractEnvVarReferences` and `buildEnvironmentVariables` to make them directly unit-testable.

* `frontend/src/components/common/Resource/EnvironmentVariables.test.ts`

  * Added unit tests covering multi-byte UTF-8 Secret values for:

    * `secretKeyRef`
    * `secretRef` / `envFrom`

## Steps to Test

1. Create a Kubernetes Secret containing non-ASCII characters:

   ```bash
   kubectl create secret generic utf8-test \
     --from-literal=API_KEY='pässwörd_🚀_日本語_العربية'
   ```

2. Create a Pod that references the Secret using either `secretKeyRef` or `envFrom.secretRef`.

3. In Headlamp, open the Pod details and view the container's **Environment Variables**.

4. Verify that the Secret value is displayed correctly.

### Before

The environment variables panel can fail to render or throw a `DOMException` when resolving a Secret value containing multi-byte UTF-8 characters.

### After

The Secret value is decoded and displayed correctly, including emojis, CJK, Arabic, and accented characters.

### Unit tests

Run:

```bash
cd frontend
npm test -- src/components/common/Resource/EnvironmentVariables.test.ts --run
```

Expected result:

```text
Test Files  1 passed (1)
Tests       2 passed (2)
```

## Notes for Reviewers

* `js-base64` is already a direct frontend dependency, so no new dependency is introduced.
* Only Kubernetes Secret decoding paths are changed. ConfigMap values are plain strings and are unaffected.
* Exporting `extractEnvVarReferences` and `buildEnvironmentVariables` is limited to enabling direct unit testing; no restructuring of the existing implementation is required.
