### PR TITLE
fix: Ingress rules show http:// instead of https:// when a TLS entry covers multiple hosts

### DIFF
--- a/frontend/src/components/ingress/Details.test.tsx
+++ b/frontend/src/components/ingress/Details.test.tsx
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 import { TestContext } from '../../test';
 import IngressDetails from './Details';
+import { LinkStringFormat } from './Details';
 
 const { mockDetailsGrid } = vi.hoisted(() => ({
   mockDetailsGrid: vi.fn(),
@@ -179,5 +180,58 @@ describe('IngressDetails', () => {
     expect(sections).toHaveLength(1);
     expect(sections[0].id).toBe('headlamp.ingress-rules');
     expect(sections[0].section).toBeTruthy();
+  });
+
+  it('resolves https:// for all hosts when a TLS entry lists multiple hosts', () => {
+    const multiHostIngress: any = {
+      jsonData: {
+        spec: {
+          tls: [{ hosts: ['foo.example.com', 'bar.example.com'], secretName: 'tls-secret' }],
+        },
+      },
+      spec: {
+        tls: [{ hosts: ['foo.example.com', 'bar.example.com'], secretName: 'tls-secret' }],
+        rules: [
+          {
+            host: 'foo.example.com',
+            http: {
+              paths: [
+                {
+                  path: '/',
+                  pathType: 'Prefix',
+                  backend: { service: { name: 'svc', port: { number: 80 } } },
+                },
+              ],
+            },
+          },
+          {
+            host: 'bar.example.com',
+            http: {
+              paths: [
+                {
+                  path: '/',
+                  pathType: 'Prefix',
+                  backend: { service: { name: 'svc', port: { number: 80 } } },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    const { rerender } = render(
+      <TestContext routerMap={{ namespace: 'default', name: 'test-ingress' }}>
+        <LinkStringFormat url="foo.example.com" item={multiHostIngress} />
+      </TestContext>
+    );
+    expect(screen.getByRole('link').getAttribute('href')).toMatch(/^https:\/\//);
+
+    rerender(
+      <TestContext routerMap={{ namespace: 'default', name: 'test-ingress' }}>
+        <LinkStringFormat url="bar.example.com" item={multiHostIngress} />
+      </TestContext>
+    );
+    expect(screen.getByRole('link').getAttribute('href')).toMatch(/^https:\/\//);
   });
 });

--- a/frontend/src/components/ingress/Details.tsx
+++ b/frontend/src/components/ingress/Details.tsx
@@ -31,7 +31,7 @@ import SimpleTable from '../common/SimpleTable';
  * Is https used in the ingress item
  */
 function isHttpsUsed(item: Ingress, url: String) {
-  const hostList = item.jsonData.spec?.tls?.map(({ ...hosts }) => `${hosts.hosts}`) ?? [];
+  const hostList = item.jsonData.spec?.tls?.flatMap(entry => entry.hosts ?? []) ?? [];
   const isHttps = hostList.includes(`${url}`);
 
   return isHttps;


### PR DESCRIPTION
## Summary

Fixes a bug where Ingress rules displayed `http://` links for hostnames covered by TLS when multiple hostnames shared a single TLS entry.

The `isHttpsUsed` function in `frontend/src/components/ingress/Details.tsx` built the host list by mapping over TLS entries and coercing each entry's `hosts` array to a string using a template literal:

```ts
item.jsonData.spec?.tls?.map(({ ...hosts }) => `${hosts.hosts}`)
```

When a TLS entry contains multiple hosts, `hosts.hosts` is an array such as `['foo.example.com', 'bar.example.com']`. The template literal converts it to `"foo.example.com,bar.example.com"`, so `includes('foo.example.com')` never matches and both hosts fall back to `http://`.

Single-host TLS entries were unaffected because `['only.example.com']` stringifies to `"only.example.com"`, which happens to match.

The fix replaces `map` with `flatMap` so each hostname is kept as an individual element:

```ts
item.jsonData.spec?.tls?.flatMap(entry => entry.hosts ?? [])
```

## Related Issue

Fixes #7609

## Changes

* `frontend/src/components/ingress/Details.tsx`: replaced the `map` + template literal with `flatMap` in `isHttpsUsed` to correctly collect individual hostnames across TLS entries.
* `frontend/src/components/ingress/Details.test.tsx`: added a regression test verifying that both hosts in a multi-host TLS entry resolve to `https://` links.

## Steps to Test

1. Create an Ingress with two hosts under one TLS entry:

   ```yaml
   spec:
     tls:
       - hosts:
           - foo.example.com
           - bar.example.com
         secretName: my-tls-secret
     rules:
       - host: foo.example.com
         ...
       - host: bar.example.com
         ...
   ```
2. Open Headlamp → **Networking → Ingresses** → select the Ingress.
3. Check the Rules table.

**Before:** `foo.example.com` and `bar.example.com` are linked with `http://`.

**After:** Both are correctly linked with `https://`.

Alternatively, run the regression test directly:

```bash
cd frontend
npm test -- src/components/ingress/Details.test.tsx --run
```

Expected: `Test Files 1 passed (1), Tests 4 passed (4)`.

## Notes for Reviewers

* The change is a single-line fix in `isHttpsUsed`. No other behaviour is altered.
* TLS entries with a single host continue to work identically — the existing three tests confirm this.
