### PR TITLE
frontend: ingress: Fix pathType lookup on rules without http

### DIFF
--- a/frontend/src/components/ingress/Details.tsx
+++ b/frontend/src/components/ingress/Details.tsx
@@ -77,19 +77,19 @@ export function LinkStringFormat({ url, item, urlPath }: LinkStringFormatProps) 
     }
 
     /*
-     * Since we cannot access the prefix from the ingress object, we have to access it from the rules array
+     * The pathType is not part of the rendered path, so look it up from the rules.
+     * Scope the lookup to the rules for this row's host: different hosts may expose
+     * the same path with different path types, and a host-agnostic search would
+     * report whichever rule happened to come last.
+     *
+     * getRules() is used rather than spec.rules because it normalizes rules that
+     * carry no http block (which is valid for a networking.k8s.io/v1 Ingress).
      */
-    const rules: any[] | undefined = item.spec.rules;
-    let currentPathType;
-    if (rules) {
-      for (let i = 0; i < rules.length; i++) {
-        for (let j = 0; j < rules[i].http.paths.length; j++) {
-          if (rules[i].http.paths[j].path === urlPath) {
-            currentPathType = rules[i].http.paths[j].pathType;
-          }
-        }
-      }
-    }
+    const currentPathType = item
+      .getRules()
+      .filter(rule => (rule.host || '*') === url)
+      .flatMap(rule => rule.http?.paths ?? [])
+      .find(path => path.path === urlPath)?.pathType;
 
     function isValidURL(url: string): boolean {
       try {
@@ -119,7 +119,7 @@ export function LinkStringFormat({ url, item, urlPath }: LinkStringFormatProps) 
           >
             {urlPath}
           </MuiLink>
-          {`(${currentPathType})`}
+          {currentPathType && `(${currentPathType})`}
         </Box>
       );
     }

--- a/frontend/src/components/ingress/LinkStringFormat.stories.tsx
+++ b/frontend/src/components/ingress/LinkStringFormat.stories.tsx
@@ -152,21 +152,21 @@ const multiplePath = new Ingress({
 
 export const Empty = Template.bind({});
 Empty.args = {
-  url: 'exampleurl.com',
+  url: 'examplehost.com',
   item: noPath,
   urlPath: '/',
 };
 
 export const soloPath = Template.bind({});
 soloPath.args = {
-  url: 'exampleurl.com',
+  url: 'examplehost.com',
   item: onePath,
   urlPath: '/pathA',
 };
 
 export const morePath = Template.bind({});
 morePath.args = {
-  url: 'exampleurl.com',
+  url: 'examplehost.com',
   item: multiplePath,
   urlPath: '/pathB',
 };

--- a/frontend/src/components/ingress/LinkStringFormat.test.tsx
+++ b/frontend/src/components/ingress/LinkStringFormat.test.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import App from '../../App';
+import Ingress, { KubeIngress } from '../../lib/k8s/ingress';
+import { LinkStringFormat } from './Details';
+
+// cyclic imports fix
+// eslint-disable-next-line no-unused-vars
+const _dont_delete_me = App;
+
+function makeIngress(spec: KubeIngress['spec']) {
+  return new Ingress({
+    kind: 'Ingress',
+    apiVersion: 'networking.k8s.io/v1',
+    metadata: {
+      name: 'test',
+      namespace: 'test',
+      uid: '',
+      creationTimestamp: '',
+    },
+    spec,
+  } as KubeIngress);
+}
+
+const backend = { service: { name: 'test', port: { number: 80 } } };
+
+describe('LinkStringFormat', () => {
+  it('renders the host without crashing when a rule carries no http block', () => {
+    // spec.rules[].http is optional in networking.k8s.io/v1, so a rule may hold
+    // only a host. The pathType lookup must not walk into an undefined http.
+    const item = makeIngress({ rules: [{ host: 'foo.example.com' }] as any });
+
+    render(<LinkStringFormat url="foo.example.com" item={item} />);
+
+    expect(screen.getByRole('link', { name: 'http://foo.example.com/' })).toBeInTheDocument();
+  });
+
+  it('renders a path row without crashing when another rule carries no http block', () => {
+    const item = makeIngress({
+      rules: [
+        { host: 'bar.example.com' },
+        {
+          host: 'foo.example.com',
+          http: { paths: [{ path: '/a', pathType: 'Prefix', backend }] },
+        },
+      ] as any,
+    });
+
+    render(<LinkStringFormat url="foo.example.com" item={item} urlPath="/a" />);
+
+    expect(screen.getByRole('link', { name: '/a' })).toBeInTheDocument();
+    expect(screen.getByText('(Prefix)')).toBeInTheDocument();
+  });
+
+  it('shows the pathType from the rule matching the row host, not the last rule', () => {
+    // Both hosts expose "/" but with different path types. Each row must report
+    // its own host's pathType.
+    const item = makeIngress({
+      rules: [
+        { host: 'a.example.com', http: { paths: [{ path: '/', pathType: 'Prefix', backend }] } },
+        { host: 'b.example.com', http: { paths: [{ path: '/', pathType: 'Exact', backend }] } },
+      ] as any,
+    });
+
+    const { unmount } = render(<LinkStringFormat url="a.example.com" item={item} urlPath="/" />);
+    expect(screen.getByText('(Prefix)')).toBeInTheDocument();
+    expect(screen.queryByText('(Exact)')).not.toBeInTheDocument();
+    unmount();
+
+    render(<LinkStringFormat url="b.example.com" item={item} urlPath="/" />);
+    expect(screen.getByText('(Exact)')).toBeInTheDocument();
+    expect(screen.queryByText('(Prefix)')).not.toBeInTheDocument();
+  });
+
+  it('omits the suffix instead of rendering "(undefined)" when no pathType is found', () => {
+    const item = makeIngress({
+      rules: [
+        {
+          host: 'foo.example.com',
+          http: { paths: [{ path: '/known', pathType: 'Exact', backend }] },
+        },
+      ] as any,
+    });
+
+    render(<LinkStringFormat url="foo.example.com" item={item} urlPath="/unknown" />);
+
+    expect(screen.getByRole('link', { name: '/unknown' })).toBeInTheDocument();
+    expect(screen.queryByText(/undefined/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ingress/__snapshots__/Details.WithWildcardTLS.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.WithWildcardTLS.stories.storyshot
@@ -234,7 +234,131 @@
       >
         <div
           class="MuiBox-root css-p0cik4"
-        />
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+                  >
+                    Rules
+                  </h2>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
+              <div
+                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-onzayo-MuiPaper-root-MuiTableContainer-root"
+                tabindex="0"
+              >
+                <table
+                  class="MuiTable-root css-14jq1ex-MuiTable-root"
+                >
+                  <thead
+                    class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+                    >
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Host
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Path
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Backends
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                          href="http://*.one.domain.tld/"
+                        >
+                          http://*.one.domain.tld/
+                        </a>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <div
+                          class="MuiBox-root css-0"
+                          style="display: flex; flex-direction: column; flex-wrap: nowrap; margin-bottom: 5px;"
+                        />
+                      </td>
+                    </tr>
+                    <tr
+                      class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                          href="http://*.two.domain.tld/"
+                        >
+                          http://*.two.domain.tld/
+                        </a>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      />
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <div
+                          class="MuiBox-root css-0"
+                          style="display: flex; flex-direction: column; flex-wrap: nowrap; margin-bottom: 5px;"
+                        />
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"

--- a/frontend/src/components/ingress/__snapshots__/LinkStringFormat.Empty.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/LinkStringFormat.Empty.stories.storyshot
@@ -6,7 +6,7 @@
     >
       <a
         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
-        href="http://exampleurl.com/"
+        href="http://examplehost.com/"
         style="margin-right: 5px;"
       >
         /

--- a/frontend/src/components/ingress/__snapshots__/LinkStringFormat.morePath.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/LinkStringFormat.morePath.stories.storyshot
@@ -6,7 +6,7 @@
     >
       <a
         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
-        href="http://exampleurl.com/pathB"
+        href="http://examplehost.com/pathB"
         style="margin-right: 5px;"
       >
         /pathB

--- a/frontend/src/components/ingress/__snapshots__/LinkStringFormat.soloPath.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/LinkStringFormat.soloPath.stories.storyshot
@@ -6,7 +6,7 @@
     >
       <a
         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
-        href="http://exampleurl.com/pathA"
+        href="http://examplehost.com/pathA"
         style="margin-right: 5px;"
       >
         /pathA

--- a/frontend/src/lib/k8s/ingress.test.ts
+++ b/frontend/src/lib/k8s/ingress.test.ts
@@ -236,6 +236,33 @@ describe('Ingress class', () => {
       expect(rules[0].http!.paths).toEqual([]);
     });
 
+    it('preserves pathType on normalized paths', () => {
+      const ingress = new Ingress(JSON.parse(JSON.stringify(mockIngressData)));
+      const rules = ingress.getRules();
+      expect(rules[0].http!.paths[0].pathType).toBe('Prefix');
+      expect(rules[0].http!.paths[1].pathType).toBe('Prefix');
+    });
+
+    it('leaves pathType undefined for legacy rules that do not define it', () => {
+      const data = JSON.parse(JSON.stringify(mockIngressData));
+      data.spec.rules = [
+        {
+          host: 'legacy.example.com',
+          http: {
+            paths: [
+              {
+                path: '/api',
+                backend: { serviceName: 'legacy-svc', servicePort: '8080' },
+              },
+            ],
+          },
+        },
+      ];
+      const ingress = new Ingress(data);
+      const rules = ingress.getRules();
+      expect(rules[0].http!.paths[0].pathType).toBeUndefined();
+    });
+
     it('caches rules and returns cached result on subsequent calls', () => {
       // Create a fresh instance with deep-cloned data to avoid shared refs
       const data = JSON.parse(JSON.stringify(mockIngressData));

--- a/frontend/src/lib/k8s/ingress.ts
+++ b/frontend/src/lib/k8s/ingress.ts
@@ -157,10 +157,17 @@ class Ingress extends KubeObject<KubeIngress> {
 
     this.spec!.rules?.forEach(({ http, host }) => {
       if (http) {
-        const paths = http.paths.map(({ backend, path }) => {
+        const paths = http.paths.map(pathEntry => {
+          const { backend, path } = pathEntry;
+          // pathType only exists on networking.k8s.io/v1 rules, so it stays undefined
+          // for the legacy shape. Carry it through either way: consumers rely on
+          // getRules() as the single normalized view of spec.rules.
+          const pathType = (pathEntry as { pathType?: string }).pathType;
+
           if (!!(backend as LegacyIngressBackend).serviceName) {
             return {
               path,
+              pathType,
               backend: {
                 service: {
                   name: (backend as LegacyIngressBackend).serviceName,
@@ -173,6 +180,7 @@ class Ingress extends KubeObject<KubeIngress> {
           } else {
             return {
               path,
+              pathType,
               backend: backend as IngressBackend,
             };
           }


### PR DESCRIPTION
## Summary

Fixes the pathType lookup in the Ingress details view. It walked the raw spec.rules and dereferenced rules[i].http.paths without a guard, which threw for an Ingress whose rule carries no http block - valid in networking.k8s.io/v1. Because each DetailsGrid section renders inside its own <ErrorBoundary>, the throw doesn't take down the page - it silently kills the Rules section, which renders nothing with no indication to the user that anything went wrong. The same loop also resolved pathType by path alone (ignoring the host) and rendered the literal string (undefined) when nothing matched.

## Related Issue

Fixes #7611

## Changes

- frontend/src/components/ingress/Details.tsx - resolve pathType from item.getRules() (which already normalizes rules with no http block) scoped to the row's own host, replacing the unguarded nested loop over item.spec.rules. Dropping the const rules: any[] cast is what lets the type checker see that http is optional.
- frontend/src/components/ingress/Details.tsx - render the (pathType) suffix only when a pathType was actually found.
- frontend/src/lib/k8s/ingress.ts - getRules() now carries pathType through normalization, so it stays the single normalized view of spec.rules. It stays undefined for the legacy rule shape, which has no such field.
- frontend/src/components/ingress/LinkStringFormat.test.tsx - new tests covering all three defects.
- frontend/src/lib/k8s/ingress.test.ts - tests that getRules() preserves pathType and leaves it undefined for legacy rules.
- frontend/src/components/ingress/LinkStringFormat.stories.tsx - the three stories passed url: 'exampleurl.com' while their rules declared host: 'examplehost.com'. That pairing cannot occur in the app (the Path column always passes data.host as url); the old host-agnostic lookup simply never noticed. Aligned the fixtures so they exercise a realistic combination - the stories still render the (Prefix) suffix, only the link host changes.

## Steps to Test

1. Apply an Ingress with a host-only rule and open its details page. Before this change the Rules section silently renders nothing (caught by its ErrorBoundary) and the console shows TypeError: Cannot read properties of undefined (reading 'paths'); after it, the Rules table renders normally.

apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: crash-repro
spec:
  rules:
    - host: foo.example.com   # no http block

2. Apply an Ingress where two hosts expose the same path with different path types, and check the Path column. Before, both rows showed the last rule's pathType; after, each row shows its own.

spec:
  rules:
    - host: a.example.com
      http:
        paths: [{ path: /, pathType: Prefix, backend: { service: { name: svc-a, port: { number: 80 } } } }]
    - host: b.example.com
      http:
        paths: [{ path: /, pathType: Exact, backend: { service: { name: svc-b, port: { number: 80 } } } }]

3. cd frontend && npx vitest run src/components/ingress src/lib/k8s/ingress.test.ts - 22 passed.

All five new/updated tests fail on main and pass with this change - the two crash cases fail with the real TypeError above.

## Screenshots (if applicable)
# Before:

https://github.com/user-attachments/assets/4686bb9c-9b22-4026-91af-7d6dac3a1549

<img width="1600" height="809" alt="WhatsApp Image 2026-09-08 at 6 59 20 PM" src="https://github.com/user-attachments/assets/f6259b36-d187-4e44-b82d-8ee18cc8201d" />


# After:

https://github.com/user-attachments/assets/ea811830-9892-42ad-aa33-4af836a8e624


## Notes for the Reviewer

This repo's own fixture already reproduced the bug. WILDCARD_TLS_INGRESS in frontend/src/components/ingress/storyHelper.ts is:


rules: [{ host: '*.one.domain.tld' }, { host: '*.two.domain.tld' }]
Host-only rules - exactly the crash case. Its committed snapshot had captured the resulting empty render where the Rules section belongs (the ErrorBoundary swallows the error with no fallback UI). That snapshot now gains the whole table (Rules / Host / Path / Backends plus both hosts), which is the most direct evidence that the section was silently broken. Verified live in Storybook against the Ingress/DetailsView → WithWildcardTLS story as well as the automated snapshot.

The LinkStringFormat props signature is unchanged, so this is not a plugin-API change.

Two pre-existing storybook/unit-test failures on main are unrelated and untouched (Version Dialog > VersionDialog, GraphView > HungSourceRepro, and a handful more in Settings/GraphSources/pluginLib that also fail on a clean checkout) — I diffed a full vitest run on this branch against one on main and confirmed no new failures.

Out of scope: the http:// protocol on the wildcard-TLS links comes from isHttpsUsed not matching multi-host TLS entries, which is #7480 / #7609.
