### PR TITLE
backend: lock the repositories file before listing repos

### DIFF
--- a/backend/pkg/helm/repository.go
+++ b/backend/pkg/helm/repository.go
@@ -84,20 +84,31 @@ func createFileIfNotThere(fileName string) error {
 	return err
 }
 
-func lockRepositoryFile(lockCtx context.Context, repositoryConfig string) (bool, *flock.Flock, error) {
-	var lockPath string
-
+func repositoryLockPath(repositoryConfig string) string {
 	repoFileExt := filepath.Ext(repositoryConfig)
 
 	if len(repoFileExt) > 0 && len(repoFileExt) < len(repositoryConfig) {
-		lockPath = strings.Replace(repositoryConfig, repoFileExt, ".lock", 1)
-	} else {
-		lockPath = repositoryConfig + ".lock"
+		return strings.Replace(repositoryConfig, repoFileExt, ".lock", 1)
 	}
 
-	fileLock := flock.New(lockPath)
+	return repositoryConfig + ".lock"
+}
+
+func lockRepositoryFile(lockCtx context.Context, repositoryConfig string) (bool, *flock.Flock, error) {
+	fileLock := flock.New(repositoryLockPath(repositoryConfig))
 
 	locked, err := fileLock.TryLockContext(lockCtx, time.Second)
+
+	return locked, fileLock, err
+}
+
+// lockRepositoryFileForRead takes a shared lock, so it can run alongside other
+// reads but still waits out a concurrent add/update/remove, since repo.File's
+// WriteFile truncates the file before writing rather than replacing it atomically.
+func lockRepositoryFileForRead(lockCtx context.Context, repositoryConfig string) (bool, *flock.Flock, error) {
+	fileLock := flock.New(repositoryLockPath(repositoryConfig))
+
+	locked, err := fileLock.TryRLockContext(lockCtx, time.Second)
 
 	return locked, fileLock, err
 }
@@ -272,6 +283,21 @@ func listRepositories(settings *cli.EnvSettings) ([]repositoryInfo, error) {
 		logger.Log(logger.LevelError, nil, err, "creating empty RepositoryConfig file")
 		return nil, err
 	}
+
+	lockCtx, cancel := context.WithTimeout(context.Background(), timeoutForLock)
+	defer cancel()
+
+	locked, fileLock, err := lockRepositoryFileForRead(lockCtx, settings.RepositoryConfig)
+	if err = ensureRepositoryFileLocked(locked, err); err != nil {
+		logger.Log(logger.LevelError, nil, err, "locking repository config file")
+		return nil, err
+	}
+
+	defer func() {
+		if err := fileLock.Unlock(); err != nil {
+			logger.Log(logger.LevelError, nil, err, "unlocking repository config file")
+		}
+	}()
 
 	repoFile, err := repo.LoadFile(settings.RepositoryConfig)
 	if err != nil {

--- a/backend/pkg/helm/repository_internal_test.go
+++ b/backend/pkg/helm/repository_internal_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package helm
 
 import (
+	"context"
 	"errors"
 	"io/fs"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -64,4 +66,42 @@ func TestEnsureRepositoryFileLocked(t *testing.T) {
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, errRepositoryLockNotAcquired))
 	})
+}
+
+func TestLockRepositoryFileForReadWaitsOnWriteLock(t *testing.T) {
+	repoConfig := filepath.Join(t.TempDir(), "repositories.yaml")
+
+	writeCtx, writeCancel := context.WithTimeout(context.Background(), time.Second)
+	defer writeCancel()
+
+	writeLocked, writeFileLock, err := lockRepositoryFile(writeCtx, repoConfig)
+	require.NoError(t, err)
+	require.True(t, writeLocked)
+
+	defer func() { assert.NoError(t, writeFileLock.Unlock()) }()
+
+	readCtx, readCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer readCancel()
+
+	readLocked, _, err := lockRepositoryFileForRead(readCtx, repoConfig)
+	assert.False(t, readLocked)
+	assert.Error(t, err)
+}
+
+func TestLockRepositoryFileForReadAllowsConcurrentReaders(t *testing.T) {
+	repoConfig := filepath.Join(t.TempDir(), "repositories.yaml")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	firstLocked, firstFileLock, err := lockRepositoryFileForRead(ctx, repoConfig)
+	require.NoError(t, err)
+	require.True(t, firstLocked)
+
+	defer func() { assert.NoError(t, firstFileLock.Unlock()) }()
+
+	secondLocked, secondFileLock, err := lockRepositoryFileForRead(ctx, repoConfig)
+	require.NoError(t, err)
+	assert.True(t, secondLocked)
+	assert.NoError(t, secondFileLock.Unlock())
 }


### PR DESCRIPTION
## Summary

This PR fixes a torn read race in ListRepo by taking a shared file lock before reading repositories.yaml.

## Related Issue

No existing issue tracks this; found by reading the locking code around AddRepo/RemoveRepo/UpdateRepository.

## Changes

- Added lockRepositoryFileForRead, which takes a shared lock instead of the exclusive lock the write paths use
- ListRepo now takes that read lock before loading repositories.yaml and releases it afterward
- Extracted the lock path computation shared by both lock functions into repositoryLockPath

## Steps to Test

1. Run go test ./pkg/helm/... -run TestLockRepositoryFile from the backend module
2. TestLockRepositoryFileForReadWaitsOnWriteLock confirms a read lock attempt fails while a write lock is held
3. TestLockRepositoryFileForReadAllowsConcurrentReaders confirms two read locks can be held at once

## Screenshots (if applicable)

Not applicable, backend only change.

## Notes for the Reviewer

AddRepo, RemoveRepo, and UpdateRepository already take an exclusive lock before touching repositories.yaml, but ListRepo read it with no lock at all. Helm's repo.File.WriteFile truncates the file before writing rather than replacing it atomically, so a list request racing a concurrent add, remove, or update could previously read a truncated or partial file.