### PR TITLE
0075: app: Apply runtime product identity

### DIFF
--- a/app/e2e-tests/playwright.electron.config.ts
+++ b/app/e2e-tests/playwright.electron.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
     'updateChecks.spec.ts',
     'oauthProvider.spec.ts',
     'protocolScheme.spec.ts',
+    'runtimeProductIdentity.spec.ts',
   ],
   timeout: 60 * 1000,
   expect: {

--- a/app/e2e-tests/tests/runtimeProductIdentity.spec.ts
+++ b/app/e2e-tests/tests/runtimeProductIdentity.spec.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import { buildSync } from 'esbuild';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { _electron } from 'playwright';
+
+const appPath = path.resolve(__dirname, '../..');
+const electronExecutable = process.platform === 'win32' ? 'electron.cmd' : 'electron';
+const electronPath = path.resolve(appPath, `node_modules/.bin/${electronExecutable}`);
+
+test('uses product identity while preserving custom Electron storage', async () => {
+  const configHome = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-product-e2e-')),
+  );
+  const manifestFile = path.join(configHome, 'app-build-manifest.json');
+  const customUserData = path.join(configHome, 'custom-profile');
+  const runtimeEntry = path.join(configHome, 'runtime-product-identity.mjs');
+  fs.writeFileSync(
+    manifestFile,
+    JSON.stringify({ product: { name: 'example-desktop', productName: 'Example Desktop' } }),
+  );
+  buildSync({
+    bundle: true,
+    entryPoints: [path.join(appPath, 'electron/runtimeProductIdentity.ts')],
+    external: ['electron'],
+    format: 'esm',
+    outfile: runtimeEntry,
+    platform: 'node',
+  });
+
+  const electronApp = await _electron.launch({
+    cwd: configHome,
+    executablePath: electronPath,
+    args: [runtimeEntry, `--user-data-dir=${customUserData}`],
+    env: { ...process.env, HEADLAMP_BUILD_MANIFEST: manifestFile },
+  });
+
+  try {
+    const runtimeIdentity = await electronApp.evaluate(({ app }) => ({
+      name: app.getName(),
+      userData: app.getPath('userData'),
+    }));
+    expect(runtimeIdentity).toEqual({
+      name: 'Example Desktop',
+      userData: customUserData,
+    });
+  } finally {
+    await electronApp.close();
+    fs.rmSync(configHome, { force: true, recursive: true });
+  }
+});

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import './runtimeProductIdentity';
 import { ChildProcessWithoutNullStreams, execFileSync, spawn } from 'child_process';
 import { randomBytes } from 'crypto';
 import dotenv from 'dotenv';

--- a/app/electron/runtimeProductIdentity.test.ts
+++ b/app/electron/runtimeProductIdentity.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runtimeApp = vi.hoisted(() => ({
+  commandLine: { hasSwitch: vi.fn(() => false) },
+  getName: vi.fn(() => 'Headlamp'),
+  getPath: vi.fn(() => ''),
+  isPackaged: false,
+  setName: vi.fn(),
+  setPath: vi.fn(),
+}));
+
+vi.mock('electron', () => ({ app: runtimeApp }));
+
+import {
+  applyRuntimeProductIdentity,
+  resolveRuntimeBuildManifestPath,
+} from './runtimeProductIdentity';
+
+const defaultUserDataPath = path.join('Users', 'test', 'AppData', 'Headlamp');
+
+describe('applyRuntimeProductIdentity', () => {
+  beforeEach(() => {
+    runtimeApp.commandLine.hasSwitch.mockReturnValue(false);
+    runtimeApp.getName.mockReturnValue('Headlamp');
+    runtimeApp.getPath.mockReturnValue(defaultUserDataPath);
+    runtimeApp.commandLine.hasSwitch.mockClear();
+    runtimeApp.getName.mockClear();
+    runtimeApp.getPath.mockClear();
+    runtimeApp.setName.mockClear();
+    runtimeApp.setPath.mockClear();
+  });
+
+  it('uses the product display name for the Electron runtime', () => {
+    expect(
+      applyRuntimeProductIdentity(runtimeApp, {
+        product: { name: 'example-desktop', productName: 'Example Desktop' },
+      })
+    ).toBe('Example Desktop');
+    expect(runtimeApp.setName).toHaveBeenCalledWith('Example Desktop');
+    expect(runtimeApp.setPath).toHaveBeenCalledWith(
+      'userData',
+      path.join('Users', 'test', 'AppData', 'Example Desktop')
+    );
+  });
+
+  it('preserves the package name when product metadata is absent', () => {
+    expect(applyRuntimeProductIdentity(runtimeApp, {})).toBe('Headlamp');
+    expect(runtimeApp.setName).not.toHaveBeenCalled();
+    expect(runtimeApp.setPath).not.toHaveBeenCalled();
+  });
+
+  it('preserves an explicitly customized user data path', () => {
+    runtimeApp.getPath.mockReturnValue('/tmp/custom-profile');
+
+    expect(
+      applyRuntimeProductIdentity(runtimeApp, { product: { productName: 'Example Desktop' } })
+    ).toBe('Example Desktop');
+    expect(runtimeApp.setName).toHaveBeenCalledWith('Example Desktop');
+    expect(runtimeApp.setPath).not.toHaveBeenCalled();
+  });
+
+  it('preserves an explicit user data path with the package name', () => {
+    runtimeApp.commandLine.hasSwitch.mockReturnValue(true);
+
+    applyRuntimeProductIdentity(runtimeApp, {
+      product: { productName: 'Example Desktop' },
+    });
+
+    expect(runtimeApp.setPath).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveRuntimeBuildManifestPath', () => {
+  it('uses an explicitly selected development manifest', () => {
+    expect(
+      resolveRuntimeBuildManifestPath(
+        runtimeApp,
+        { HEADLAMP_BUILD_MANIFEST: './product/manifest.json' },
+        path.join('workspace', 'app'),
+        path.join('packaged', 'resources')
+      )
+    ).toBe(path.resolve('workspace', 'app', 'product', 'manifest.json'));
+  });
+
+  it('uses the packaged resources manifest instead of a development override', () => {
+    runtimeApp.isPackaged = true;
+
+    expect(
+      resolveRuntimeBuildManifestPath(
+        runtimeApp,
+        { HEADLAMP_BUILD_MANIFEST: './product/manifest.json' },
+        path.join('workspace', 'app'),
+        path.join('packaged', 'resources')
+      )
+    ).toBe(path.join('packaged', 'resources', 'app-build-manifest.json'));
+
+    runtimeApp.isPackaged = false;
+  });
+});

--- a/app/electron/runtimeProductIdentity.ts
+++ b/app/electron/runtimeProductIdentity.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { app } from 'electron';
+import fs from 'node:fs';
+import path from 'node:path';
+import { readProductMetadata } from '../scripts/product-metadata';
+
+/** Electron application methods needed to apply runtime product identity. */
+type RuntimeAppIdentity = Pick<
+  Electron.App,
+  'getName' | 'getPath' | 'isPackaged' | 'setName' | 'setPath'
+> & {
+  commandLine: Pick<Electron.CommandLine, 'hasSwitch'>;
+};
+
+type RuntimeManifestEnvironment = {
+  HEADLAMP_BUILD_MANIFEST?: string;
+};
+
+/**
+ * Resolves the build manifest available to the Electron runtime.
+ *
+ * @param runtimeApp Electron application whose packaging state selects the default path.
+ * @param env Environment variables used to select an external development manifest.
+ * @param cwd Directory used to resolve a relative development manifest path.
+ * @param resourcesPath Electron's packaged resource directory.
+ * @returns The selected development manifest or packaged resource manifest path.
+ */
+export function resolveRuntimeBuildManifestPath(
+  runtimeApp: Pick<RuntimeAppIdentity, 'isPackaged'>,
+  env: RuntimeManifestEnvironment = {
+    HEADLAMP_BUILD_MANIFEST: process.env.HEADLAMP_BUILD_MANIFEST,
+  },
+  cwd: string = process.cwd(),
+  resourcesPath: string = process.resourcesPath
+): string {
+  if (!runtimeApp.isPackaged && env.HEADLAMP_BUILD_MANIFEST) {
+    return path.resolve(cwd, env.HEADLAMP_BUILD_MANIFEST);
+  }
+  return runtimeApp.isPackaged
+    ? path.join(resourcesPath, 'app-build-manifest.json')
+    : path.resolve(cwd, 'app-build-manifest.json');
+}
+
+/**
+ * Applies the product manifest's display name before storage paths are resolved.
+ *
+ * @param runtimeApp Electron application whose runtime identity should be updated.
+ * @param manifest Build manifest containing optional product metadata.
+ * @returns The configured product name, or the existing Electron application name.
+ */
+export function applyRuntimeProductIdentity(
+  runtimeApp: RuntimeAppIdentity,
+  manifest: unknown
+): string {
+  const { productName } = readProductMetadata(manifest) ?? {};
+  if (productName) {
+    const packageName = runtimeApp.getName();
+    const userDataPath = runtimeApp.getPath('userData');
+    runtimeApp.setName(productName);
+    if (
+      !runtimeApp.commandLine.hasSwitch('user-data-dir') &&
+      path.basename(userDataPath) === packageName
+    ) {
+      runtimeApp.setPath('userData', path.join(path.dirname(userDataPath), productName));
+    }
+    return productName;
+  }
+  return runtimeApp.getName();
+}
+
+const manifestPath = resolveRuntimeBuildManifestPath(app);
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as unknown;
+applyRuntimeProductIdentity(app, manifest);

--- a/app/scripts/build-manifest.ts
+++ b/app/scripts/build-manifest.ts
@@ -18,6 +18,10 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { ProductMetadata } from './product-metadata.ts';
+import { readProductMetadata } from './product-metadata.ts';
+
+export { readProductMetadata } from './product-metadata.ts';
 
 type ManifestEnvironment = {
   [key: string]: string | undefined;
@@ -80,15 +84,6 @@ type BuildVerification = {
 
   /** Expected hexadecimal SHA-256 digest. */
   sha256: string;
-};
-
-type ProductMetadata = {
-  name?: string;
-  productName?: string;
-  version?: string;
-  appId?: string;
-  artifactName?: string;
-  protocols?: Record<string, unknown>;
 };
 
 /**
@@ -312,49 +307,10 @@ export function validateBuildManifest(value: unknown): BuildManifest {
  * @throws When the manifest or product metadata is malformed.
  */
 export function applyProductMetadata<T extends object>(config: T, manifest: unknown): T {
-  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
-    throw new Error('Build manifest must be an object');
-  }
-
-  const product = (manifest as BuildManifest).product;
-  if (product === undefined) {
+  const metadata = readProductMetadata(manifest);
+  if (metadata === undefined) {
     return config;
   }
-  if (!product || typeof product !== 'object' || Array.isArray(product)) {
-    throw new Error('Build manifest product must be an object');
-  }
-
-  const scalarFields = ['name', 'productName', 'version', 'appId', 'artifactName'] as const;
-  for (const field of scalarFields) {
-    if (product[field] !== undefined && typeof product[field] !== 'string') {
-      throw new Error(`Build manifest product.${field} must be a string`);
-    }
-  }
-  if (
-    product.protocols !== undefined &&
-    (!product.protocols ||
-      typeof product.protocols !== 'object' ||
-      Array.isArray(product.protocols))
-  ) {
-    throw new Error('Build manifest product.protocols must be an object');
-  }
-  if (product.protocols !== undefined) {
-    // The app reads this same field at runtime to decide which deep links to
-    // accept, so an unusable value would silently fall back to the Headlamp
-    // scheme while the installer registers something else.
-    const schemes = (product.protocols as Record<string, unknown>).schemes;
-    if (
-      !Array.isArray(schemes) ||
-      schemes.length === 0 ||
-      schemes.some(scheme => typeof scheme !== 'string' || scheme === '')
-    ) {
-      throw new Error(
-        'Build manifest product.protocols.schemes must be a non-empty array of strings'
-      );
-    }
-  }
-
-  const metadata = product as ProductMetadata;
   const configRecord = config as Record<string, unknown>;
 
   const currentExtraMetadata =

--- a/app/scripts/product-metadata.ts
+++ b/app/scripts/product-metadata.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Product identity fields consumed by Electron Builder and the app runtime. */
+export type ProductMetadata = {
+  name?: string;
+  productName?: string;
+  version?: string;
+  appId?: string;
+  artifactName?: string;
+  protocols?: Record<string, unknown>;
+};
+
+/**
+ * Reads and validates product metadata without depending on build-time paths.
+ *
+ * @param manifest Parsed application build manifest.
+ * @returns Validated product metadata, or undefined when it is not configured.
+ * @throws When the manifest or product metadata is malformed.
+ */
+export function readProductMetadata(manifest: unknown): ProductMetadata | undefined {
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+    throw new Error('Build manifest must be an object');
+  }
+
+  const product = (manifest as { product?: unknown }).product;
+  if (product === undefined) {
+    return undefined;
+  }
+  if (!product || typeof product !== 'object' || Array.isArray(product)) {
+    throw new Error('Build manifest product must be an object');
+  }
+
+  const metadata = product as ProductMetadata;
+  const scalarFields = ['name', 'productName', 'version', 'appId', 'artifactName'] as const;
+  for (const field of scalarFields) {
+    if (metadata[field] !== undefined && typeof metadata[field] !== 'string') {
+      throw new Error(`Build manifest product.${field} must be a string`);
+    }
+  }
+  if (
+    metadata.protocols !== undefined &&
+    (!metadata.protocols ||
+      typeof metadata.protocols !== 'object' ||
+      Array.isArray(metadata.protocols))
+  ) {
+    throw new Error('Build manifest product.protocols must be an object');
+  }
+  if (metadata.protocols !== undefined) {
+    const schemes = metadata.protocols.schemes;
+    if (
+      !Array.isArray(schemes) ||
+      schemes.length === 0 ||
+      schemes.some(scheme => typeof scheme !== 'string' || scheme === '')
+    ) {
+      throw new Error(
+        'Build manifest product.protocols.schemes must be a non-empty array of strings'
+      );
+    }
+  }
+
+  return metadata;
+}


### PR DESCRIPTION
## Summary

Apply the product manifest's display name to the Electron runtime before
storage-dependent modules load. Branded development builds then use their own
default profile directory instead of sharing Headlamp's profile.

## Source

- Original patch series PR: https://github.com/Azure/aks-desktop/pull/823
- AKS Desktop patch-introduction commit:
  https://github.com/Azure/aks-desktop/commit/e524330122ef6299a4ab932193a53945552b7ae3
- Product manifest foundation: https://github.com/kubernetes-sigs/headlamp/pull/6831

## Changes

- Apply the manifest product name before the Electron main module initializes.
- Share product metadata validation between build configuration and runtime
  identity without importing build-only path resolution into Electron startup.
- Rename the default `userData` path while preserving explicitly customized
  profile paths.
- Add focused unit coverage and a real-Electron end-to-end test.

## Improvements over the existing changes

- Put the unit and end-to-end coverage in commits before the implementation so
  reviewers can see the missing behavior independently from the fix.
- Cover every runtime identity branch, including absent metadata and custom
  profile paths, because branding must not override an explicit storage choice.
- Exercise manifest loading and Electron's runtime API in a focused end-to-end
  test, avoiding unrelated backend and renderer startup work.
- Document the runtime identity contract and function inputs and output with
  TSDoc so the early-startup ordering requirement remains visible.
- Resolve the same manifest into two process-specific consumers: the frontend
  receives `REACT_APP_HEADLAMP_PRODUCT_NAME` through `make-env.js`, while the
  Electron main process applies the name before frontend code can run.

## Validation

- Runtime identity unit coverage: 100% statements, branches, functions, and
  lines across 6 cases (80% branch threshold enforced).
- Product metadata and runtime identity tests: 173 passed.
- App unit tests: 30 files and 583 tests passed.
- Electron end-to-end test: 1 test passed.
- App TypeScript check passed.
- App lint, formatting, and Electron compilation passed.

## Screenshots

Not applicable. This changes Electron startup identity and storage paths without
changing visible UI.

Assisted by copilot.