### PR TITLE
0077: app: Share development plugin profile

### DIFF
--- a/app/e2e-tests/playwright.electron.config.ts
+++ b/app/e2e-tests/playwright.electron.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
     'buildManifest.spec.ts',
     'buildManifestProduct.spec.ts',
     'clusterRename.spec.ts',
+    'configDirectories.spec.ts',
     'namespaces.spec.ts',
     'clusterAutoConnect.spec.ts',
     'externalBackendToken.spec.ts',

--- a/app/e2e-tests/tests/configDirectories.spec.ts
+++ b/app/e2e-tests/tests/configDirectories.spec.ts
@@ -17,6 +17,7 @@
 import { expect, test } from '@playwright/test';
 import findProcess from 'find-process';
 import fs from 'fs';
+import net from 'net';
 import os from 'os';
 import path from 'path';
 import { _electron } from 'playwright';
@@ -25,10 +26,28 @@ const electronExecutable = process.platform === 'win32' ? 'electron.cmd' : 'elec
 const electronPath = path.resolve(__dirname, `../../node_modules/.bin/${electronExecutable}`);
 const appPath = path.resolve(__dirname, '../../');
 
-test('passes app-specific storage directories to the backend', async () => {
-  test.skip(process.env.PLAYWRIGHT_TEST_MODE !== 'app', 'Requires Electron app mode');
-
+test('uses Headlamp development config directories for branded products', async () => {
   const configHome = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-e2e-config-'));
+  // Give Electron a branded identity while verifying that development still uses Headlamp paths.
+  const manifestFile = path.join(configHome, 'app-build-manifest.json');
+  fs.writeFileSync(
+    manifestFile,
+    JSON.stringify({ product: { name: 'example-desktop', productName: 'Example Desktop' } })
+  );
+  const backendPort = await new Promise<number>((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    // Restrict the temporary listener to local IPv4 instead of exposing it on external interfaces.
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close();
+        reject(new Error('Failed to reserve an Electron backend port'));
+        return;
+      }
+      server.close(error => (error ? reject(error) : resolve(address.port)));
+    });
+  });
   const appName = 'Headlamp';
   const configBase =
     process.platform === 'darwin'
@@ -44,11 +63,12 @@ test('passes app-specific storage directories to the backend', async () => {
   const electronApp = await _electron.launch({
     cwd: appPath,
     executablePath: electronPath,
-    args: ['.'],
+    args: ['.', `--port=${backendPort}`],
     env: {
       ...process.env,
       APPDATA: configHome,
       ELECTRON_DEV: 'true',
+      HEADLAMP_BUILD_MANIFEST: manifestFile,
       HOME: configHome,
       LOCALAPPDATA: configHome,
       XDG_CONFIG_HOME: configHome,

--- a/app/electron/bootstrap.test.ts
+++ b/app/electron/bootstrap.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+
+const initializationOrder = vi.hoisted(() => [] as string[]);
+
+vi.mock('./runtimeProductIdentity', () => {
+  initializationOrder.push('runtimeProductIdentity');
+  return {};
+});
+
+vi.mock('./main', () => {
+  initializationOrder.push('main');
+  return {};
+});
+
+await import('./bootstrap');
+
+describe('Electron bootstrap', () => {
+  it('applies runtime product identity before loading the main process', () => {
+    expect(initializationOrder).toEqual(['runtimeProductIdentity', 'main']);
+  });
+
+  it('is the Electron main-process build entry', () => {
+    const buildScript = fs.readFileSync(
+      new URL('../scripts/build-electron.js', import.meta.url),
+      'utf8'
+    );
+
+    expect(buildScript).toContain(
+      "entryPoints: [path.resolve(__dirname, '../electron/bootstrap.ts')]"
+    );
+  });
+});

--- a/app/electron/bootstrap.ts
+++ b/app/electron/bootstrap.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import './runtimeProductIdentity';
+import './main';

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import './runtimeProductIdentity';
 import { ChildProcessWithoutNullStreams, execFileSync, spawn } from 'child_process';
 import dotenv from 'dotenv';
 import {
@@ -75,6 +74,7 @@ import {
   runScript,
   setupRunCmdHandlers,
 } from './runCmd';
+import { pluginConfigDirName } from './runtimeProductIdentity';
 import { isTrustedDocumentUrl, setupSecureStorageHandlers } from './secureStorage';
 import { loadSettings, SETTINGS_PATH } from './settings';
 import { getShellEnv } from './shellEnv';
@@ -95,11 +95,13 @@ import {
   saveZoomFactor,
 } from './zoom';
 
+const isDev = !!process.env.ELECTRON_DEV;
+
 if (process.env.APPIMAGE) {
   app.commandLine.appendSwitch('disable-setuid-sandbox');
 }
 
-setAppConfigDirName(app.getName());
+setAppConfigDirName(pluginConfigDirName(app.getName(), isDev));
 
 // On Linux, force the GTK 3 backend. Electron 36+ defaults to GTK 4, which
 // conflicts with GTK 2/3 symbols pulled into the process by IM modules and
@@ -123,7 +125,6 @@ dotenv.config({ path: path.join(process.resourcesPath, '.env') });
 const settings = loadSettings(SETTINGS_PATH);
 const ensureCertificates = createCertificateSetup(settings);
 
-const isDev = !!process.env.ELECTRON_DEV;
 let frontendPath = '';
 
 if (isDev) {

--- a/app/electron/runtimeProductIdentity.test.ts
+++ b/app/electron/runtimeProductIdentity.test.ts
@@ -30,10 +30,21 @@ vi.mock('electron', () => ({ app: runtimeApp }));
 
 import {
   applyRuntimeProductIdentity,
+  pluginConfigDirName,
   resolveRuntimeBuildManifestPath,
 } from './runtimeProductIdentity';
 
 const defaultUserDataPath = path.join('Users', 'test', 'AppData', 'Headlamp');
+
+describe('pluginConfigDirName', () => {
+  it('shares the Headlamp plugin profile with development tooling', () => {
+    expect(pluginConfigDirName('AKS Desktop', true)).toBe('Headlamp');
+  });
+
+  it('uses the branded plugin profile in packaged applications', () => {
+    expect(pluginConfigDirName('AKS Desktop', false)).toBe('AKS Desktop');
+  });
+});
 
 describe('applyRuntimeProductIdentity', () => {
   beforeEach(() => {

--- a/app/electron/runtimeProductIdentity.ts
+++ b/app/electron/runtimeProductIdentity.ts
@@ -57,6 +57,17 @@ export function resolveRuntimeBuildManifestPath(
 }
 
 /**
+ * Selects the plugin profile shared with the backend and plugin development tooling.
+ *
+ * @param appName Electron application name used for packaged plugin storage.
+ * @param isDevelopment Whether Electron is running in development mode.
+ * @returns The Headlamp development profile or the packaged application name.
+ */
+export function pluginConfigDirName(appName: string, isDevelopment: boolean): string {
+  return isDevelopment ? 'Headlamp' : appName;
+}
+
+/**
  * Applies the product manifest's display name before storage paths are resolved.
  *
  * @param runtimeApp Electron application whose runtime identity should be updated.

--- a/app/scripts/build-electron.js
+++ b/app/scripts/build-electron.js
@@ -49,7 +49,7 @@ const commonOptions = {
 
 const entryPoints = [
   {
-    entryPoints: [path.resolve(__dirname, '../electron/main.ts')],
+    entryPoints: [path.resolve(__dirname, '../electron/bootstrap.ts')],
     outfile: path.resolve(__dirname, '../build/main.js'),
     plugins: [mcpAdapterExternalPlugin, lazyDependenciesExternalPlugin],
   },


### PR DESCRIPTION
## Summary

Branded development builds change Electron's runtime name, but Headlamp's
backend and plugin tooling still use the `Headlamp` config directory. Using the
branded name for plugin configuration during development creates a separate,
empty profile, so locally installed plugins and kubeconfigs appear to disappear.

Use the shared `Headlamp` plugin profile in development so branded builds work
with the same plugins, user configuration, and kubeconfigs as the surrounding
tooling. Packaged applications continue using isolated profiles under their
branded product names, preserving the expected separation between products.

## Stack status

Patch 0077 depends on the runtime product identity introduced by patch 0075,
which merged in 
- https://github.com/kubernetes-sigs/headlamp/pull/7615.

This branch is rebased onto the current `main` and contains only the two
0077-specific commits.

## Improvements over the existing changes

- Activates the existing config-directory Electron spec and runs it with a
  branded manifest. This verifies the backend receives shared development paths,
  rather than testing the path selector only in isolation.
- Reserves an available backend port in the E2E test so concurrent Headlamp
  worktrees do not cause unrelated port collisions.
- Documents the new exported helper, parameters, and return value with TSDoc.
- Covers all branches in `runtimeProductIdentity.ts`; measured branch coverage
  is 100%, above the requested 80% minimum.
- Uses platform-native path expectations so the runtime identity unit test also
  passes on Windows.

## Provenance

- Original Azure PR:
  https://github.com/Azure/aks-desktop/pull/823
- Azure commit that first carried patch 0077:
  https://github.com/Azure/aks-desktop/pull/823/commits/b3b5fa1d18a13ae96aa0885605e6d7498816edc2
- Original Headlamp patch commit: `3f8b23494064e8f896e59283e72f99dc2540d452`,
  authored by Rene Dudfield on 2026-09-03. The upstreamed implementation commit
  preserves the original author and author date.

No earlier Azure/aks-desktop PR with equivalent development-profile behavior was
found; PR 823 is the original change.

## Testing

- `npm --prefix app test -- electron/runtimeProductIdentity.test.ts`
  - 8 tests passed
  - 100% statements, branches, functions, and lines
- `npm --prefix app test`
  - 30 test files and 588 tests passed
- `npm --prefix app/e2e-tests run test-app -- tests/configDirectories.spec.ts`
  - 1 Electron E2E test passed, 0 skipped
- `npm --prefix app run tsc`
- `npm --prefix app run lint`
- `npm --prefix app run compile-electron`

## Screenshots

Not applicable. This changes runtime storage-directory selection and has no
visual difference.

Assisted by copilot