### PR TITLE
frontend: Resource: Scope container env var lookups to the pod's cluster

### DIFF
--- a/frontend/src/components/common/Resource/ContainerEnvironmentVariables.test.tsx
+++ b/frontend/src/components/common/Resource/ContainerEnvironmentVariables.test.tsx
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { fireEvent, render } from '@testing-library/react';
+import { Base64 } from 'js-base64';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { KubeContainer } from '../../../lib/k8s/cluster';
+import { KubePod } from '../../../lib/k8s/pod';
+import { createMuiTheme } from '../../../lib/themes';
+import { TestContext } from '../../../test';
+
+// The k8s classes form an import cycle through lib/k8s/index.ts, so the base class is
+// stubbed the same way EnvironmentVariables.test.ts does it.
+const { MockKubeObject } = vi.hoisted(() => {
+  class MockKubeObject {
+    jsonData: any;
+    cluster: string | undefined;
+    static kind = '';
+    constructor(data: any, cluster?: string) {
+      this.jsonData = data;
+      this.cluster = cluster;
+    }
+    get kind() {
+      return this.jsonData?.kind;
+    }
+    get metadata() {
+      return this.jsonData?.metadata;
+    }
+    // Pod exposes spec/status off jsonData, and ContainerInfo hands its resource
+    // straight to ContainerEnvironmentVariables as a KubePod.
+    get spec() {
+      return this.jsonData?.spec;
+    }
+    get status() {
+      return this.jsonData?.status;
+    }
+  }
+  return { MockKubeObject };
+});
+
+vi.mock('../../../lib/k8s/KubeObject', () => ({ KubeObject: MockKubeObject }));
+vi.mock('../../../lib/k8s/deployment', () => ({ default: class extends MockKubeObject {} }));
+vi.mock('../../../lib/k8s/replicaSet', () => ({ default: class extends MockKubeObject {} }));
+vi.mock('../../../lib/k8s/statefulSet', () => ({ default: class extends MockKubeObject {} }));
+vi.mock('../../../lib/k8s/daemonSet', () => ({ default: class extends MockKubeObject {} }));
+vi.mock('../../../lib/k8s/job', () => ({ default: class extends MockKubeObject {} }));
+vi.mock('../../../lib/k8s/pod', () => ({ default: class extends MockKubeObject {} }));
+vi.mock('../../../lib/k8s/secret', () => ({
+  default: class Secret extends MockKubeObject {
+    static kind = 'Secret';
+    static detailsRoute = 'secret';
+    static useGet = vi.fn(() => [null, null]);
+    get data() {
+      return this.jsonData?.data;
+    }
+  },
+}));
+vi.mock('../../../lib/k8s/configMap', () => ({
+  default: class ConfigMap extends MockKubeObject {
+    static kind = 'ConfigMap';
+    static detailsRoute = 'configMap';
+    static useGet = vi.fn(() => [null, null]);
+    get data() {
+      return this.jsonData?.data;
+    }
+  },
+}));
+
+import ConfigMap from '../../../lib/k8s/configMap';
+import Secret from '../../../lib/k8s/secret';
+import { ContainerEnvironmentVariables, ContainerInfo } from './Resource';
+
+const NAMESPACE = 'default';
+const POD_CLUSTER = 'cluster-b';
+const SECRET_NAME = 'app-secrets';
+const CONFIGMAP_NAME = 'app-config';
+
+const podJson = {
+  kind: 'Pod',
+  apiVersion: 'v1',
+  metadata: {
+    name: 'test-pod',
+    namespace: NAMESPACE,
+    uid: 'pod-uid',
+    creationTimestamp: '2025-01-01T00:00:00Z',
+  },
+  status: {
+    containerStatuses: [{ name: 'test-container', started: true }],
+  },
+};
+
+const container: KubeContainer = {
+  name: 'test-container',
+  image: 'nginx',
+  imagePullPolicy: 'IfNotPresent',
+  env: [
+    {
+      name: 'API_KEY',
+      valueFrom: { secretKeyRef: { name: SECRET_NAME, key: 'API_KEY' } },
+    },
+    {
+      name: 'LOG_LEVEL',
+      valueFrom: { configMapKeyRef: { name: CONFIGMAP_NAME, key: 'LOG_LEVEL' } },
+    },
+  ],
+};
+
+const theme = createMuiTheme({ base: 'light', name: 'light' });
+
+function renderInContext(children: React.ReactNode) {
+  return render(
+    <TestContext>
+      <ThemeProvider theme={theme}>{children}</ThemeProvider>
+    </TestContext>
+  );
+}
+
+/** Options passed to a mocked useGet on its most recent call. */
+function lastUseGetOptions(resourceClass: any) {
+  const calls = resourceClass.useGet.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[calls.length - 1][2];
+}
+
+describe('ContainerEnvironmentVariables cluster scoping', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves referenced Secrets against the given cluster', () => {
+    renderInContext(
+      <ContainerEnvironmentVariables
+        pod={podJson as unknown as KubePod}
+        container={container}
+        cluster={POD_CLUSTER}
+      />
+    );
+
+    expect(Secret.useGet).toHaveBeenCalledWith(SECRET_NAME, NAMESPACE, { cluster: POD_CLUSTER });
+  });
+
+  it('resolves referenced ConfigMaps against the given cluster', () => {
+    renderInContext(
+      <ContainerEnvironmentVariables
+        pod={podJson as unknown as KubePod}
+        container={container}
+        cluster={POD_CLUSTER}
+      />
+    );
+
+    expect(ConfigMap.useGet).toHaveBeenCalledWith(CONFIGMAP_NAME, NAMESPACE, {
+      cluster: POD_CLUSTER,
+    });
+  });
+
+  // Without a cluster the lookup keeps falling back to the current one, which is the
+  // behaviour every existing caller relies on.
+  it('leaves the cluster undefined when none is given', () => {
+    renderInContext(
+      <ContainerEnvironmentVariables pod={podJson as unknown as KubePod} container={container} />
+    );
+
+    expect(lastUseGetOptions(Secret)).toEqual({ cluster: undefined });
+    expect(lastUseGetOptions(ConfigMap)).toEqual({ cluster: undefined });
+  });
+
+  it("forwards the pod's own cluster from ContainerInfo", () => {
+    const pod = new (MockKubeObject as any)(podJson, POD_CLUSTER);
+
+    renderInContext(
+      <ContainerInfo
+        resource={pod}
+        container={container}
+        status={{ name: 'test-container', started: true } as any}
+      />
+    );
+
+    expect(lastUseGetOptions(Secret)).toEqual({ cluster: POD_CLUSTER });
+    expect(lastUseGetOptions(ConfigMap)).toEqual({ cluster: POD_CLUSTER });
+  });
+});
+
+describe('ContainerEnvironmentVariables secret values', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('decodes a Secret fetched from the pod cluster', () => {
+    const plaintext = 'cluster-b-password';
+    const secret = new (Secret as any)(
+      {
+        kind: 'Secret',
+        apiVersion: 'v1',
+        metadata: { name: SECRET_NAME, namespace: NAMESPACE, uid: 'secret-uid' },
+        data: { API_KEY: Base64.encode(plaintext) },
+      },
+      POD_CLUSTER
+    );
+    (Secret as any).useGet.mockReturnValue([secret, null]);
+
+    const { getByRole, getByDisplayValue } = renderInContext(
+      <ContainerEnvironmentVariables
+        pod={podJson as unknown as KubePod}
+        container={container}
+        cluster={POD_CLUSTER}
+      />
+    );
+
+    fireEvent.click(getByRole('button', { name: /toggle field visibility/i }));
+
+    expect(getByDisplayValue(plaintext)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -720,6 +720,12 @@ export function ConditionsTable(props: ConditionsTableProps) {
 export interface EnvironmentVariablesProps {
   pod?: KubePod;
   container?: KubeContainer;
+  /**
+   * Cluster the pod belongs to. Referenced Secrets and ConfigMaps are resolved against
+   * it, so a pod shown from a cluster other than the one in the URL still reads its own
+   * cluster's values. Falls back to the current cluster when not given.
+   */
+  cluster?: string;
 }
 
 interface EnvVarReference {
@@ -828,10 +834,11 @@ export function extractEnvVarReferences(container: KubeContainer): EnvVarReferen
 function SecretFetcher(props: {
   name: string;
   namespace: string;
+  cluster?: string;
   onResult: (name: string, resource: KubeObject | null, error: ApiError | null) => void;
 }) {
-  const { name, namespace, onResult } = props;
-  const [secret, error] = Secret.useGet(name, namespace);
+  const { name, namespace, cluster, onResult } = props;
+  const [secret, error] = Secret.useGet(name, namespace, { cluster });
 
   React.useEffect(() => {
     // Only call onResult when we have a definitive result (either data or error)
@@ -850,10 +857,11 @@ function SecretFetcher(props: {
 function ConfigMapFetcher(props: {
   name: string;
   namespace: string;
+  cluster?: string;
   onResult: (name: string, resource: KubeObject | null, error: ApiError | null) => void;
 }) {
-  const { name, namespace, onResult } = props;
-  const [configMap, error] = ConfigMap.useGet(name, namespace);
+  const { name, namespace, cluster, onResult } = props;
+  const [configMap, error] = ConfigMap.useGet(name, namespace, { cluster });
 
   React.useEffect(() => {
     if (configMap || error) {
@@ -1119,7 +1127,7 @@ export function buildEnvironmentVariables(
  * Secrets and ConfigMaps as needed.
  */
 export function ContainerEnvironmentVariables(props: EnvironmentVariablesProps) {
-  const { pod, container } = props;
+  const { pod, container, cluster } = props;
   const { t } = useTranslation();
   const { enqueueSnackbar } = useSnackbar();
 
@@ -1313,6 +1321,7 @@ export function ContainerEnvironmentVariables(props: EnvironmentVariablesProps) 
                 name: data.from?.metadata?.name,
                 namespace: data.from?.metadata?.namespace,
               }}
+              activeCluster={cluster}
             >
               {`${data.from?.kind}: ${data.from?.metadata?.name}`}
             </Link>
@@ -1333,6 +1342,7 @@ export function ContainerEnvironmentVariables(props: EnvironmentVariablesProps) 
           key={`secret-${name}`}
           name={name}
           namespace={namespace}
+          cluster={cluster}
           onResult={handleSecretFetched}
         />
       ))}
@@ -1341,6 +1351,7 @@ export function ContainerEnvironmentVariables(props: EnvironmentVariablesProps) 
           key={`configmap-${name}`}
           name={name}
           namespace={namespace}
+          cluster={cluster}
           onResult={handleConfigMapFetched}
         />
       ))}
@@ -1682,7 +1693,13 @@ export function ContainerInfo(props: ContainerInfoProps) {
       },
       {
         name: t('glossary|Environment'),
-        value: <ContainerEnvironmentVariables pod={resource as KubePod} container={container} />,
+        value: (
+          <ContainerEnvironmentVariables
+            pod={resource as KubePod}
+            container={container}
+            cluster={(resource as KubeObject)?.cluster}
+          />
+        ),
         hide: _.isEmpty(container?.env) && _.isEmpty(container?.envFrom),
       },
       {


### PR DESCRIPTION
## Summary

This PR fixes a multi-cluster bug where a container's environment variables were resolved
against the wrong cluster, by forwarding the pod's cluster to the Secret and ConfigMap
lookups.

`SecretFetcher` and `ConfigMapFetcher` called `useGet` without a cluster:

```tsx
const [secret, error] = Secret.useGet(name, namespace);
const [configMap, error] = ConfigMap.useGet(name, namespace);
```

`useGet` takes the cluster in its third argument (`KubeObject.ts:463-472`). With it
omitted, both fall back to the cluster in the URL rather than the cluster the pod on
screen belongs to. When those differ, the values shown come from a same-named Secret or
ConfigMap in a different cluster, with nothing to indicate it, and the copy button copies
the wrong value. Where only the pod's own cluster has the resource, the row shows a
spurious 404 instead. The "From" link had the same problem and navigated to the wrong
cluster.

The cluster was already available at the call site and simply not passed on.
`ContainerInfo` declares `ContainerInfoKubeObjectProps` with `resource: KubeObject | null`,
and all four callers of `ContainersSection` (`pod`, `daemonset`, `statefulset`, `job`
details) pass the KubeObject, which carries `.cluster`.

## Related Issue

Fixes #7622

## Changes

- Updated `frontend/src/components/common/Resource/Resource.tsx`:
  - `EnvironmentVariablesProps` gains an optional `cluster`.
  - `SecretFetcher` and `ConfigMapFetcher` accept a `cluster` and pass it to `useGet`.
  - `ContainerEnvironmentVariables` forwards it to both fetchers and sets `activeCluster`
    on the "From" link.
  - `ContainerInfo` reads the cluster off its `resource` and hands it down.
- Added `frontend/src/components/common/Resource/ContainerEnvironmentVariables.test.tsx`
  covering the cluster forwarding, the `ContainerInfo` handoff, and the no-cluster
  fallback.

Nothing above `ContainerInfo` changes. Callers on the deprecated
`ContainerInfoLegacyProps` shape pass `undefined`, which is exactly the current fallback
to the URL cluster, so no existing behaviour moves.

## Steps to Test

1. Connect two clusters. Create the same-named Secret in both, with different values:

   ```bash
   kubectl --context cluster-a create secret generic app-secrets --from-literal=API_KEY='from-cluster-a'
   kubectl --context cluster-b create secret generic app-secrets --from-literal=API_KEY='from-cluster-b'
   ```

2. Create a Pod in cluster B that consumes it via `secretKeyRef` on `app-secrets`/`API_KEY`.
3. Select both clusters so the resource map aggregates them, and open the map while the
   URL is on cluster A.
4. Click the cluster B pod. `KubeObjectDetails` renders the details with
   `cluster={resource.cluster}` while the URL still points at cluster A.
5. Expand the container and reveal the env var. On `main` it shows `from-cluster-a`; with
   this change it shows `from-cluster-b`.
6. Hover the "From" link. On `main` it points at cluster A's Secret; with this change it
   points at `/c/cluster-b/secrets/default/app-secrets`.
7. Run the tests:

   ```bash
   cd frontend
   npx vitest run src/components/common/Resource/ContainerEnvironmentVariables.test.tsx
   ```

   Reverting the `Resource.tsx` change makes 4 of the 5 cases fail. The fifth asserts that
   a fetched Secret still decodes correctly and passes either way, as a control.

## Screenshots (if applicable)

## Notes for the Reviewer

- Same class of bug as the CronJob details page fetching its object without the `cluster`
  prop it was given. This is the container env var path of the same problem, so it may be
  worth a broader sweep for other `useGet`/`useList` calls inside components that already
  receive a cluster.
- Worth confirming the intent of one detail: the fix always passes an options object now,
  so `useGet` receives `{ cluster: undefined }` where it previously received no third
  argument at all. That is equivalent for the current `useKubeObject` implementation, and
  a test pins it, but say the word if you would rather the object were omitted entirely
  when there is no cluster.
- The env var section only ever renders for actual Pods, because
  `ContainerEnvironmentVariables` guards on `pod.status.containerStatuses` and `Pod` is the
  class that exposes `spec`/`status` getters. The DaemonSet, StatefulSet and Job callers of
  `ContainersSection` therefore never reach this code. That is pre-existing behaviour and
  this PR does not change it, but it is why the test mock needs those getters.
- The new test file mocks `lib/k8s/KubeObject` and the workload classes the same way the
  neighbouring `EnvironmentVariables.test.ts` does, because importing `Resource.tsx`
  without those mocks hits a genuine import cycle through `lib/k8s/index.ts`.
- `tsc --noEmit`, eslint and prettier are clean. The full
  `src/components/common/Resource/` suite passes (19 files, 159 tests).