### PR TITLE
backend: helm: Verify user before uninstall and rollback

### DIFF
--- a/backend/pkg/helm/release.go
+++ b/backend/pkg/helm/release.go
@@ -432,6 +432,11 @@ func (h *Handler) UninstallRelease(clientConfig clientcmd.ClientConfig, w http.R
 }
 
 func (h *Handler) uninstallRelease(req UninstallReleaseRequest, actionConfig *action.Configuration) {
+	if !VerifyUser(actionConfig, req.Name) {
+		h.setReleaseStatusSilent("uninstall", req.Name, failed, errors.New("user is not authorized to perform this operation"))
+		return
+	}
+
 	// Get uninstall client
 	uninstallClient := action.NewUninstall(actionConfig)
 
@@ -527,6 +532,11 @@ func (h *Handler) RollbackRelease(clientConfig clientcmd.ClientConfig, w http.Re
 }
 
 func (h *Handler) rollbackRelease(req RollbackReleaseRequest, actionConfig *action.Configuration) {
+	if !VerifyUser(actionConfig, req.Name) {
+		h.setReleaseStatusSilent("rollback", req.Name, failed, errors.New("user is not authorized to perform this operation"))
+		return
+	}
+
 	rollbackClient := action.NewRollback(actionConfig)
 	rollbackClient.Version = req.Revision
 
@@ -683,12 +693,12 @@ func (h *Handler) getChart(
 }
 
 // Verify the user has minimal privileges by performing a whoami check.
-// This prevents spurious downloads by ensuring basic authentication before proceeding.
-func VerifyUser(actionConfig *action.Configuration, req InstallRequest) bool {
+// This prevents spurious downloads and unauthorized actions by ensuring basic authentication before proceeding.
+func VerifyUser(actionConfig *action.Configuration, releaseName string) bool {
 	restConfig, err := actionConfig.RESTClientGetter.ToRESTConfig()
 	if err != nil {
 		logger.Log(logger.LevelError,
-			map[string]string{logFieldChart: req.Chart, logFieldReleaseName: req.Name},
+			map[string]string{logFieldReleaseName: releaseName},
 			err, "getting chart")
 
 		return false
@@ -697,7 +707,7 @@ func VerifyUser(actionConfig *action.Configuration, req InstallRequest) bool {
 	cs, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		logger.Log(logger.LevelError,
-			map[string]string{logFieldChart: req.Chart, logFieldReleaseName: req.Name},
+			map[string]string{logFieldReleaseName: releaseName},
 			err, "getting chart")
 
 		return false
@@ -707,14 +717,14 @@ func VerifyUser(actionConfig *action.Configuration, req InstallRequest) bool {
 		&authv1.SelfSubjectReview{}, metav1.CreateOptions{})
 	if err != nil {
 		logger.Log(logger.LevelError,
-			map[string]string{logFieldChart: req.Chart, logFieldReleaseName: req.Name},
+			map[string]string{logFieldReleaseName: releaseName},
 			err, "getting chart")
 
 		return false
 	}
 
 	if user := review.Status.UserInfo.Username; user == "" || user == "system:anonymous" {
-		logger.Log(logger.LevelError, map[string]string{logFieldChart: req.Chart, logFieldReleaseName: req.Name},
+		logger.Log(logger.LevelError, map[string]string{logFieldReleaseName: releaseName},
 			errors.New("insufficient privileges"), "getting chart: user is not authorized to perform this operation")
 
 		return false
@@ -731,7 +741,7 @@ func (h *Handler) installRelease(req InstallRequest, actionConfig *action.Config
 	installClient.CreateNamespace = req.CreateNamespace
 	installClient.Version = req.Version
 
-	if !VerifyUser(actionConfig, req) {
+	if !VerifyUser(actionConfig, req.Name) {
 		return
 	}
 

--- a/backend/pkg/helm/release_internal_test.go
+++ b/backend/pkg/helm/release_internal_test.go
@@ -2,6 +2,7 @@ package helm
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -13,6 +14,16 @@ import (
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
+	kubefake "helm.sh/helm/v3/pkg/kube/fake"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/storage"
+	"helm.sh/helm/v3/pkg/storage/driver"
+	authv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 func TestGetActionStatus_NilErr(t *testing.T) {
@@ -73,4 +84,240 @@ func TestGetChart_InvalidType(t *testing.T) {
 	assert.Equal(t, "failed", statusMap.Status)
 	assert.NotNil(t, statusMap.Err)
 	assert.Contains(t, *statusMap.Err, "chart type \"library\" is not installable")
+}
+
+type authRESTGetter struct {
+	cfg *rest.Config
+}
+
+var _ genericclioptions.RESTClientGetter = (*authRESTGetter)(nil)
+
+func (a *authRESTGetter) ToRESTConfig() (*rest.Config, error) {
+	return a.cfg, nil
+}
+
+func (a *authRESTGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	return nil, nil
+}
+
+func (a *authRESTGetter) ToRESTMapper() (meta.RESTMapper, error) {
+	return nil, nil
+}
+
+func (a *authRESTGetter) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	return nil
+}
+
+func newAuthTestServer(t *testing.T, username string) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/apis/authentication.k8s.io/v1/selfsubjectreviews" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(&authv1.SelfSubjectReview{
+				Status: authv1.SelfSubjectReviewStatus{
+					UserInfo: authv1.UserInfo{
+						Username: username,
+					},
+				},
+			})
+
+			return
+		}
+		http.NotFound(w, r)
+	}))
+}
+
+func TestUninstallRelease_UserVerification(t *testing.T) {
+	tests := []struct {
+		name          string
+		username      string
+		expectSuccess bool
+	}{
+		{
+			name:          "anonymous user rejected before uninstall Run",
+			username:      "system:anonymous",
+			expectSuccess: false,
+		},
+		{
+			name:          "unauthenticated user (empty username) rejected before uninstall Run",
+			username:      "",
+			expectSuccess: false,
+		},
+		{
+			name:          "authenticated user permitted and uninstalls release",
+			username:      "alice",
+			expectSuccess: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newAuthTestServer(t, tt.username)
+			defer server.Close()
+
+			memDriver := driver.NewMemory()
+			storageInst := storage.Init(memDriver)
+
+			rel := &release.Release{
+				Name:    "my-release",
+				Version: 1,
+				Info: &release.Info{
+					Status: release.StatusDeployed,
+				},
+			}
+			require.NoError(t, storageInst.Create(rel))
+
+			actionConfig := &action.Configuration{
+				RESTClientGetter: &authRESTGetter{
+					cfg: &rest.Config{Host: server.URL},
+				},
+				Releases: storageInst,
+				Log:      func(string, ...interface{}) {},
+			}
+
+			if tt.expectSuccess {
+				actionConfig.KubeClient = &kubefake.PrintingKubeClient{}
+			} else {
+				// If action.Uninstall.Run() were called, nil KubeClient would panic.
+				// Leaving KubeClient nil verifies Run() is never reached when authorization fails.
+				actionConfig.KubeClient = nil
+			}
+
+			h := &Handler{
+				Cache: cache.New[interface{}](),
+			}
+
+			req := UninstallReleaseRequest{
+				Name:      "my-release",
+				Namespace: "default",
+			}
+
+			h.uninstallRelease(req, actionConfig)
+
+			stat, err := h.getReleaseStatus("uninstall", "my-release")
+			require.NoError(t, err)
+
+			if tt.expectSuccess {
+				assert.Equal(t, "success", stat.Status)
+				assert.Nil(t, stat.Err)
+				// Since uninstall purged the release, it should no longer be found in storage.
+				_, err := actionConfig.Releases.Last("my-release")
+				assert.ErrorIs(t, err, driver.ErrReleaseNotFound)
+			} else {
+				assert.Equal(t, "failed", stat.Status)
+				require.NotNil(t, stat.Err)
+				assert.Equal(t, "user is not authorized to perform this operation", *stat.Err)
+				// The release must remain deployed because Run() was not executed.
+				currentRel, err := actionConfig.Releases.Last("my-release")
+				require.NoError(t, err)
+				assert.Equal(t, release.StatusDeployed, currentRel.Info.Status)
+			}
+		})
+	}
+}
+
+func TestRollbackRelease_UserVerification(t *testing.T) {
+	tests := []struct {
+		name          string
+		username      string
+		expectSuccess bool
+	}{
+		{
+			name:          "anonymous user rejected before rollback Run",
+			username:      "system:anonymous",
+			expectSuccess: false,
+		},
+		{
+			name:          "unauthenticated user (empty username) rejected before rollback Run",
+			username:      "",
+			expectSuccess: false,
+		},
+		{
+			name:          "authenticated user permitted and rolls back release",
+			username:      "alice",
+			expectSuccess: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newAuthTestServer(t, tt.username)
+			defer server.Close()
+
+			memDriver := driver.NewMemory()
+			storageInst := storage.Init(memDriver)
+
+			rel1 := &release.Release{
+				Name:    "my-release",
+				Version: 1,
+				Info: &release.Info{
+					Status: release.StatusSuperseded,
+				},
+			}
+			rel2 := &release.Release{
+				Name:    "my-release",
+				Version: 2,
+				Info: &release.Info{
+					Status: release.StatusDeployed,
+				},
+			}
+			require.NoError(t, storageInst.Create(rel1))
+			require.NoError(t, storageInst.Create(rel2))
+
+			actionConfig := &action.Configuration{
+				RESTClientGetter: &authRESTGetter{
+					cfg: &rest.Config{Host: server.URL},
+				},
+				Releases: storageInst,
+				Log:      func(string, ...interface{}) {},
+			}
+
+			if tt.expectSuccess {
+				actionConfig.KubeClient = &kubefake.PrintingKubeClient{}
+			} else {
+				// If action.Rollback.Run() were called, nil KubeClient would panic.
+				// Leaving KubeClient nil verifies Run() is never reached when authorization fails.
+				actionConfig.KubeClient = nil
+			}
+
+			h := &Handler{
+				Cache: cache.New[interface{}](),
+			}
+
+			req := RollbackReleaseRequest{
+				Name:      "my-release",
+				Namespace: "default",
+				Revision:  1,
+			}
+
+			h.rollbackRelease(req, actionConfig)
+
+			stat, err := h.getReleaseStatus("rollback", "my-release")
+			require.NoError(t, err)
+
+			history, err := actionConfig.Releases.History("my-release")
+			require.NoError(t, err)
+
+			if tt.expectSuccess {
+				assert.Equal(t, "success", stat.Status)
+				assert.Nil(t, stat.Err)
+				// Revision 3 should have been created
+				assert.Len(t, history, 3)
+				lastRel, err := actionConfig.Releases.Last("my-release")
+				require.NoError(t, err)
+				assert.Equal(t, 3, lastRel.Version)
+			} else {
+				assert.Equal(t, "failed", stat.Status)
+				require.NotNil(t, stat.Err)
+				assert.Equal(t, "user is not authorized to perform this operation", *stat.Err)
+				// History must remain untouched (only 2 revisions), Run() was not executed.
+				assert.Len(t, history, 2)
+				lastRel, err := actionConfig.Releases.Last("my-release")
+				require.NoError(t, err)
+				assert.Equal(t, 2, lastRel.Version)
+				assert.Equal(t, release.StatusDeployed, lastRel.Info.Status)
+			}
+		})
+	}
 }

--- a/backend/pkg/helm/release_test.go
+++ b/backend/pkg/helm/release_test.go
@@ -337,7 +337,7 @@ func TestVerifyUser(t *testing.T) {
 				}
 			}
 
-			result := helm.VerifyUser(actionConfig, tt.req)
+			result := helm.VerifyUser(actionConfig, tt.req.Name)
 			assert.Equal(t, result, tt.wantResult)
 		})
 	}


### PR DESCRIPTION
## Summary

This change ensures Helm uninstall and rollback operations verify the requesting user's identity before performing the mutation.

`InstallRelease` already uses the existing `VerifyUser()` check, but uninstall and rollback were able to proceed directly to the Helm action without the same verification.

## Related Issue

Fixes #7608

## Changes

* Add `VerifyUser()` checks to Helm uninstall and rollback operations.
* Reuse the existing SelfSubjectReview-based user verification.
* Prevent the Helm action from running when the user is anonymous or unauthenticated.
* Preserve the existing asynchronous operation and status handling.
* Add regression tests covering anonymous, unauthenticated, and authenticated users for both uninstall and rollback.
* Keep `VerifyUser()` type-safe by passing the release name directly.

## Steps to Test

1. Run the Helm package tests:
   `go test -v ./pkg/helm/...`

2. Run static analysis:
   `go vet ./pkg/helm/...`

3. Verify the diff:
   `git diff --check`

4. Verify that:

   * anonymous and unauthenticated users are rejected before the Helm operation runs;
   * the operation is marked as failed when authorization fails;
   * authenticated users can still uninstall releases;
   * authenticated users can still roll back releases.

## Screenshots

Not applicable. This is a backend-only change.

## Notes for Reviewer

The authorization check is intentionally placed before the Helm action is created/executed so uninstall and rollback follow the same authorization boundary as the existing install flow.

The change is limited to the Helm release authorization path and its regression tests.
