### PR TITLE
github: Use Docker runtime for minikube chart tests

### DIFF
--- a/.github/workflows/helm-chart-lint-test.yml
+++ b/.github/workflows/helm-chart-lint-test.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Setup Minikube
         uses: medyagh/setup-minikube@d8c0eb871f6f455542491d86a574477bd3894533 # latest
+        with:
+          container-runtime: docker
 
       - name: Build image & Run chart-testing (install)
         run: |


### PR DESCRIPTION
minikube v1.39.0 changed its default container runtime to containerd. The chart tests use `minikube docker-env` with Docker Buildx, which is incompatible with minikube's experimental containerd Docker API proxy and fails while inspecting the BuildKit image.

### Changes

- Explicitly use the Docker runtime for minikube chart tests