### PR TITLE
docs: Fix broken links reported by docusaurus

### DIFF
--- a/docs/development/gateway.md
+++ b/docs/development/gateway.md
@@ -6,13 +6,13 @@ This guide documents the usage of Gateway API manifests for testing and developm
 
 | File                                                                                         | Description                               |
 | -------------------------------------------------------------------------------------------- | ----------------------------------------- |
-| [`gatewayclass.yaml`](../../frontend/src/components/gateway/manifests/gatewayclass.yaml)     | Defines the GatewayClass used by Gateway. |
-| [`gateway.yaml`](../../frontend/src/components/gateway/manifests/gateway.yaml)               | Configures the Gateway resource.          |
-| [`httproute.yaml`](../../frontend/src/components/gateway/manifests/httproute.yaml)           | Configures HTTP route rules.              |
-| [`grpcroute.yaml`](../../frontend/src/components/gateway/manifests/grpcroute.yaml)           | Configures gRPC route rules.              |
-| [`referencegrant.yaml`](../../frontend/src/components/gateway/manifests/referencegrant.yaml) | Grants cross-namespace access.            |
-| [`backendtls.yaml`](../../frontend/src/components/gateway/manifests/backendtls.yaml)         | Configures TLS for backends.              |
-| [`backendtraffic.yaml`](../../frontend/src/components/gateway/manifests/backendtraffic.yaml) | Configures traffic policies to backends.  |
+| [`gatewayclass.yaml`](https://github.com/kubernetes-sigs/headlamp/blob/main/frontend/src/components/gateway/manifests/gatewayclass.yaml)     | Defines the GatewayClass used by Gateway. |
+| [`gateway.yaml`](https://github.com/kubernetes-sigs/headlamp/blob/main/frontend/src/components/gateway/manifests/gateway.yaml)               | Configures the Gateway resource.          |
+| [`httproute.yaml`](https://github.com/kubernetes-sigs/headlamp/blob/main/frontend/src/components/gateway/manifests/httproute.yaml)           | Configures HTTP route rules.              |
+| [`grpcroute.yaml`](https://github.com/kubernetes-sigs/headlamp/blob/main/frontend/src/components/gateway/manifests/grpcroute.yaml)           | Configures gRPC route rules.              |
+| [`referencegrant.yaml`](https://github.com/kubernetes-sigs/headlamp/blob/main/frontend/src/components/gateway/manifests/referencegrant.yaml) | Grants cross-namespace access.            |
+| [`backendtls.yaml`](https://github.com/kubernetes-sigs/headlamp/blob/main/frontend/src/components/gateway/manifests/backendtls.yaml)         | Configures TLS for backends.              |
+| [`backendtraffic.yaml`](https://github.com/kubernetes-sigs/headlamp/blob/main/frontend/src/components/gateway/manifests/backendtraffic.yaml) | Configures traffic policies to backends.  |
 
 > These files are located in:  
 > `frontend/src/components/gateway/manifests/`

--- a/docs/development/plugins/building.md
+++ b/docs/development/plugins/building.md
@@ -117,7 +117,7 @@ When deploying Headlamp with plugins, it is easier to use a container image with
 
 Some plugins already have a published container image. For Headlamp's official plugins, see this [list](https://github.com/orgs/headlamp-k8s/packages?tab=packages&q=headlamp-plugin).
 
-You can thus deploy Headlamp with an init container, such as the [Flux UI plugin image](ghcr.io/headlamp-k8s/headlamp-plugin-flux:v0.3.0):
+You can thus deploy Headlamp with an init container, such as the Flux UI plugin image (`ghcr.io/headlamp-k8s/headlamp-plugin-flux:v0.3.0`):
 
 ```yaml
 apiVersion: apps/v1

--- a/docs/development/plugins/functionality/index.md
+++ b/docs/development/plugins/functionality/index.md
@@ -56,77 +56,77 @@ have so far:
 ### App Bar Action
 
 Show a component in the top right of the app bar with
-[registerAppBarAction](../../api/plugin/registry/functions/registerAppBarAction.md).
+[registerAppBarAction](../../api/plugin/registry/functions/registerAppBarAction).
 
 ![screenshot of the header showing two actions](../images/podcounter_screenshot.png)
 
 - Example plugin: [How To Register an App Bar Action](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/pod-counter)
-- API reference: [registerAppBarAction](../../api/plugin/registry/functions/registerAppBarAction.md)
+- API reference: [registerAppBarAction](../../api/plugin/registry/functions/registerAppBarAction)
 
 ### App Logo
 
 Change the logo in the top left with
-[registerAppLogo](../../api/plugin/registry/functions/registerAppLogo.md).
+[registerAppLogo](../../api/plugin/registry/functions/registerAppLogo).
 
 ![screenshot of the logo being changed](../images/change-logo.png)
 
 - Example plugin: [How To Change The Logo](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/change-logo)
-- API reference: [registerAppLogo](../../api/plugin/registry/functions/registerAppLogo.md)
+- API reference: [registerAppLogo](../../api/plugin/registry/functions/registerAppLogo)
 
 ### App Menus
 
 Add menus when Headlamp runs as an app with
-[Headlamp.setAppMenu](../../api/plugin/lib/classes/Headlamp.md#setappmenu).
+[Headlamp.setAppMenu](../../api/plugin/lib/classes/Headlamp#setappmenu).
 
 ![screenshot of the logo being changed](../images/app-menus.png)
 
 - Example plugin: [How To Add App Menus](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/app-menus)
-- API reference: [Headlamp.setAppMenu](../../api/plugin/lib/classes/Headlamp.md#setappmenu)
+- API reference: [Headlamp.setAppMenu](../../api/plugin/lib/classes/Headlamp#setappmenu)
 
 ### Cluster Chooser
 
 Change the Cluster Chooser button in the top right of the app bar with
-[registerClusterChooser](../../api/plugin/registry/functions/registerClusterChooser.md).
+[registerClusterChooser](../../api/plugin/registry/functions/registerClusterChooser).
 
 ![screenshot of the cluster chooser button](../images/cluster-chooser.png)
 
 - Example plugin: [How To Register Cluster Chooser button](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/cluster-chooser)
-- API reference: [registerClusterChooser](../../api/plugin/registry/functions/registerClusterChooser.md)
+- API reference: [registerClusterChooser](../../api/plugin/registry/functions/registerClusterChooser)
 
 ### Cluster Empty State
 
 Customize the Home page shown when no clusters are configured with
-[registerClusterEmptyState](../../api/plugin/registry/functions/registerClusterEmptyState.md).
+[registerClusterEmptyState](../../api/plugin/registry/functions/registerClusterEmptyState).
 The registered component receives Headlamp's standard empty state as
 `defaultContent`. Render it to extend the default onboarding, or omit it to
 replace the empty state completely.
 
 - Example plugin: [How To Customize The Cluster Empty State](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/cluster-chooser)
-- API reference: [registerClusterEmptyState](../../api/plugin/registry/functions/registerClusterEmptyState.md)
+- API reference: [registerClusterEmptyState](../../api/plugin/registry/functions/registerClusterEmptyState)
 
 ### Details View Header Action
 
 Show a component in the top right of a detail view with
-[registerDetailsViewHeaderAction](../../api/plugin/registry/functions/registerDetailsViewHeaderAction.md).
+[registerDetailsViewHeaderAction](../../api/plugin/registry/functions/registerDetailsViewHeaderAction).
 
 ![screenshot of the header showing two actions](../images/header_actions_screenshot.png)
 
 - Example plugin: [How To set a Details View Header Action](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/details-view)
-- API reference: [registerDetailsViewHeaderAction](../../api/plugin/registry/functions/registerDetailsViewHeaderAction.md)
+- API reference: [registerDetailsViewHeaderAction](../../api/plugin/registry/functions/registerDetailsViewHeaderAction)
 
 ### Details View Section
 
 Change sections in a Kubernetes resource's details view with
-[registerDetailsViewSectionsProcessor](../../api/plugin/registry/functions/registerDetailsViewSectionsProcessor.md).
+[registerDetailsViewSectionsProcessor](../../api/plugin/registry/functions/registerDetailsViewSectionsProcessor).
 This lets you add, remove, update, or move sections.
 
 Or, add a component to the bottom of a details view with
-[registerDetailsViewSection](../../api/plugin/registry/functions/registerDetailsViewSection.md).
+[registerDetailsViewSection](../../api/plugin/registry/functions/registerDetailsViewSection).
 
 ![screenshot of the appended Details View Section](../images/details-view.jpeg)
 
 - Example plugin: [How To set a Details View Section](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/details-view)
-- API reference: [registerDetailsViewSection](../../api/plugin/registry/functions/registerDetailsViewSection.md)
+- API reference: [registerDetailsViewSection](../../api/plugin/registry/functions/registerDetailsViewSection)
 
 ### Dynamic Clusters
 
@@ -189,20 +189,20 @@ be shared with workloads or other cluster users.
 ### Route
 
 Show a component in the main area at a given URL with
-[registerRoute](../../api/plugin/registry/functions/registerRoute.md).
+[registerRoute](../../api/plugin/registry/functions/registerRoute).
 
 - Example plugin: [How To Register a Route](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/sidebar)
-- API reference: [registerRoute](../../api/plugin/registry/functions/registerRoute.md)
-- API reference: [registerRouteFilter](../../api/plugin/registry/functions/registerRouteFilter.md)
+- API reference: [registerRoute](../../api/plugin/registry/functions/registerRoute)
+- API reference: [registerRouteFilter](../../api/plugin/registry/functions/registerRouteFilter)
 
 ### Sidebar Item
 
 Add items to the left sidebar with
-[registerSidebarEntry](../../api/plugin/registry/functions/registerSidebarEntry.md).
+[registerSidebarEntry](../../api/plugin/registry/functions/registerSidebarEntry).
 Filter items with
-[registerSidebarEntryFilter](../../api/plugin/registry/functions/registerSidebarEntryFilter.md).
+[registerSidebarEntryFilter](../../api/plugin/registry/functions/registerSidebarEntryFilter).
 Filter items from the home (non-cluster) sidebar with
-[registerHomeSidebarEntryFilter](../../api/plugin/registry/functions/registerHomeSidebarEntryFilter.md).
+[registerHomeSidebarEntryFilter](../../api/plugin/registry/functions/registerHomeSidebarEntryFilter).
 Use `entryType: 'subheader'` with `registerSidebarEntry` to add a
 non-clickable section header that groups sidebar entries. Subheaders render as
 dividers when the sidebar is collapsed. Use `sx` to override the default
@@ -211,25 +211,25 @@ subheader styles.
 ![screenshot of the sidebar being changed](../images/sidebar.png)
 
 - Example plugin: [How To add items to the sidebar](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/sidebar)
-- API reference: [registerSidebarEntry](../../api/plugin/registry/functions/registerSidebarEntry.md)
-- API reference: [registerSidebarEntryFilter](../../api/plugin/registry/functions/registerSidebarEntryFilter.md)
-- API reference: [registerHomeSidebarEntryFilter](../../api/plugin/registry/functions/registerHomeSidebarEntryFilter.md)
+- API reference: [registerSidebarEntry](../../api/plugin/registry/functions/registerSidebarEntry)
+- API reference: [registerSidebarEntryFilter](../../api/plugin/registry/functions/registerSidebarEntryFilter)
+- API reference: [registerHomeSidebarEntryFilter](../../api/plugin/registry/functions/registerHomeSidebarEntryFilter)
 
 ### Tables
 
 Change tables in Headlamp with
-[registerResourceTableColumnsProcessor](../../api/plugin/registry/functions/registerResourceTableColumnsProcessor.md).
+[registerResourceTableColumnsProcessor](../../api/plugin/registry/functions/registerResourceTableColumnsProcessor).
 This lets you add, remove, update, or move table columns.
 
 ![screenshot of the pods list with a context menu added by a plugin](../images/table-context-menu.png)
 
 - Example plugin: [How to add a context menu to each row in the pods list table](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/tables)
-- API reference: [registerResourceTableColumnsProcessor](../../api/plugin/registry/functions/registerResourceTableColumnsProcessor.md)
+- API reference: [registerResourceTableColumnsProcessor](../../api/plugin/registry/functions/registerResourceTableColumnsProcessor)
 
 ### Project Creation
 
 Add a project creation choice with
-[registerCustomCreateProject](../../api/plugin/registry/functions/registerCustomCreateProject.md).
+[registerCustomCreateProject](../../api/plugin/registry/functions/registerCustomCreateProject).
 To replace one of Headlamp's built-in choices in the same position, use its ID
 from `DefaultCreateProject`:
 
@@ -257,24 +257,24 @@ project creation menu.
 | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | ![Default project creation choices on a mobile viewport](../images/project-creation/default-choices-mobile.png) | ![Project creation choices replaced by a plugin on a mobile viewport](../images/project-creation/replaced-choices-mobile.png) |
 
-- API reference: [registerCustomCreateProject](../../api/plugin/registry/functions/registerCustomCreateProject.md)
+- API reference: [registerCustomCreateProject](../../api/plugin/registry/functions/registerCustomCreateProject)
 
 ### Headlamp Events
 
 Headlamp fires events when something important happens.
 
 React to Headlamp events with
-[registerHeadlampEventCallback](../../api/plugin/registry/functions/registerHeadlampEventCallback.md).
+[registerHeadlampEventCallback](../../api/plugin/registry/functions/registerHeadlampEventCallback).
 
 ![screenshot of a snackbar notification when an event occurred](../images/event-snackbar.png)
 
 - Example plugin: [How to show snackbars for Headlamp events](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/headlamp-events)
-- API reference: [registerHeadlampEventCallback](../../api/plugin/registry/functions/registerHeadlampEventCallback.md)
+- API reference: [registerHeadlampEventCallback](../../api/plugin/registry/functions/registerHeadlampEventCallback)
 
 ### Plugin Settings
 
 Plugins can have user settings. Create them with
-[registerPluginSettings](../../api/plugin/registry/functions/registerPluginSettings.md).
+[registerPluginSettings](../../api/plugin/registry/functions/registerPluginSettings).
 
 - Example plugin: [How to create plugin settings and use them](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/change-logo)
 
@@ -283,7 +283,7 @@ Plugins can have user settings. Create them with
 ### App Theme
 
 Add a custom Headlamp theme with
-[registerAppTheme](../../api/plugin/registry/functions/registerAppTheme.md).
+[registerAppTheme](../../api/plugin/registry/functions/registerAppTheme).
 The theme name must be unique. You can specify 'light' or 'dark' as a base.
 The default is 'light'.
 
@@ -308,7 +308,7 @@ for a working `registerAppTheme({ ..., terminal: { ... } })` call.
 ### UI Panels
 
 Register a side panel with
-[registerUIPanel](../../api/plugin/registry/functions/registerUIPanel.md).
+[registerUIPanel](../../api/plugin/registry/functions/registerUIPanel).
 A side panel is a UI element on one side of the application. You can define
 more than one panel per side. Each panel needs a unique ID, a side (top, left,
 right, bottom), and a React component.
@@ -371,7 +371,7 @@ for a complete relation provider registration.
 Customize Headlamp's Projects feature with several registration functions:
 
 Group namespaces into separate project entries with
-[registerProjectGrouping](../../api/plugin/registry/functions/registerProjectGrouping.md).
+[registerProjectGrouping](../../api/plugin/registry/functions/registerProjectGrouping).
 By default, Headlamp combines namespaces with the same project ID across clusters,
 which is useful when they form one logical application. Use custom grouping when
 clusters represent distinct environments, tenants, or ownership boundaries and
@@ -381,11 +381,11 @@ opaque key. Namespaces with the same project ID and key are shown as one project
 entry. Return the project ID to preserve Headlamp's default cross-cluster grouping.
 
 Add custom tabs to the project details view with
-[registerProjectDetailsTab](../../api/plugin/registry/functions/registerProjectDetailsTab.md).
+[registerProjectDetailsTab](../../api/plugin/registry/functions/registerProjectDetailsTab).
 Each tab needs a unique ID, a label, and a React component that receives the project as a prop.
 
 Add custom sections to the project overview page with
-[registerProjectOverviewSection](../../api/plugin/registry/functions/registerProjectOverviewSection.md).
+[registerProjectOverviewSection](../../api/plugin/registry/functions/registerProjectOverviewSection).
 Each section needs a unique `id` and a component. The component receives the current
 `project` and its loaded `projectResources`.
 
@@ -406,7 +406,7 @@ registerProjectOverviewSection({
 ```
 
 Add action buttons to the project details header with
-[registerProjectHeaderAction](../../api/plugin/registry/functions/registerProjectHeaderAction.md).
+[registerProjectHeaderAction](../../api/plugin/registry/functions/registerProjectHeaderAction).
 The action component receives the current project and an optional
 `setSelectedTab?: (tabId: string) => void` callback. Call it with the ID of a
 registered, enabled tab to select that tab. Unknown tabs and tabs without a
@@ -422,7 +422,7 @@ registerProjectHeaderAction({
 ```
 
 Register custom API resources (e.g. CRDs) for project resource tracking with
-[registerProjectApiResource](../../api/plugin/registry/functions/registerProjectApiResource.md).
+[registerProjectApiResource](../../api/plugin/registry/functions/registerProjectApiResource).
 Once registered, the CRD resources will appear in the project's resource count,
 health status, and Resources tab. Only namespaced resources can be registered,
 since Projects are scoped to namespaces.

--- a/docs/development/plugins/functionality/index.md
+++ b/docs/development/plugins/functionality/index.md
@@ -56,77 +56,77 @@ have so far:
 ### App Bar Action
 
 Show a component in the top right of the app bar with
-[registerAppBarAction](../../api/plugin/registry/functions/registerappbaraction).
+[registerAppBarAction](../../api/plugin/registry/functions/registerAppBarAction.md).
 
 ![screenshot of the header showing two actions](../images/podcounter_screenshot.png)
 
 - Example plugin: [How To Register an App Bar Action](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/pod-counter)
-- API reference: [registerAppBarAction](../../api/plugin/registry/functions/registerappbaraction)
+- API reference: [registerAppBarAction](../../api/plugin/registry/functions/registerAppBarAction.md)
 
 ### App Logo
 
 Change the logo in the top left with
-[registerAppLogo](../../api/plugin/registry/functions/registerapplogo).
+[registerAppLogo](../../api/plugin/registry/functions/registerAppLogo.md).
 
 ![screenshot of the logo being changed](../images/change-logo.png)
 
 - Example plugin: [How To Change The Logo](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/change-logo)
-- API reference: [registerAppLogo](../../api/plugin/registry/functions/registerapplogo)
+- API reference: [registerAppLogo](../../api/plugin/registry/functions/registerAppLogo.md)
 
 ### App Menus
 
 Add menus when Headlamp runs as an app with
-[Headlamp.setAppMenu](../../api/plugin/lib/classes/Headlamp#setappmenu).
+[Headlamp.setAppMenu](../../api/plugin/lib/classes/Headlamp.md#setappmenu).
 
 ![screenshot of the logo being changed](../images/app-menus.png)
 
 - Example plugin: [How To Add App Menus](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/app-menus)
-- API reference: [Headlamp.setAppMenu](../../api/plugin/lib/classes/Headlamp#setappmenu)
+- API reference: [Headlamp.setAppMenu](../../api/plugin/lib/classes/Headlamp.md#setappmenu)
 
 ### Cluster Chooser
 
 Change the Cluster Chooser button in the top right of the app bar with
-[registerClusterChooser](../../api/plugin/registry/functions/registerclusterchooser).
+[registerClusterChooser](../../api/plugin/registry/functions/registerClusterChooser.md).
 
 ![screenshot of the cluster chooser button](../images/cluster-chooser.png)
 
 - Example plugin: [How To Register Cluster Chooser button](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/cluster-chooser)
-- API reference: [registerClusterChooser](../../api/plugin/registry/functions/registerclusterchooser)
+- API reference: [registerClusterChooser](../../api/plugin/registry/functions/registerClusterChooser.md)
 
 ### Cluster Empty State
 
 Customize the Home page shown when no clusters are configured with
-[registerClusterEmptyState](../../api/plugin/registry/functions/registerclusteremptystate).
+[registerClusterEmptyState](../../api/plugin/registry/functions/registerClusterEmptyState.md).
 The registered component receives Headlamp's standard empty state as
 `defaultContent`. Render it to extend the default onboarding, or omit it to
 replace the empty state completely.
 
 - Example plugin: [How To Customize The Cluster Empty State](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/cluster-chooser)
-- API reference: [registerClusterEmptyState](../../api/plugin/registry/functions/registerclusteremptystate)
+- API reference: [registerClusterEmptyState](../../api/plugin/registry/functions/registerClusterEmptyState.md)
 
 ### Details View Header Action
 
 Show a component in the top right of a detail view with
-[registerDetailsViewHeaderAction](../../api/plugin/registry/functions/registerdetailsviewheaderaction).
+[registerDetailsViewHeaderAction](../../api/plugin/registry/functions/registerDetailsViewHeaderAction.md).
 
 ![screenshot of the header showing two actions](../images/header_actions_screenshot.png)
 
 - Example plugin: [How To set a Details View Header Action](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/details-view)
-- API reference: [registerDetailsViewHeaderAction](../../api/plugin/registry/functions/registerdetailsviewheaderaction)
+- API reference: [registerDetailsViewHeaderAction](../../api/plugin/registry/functions/registerDetailsViewHeaderAction.md)
 
 ### Details View Section
 
 Change sections in a Kubernetes resource's details view with
-[registerDetailsViewSectionsProcessor](../../api/plugin/registry/functions/registerdetailsviewsectionsprocessor).
+[registerDetailsViewSectionsProcessor](../../api/plugin/registry/functions/registerDetailsViewSectionsProcessor.md).
 This lets you add, remove, update, or move sections.
 
 Or, add a component to the bottom of a details view with
-[registerDetailsViewSection](../../api/plugin/registry/functions/registerdetailsviewsection).
+[registerDetailsViewSection](../../api/plugin/registry/functions/registerDetailsViewSection.md).
 
 ![screenshot of the appended Details View Section](../images/details-view.jpeg)
 
 - Example plugin: [How To set a Details View Section](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/details-view)
-- API reference: [registerDetailsViewSection](../../api/plugin/registry/functions/registerdetailsviewsection)
+- API reference: [registerDetailsViewSection](../../api/plugin/registry/functions/registerDetailsViewSection.md)
 
 ### Dynamic Clusters
 
@@ -189,20 +189,20 @@ be shared with workloads or other cluster users.
 ### Route
 
 Show a component in the main area at a given URL with
-[registerRoute](../../api/plugin/registry/functions/registerroute).
+[registerRoute](../../api/plugin/registry/functions/registerRoute.md).
 
 - Example plugin: [How To Register a Route](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/sidebar)
-- API reference: [registerRoute](../../api/plugin/registry/functions/registerroute)
-- API reference: [registerRouteFilter](../../api/plugin/registry/functions/registerroutefilter)
+- API reference: [registerRoute](../../api/plugin/registry/functions/registerRoute.md)
+- API reference: [registerRouteFilter](../../api/plugin/registry/functions/registerRouteFilter.md)
 
 ### Sidebar Item
 
 Add items to the left sidebar with
-[registerSidebarEntry](../../api/plugin/registry/functions/registersidebarentry).
+[registerSidebarEntry](../../api/plugin/registry/functions/registerSidebarEntry.md).
 Filter items with
-[registerSidebarEntryFilter](../../api/plugin/registry/functions/registersidebarentryfilter).
+[registerSidebarEntryFilter](../../api/plugin/registry/functions/registerSidebarEntryFilter.md).
 Filter items from the home (non-cluster) sidebar with
-[registerHomeSidebarEntryFilter](../../api/plugin/registry/functions/registerhomesidebarentryfilter).
+[registerHomeSidebarEntryFilter](../../api/plugin/registry/functions/registerHomeSidebarEntryFilter.md).
 Use `entryType: 'subheader'` with `registerSidebarEntry` to add a
 non-clickable section header that groups sidebar entries. Subheaders render as
 dividers when the sidebar is collapsed. Use `sx` to override the default
@@ -211,25 +211,25 @@ subheader styles.
 ![screenshot of the sidebar being changed](../images/sidebar.png)
 
 - Example plugin: [How To add items to the sidebar](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/sidebar)
-- API reference: [registerSidebarEntry](../../api/plugin/registry/functions/registersidebarentry)
-- API reference: [registerSidebarEntryFilter](../../api/plugin/registry/functions/registersidebarentryfilter)
-- API reference: [registerHomeSidebarEntryFilter](../../api/plugin/registry/functions/registerhomesidebarentryfilter)
+- API reference: [registerSidebarEntry](../../api/plugin/registry/functions/registerSidebarEntry.md)
+- API reference: [registerSidebarEntryFilter](../../api/plugin/registry/functions/registerSidebarEntryFilter.md)
+- API reference: [registerHomeSidebarEntryFilter](../../api/plugin/registry/functions/registerHomeSidebarEntryFilter.md)
 
 ### Tables
 
 Change tables in Headlamp with
-[registerResourceTableColumnsProcessor](../../api/plugin/registry/functions/registersidebarentry).
+[registerResourceTableColumnsProcessor](../../api/plugin/registry/functions/registerResourceTableColumnsProcessor.md).
 This lets you add, remove, update, or move table columns.
 
 ![screenshot of the pods list with a context menu added by a plugin](../images/table-context-menu.png)
 
 - Example plugin: [How to add a context menu to each row in the pods list table](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/tables)
-- API reference: [registerResourceTableColumnsProcessor](../../api/plugin/registry/functions/registerresourcetablecolumnsprocessor)
+- API reference: [registerResourceTableColumnsProcessor](../../api/plugin/registry/functions/registerResourceTableColumnsProcessor.md)
 
 ### Project Creation
 
 Add a project creation choice with
-[registerCustomCreateProject](../../api/plugin/registry/functions/registercustomcreateproject).
+[registerCustomCreateProject](../../api/plugin/registry/functions/registerCustomCreateProject.md).
 To replace one of Headlamp's built-in choices in the same position, use its ID
 from `DefaultCreateProject`:
 
@@ -257,24 +257,24 @@ project creation menu.
 | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | ![Default project creation choices on a mobile viewport](../images/project-creation/default-choices-mobile.png) | ![Project creation choices replaced by a plugin on a mobile viewport](../images/project-creation/replaced-choices-mobile.png) |
 
-- API reference: [registerCustomCreateProject](../../api/plugin/registry/functions/registercustomcreateproject)
+- API reference: [registerCustomCreateProject](../../api/plugin/registry/functions/registerCustomCreateProject.md)
 
 ### Headlamp Events
 
 Headlamp fires events when something important happens.
 
 React to Headlamp events with
-[registerHeadlampEventCallback](../../api/plugin/registry/functions/registerheadlampeventcallback).
+[registerHeadlampEventCallback](../../api/plugin/registry/functions/registerHeadlampEventCallback.md).
 
 ![screenshot of a snackbar notification when an event occurred](../images/event-snackbar.png)
 
 - Example plugin: [How to show snackbars for Headlamp events](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/headlamp-events)
-- API reference: [registerHeadlampEventCallback](../../api/plugin/registry/functions/registerheadlampeventcallback)
+- API reference: [registerHeadlampEventCallback](../../api/plugin/registry/functions/registerHeadlampEventCallback.md)
 
 ### Plugin Settings
 
 Plugins can have user settings. Create them with
-[registerPluginSettings](../../api/plugin/registry/functions/registerpluginsettings).
+[registerPluginSettings](../../api/plugin/registry/functions/registerPluginSettings.md).
 
 - Example plugin: [How to create plugin settings and use them](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/change-logo)
 
@@ -283,7 +283,7 @@ Plugins can have user settings. Create them with
 ### App Theme
 
 Add a custom Headlamp theme with
-[registerAppTheme](../../api/plugin/registry/functions/registerapptheme).
+[registerAppTheme](../../api/plugin/registry/functions/registerAppTheme.md).
 The theme name must be unique. You can specify 'light' or 'dark' as a base.
 The default is 'light'.
 
@@ -308,7 +308,7 @@ for a working `registerAppTheme({ ..., terminal: { ... } })` call.
 ### UI Panels
 
 Register a side panel with
-[registerUIPanel](../../api/plugin/registry/functions/registerUIPanel).
+[registerUIPanel](../../api/plugin/registry/functions/registerUIPanel.md).
 A side panel is a UI element on one side of the application. You can define
 more than one panel per side. Each panel needs a unique ID, a side (top, left,
 right, bottom), and a React component.
@@ -371,7 +371,7 @@ for a complete relation provider registration.
 Customize Headlamp's Projects feature with several registration functions:
 
 Group namespaces into separate project entries with
-[registerProjectGrouping](../../api/plugin/registry/functions/registerProjectGrouping).
+[registerProjectGrouping](../../api/plugin/registry/functions/registerProjectGrouping.md).
 By default, Headlamp combines namespaces with the same project ID across clusters,
 which is useful when they form one logical application. Use custom grouping when
 clusters represent distinct environments, tenants, or ownership boundaries and
@@ -381,11 +381,11 @@ opaque key. Namespaces with the same project ID and key are shown as one project
 entry. Return the project ID to preserve Headlamp's default cross-cluster grouping.
 
 Add custom tabs to the project details view with
-[registerProjectDetailsTab](../../api/plugin/registry/functions/registerProjectDetailsTab).
+[registerProjectDetailsTab](../../api/plugin/registry/functions/registerProjectDetailsTab.md).
 Each tab needs a unique ID, a label, and a React component that receives the project as a prop.
 
 Add custom sections to the project overview page with
-[registerProjectOverviewSection](../../api/plugin/registry/functions/registerProjectOverviewSection).
+[registerProjectOverviewSection](../../api/plugin/registry/functions/registerProjectOverviewSection.md).
 Each section needs a unique `id` and a component. The component receives the current
 `project` and its loaded `projectResources`.
 
@@ -406,7 +406,7 @@ registerProjectOverviewSection({
 ```
 
 Add action buttons to the project details header with
-[registerProjectHeaderAction](../../api/plugin/registry/functions/registerProjectHeaderAction).
+[registerProjectHeaderAction](../../api/plugin/registry/functions/registerProjectHeaderAction.md).
 The action component receives the current project and an optional
 `setSelectedTab?: (tabId: string) => void` callback. Call it with the ID of a
 registered, enabled tab to select that tab. Unknown tabs and tabs without a
@@ -422,7 +422,7 @@ registerProjectHeaderAction({
 ```
 
 Register custom API resources (e.g. CRDs) for project resource tracking with
-[registerProjectApiResource](../../api/plugin/registry/functions/registerProjectApiResource).
+[registerProjectApiResource](../../api/plugin/registry/functions/registerProjectApiResource.md).
 Once registered, the CRD resources will appear in the project's resource count,
 health status, and Resources tab. Only namespaced resources can be registered,
 since Projects are scoped to namespaces.

--- a/docs/development/plugins/getting-started.md
+++ b/docs/development/plugins/getting-started.md
@@ -255,7 +255,7 @@ Now that you've created your first plugin, explore these advanced topics:
 ### Plugin's Changes Not Reflecting
 - Ensure you saved your changes
 - Check if the development server is running (`npm run start`) without errors
-- Remove the installed plugin from Headlamp's plugins folder (see [plugin locations](./architecture.md#plugin-locations)) and re-run `npm run start`
+- Remove the installed plugin from Headlamp's plugins folder (see [plugin locations](./building.md#manual-installation)) and re-run `npm run start`
 - Restart Headlamp if necessary
 
 ### Build Errors

--- a/docs/development/plugins/index.md
+++ b/docs/development/plugins/index.md
@@ -62,6 +62,6 @@ Add support for multiple languages and locales
 
 👉 **Ready to build?** Jump into [Building & Shipping](./building.md)
 
-👉 **Need architectural details?** Read about [Plugin Architecture](./architecture.md)
+👉 **Need architectural details?** Read about [Plugin Architecture](../architecture.md)
 
 The Headlamp plugin ecosystem is growing rapidly. Whether you're building internal tools or creating plugins for the community, you're contributing to making Kubernetes more accessible and powerful for everyone!

--- a/docs/installation/in-cluster/basic-auth.md
+++ b/docs/installation/in-cluster/basic-auth.md
@@ -129,7 +129,7 @@ kubectl create secret generic headlamp-basic-auth \
 - **Basic authentication only controls access to the UI**. Headlamp will still require Kubernetes authentication (token or kubeconfig) after the UI loads.
 - **Authorization within the UI is controlled entirely by Kubernetes RBAC**. The username/password does not determine what resources users can view or modify.
 - This approach is intended for simple access control and is **not a replacement for full identity management solutions**.
-- For environments requiring per-user identity, auditing, or single sign-on, [OIDC-based authentication](../oidc/) is recommended instead.
+- For environments requiring per-user identity, auditing, or single sign-on, [OIDC-based authentication](./oidc.md) is recommended instead.
 
 ---
 

--- a/docs/tutorials/plugin-development/index.mdx
+++ b/docs/tutorials/plugin-development/index.mdx
@@ -53,6 +53,6 @@ Apply your fundamentals knowledge to build a focused, single-purpose plugin:
 
 ## Additional Resources
 
-- [Plugin API Reference](../../development/api/API.md)
+- [Plugin API Reference](/docs/latest/development/api/)
 - [Example Plugins](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples)
 - [#headlamp on Kubernetes Slack](https://kubernetes.slack.com/messages/headlamp)

--- a/docs/tutorials/plugin-development/index.mdx
+++ b/docs/tutorials/plugin-development/index.mdx
@@ -53,6 +53,6 @@ Apply your fundamentals knowledge to build a focused, single-purpose plugin:
 
 ## Additional Resources
 
-- [Plugin API Reference](/docs/development/api/)
+- [Plugin API Reference](../../development/api/API.md)
 - [Example Plugins](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples)
 - [#headlamp on Kubernetes Slack](https://kubernetes.slack.com/messages/headlamp)

--- a/docs/tutorials/plugin-development/whoami-plugin/index.md
+++ b/docs/tutorials/plugin-development/whoami-plugin/index.md
@@ -18,12 +18,11 @@ In this tutorial, you'll build a focused, single-purpose plugin that adds a **Wh
 2. [What You'll Build](#what-youll-build)
 3. [Create the Plugin](#create-the-plugin)
 4. [Add the Sidebar Entry](#add-the-sidebar-entry)
-5. [Build the WhoAmI Page](#build-the-whoami-page)
-6. [Fetch User Identity](#fetch-user-identity)
-7. [Display the Identity](#display-the-identity)
-8. [Supporting Multi-Cluster](#supporting-multi-cluster)
-9. [Troubleshooting](#troubleshooting)
-10. [Quick Reference](#quick-reference)
+5. [Fetch User Identity](#fetch-user-identity)
+6. [Display the Identity](#display-the-identity)
+7. [Supporting Multi-Cluster](#supporting-multi-cluster)
+8. [Troubleshooting](#troubleshooting)
+9. [Quick Reference](#quick-reference)
 
 ---
 


### PR DESCRIPTION
## Summary

This PR fixes the broken documentation links and anchors reported by the
Docusaurus build in #7640 so the headlamp website build no longer warns
about them

## Related Issue

#7640

Not using "Fixes" because 3 of the reported items are not addressed here:
- `/blog/2021/04/07/...` → `plugins/how-to/` lives in headlamp-website
- `#using-glasskube` on `/` lives in headlamp-website
- `URL_FOR_PLUGIN` in `publishing.md` a placeholder that was never
  filled in; needs a maintainer to say what it should point to

## Changes

- `docs/development/plugins/functionality/index.md` 27 API reference
  links: corrected case on 17, added `.md` to all so they resolve at
  build time also fixed `registerResourceTableColumnsProcessor` which
  linked to `registerSidebarEntry` (pre-existing copy-paste error)
  
- `docs/development/gateway.md` 7 manifest links pointed at
  `../../frontend/src/...`, outside the docs root; now point at the files
  on github
  
- `docs/development/plugins/index.md`  `./architecture.md`  `../architecture.md`

- `docs/development/plugins/getting-started.md` `./architecture.md#plugin-locations` `./building.md#manual-installation`, the           section with the per-OS plugin directory table
  
- `docs/development/plugins/building.md`  `ghcr.io/...` image name was
  wrapped in link syntax; now inline code
  
- `docs/installation/in-cluster/basic-auth.md`  `../oidc/`   `./oidc.md`

- `docs/tutorials/plugin-development/index.mdx`  `/docs/development/api/`
  (missing `/latest/`) → `../../development/api/API.md`
  
- `docs/tutorials/plugin-development/whoami-plugin/index.md` removed
  the TOC entry `#build-the-whoami-page` which has no matching section
  and renumbered

## Steps to Test

1. Clone https://github.com/headlamp-k8s/headlamp-website and
   `npm install`.
   
2. In a headlamp checkout of this branch, run
   `cd frontend && npm install && npm run build-typedoc`
   
3. In headlamp-website: `./link-docs.sh <path-to-headlamp>/docs`
   then `npm run build`
   
4. The build output should list only 3 broken links/anchors the 3
   listed under Related Issue above. On `main` it lists 36
   
5. Optionally `npm start` open
   `/docs/latest/development/plugins/functionality/` and click the API
   reference links under App Bar Action, Route, Sidebar Item, Tables etc
   each should load the corresponding API page

