### PR TITLE
Remount plugin settings page when navigating between plugins

### DIFF
--- a/frontend/src/components/App/PluginSettings/PluginSettingsDetails.test.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettingsDetails.test.tsx
@@ -15,9 +15,13 @@
  */
 
 import { ThemeProvider } from '@mui/material/styles';
-import { render, waitFor } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { Provider } from 'react-redux';
+import { Route, Router } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
 import { createMuiTheme } from '../../../lib/themes';
+import { ConfigStore } from '../../../plugin/configStore';
 import { PluginInfo, setPluginSettings } from '../../../plugin/pluginsSlice';
 import { HeadlampEventType } from '../../../redux/headlampEventSlice';
 import store from '../../../redux/stores/store';
@@ -54,5 +58,52 @@ describe('PluginSettingsDetails events', () => {
         { type: HeadlampEventType.PLUGIN_DETAILS_VIEW, data: { plugin } },
       ]);
     });
+  });
+});
+
+describe('PluginSettingsDetails navigation between plugins', () => {
+  it('does not show the previous plugin data after navigating to another plugin', async () => {
+    const pluginA: PluginInfo = {
+      name: 'plugin-a',
+      description: 'Plugin A',
+      isEnabled: true,
+      isCompatible: true,
+      isLoaded: true,
+      type: 'user',
+      homepage: '',
+      displaySettingsComponentWithSaveButton: true,
+      settingsComponent: ({ data }) => <div data-testid="settings-value">{data?.greeting}</div>,
+    };
+    const pluginB: PluginInfo = {
+      ...pluginA,
+      name: 'plugin-b',
+      description: 'Plugin B',
+      settingsComponent: ({ data }) => <div data-testid="settings-value">{data?.greeting}</div>,
+    };
+
+    store.dispatch(setPluginSettings([pluginA, pluginB]));
+    new ConfigStore('plugin-a').set({ greeting: 'hello-a' });
+    new ConfigStore('plugin-b').set({ greeting: 'hello-b' });
+
+    const history = createMemoryHistory({ initialEntries: [`/settings/plugins/${pluginA.name}`] });
+    const { findByTestId } = render(
+      <Provider store={store}>
+        <ThemeProvider theme={theme}>
+          <Router history={history}>
+            <Route path="/settings/plugins/:name/:type?">
+              <PluginSettingsDetails />
+            </Route>
+          </Router>
+        </ThemeProvider>
+      </Provider>
+    );
+
+    expect(await findByTestId('settings-value')).toHaveTextContent('hello-a');
+
+    act(() => {
+      history.push(`/settings/plugins/${pluginB.name}`);
+    });
+
+    expect(await findByTestId('settings-value')).toHaveTextContent('hello-b');
   });
 });

--- a/frontend/src/components/App/PluginSettings/PluginSettingsDetails.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettingsDetails.tsx
@@ -122,7 +122,12 @@ export default function PluginSettingsDetails() {
     return <NotFoundComponent />;
   }
 
-  return <PluginSettingsDetailsInitializer plugin={plugin} />;
+  // Remount when navigating between different plugins' settings pages so
+  // PluginSettingsDetailsPure's internal data state doesn't carry over from
+  // the previously viewed plugin.
+  return (
+    <PluginSettingsDetailsInitializer key={plugin.name + (plugin.type || '')} plugin={plugin} />
+  );
 }
 
 const ScrollableBox = (props: BoxProps) => (


### PR DESCRIPTION
## Summary

This PR fixes a bug where navigating directly from one plugin's settings page to another's could leave the previous plugin's unsaved data on screen, and persist it over the new plugin's config on Save.

## Related Issue

Found by reading the code, not tied to an existing issue.

## Changes

- Fixed `PluginSettingsDetails` so it remounts when the viewed plugin changes, instead of reusing the same component instance with stale internal state
- Added a regression test covering navigation between two different plugins' settings pages

## Steps to Test

1. Install two plugins that each expose a settings component with a save button.
2. Open the first plugin's settings page and edit a field without saving.
3. Navigate directly to the second plugin's settings page (e.g. via browser back/forward between two previously visited settings URLs).
4. Observe the second plugin's settings show its own current config, not leftover data from the first plugin.

## Screenshots (if applicable)

Not applicable; behavior is only visible mid-navigation and is covered by the added test.

## Notes for the Reviewer

- `PluginSettingsDetailsPure` seeds its `data` state from the `config` prop with `useState`, which only runs once on mount. Without a remount, navigating between plugins re-renders the same instance with a new `config` but doesn't reset `data`.
- Fixed by keying `PluginSettingsDetailsInitializer` by the plugin's name and type in `PluginSettingsDetails`, so switching plugins forces React to remount it with fresh state.