### PR TITLE
0073: app: package: Approve Electron install script

### DIFF
--- a/app/electron/package.test.ts
+++ b/app/electron/package.test.ts
@@ -30,6 +30,10 @@ const packageJson = JSON.parse(
       executableName?: string;
     };
   };
+  /** Dependency lifecycle scripts explicitly approved by npm. */
+  allowScripts?: Record<string, boolean>;
+  /** Desktop build dependencies keyed by package name. */
+  devDependencies: Record<string, string>;
   optionalDependencies: Record<string, string>;
 };
 const require = createRequire(import.meta.url);
@@ -38,6 +42,28 @@ const { expandMsiArtifactName } = require('../windows/msi/artifact-name.js') as 
 };
 
 describe('desktop package configuration', () => {
+  it('allows only the Electron install script', () => {
+    const packageLock = JSON.parse(
+      fs.readFileSync(new URL('../package-lock.json', import.meta.url), 'utf8')
+    );
+    const lockedElectron = packageLock.packages['node_modules/electron'];
+
+    expect(packageJson.allowScripts).toEqual({ electron: true });
+    expect(lockedElectron.hasInstallScript).toBe(true);
+    expect(packageJson.devDependencies.electron).toBe(`^${lockedElectron.version}`);
+  });
+
+  it('has the Electron binary installed by its approved script', () => {
+    const electronDirectory = new URL('../node_modules/electron/', import.meta.url);
+    const electronPackage = JSON.parse(
+      fs.readFileSync(new URL('package.json', electronDirectory), 'utf8')
+    );
+    const executablePath = fs.readFileSync(new URL('path.txt', electronDirectory), 'utf8').trim();
+
+    expect(electronPackage.scripts.postinstall).toBe('node install.js');
+    expect(fs.existsSync(new URL(`dist/${executablePath}`, electronDirectory))).toBe(true);
+  });
+
   it('uses the product name for artifact filenames', () => {
     expect(packageJson.build.artifactName).toBe('${productName}-${version}-${os}-${arch}.${ext}');
   });

--- a/app/package.json
+++ b/app/package.json
@@ -9,6 +9,9 @@
     "npm": ">=11.0.0",
     "node": ">=22.6.0"
   },
+  "allowScripts": {
+    "electron": true
+  },
   "scripts": {
     "build": "npm run copy-icons && npm run copy-plugins && npm run compile-electron && electron-builder --config electron-builder.config.ts --dir --publish never",
     "compile-electron": "node scripts/build-electron.js",


### PR DESCRIPTION
## Summary

With npm 12, dependency lifecycle scripts are blocked unless the nearest package
manifest explicitly approves them. That causes a fresh Headlamp app install to
skip Electron's postinstall, leaving the desktop runtime unavailable for local
development and application builds.

Approve only Electron's install script so fresh installs reliably download the
required runtime. Keeping the allowlist limited to Electron preserves npm's
deny-by-default protection for every unrelated dependency script.

Add package tests before the manifest change to guard the exact allowlist, tie
the declared Electron range to the locked version, and verify that dependency
installation produced Electron's `path.txt` marker and referenced executable.

## Original change and related work

- Original AKS Desktop PR: https://github.com/Azure/aks-desktop/pull/823
- AKS Desktop carrier commit: https://github.com/Azure/aks-desktop/commit/e524330122ef6299a4ab932193a53945552b7ae3
- Original embedded Headlamp commit: `8603e2f62ff714b41d45edd29384f0579df919e1`

PR 823 is the only related Azure/aks-desktop PR found for patch 0073. The
upstream change preserves the original author and author date.

## Improvements over the existing changes

- Adds the tests before the original patch so the policy regression is visible
  independently from its implementation.
- Checks the allowlist is exactly `{ "electron": true }`, preventing accidental
  approval of unrelated dependency scripts.
- Derives the expected Electron range from the lockfile instead of hard-coding a
  version, so dependency updates must keep the manifest and lockfile aligned.
- Verifies Electron's real postinstall artifact and executable. This matters
  because checking only the manifest shape would not prove the desktop runtime
  was installed.

## Test coverage

- `npm test -- electron/package.test.ts`
- Focused Istanbul run with `--coverage.thresholds.branches=80` passes and
  reports 100% branches for the executable package helper covered by the suite.
  The changed `package.json` policy is declarative and has no instrumentable
  branches.
- `npm run app:tsc`
- `npm run app:lint`
- A clean offline `npm@12.0.1 ci` verified Electron's `path.txt` and executable.
  npm also confirmed that four unrelated dependency install scripts remained
  blocked.

The package test runs after app dependency installation in the existing app CI,
providing the relevant install-level end-to-end check. A browser or Electron UI
e2e test would not exercise npm's install-time policy.

## Screenshots

Not applicable. This changes dependency installation policy and has no visual
or runtime UI difference.

Assisted by copilot
