### PR TITLE
frontend: AddCluster: restore Storybook stories and fix list keys

### DIFF
--- a/frontend/src/components/App/CreateCluster/AddCluster.stories.tsx
+++ b/frontend/src/components/App/CreateCluster/AddCluster.stories.tsx
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import {
+  type ClusterProviderSliceState,
+  initialState as CLUSTER_PROVIDER_INITIAL_STATE,
+} from '../../../redux/clusterProviderSlice';
+import reducers from '../../../redux/reducers/reducers';
+import { TestContext } from '../../../test';
+import {
+  initialState as SIDEBAR_INITIAL_STATE,
+  type SidebarState,
+} from '../../Sidebar/sidebarSlice';
+import AddCluster from './AddCluster';
+
+/**
+ * Storybook coverage for AddCluster (provider chooser).
+ *
+ * Form / connection-test states named in older #4687 wording live in
+ * KubeConfigLoader, which already has stories. A prior AddCluster stories PR
+ * (#5171) was reverted (#5301) after CI failures — one cause was replacing
+ * `window.process` wholesale (which can wipe `process.env` under Vitest/jsdom).
+ */
+
+function createStoryStore({
+  clusterProvider,
+  sidebar,
+}: {
+  clusterProvider?: ClusterProviderSliceState;
+  sidebar?: SidebarState;
+} = {}) {
+  return configureStore({
+    reducer: reducers,
+    preloadedState: {
+      clusterProvider: clusterProvider ?? CLUSTER_PROVIDER_INITIAL_STATE,
+      sidebar: sidebar ?? SIDEBAR_INITIAL_STATE,
+    },
+    middleware: getDefaultMiddleware =>
+      getDefaultMiddleware({
+        serializableCheck: false,
+        thunk: true,
+      }),
+  });
+}
+
+/** Safely mark the environment as Electron without clobbering process.env. */
+function ElectronEnvDecorator({ children }: { children: React.ReactNode }) {
+  const win = window as any;
+  const previousRef = React.useRef(win.process);
+  const didSetRef = React.useRef(false);
+
+  // Must run during render so isElectron() sees renderer on the first paint.
+  // Spreading the prior process keeps env/NODE_ENV intact under Vitest/jsdom.
+  if (!didSetRef.current) {
+    previousRef.current = win.process;
+    const previous = previousRef.current;
+    const base =
+      previous && typeof previous === 'object'
+        ? previous
+        : typeof process !== 'undefined'
+        ? process
+        : {};
+    win.process = {
+      ...base,
+      type: 'renderer',
+      env: (base as any).env ?? (typeof process !== 'undefined' ? process.env : {}),
+    };
+    didSetRef.current = true;
+  }
+
+  React.useEffect(() => {
+    return () => {
+      const previous = previousRef.current;
+      if (previous === undefined) {
+        delete win.process;
+      } else {
+        win.process = previous;
+      }
+    };
+  }, []);
+
+  return <>{children}</>;
+}
+
+const meta: Meta<typeof AddCluster> = {
+  title: 'App/AddCluster',
+  component: AddCluster,
+  decorators: [
+    (Story, context) => (
+      <TestContext store={context.parameters.store}>
+        <Story />
+      </TestContext>
+    ),
+  ],
+  args: {
+    open: true,
+    onChoice: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AddCluster>;
+
+/** No providers registered and no plugin catalog sidebar entry. */
+export const NoProviders: Story = {
+  parameters: {
+    store: createStoryStore({
+      clusterProvider: {
+        ...CLUSTER_PROVIDER_INITIAL_STATE,
+        clusterProviders: [],
+      },
+      sidebar: {
+        ...SIDEBAR_INITIAL_STATE,
+        entries: {},
+      },
+    }),
+  },
+};
+
+/**
+ * Plugin catalog registered + Electron so "Add Local Cluster Provider" shows.
+ * Uses a safe process mock that preserves env (see file header).
+ */
+export const WithPluginCatalog: Story = {
+  parameters: {
+    store: createStoryStore({
+      clusterProvider: {
+        ...CLUSTER_PROVIDER_INITIAL_STATE,
+        clusterProviders: [],
+      },
+      sidebar: {
+        ...SIDEBAR_INITIAL_STATE,
+        entries: {
+          pluginCatalog: {
+            name: 'pluginCatalog',
+            label: 'Plugin Catalog',
+            url: '/plugin-catalog',
+          },
+        },
+      },
+    }),
+  },
+  decorators: [
+    Story => (
+      <ElectronEnvDecorator>
+        <Story />
+      </ElectronEnvDecorator>
+    ),
+  ],
+};
+
+/** Cluster providers registered and shown in the list. */
+export const WithProviders: Story = {
+  parameters: {
+    store: createStoryStore({
+      clusterProvider: {
+        ...CLUSTER_PROVIDER_INITIAL_STATE,
+        clusterProviders: [
+          {
+            title: 'Minikube',
+            icon: () => null,
+            description: 'Run a local Kubernetes cluster with Minikube.',
+            url: '/minikube',
+          },
+        ],
+      },
+      sidebar: {
+        ...SIDEBAR_INITIAL_STATE,
+        entries: {},
+      },
+    }),
+  },
+};

--- a/frontend/src/components/App/CreateCluster/AddCluster.tsx
+++ b/frontend/src/components/App/CreateCluster/AddCluster.tsx
@@ -105,7 +105,10 @@ export default function AddCluster(props: DialogProps & { onChoice: () => void }
           {addClusterProviders.length > 0 && (
             <Grid item xs={12}>
               {addClusterProviders.map(addClusterProviderInfo => (
-                <AddClusterProvider {...addClusterProviderInfo} />
+                <AddClusterProvider
+                  key={addClusterProviderInfo.url || addClusterProviderInfo.title}
+                  {...addClusterProviderInfo}
+                />
               ))}
             </Grid>
           )}

--- a/frontend/src/components/App/CreateCluster/__snapshots__/AddCluster.NoProviders.stories.storyshot
+++ b/frontend/src/components/App/CreateCluster/__snapshots__/AddCluster.NoProviders.stories.storyshot
@@ -1,0 +1,109 @@
+<body>
+  <div>
+    <div
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-1ub3t8b-MuiGrid-root"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-1j11y9k-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-y6rp3m-MuiButton-startIcon"
+            />
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+              style="padding-top: 3px;"
+            >
+              Back
+            </p>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+                  >
+                    Add Cluster
+                  </h2>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-lpikod"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-4 css-13cu5dn-MuiGrid-root"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+                  >
+                    Proceed to select your preferred method for cluster creation and addition
+                  </p>
+                </div>
+                <div
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+                >
+                  <div
+                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-13jdyvt-MuiPaper-root-MuiCard-root"
+                  >
+                    <div
+                      class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                    >
+                      <button
+                        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-5534ty-MuiButtonBase-root-MuiButton-root"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <span
+                          class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1d6wzja-MuiButton-startIcon"
+                        />
+                        Load from KubeConfig
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+                >
+                  <h4
+                    class="MuiTypography-root MuiTypography-h4 css-1nsdt9j-MuiTypography-root"
+                  >
+                    Providers
+                  </h4>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/App/CreateCluster/__snapshots__/AddCluster.WithPluginCatalog.stories.storyshot
+++ b/frontend/src/components/App/CreateCluster/__snapshots__/AddCluster.WithPluginCatalog.stories.storyshot
@@ -1,0 +1,126 @@
+<body>
+  <div>
+    <div
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-1ub3t8b-MuiGrid-root"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-1j11y9k-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-y6rp3m-MuiButton-startIcon"
+            />
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+              style="padding-top: 3px;"
+            >
+              Back
+            </p>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+                  >
+                    Add Cluster
+                  </h2>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-lpikod"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-4 css-13cu5dn-MuiGrid-root"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+                  >
+                    Proceed to select your preferred method for cluster creation and addition
+                  </p>
+                </div>
+                <div
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+                >
+                  <div
+                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-13jdyvt-MuiPaper-root-MuiCard-root"
+                  >
+                    <div
+                      class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                    >
+                      <button
+                        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-5534ty-MuiButtonBase-root-MuiButton-root"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <span
+                          class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1d6wzja-MuiButton-startIcon"
+                        />
+                        Load from KubeConfig
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+                >
+                  <h4
+                    class="MuiTypography-root MuiTypography-h4 css-1nsdt9j-MuiTypography-root"
+                  >
+                    Providers
+                  </h4>
+                </div>
+                <div
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-5534ty-MuiButtonBase-root-MuiButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1d6wzja-MuiButton-startIcon"
+                    />
+                    Add Local Cluster Provider
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/App/CreateCluster/__snapshots__/AddCluster.WithProviders.stories.storyshot
+++ b/frontend/src/components/App/CreateCluster/__snapshots__/AddCluster.WithProviders.stories.storyshot
@@ -1,0 +1,152 @@
+<body>
+  <div>
+    <div
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-1ub3t8b-MuiGrid-root"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-1j11y9k-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-y6rp3m-MuiButton-startIcon"
+            />
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+              style="padding-top: 3px;"
+            >
+              Back
+            </p>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+                  >
+                    Add Cluster
+                  </h2>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-lpikod"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-4 css-13cu5dn-MuiGrid-root"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+                  >
+                    Proceed to select your preferred method for cluster creation and addition
+                  </p>
+                </div>
+                <div
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+                >
+                  <div
+                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-13jdyvt-MuiPaper-root-MuiCard-root"
+                  >
+                    <div
+                      class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                    >
+                      <button
+                        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-5534ty-MuiButtonBase-root-MuiButton-root"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <span
+                          class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1d6wzja-MuiButton-startIcon"
+                        />
+                        Load from KubeConfig
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+                >
+                  <h4
+                    class="MuiTypography-root MuiTypography-h4 css-1nsdt9j-MuiTypography-root"
+                  >
+                    Providers
+                  </h4>
+                </div>
+                <div
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+                >
+                  <div
+                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-13jdyvt-MuiPaper-root-MuiCard-root"
+                  >
+                    <div
+                      class="MuiCardHeader-root css-185gdzj-MuiCardHeader-root"
+                    >
+                      <div
+                        class="MuiCardHeader-avatar css-1ssile9-MuiCardHeader-avatar"
+                      />
+                      <div
+                        class="MuiCardHeader-content css-1qbkelo-MuiCardHeader-content"
+                      >
+                        <span
+                          class="MuiTypography-root MuiTypography-body2 MuiCardHeader-title css-z2qth0-MuiTypography-root"
+                        >
+                          Minikube
+                        </span>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+                      >
+                        Run a local Kubernetes cluster with Minikube.
+                      </p>
+                      <button
+                        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-z6jpz4-MuiButtonBase-root-MuiButton-root"
+                        tabindex="0"
+                        type="button"
+                      >
+                        Add
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
## Summary
Restores Storybook coverage for `AddCluster` after #5171 was reverted in #5301.

`AddCluster` is the provider chooser (not the kubeconfig form). These stories cover the real Redux-driven UI states:
- **NoProviders** — Load from KubeConfig only
- **WithPluginCatalog** — Electron + plugin catalog shows “Add Local Cluster Provider”
- **WithProviders** — registered provider cards

Also fixes a missing React `key` when mapping provider cards (caught while running storyshots).

### Why this should not repeat the #5301 CI failure
The earlier Electron story replaced `window.process` wholesale, which under Vitest/jsdom can wipe `process.env` / `NODE_ENV` and break later MUI theme creation. This PR’s Electron decorator **spreads** the prior process (keeping `env`) and restores it on unmount. Storyshots for `App/AddCluster` pass locally (3/3).

Form / connection-test wording in older #4687 titles belongs to `KubeConfigLoader` (already has stories).

## Related Issue
Fixes #4687

## Test plan
- [x] `cd frontend && npm test -- --run src/storybook.test.tsx -t "App/AddCluster"` (3 passed)
- [ ] Review stories in Storybook under `App > AddCluster`
- [ ] Confirm CI storybook/snapshot jobs are green