### PR TITLE
fix: show extended resources in node capacity and allocatable

### DIFF
--- a/frontend/src/components/node/Details.tsx
+++ b/frontend/src/components/node/Details.tsx
@@ -353,13 +353,10 @@ export default function NodeDetails(props: { name?: string; cluster?: string }) 
           if (!item) return [];
           const roles = item.getRoles();
           const nodePool = item.getNodePool();
-          // The keys of interest are reported by the API in kebab-case.
-          const reportedKeys = ['cpu', 'memory', 'pods', 'ephemeral-storage'];
-          const pickResources = (res: { [key: string]: string } = {}) =>
-            Object.fromEntries(reportedKeys.filter(key => res[key]).map(key => [key, res[key]]));
+          const pickResources = (res: { [key: string]: string } = {}) => res;
+
           const capacity = pickResources(item.status?.capacity);
           const allocatable = pickResources(item.status?.allocatable);
-
           return [
             {
               name: t('translation|Roles'),


### PR DESCRIPTION
**### Description**

Fixes #7244

**1.  What does this PR do?**

The Node Details page was only displaying a hardcoded set of resource keys (`cpu`, `memory`, `pods`, and `ephemeral-storage`) for Capacity and Allocatable resources.

This prevented Kubernetes extended resources such as GPUs and hugepages from being displayed.

This change updates `pickResources` to return all resources provided by the Kubernetes API, allowing extended resources to appear in the Node Details page.

**###2. Changes**

-  Removed the hardcoded `reportedKeys` list.

-  Updated `pickResources` to return all resource entries.

- This allows resources such as GPUs and hugepages to be displayed in Capacity and Allocatable.

**### 3.Testing**

- Ran the existing test suite.

- Verified the code changes with `git diff --check`.

- Pre-commit checks completed successfully.
