### PR TITLE
helm: scope release status cache key by namespace

### DIFF
--- a/backend/pkg/helm/handler.go
+++ b/backend/pkg/helm/handler.go
@@ -128,8 +128,8 @@ type stat struct {
 }
 
 // getReleaseStatus returns the status of the release.
-func (h *Handler) getReleaseStatus(actionName, releaseName string) (*stat, error) {
-	key := "helm_" + actionName + "_" + releaseName
+func (h *Handler) getReleaseStatus(namespace, actionName, releaseName string) (*stat, error) {
+	key := "helm_" + namespace + "_" + actionName + "_" + releaseName
 
 	value, err := h.Cache.Get(context.Background(), key)
 	if err != nil {
@@ -161,11 +161,11 @@ func (h *Handler) getReleaseStatus(actionName, releaseName string) (*stat, error
 }
 
 // setReleaseStatus sets the status of the release
-// Key of the object is action_name + "_" + release_name
+// Key of the object is namespace + "_" + action_name + "_" + release_name
 // action_name is the name of the action, e.g. install, upgrade, delete
 // status is one of the following: processing, success, failed.
-func (h *Handler) setReleaseStatus(actionName, releaseName, status string, err error) error {
-	key := "helm_" + actionName + "_" + releaseName
+func (h *Handler) setReleaseStatus(namespace, actionName, releaseName, status string, err error) error {
+	key := "helm_" + namespace + "_" + actionName + "_" + releaseName
 
 	stat := stat{
 		Status: status,
@@ -187,8 +187,8 @@ func (h *Handler) setReleaseStatus(actionName, releaseName, status string, err e
 	return nil
 }
 
-func (h *Handler) setReleaseStatusSilent(actionName, releaseName, status string, err error) {
-	cacheErr := h.setReleaseStatus(actionName, releaseName, status, err)
+func (h *Handler) setReleaseStatusSilent(namespace, actionName, releaseName, status string, err error) {
+	cacheErr := h.setReleaseStatus(namespace, actionName, releaseName, status, err)
 	if cacheErr != nil {
 		logger.Log(logger.LevelError, map[string]string{logFieldReleaseName: releaseName, "status": status},
 			cacheErr, "unable to set status")

--- a/backend/pkg/helm/handler_test.go
+++ b/backend/pkg/helm/handler_test.go
@@ -73,10 +73,10 @@ func TestSetAndGetReleaseStatusNoError(t *testing.T) {
 	h, err := NewHandler(newTestCache())
 	require.NoError(t, err)
 
-	err = h.setReleaseStatus("install", "myrelease", "processing", nil)
+	err = h.setReleaseStatus("default", "install", "myrelease", "processing", nil)
 	require.NoError(t, err)
 
-	s, err := h.getReleaseStatus("install", "myrelease")
+	s, err := h.getReleaseStatus("default", "install", "myrelease")
 	require.NoError(t, err)
 	assert.Equal(t, "processing", s.Status)
 	assert.Nil(t, s.Err)
@@ -87,10 +87,10 @@ func TestSetAndGetReleaseStatusWithError(t *testing.T) {
 	require.NoError(t, err)
 
 	releaseErr := errors.New("something went wrong")
-	err = h.setReleaseStatus("upgrade", "myrelease", "failed", releaseErr)
+	err = h.setReleaseStatus("default", "upgrade", "myrelease", "failed", releaseErr)
 	require.NoError(t, err)
 
-	s, err := h.getReleaseStatus("upgrade", "myrelease")
+	s, err := h.getReleaseStatus("default", "upgrade", "myrelease")
 	require.NoError(t, err)
 	assert.Equal(t, "failed", s.Status)
 	require.NotNil(t, s.Err)
@@ -101,7 +101,7 @@ func TestGetReleaseStatusCacheMiss(t *testing.T) {
 	h, err := NewHandler(newTestCache())
 	require.NoError(t, err)
 
-	s, err := h.getReleaseStatus("install", "nonexistent")
+	s, err := h.getReleaseStatus("default", "install", "nonexistent")
 	// cache miss must return an error and no status
 	assert.Error(t, err)
 	assert.Nil(t, s)
@@ -111,10 +111,10 @@ func TestSetReleaseStatusOverwritesPreviousValue(t *testing.T) {
 	h, err := NewHandler(newTestCache())
 	require.NoError(t, err)
 
-	require.NoError(t, h.setReleaseStatus("install", "myrelease", "processing", nil))
-	require.NoError(t, h.setReleaseStatus("install", "myrelease", "success", nil))
+	require.NoError(t, h.setReleaseStatus("default", "install", "myrelease", "processing", nil))
+	require.NoError(t, h.setReleaseStatus("default", "install", "myrelease", "success", nil))
 
-	s, err := h.getReleaseStatus("install", "myrelease")
+	s, err := h.getReleaseStatus("default", "install", "myrelease")
 	require.NoError(t, err)
 	assert.Equal(t, "success", s.Status)
 }
@@ -123,11 +123,29 @@ func TestSetReleaseStatusSilentDoesNotPanic(t *testing.T) {
 	h, err := NewHandler(newTestCache())
 	require.NoError(t, err)
 	// should not panic even when called with an error value
-	h.setReleaseStatusSilent("delete", "myrelease", "failed", errors.New("oops"))
+	h.setReleaseStatusSilent("default", "delete", "myrelease", "failed", errors.New("oops"))
 
-	s, err := h.getReleaseStatus("delete", "myrelease")
+	s, err := h.getReleaseStatus("default", "delete", "myrelease")
 	require.NoError(t, err)
 	assert.Equal(t, "failed", s.Status)
+}
+
+func TestSetReleaseStatusNamespaceIsolation(t *testing.T) {
+	h, err := NewHandler(newTestCache())
+	require.NoError(t, err)
+
+	// Two different namespaces installing a release with the same name and
+	// action must not collide in the status cache.
+	require.NoError(t, h.setReleaseStatus("staging", "install", "redis", "processing", nil))
+	require.NoError(t, h.setReleaseStatus("prod", "install", "redis", "success", nil))
+
+	staging, err := h.getReleaseStatus("staging", "install", "redis")
+	require.NoError(t, err)
+	assert.Equal(t, "processing", staging.Status)
+
+	prod, err := h.getReleaseStatus("prod", "install", "redis")
+	require.NoError(t, err)
+	assert.Equal(t, "success", prod.Status)
 }
 
 func TestRestConfigGetterToRESTConfig(t *testing.T) {
@@ -179,14 +197,14 @@ func TestSetReleaseStatusKeyIsolation(t *testing.T) {
 	h, err := NewHandler(newTestCache())
 	require.NoError(t, err)
 
-	require.NoError(t, h.setReleaseStatus("install", "rel", "processing", nil))
-	require.NoError(t, h.setReleaseStatus("upgrade", "rel", "success", nil))
+	require.NoError(t, h.setReleaseStatus("default", "install", "rel", "processing", nil))
+	require.NoError(t, h.setReleaseStatus("default", "upgrade", "rel", "success", nil))
 
-	install, err := h.getReleaseStatus("install", "rel")
+	install, err := h.getReleaseStatus("default", "install", "rel")
 	require.NoError(t, err)
 	assert.Equal(t, "processing", install.Status)
 
-	upgrade, err := h.getReleaseStatus("upgrade", "rel")
+	upgrade, err := h.getReleaseStatus("default", "upgrade", "rel")
 	require.NoError(t, err)
 	assert.Equal(t, "success", upgrade.Status)
 }
@@ -223,10 +241,10 @@ func TestGetReleaseStatusUnmarshalError(t *testing.T) {
 	h, err := NewHandler(c)
 	require.NoError(t, err)
 
-	key := "helm_install_badrelease"
+	key := "helm_default_install_badrelease"
 	err = c.SetWithTTL(context.Background(), key, "this-is-not-a-stat-struct", statusCacheTimeout)
 	require.NoError(t, err)
 
-	_, err = h.getReleaseStatus("install", "badrelease")
+	_, err = h.getReleaseStatus("default", "install", "badrelease")
 	assert.Error(t, err)
 }

--- a/backend/pkg/helm/release.go
+++ b/backend/pkg/helm/release.go
@@ -401,7 +401,7 @@ func (h *Handler) UninstallRelease(clientConfig clientcmd.ClientConfig, w http.R
 		return
 	}
 
-	err = h.setReleaseStatus("uninstall", req.Name, processing, nil)
+	err = h.setReleaseStatus(req.Namespace, "uninstall", req.Name, processing, nil)
 	if err != nil {
 		logger.Log(logger.LevelError, map[string]string{logFieldRequest: opUninstallRelease, logFieldReleaseName: req.Name},
 			err, "setting status")
@@ -445,7 +445,7 @@ func (h *Handler) uninstallRelease(req UninstallReleaseRequest, actionConfig *ac
 		status = failed
 	}
 
-	h.setReleaseStatusSilent("uninstall", req.Name, status, err)
+	h.setReleaseStatusSilent(req.Namespace, "uninstall", req.Name, status, err)
 }
 
 type RollbackReleaseRequest struct {
@@ -498,7 +498,7 @@ func (h *Handler) RollbackRelease(clientConfig clientcmd.ClientConfig, w http.Re
 		return
 	}
 
-	err = h.setReleaseStatus("rollback", req.Name, processing, nil)
+	err = h.setReleaseStatus(req.Namespace, "rollback", req.Name, processing, nil)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "setting status")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -540,7 +540,7 @@ func (h *Handler) rollbackRelease(req RollbackReleaseRequest, actionConfig *acti
 		status = failed
 	}
 
-	h.setReleaseStatusSilent("rollback", req.Name, status, err)
+	h.setReleaseStatusSilent(req.Namespace, "rollback", req.Name, status, err)
 }
 
 type CommonInstallUpdateRequest struct {
@@ -612,7 +612,7 @@ func (h *Handler) InstallRelease(clientConfig clientcmd.ClientConfig, w http.Res
 		return
 	}
 
-	err = h.setReleaseStatus("install", req.Name, processing, nil)
+	err = h.setReleaseStatus(req.Namespace, "install", req.Name, processing, nil)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "setting status")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -629,6 +629,7 @@ func (h *Handler) InstallRelease(clientConfig clientcmd.ClientConfig, w http.Res
 
 // Returns the chart, and err, and if dependencyUpdate is true then we also update the chart dependencies.
 func (h *Handler) getChart(
+	namespace string,
 	actionName string,
 	reqChart string,
 	reqName string,
@@ -639,21 +640,21 @@ func (h *Handler) getChart(
 	// locate chart
 	chartPath, err := chartPathOptions.LocateChart(reqChart, settings)
 	if err != nil {
-		h.logActionState(zlog.Error(), err, actionName, reqChart, reqName, failed, "locating chart")
+		h.logActionState(zlog.Error(), err, namespace, actionName, reqChart, reqName, failed, "locating chart")
 		return nil, err
 	}
 
 	// load chart
 	chart, err := loader.Load(chartPath)
 	if err != nil {
-		h.logActionState(zlog.Error(), err, actionName, reqChart, reqName, failed, "loading chart")
+		h.logActionState(zlog.Error(), err, namespace, actionName, reqChart, reqName, failed, "loading chart")
 		return nil, err
 	}
 
 	// chart is installable only if it is of type application or empty
 	if chart.Metadata.Type != "" && chart.Metadata.Type != "application" {
 		typeErr := fmt.Errorf("chart type %q is not installable", chart.Metadata.Type)
-		h.logActionState(zlog.Error(), typeErr, actionName, reqChart, reqName, failed, "chart is not installable")
+		h.logActionState(zlog.Error(), typeErr, namespace, actionName, reqChart, reqName, failed, "chart is not installable")
 
 		return nil, typeErr
 	}
@@ -673,7 +674,7 @@ func (h *Handler) getChart(
 
 			err = manager.Update()
 			if err != nil {
-				h.logActionState(zlog.Error(), err, actionName, reqChart, reqName, failed, "updating dependencies")
+				h.logActionState(zlog.Error(), err, namespace, actionName, reqChart, reqName, failed, "updating dependencies")
 				return nil, err
 			}
 		}
@@ -735,7 +736,7 @@ func (h *Handler) installRelease(req InstallRequest, actionConfig *action.Config
 		return
 	}
 
-	chart, err := h.getChart("install", req.Chart, req.Name,
+	chart, err := h.getChart(req.Namespace, "install", req.Chart, req.Name,
 		installClient.ChartPathOptions, req.DependencyUpdate, h.EnvSettings)
 	if err != nil {
 		logger.Log(logger.LevelError, map[string]string{logFieldChart: req.Chart, logFieldReleaseName: req.Name},
@@ -748,7 +749,7 @@ func (h *Handler) installRelease(req InstallRequest, actionConfig *action.Config
 	if err != nil {
 		logger.Log(logger.LevelError, map[string]string{logFieldChart: req.Chart, logFieldReleaseName: req.Name},
 			err, "decoding values")
-		h.setReleaseStatusSilent("install", req.Name, failed, err)
+		h.setReleaseStatusSilent(req.Namespace, "install", req.Name, failed, err)
 
 		return
 	}
@@ -757,7 +758,7 @@ func (h *Handler) installRelease(req InstallRequest, actionConfig *action.Config
 	if err = yaml.Unmarshal(decodedBytes, &values); err != nil {
 		logger.Log(logger.LevelError, map[string]string{logFieldChart: req.Chart, logFieldReleaseName: req.Name},
 			err, "unmarshalling values")
-		h.setReleaseStatusSilent("install", req.Name, failed, err)
+		h.setReleaseStatusSilent(req.Namespace, "install", req.Name, failed, err)
 
 		return
 	}
@@ -765,12 +766,12 @@ func (h *Handler) installRelease(req InstallRequest, actionConfig *action.Config
 	if _, err = installClient.Run(chart, values); err != nil {
 		logger.Log(logger.LevelError, map[string]string{logFieldChart: req.Chart, logFieldReleaseName: req.Name},
 			err, "installing chart")
-		h.setReleaseStatusSilent("install", req.Name, failed, err)
+		h.setReleaseStatusSilent(req.Namespace, "install", req.Name, failed, err)
 
 		return
 	}
 
-	h.setReleaseStatusSilent("install", req.Name, success, nil)
+	h.setReleaseStatusSilent(req.Namespace, "install", req.Name, success, nil)
 }
 
 type UpgradeReleaseRequest struct {
@@ -815,7 +816,7 @@ func (h *Handler) UpgradeRelease(clientConfig clientcmd.ClientConfig, w http.Res
 		return
 	}
 
-	err = h.setReleaseStatus("upgrade", req.Name, processing, nil)
+	err = h.setReleaseStatus(req.Namespace, "upgrade", req.Name, processing, nil)
 	if err != nil {
 		handleError(w, req.Name, err, "setting status", http.StatusInternalServerError)
 		return
@@ -830,6 +831,7 @@ func (h *Handler) UpgradeRelease(clientConfig clientcmd.ClientConfig, w http.Res
 
 func (h *Handler) logActionState(zlog *zerolog.Event,
 	err error,
+	namespace string,
 	action string,
 	chart string,
 	releaseName string,
@@ -846,7 +848,7 @@ func (h *Handler) logActionState(zlog *zerolog.Event,
 		Str("status", status).
 		Msg(message)
 
-	h.setReleaseStatusSilent(action, releaseName, status, err)
+	h.setReleaseStatusSilent(namespace, action, releaseName, status, err)
 }
 
 func (h *Handler) upgradeRelease(req UpgradeReleaseRequest, actionConfig *action.Configuration) {
@@ -856,7 +858,7 @@ func (h *Handler) upgradeRelease(req UpgradeReleaseRequest, actionConfig *action
 	upgradeClient.Description = req.Description
 	upgradeClient.Version = req.Version
 
-	chart, err := h.getChart("upgrade", req.Chart, req.Name, upgradeClient.ChartPathOptions, true, h.EnvSettings)
+	chart, err := h.getChart(req.Namespace, "upgrade", req.Chart, req.Name, upgradeClient.ChartPathOptions, true, h.EnvSettings)
 	if err != nil {
 		logger.Log(logger.LevelError, map[string]string{logFieldChart: req.Chart, logFieldReleaseName: req.Name},
 			err, "getting chart")
@@ -868,29 +870,30 @@ func (h *Handler) upgradeRelease(req UpgradeReleaseRequest, actionConfig *action
 
 	valuesStr, err := base64.StdEncoding.DecodeString(req.Values)
 	if err != nil {
-		h.logActionState(zlog.Error(), err, "upgrade", req.Chart, req.Name, failed, "values decoding failed")
+		h.logActionState(zlog.Error(), err, req.Namespace, "upgrade", req.Chart, req.Name, failed, "values decoding failed")
 		return
 	}
 
 	err = yaml.Unmarshal(valuesStr, &values)
 	if err != nil {
-		h.logActionState(zlog.Error(), err, "upgrade", req.Chart, req.Name, failed, "values un-marshalling failed")
+		h.logActionState(zlog.Error(), err, req.Namespace, "upgrade", req.Chart, req.Name, failed, "values un-marshalling failed")
 		return
 	}
 
 	// Upgrade chart
 	_, err = upgradeClient.Run(req.Name, chart, values)
 	if err != nil {
-		h.logActionState(zlog.Error(), err, "upgrade", req.Chart, req.Name, failed, "chart upgrade failed")
+		h.logActionState(zlog.Error(), err, req.Namespace, "upgrade", req.Chart, req.Name, failed, "chart upgrade failed")
 		return
 	}
 
-	h.logActionState(zlog.Info(), nil, "upgrade", req.Chart, req.Name, success, "chart upgradeable is successful")
+	h.logActionState(zlog.Info(), nil, req.Namespace, "upgrade", req.Chart, req.Name, success, "chart upgradeable is successful")
 }
 
 type ActionStatusRequest struct {
-	Name   string `json:"name" validate:"required"`
-	Action string `json:"action" validate:"required"`
+	Name      string `json:"name" validate:"required"`
+	Action    string `json:"action" validate:"required"`
+	Namespace string `json:"namespace"`
 }
 
 func (a *ActionStatusRequest) Validate() error {
@@ -930,7 +933,7 @@ func (h *Handler) GetActionStatus(clientConfig clientcmd.ClientConfig, w http.Re
 		return
 	}
 
-	stat, err := h.getReleaseStatus(request.Action, request.Name)
+	stat, err := h.getReleaseStatus(request.Namespace, request.Action, request.Name)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "getting status")
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/backend/pkg/helm/release_internal_test.go
+++ b/backend/pkg/helm/release_internal_test.go
@@ -25,7 +25,7 @@ func TestGetActionStatus_NilErr(t *testing.T) {
 		Status: "failed",
 		Err:    nil,
 	}
-	err := h.Cache.Set(context.Background(), "helm_install_test-release", statusVal)
+	err := h.Cache.Set(context.Background(), "helm__install_test-release", statusVal)
 	require.NoError(t, err)
 
 	url := "/clusters/minikube/helm/releases/status?action=install&name=test-release"
@@ -59,14 +59,14 @@ func TestGetChart_InvalidType(t *testing.T) {
 	require.NoError(t, err)
 
 	opts := action.ChartPathOptions{}
-	loadedChart, err := h.getChart("install", chartDir, "test-release", opts, false, h.EnvSettings)
+	loadedChart, err := h.getChart("default", "install", chartDir, "test-release", opts, false, h.EnvSettings)
 
 	assert.Nil(t, loadedChart)
 	require.Error(t, err)
 	assert.Equal(t, "chart type \"library\" is not installable", err.Error())
 
 	// Verify that the failed status was logged to the cache
-	statusVal, err := h.Cache.Get(context.Background(), "helm_install_test-release")
+	statusVal, err := h.Cache.Get(context.Background(), "helm_default_install_test-release")
 	require.NoError(t, err)
 
 	statusMap := statusVal.(stat)


### PR DESCRIPTION
## Summary

This PR fixes a cache key collision in the Helm action status cache by scoping it to the release's namespace.

## Related Issue

Fixes #

## Changes

- Threaded the release's namespace into `getReleaseStatus`/`setReleaseStatus` and the action-status cache key in `backend/pkg/helm/release.go` and `handler.go`
- Updated `handler_test.go` and `release_internal_test.go` to cover the namespace-scoped key

## Steps to Test

1. Install (or upgrade) a release with the same name in two different namespaces
2. Poll the action status endpoint for each namespace's release right after
3. Before this fix, whichever write landed last would win the shared cache key, so one namespace's status could report the other's; after the fix each namespace's status is tracked independently

## Screenshots (if applicable)

Not applicable, backend-only change.

## Notes for the Reviewer

- Found by reading `backend/pkg/helm/handler.go` directly rather than from a filed issue, no issue number to link
- Existing tests in `pkg/helm` all still pass
