### PR TITLE
helm: list one entry per chart, not per chart version

### DIFF
--- a/backend/pkg/helm/charts.go
+++ b/backend/pkg/helm/charts.go
@@ -63,7 +63,7 @@ func listCharts(filter string, settings *cli.EnvSettings) ([]chartInfo, error) {
 			return nil, err
 		}
 
-		index.AddRepo(name, indexFile, true)
+		index.AddRepo(name, indexFile, false)
 
 		for _, chart := range index.All() {
 			if filter != "" {

--- a/backend/pkg/helm/charts_test.go
+++ b/backend/pkg/helm/charts_test.go
@@ -18,6 +18,7 @@ package helm_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -68,6 +69,40 @@ func TestListChart(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Contains(t, rr.Body.String(), "headlamp_test_repo/headlamp")
 	assert.NotContains(t, rr.Body.String(), "non-existing-chart")
+}
+
+func TestListChartReturnsOneEntryPerChart(t *testing.T) {
+	cache := cache.New[interface{}]()
+	require.NotNil(t, cache)
+
+	helmHandler, err := helm.NewHandlerWithSettings(cache, settings)
+	require.NoError(t, err)
+
+	testAddRepo(t, helmHandler, "headlamp_test_repo", "https://kubernetes-sigs.github.io/headlamp/")
+
+	listChartsRequest, err := http.NewRequestWithContext(context.Background(),
+		"GET", "/clusters/minikube/helm/repositories/charts?filter=headlamp", nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+
+	helmHandler.ListCharts(rr, listChartsRequest)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var listChartsResponse helm.ListAllChartsResponse
+
+	err = json.Unmarshal(rr.Body.Bytes(), &listChartsResponse)
+	require.NoError(t, err)
+
+	seen := map[string]int{}
+	for _, chart := range listChartsResponse.Charts {
+		seen[chart.Name]++
+	}
+
+	// The repository publishes many historical versions of the "headlamp" chart.
+	// Listing charts should return one entry per chart name, not one per version.
+	assert.Equal(t, 1, seen["headlamp_test_repo/headlamp"])
 }
 
 func TestListChartReturnsErrorWithoutSuccessPayload(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR fixes ListCharts returning one row per historical chart version instead of one row per chart.

## Related Issue

Found by reading the code, not tied to an existing issue.

## Changes

- Fixed `listCharts` to build its search index with `all: false`, so only the latest version of each chart is indexed
- Added a test asserting exactly one entry per chart name against a real repository with multiple published versions

## Steps to Test

1. Add a Helm repository that has published multiple versions of at least one chart (the existing tests use `https://kubernetes-sigs.github.io/headlamp/`, whose `headlamp` chart has many releases).
2. Call `GET /clusters/{cluster}/helm/repositories/charts`.
3. Before this fix, the response contains one entry per published version of the chart. After this fix, it contains exactly one entry per chart name.

## Screenshots (if applicable)

Not applicable; this is a backend API response, not a UI change.

## Notes for the Reviewer

- `index.AddRepo(name, indexFile, true)` passes Helm's own `all: true`, which indexes every version of every chart (confirmed by reading the vendored `helm.sh/helm/v3` search package). Changed to `false` so the index keeps only the newest version per chart, matching what `ListAllChartsResponse` expects.
- This endpoint isn't currently consumed by any frontend component, so today this is a latent API defect rather than something visible through the UI.