### PR TITLE
frontend: improve Global Search accessibility

### DIFF
--- a/frontend/.axe-storybook-baseline.test-a11y.json
+++ b/frontend/.axe-storybook-baseline.test-a11y.json
@@ -103,21 +103,9 @@
     "Deployments/CreateDeploymentForm/Filled": ["label"],
     "Deployments/CreateDeploymentForm/Pod Template Extras": ["label"],
     "Deployments/CreateDeploymentForm/Empty": ["label"],
-    "GlobalSearch/GlobalSearchContent/With Empty Input": [
-      "aria-input-field-name",
-      "aria-progressbar-name",
-      "aria-tooltip-name"
-    ],
-    "GlobalSearch/GlobalSearchContent/Loading Resources": [
-      "aria-progressbar-name",
-      "aria-tooltip-name",
-      "scrollable-region-focusable"
-    ],
-    "GlobalSearch/GlobalSearchContent/Found Some Results": [
-      "aria-progressbar-name",
-      "aria-tooltip-name",
-      "scrollable-region-focusable"
-    ],
+    "GlobalSearch/GlobalSearchContent/With Empty Input": ["aria-progressbar-name"],
+    "GlobalSearch/GlobalSearchContent/Loading Resources": ["aria-progressbar-name"],
+    "GlobalSearch/GlobalSearchContent/Found Some Results": ["aria-progressbar-name"],
     "Jobs/CreateJobForm/Default": ["label"],
     "Jobs/CreateJobForm/Filled": ["label"],
     "Jobs/CreateJobForm/Pod Template Extras": ["label"],
@@ -133,16 +121,8 @@
     "ReplicaSets/CreateReplicaSetForm/Empty": ["label"],
     "Service/CreateServiceForm/Default": ["label"],
     "home/ClusterTable/Connecting": ["aria-progressbar-name"],
-    "GlobalSearch/GlobalSearchContent/Bare Namespace Query": [
-      "aria-progressbar-name",
-      "aria-tooltip-name",
-      "scrollable-region-focusable"
-    ],
-    "GlobalSearch/GlobalSearchContent/Combined Namespace Query": [
-      "aria-progressbar-name",
-      "aria-tooltip-name",
-      "scrollable-region-focusable"
-    ],
+    "GlobalSearch/GlobalSearchContent/Bare Namespace Query": ["aria-progressbar-name"],
+    "GlobalSearch/GlobalSearchContent/Combined Namespace Query": ["aria-progressbar-name"],
     "GraphView/Performance Test 20000 Pods": ["color-contrast"],
     "GraphView/Performance Test 100000 Pods": ["color-contrast"],
     "StatefulSet/CreateStatefulSetForm/Default": ["label"],

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -26,7 +26,7 @@ import Typography from '@mui/material/Typography';
 import useAutocomplete from '@mui/material/useAutocomplete';
 import { UseAutocompleteReturnValue } from '@mui/material/useAutocomplete';
 import Fuse, { Expression, FuseResultMatch } from 'fuse.js';
-import { lazy, Suspense, useMemo, useRef, useState } from 'react';
+import { forwardRef, type HTMLAttributes, lazy, Suspense, useMemo, useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { generatePath, useHistory, useLocation, useRouteMatch } from 'react-router';
@@ -70,6 +70,12 @@ import { useRecent } from './useRecent';
 
 const LazyKubeIcon = lazy(() =>
   import('../resourceMap/kubeIcon/KubeIcon').then(it => ({ default: it.KubeIcon }))
+);
+
+const FocusableSearchResultsOuter = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  function FocusableSearchResultsOuter(props, ref) {
+    return <Box {...props} ref={ref} role="group" tabIndex={0} />;
+  }
 );
 
 /**
@@ -521,9 +527,13 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
         size="small"
         variant="outlined"
         placeholder={t('Search resources, pages, clusters by name')}
+        inputProps={{
+          'aria-label': t('Search resources, pages, clusters by name'),
+        }}
         InputProps={
           {
             ...autocomplete.getInputProps(),
+            'aria-label': t('Search resources, pages, clusters by name'),
             ref: (el: HTMLDivElement) => {
               const ac = autocomplete as any; // some types are wrong
               ac.setAnchorEl(el);
@@ -562,6 +572,7 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
       <Popper
         anchorEl={autocomplete.anchorEl}
         open={autocomplete.popupOpen}
+        role="presentation"
         sx={theme => ({ zIndex: theme.zIndex.modal, width: '100%', maxWidth: maxWidth + 'px' })}
       >
         <Paper
@@ -569,6 +580,8 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
           variant="outlined"
           sx={{ position: 'relative', padding: 0, margin: 0 }}
           {...autocomplete.getListboxProps()}
+          aria-labelledby={undefined}
+          aria-label={t('Search')}
         >
           {autocomplete.groupedOptions.length > 0 && (
             <FixedSizeList
@@ -578,6 +591,7 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
               itemData={autocomplete}
               itemSize={50}
               width={'100%'}
+              outerElementType={FocusableSearchResultsOuter}
             >
               {SearchRow}
             </FixedSizeList>

--- a/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.BareNamespaceQuery.stories.storyshot
+++ b/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.BareNamespaceQuery.stories.storyshot
@@ -12,6 +12,7 @@
           aria-autocomplete="list"
           aria-controls=":mock-test-id:"
           aria-expanded="true"
+          aria-label="Search resources, pages, clusters by name"
           autocapitalize="none"
           class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-1qswgw4-MuiInputBase-root-MuiOutlinedInput-root"
           role="combobox"
@@ -20,6 +21,7 @@
           <input
             aria-activedescendant=":mock-test-id:"
             aria-invalid="false"
+            aria-label="Search resources, pages, clusters by name"
             autocomplete="off"
             class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
             id=":mock-test-id:"
@@ -61,17 +63,20 @@
     data-popper-escaped=""
     data-popper-placement="bottom"
     data-popper-reference-hidden=""
-    role="tooltip"
+    role="presentation"
     style="position: absolute; top: 0px; left: 0px; margin: 0px; right: auto; bottom: auto; transform: translate(0px, 0px);"
   >
     <ul
-      aria-labelledby=":mock-test-id:"
+      aria-label="Search"
       class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-atm94b-MuiPaper-root"
       id=":mock-test-id:"
       role="listbox"
     >
       <div
+        class="MuiBox-root css-0"
+        role="group"
         style="position: relative; height: 100px; width: 100%; overflow: auto; -webkit-overflow-scrolling: touch; will-change: transform; direction: ltr;"
+        tabindex="0"
       >
         <div
           style="height: 100px; width: 100%;"

--- a/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.CombinedNamespaceQuery.stories.storyshot
+++ b/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.CombinedNamespaceQuery.stories.storyshot
@@ -12,6 +12,7 @@
           aria-autocomplete="list"
           aria-controls=":mock-test-id:"
           aria-expanded="true"
+          aria-label="Search resources, pages, clusters by name"
           autocapitalize="none"
           class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-1qswgw4-MuiInputBase-root-MuiOutlinedInput-root"
           role="combobox"
@@ -20,6 +21,7 @@
           <input
             aria-activedescendant=":mock-test-id:"
             aria-invalid="false"
+            aria-label="Search resources, pages, clusters by name"
             autocomplete="off"
             class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
             id=":mock-test-id:"
@@ -61,17 +63,20 @@
     data-popper-escaped=""
     data-popper-placement="bottom"
     data-popper-reference-hidden=""
-    role="tooltip"
+    role="presentation"
     style="position: absolute; top: 0px; left: 0px; margin: 0px; right: auto; bottom: auto; transform: translate(0px, 0px);"
   >
     <ul
-      aria-labelledby=":mock-test-id:"
+      aria-label="Search"
       class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-atm94b-MuiPaper-root"
       id=":mock-test-id:"
       role="listbox"
     >
       <div
+        class="MuiBox-root css-0"
+        role="group"
         style="position: relative; height: 100px; width: 100%; overflow: auto; -webkit-overflow-scrolling: touch; will-change: transform; direction: ltr;"
+        tabindex="0"
       >
         <div
           style="height: 100px; width: 100%;"

--- a/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.FoundSomeResults.stories.storyshot
+++ b/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.FoundSomeResults.stories.storyshot
@@ -12,6 +12,7 @@
           aria-autocomplete="list"
           aria-controls=":mock-test-id:"
           aria-expanded="true"
+          aria-label="Search resources, pages, clusters by name"
           autocapitalize="none"
           class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-1qswgw4-MuiInputBase-root-MuiOutlinedInput-root"
           role="combobox"
@@ -20,6 +21,7 @@
           <input
             aria-activedescendant=":mock-test-id:"
             aria-invalid="false"
+            aria-label="Search resources, pages, clusters by name"
             autocomplete="off"
             class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
             id=":mock-test-id:"
@@ -61,17 +63,20 @@
     data-popper-escaped=""
     data-popper-placement="bottom"
     data-popper-reference-hidden=""
-    role="tooltip"
+    role="presentation"
     style="position: absolute; top: 0px; left: 0px; margin: 0px; right: auto; bottom: auto; transform: translate(0px, 0px);"
   >
     <ul
-      aria-labelledby=":mock-test-id:"
+      aria-label="Search"
       class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-atm94b-MuiPaper-root"
       id=":mock-test-id:"
       role="listbox"
     >
       <div
+        class="MuiBox-root css-0"
+        role="group"
         style="position: relative; height: 500px; width: 100%; overflow: auto; -webkit-overflow-scrolling: touch; will-change: transform; direction: ltr;"
+        tabindex="0"
       >
         <div
           style="height: 600px; width: 100%;"

--- a/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.WithEmptyInput.stories.storyshot
+++ b/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.WithEmptyInput.stories.storyshot
@@ -10,6 +10,7 @@
           aria-activedescendant=""
           aria-autocomplete="list"
           aria-expanded="false"
+          aria-label="Search resources, pages, clusters by name"
           autocapitalize="none"
           class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-1qswgw4-MuiInputBase-root-MuiOutlinedInput-root"
           role="combobox"
@@ -17,6 +18,7 @@
         >
           <input
             aria-invalid="false"
+            aria-label="Search resources, pages, clusters by name"
             autocomplete="off"
             class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
             id=":mock-test-id:"
@@ -58,11 +60,11 @@
     data-popper-escaped=""
     data-popper-placement="bottom"
     data-popper-reference-hidden=""
-    role="tooltip"
+    role="presentation"
     style="position: absolute; top: 0px; left: 0px; margin: 0px; right: auto; bottom: auto; transform: translate(0px, 0px);"
   >
     <ul
-      aria-labelledby=":mock-test-id:"
+      aria-label="Search"
       class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-atm94b-MuiPaper-root"
       id=":mock-test-id:"
       role="listbox"


### PR DESCRIPTION
## Summary

Improves the accessibility semantics of the Global Search input and results popup.

## Related Issue

Fixes #7186
Fixes #7197
Fixes #7198

## Changes

- Adds descriptive names to the Global Search combobox, input, and results list.
- Marks the search results popup as presentational and makes the virtualized results group focusable.
- Updates Global Search Storybook snapshots and the accessibility baseline.

## Steps to Test

1. Build and serve Storybook, then open `GlobalSearch/GlobalSearchContent -> With Empty Input`.
2. Inspect the browser accessibility tree: the combobox and text field are named `Search resources, pages, clusters by name`, and the results list is named `Search`.
3. Open `Found Some Results` and confirm the result list renders normally with the same semantics.
4. Run `npm run frontend:test:a11y`; the five Global Search stories have no new accessibility violations.

## Screenshots (if applicable)

Accessibility-only change; visual appearance is unchanged.

## Notes for the Reviewer

- The remaining Global Search spinner baseline is intentionally left for #7236.
- The closed, unmerged #7585 changed the Clear tooltip title; this change fixes the outer popup semantics that Axe reports.
