### PR TITLE
frontend: NodeList: Guard against undefined node.status

### DIFF
--- a/frontend/src/components/node/Details.tsx
+++ b/frontend/src/components/node/Details.tsx
@@ -726,7 +726,7 @@ interface NodeReadyLabelProps {
 
 export function NodeReadyLabel(props: NodeReadyLabelProps) {
   const { node } = props;
-  const isReady = !!node.status.conditions?.find(
+  const isReady = !!node.status?.conditions?.find(
     condition => condition.type === 'Ready' && condition.status === 'True'
   );
   const { t } = useTranslation();

--- a/frontend/src/components/node/List.test.tsx
+++ b/frontend/src/components/node/List.test.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import App from '../../App';
+import { TestContext } from '../../test';
+import NodeList from './List';
+
+// cyclic imports fix
+// eslint-disable-next-line no-unused-vars
+const _dont_delete_me = App;
+
+const { mockListView } = vi.hoisted(() => ({
+  mockListView: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/node', () => ({
+  default: {
+    kind: 'Node',
+    useMetrics: vi.fn().mockReturnValue([[], null]),
+    useList: vi.fn().mockReturnValue({ items: [] }),
+  },
+}));
+
+vi.mock('../common/Resource/ResourceListView', () => ({
+  default: (props: any) => {
+    mockListView(props);
+    return null;
+  },
+}));
+
+describe('NodeList', () => {
+  beforeEach(() => {
+    mockListView.mockReset();
+  });
+
+  it('renders the expected columns', () => {
+    render(
+      <TestContext>
+        <NodeList />
+      </TestContext>
+    );
+
+    expect(mockListView).toHaveBeenCalled();
+    const props = mockListView.mock.calls[0][0];
+    const columnIds = props.columns.map((c: any) => (typeof c === 'string' ? c : c.id));
+    expect(columnIds).toContain('ready');
+    expect(columnIds).toContain('roles');
+    expect(columnIds).toContain('version');
+    expect(columnIds).toContain('software');
+  });
+
+  it('safely handles nodes with undefined status without crashing', () => {
+    render(
+      <TestContext>
+        <NodeList />
+      </TestContext>
+    );
+
+    const props = mockListView.mock.calls[0][0];
+    const readyCol = props.columns.find((c: any) => c?.id === 'ready');
+    const rolesCol = props.columns.find((c: any) => c?.id === 'roles');
+    const versionCol = props.columns.find((c: any) => c?.id === 'version');
+    const softwareCol = props.columns.find((c: any) => c?.id === 'software');
+
+    const nodeWithoutStatus = {
+      status: undefined,
+      getRoles: () => ['worker'],
+    };
+
+    expect(() => readyCol.getValue(nodeWithoutStatus)).not.toThrow();
+    expect(readyCol.getValue(nodeWithoutStatus)).toBe('No');
+
+    expect(() => rolesCol.getValue(nodeWithoutStatus)).not.toThrow();
+    expect(rolesCol.getValue(nodeWithoutStatus)).toBe('worker');
+
+    expect(() => versionCol.getValue(nodeWithoutStatus)).not.toThrow();
+    expect(versionCol.getValue(nodeWithoutStatus)).toBeUndefined();
+
+    expect(() => softwareCol.getValue(nodeWithoutStatus)).not.toThrow();
+    expect(softwareCol.getValue(nodeWithoutStatus)).toBeUndefined();
+  });
+});

--- a/frontend/src/components/node/List.tsx
+++ b/frontend/src/components/node/List.tsx
@@ -89,7 +89,7 @@ export default function NodeList() {
             label: t('translation|Ready'),
             filterVariant: 'multi-select',
             getValue: node => {
-              const isReady = !!node.status.conditions?.find(
+              const isReady = !!node.status?.conditions?.find(
                 condition => condition.type === 'Ready' && condition.status === 'True'
               );
               return isReady ? t('translation|Yes') : t('translation|No');
@@ -113,12 +113,7 @@ export default function NodeList() {
             id: 'roles',
             label: t('Roles'),
             gridTemplate: 'minmax(150px, .5fr)',
-            getValue: node => {
-              return Object.keys(node.metadata.labels ?? {})
-                .filter((t: String) => t.startsWith('node-role.kubernetes.io/'))
-                .map(t => t.replace('node-role.kubernetes.io/', ''))
-                .join(', ');
-            },
+            getValue: (node: Node) => node.getRoles().join(', '),
           },
           ...(hasNodePools
             ? [
@@ -148,37 +143,38 @@ export default function NodeList() {
             id: 'version',
             label: t('translation|Version'),
             gridTemplate: 'minmax(150px, .5fr)',
-            getValue: node => node.status.nodeInfo?.kubeletVersion,
+            getValue: node => node.status?.nodeInfo?.kubeletVersion,
             filterVariant: 'multi-select',
           },
           {
             id: 'software',
             label: t('translation|Software'),
             gridTemplate: 'minmax(200px, 1.5fr)',
-            getValue: node => node.status.nodeInfo?.operatingSystem,
+            getValue: node => node.status?.nodeInfo?.operatingSystem,
             render: node => {
-              if (node.status.nodeInfo === undefined) {
+              if (!node.status?.nodeInfo) {
                 return <></>;
               }
+              const nodeInfo = node.status.nodeInfo;
               let osIcon = 'mdi:desktop-classic';
-              if (node.status.nodeInfo.operatingSystem === 'linux') {
+              if (nodeInfo.operatingSystem === 'linux') {
                 osIcon = 'mdi:linux';
-              } else if (node.status.nodeInfo.operatingSystem === 'windows') {
+              } else if (nodeInfo.operatingSystem === 'windows') {
                 osIcon = 'mdi:microsoft-windows';
               }
 
               return (
                 <>
                   <HoverInfoLabel
-                    label={node.status.nodeInfo.osImage}
+                    label={nodeInfo.osImage}
                     hoverInfo={t('OS image')}
                     labelProps={{ variant: 'body2' }}
                     iconPosition="start"
                     icon={osIcon}
                   />
-                  {node.status.nodeInfo.kernelVersion && (
+                  {nodeInfo.kernelVersion && (
                     <HoverInfoLabel
-                      label={node.status.nodeInfo.kernelVersion}
+                      label={nodeInfo.kernelVersion}
                       hoverInfo={t('Kernel version')}
                       labelProps={{ variant: 'body2' }}
                       iconPosition="start"
@@ -186,7 +182,7 @@ export default function NodeList() {
                     />
                   )}
                   <HoverInfoLabel
-                    label={node.status.nodeInfo.containerRuntimeVersion}
+                    label={nodeInfo.containerRuntimeVersion}
                     hoverInfo={t('Container Runtime')}
                     labelProps={{ variant: 'body2' }}
                     iconPosition="start"

--- a/frontend/src/lib/k8s/node.test.ts
+++ b/frontend/src/lib/k8s/node.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import App from '../../App';
+import Node from './node';
+
+// cyclic imports fix
+// eslint-disable-next-line no-unused-vars
+const _dont_delete_me = App;
+
+describe('Node class', () => {
+  const makeNode = (metadata: any = {}, status?: any) =>
+    new Node({
+      apiVersion: 'v1',
+      kind: 'Node',
+      metadata: { name: 'test-node', ...metadata },
+      ...(status !== undefined ? { status } : {}),
+    } as any);
+
+  describe('getRoles', () => {
+    it('extracts role names from node-role.kubernetes.io labels', () => {
+      const node = makeNode({
+        labels: {
+          'node-role.kubernetes.io/control-plane': '',
+          'node-role.kubernetes.io/worker': '',
+          'kubernetes.io/hostname': 'test-node',
+        },
+      });
+      expect(node.getRoles()).toEqual(['control-plane', 'worker']);
+    });
+
+    it('returns empty array when no role labels exist', () => {
+      const node = makeNode({
+        labels: {
+          'kubernetes.io/hostname': 'test-node',
+        },
+      });
+      expect(node.getRoles()).toEqual([]);
+    });
+
+    it('handles undefined or empty labels gracefully', () => {
+      const node = makeNode({});
+      expect(node.getRoles()).toEqual([]);
+    });
+  });
+
+  describe('getExternalIP and getInternalIP', () => {
+    it('returns addresses when populated', () => {
+      const node = makeNode(
+        {},
+        {
+          addresses: [
+            { type: 'InternalIP', address: '10.0.0.1' },
+            { type: 'ExternalIP', address: '203.0.113.1' },
+          ],
+        }
+      );
+      expect(node.getInternalIP()).toBe('10.0.0.1');
+      expect(node.getExternalIP()).toBe('203.0.113.1');
+    });
+
+    it('returns empty string when address type is not found', () => {
+      const node = makeNode(
+        {},
+        {
+          addresses: [{ type: 'Hostname', address: 'test-node' }],
+        }
+      );
+      expect(node.getInternalIP()).toBe('');
+      expect(node.getExternalIP()).toBe('');
+    });
+
+    it('does not throw and returns empty string when status is undefined', () => {
+      const node = makeNode({}, undefined);
+      expect(node.getInternalIP()).toBe('');
+      expect(node.getExternalIP()).toBe('');
+    });
+  });
+});

--- a/frontend/src/lib/k8s/node.ts
+++ b/frontend/src/lib/k8s/node.ts
@@ -124,11 +124,11 @@ class Node extends KubeObject<KubeNode> {
   }
 
   getExternalIP(): string {
-    return this.status.addresses?.find(address => address.type === 'ExternalIP')?.address || '';
+    return this.status?.addresses?.find(address => address.type === 'ExternalIP')?.address || '';
   }
 
   getInternalIP(): string {
-    return this.status.addresses?.find(address => address.type === 'InternalIP')?.address || '';
+    return this.status?.addresses?.find(address => address.type === 'InternalIP')?.address || '';
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes unhandled `TypeError: Cannot read properties of undefined` runtime crashes across the Node list and details views when `node.status` is omitted or undefined (e.g. prior to initial node registration/heartbeat, in mock fixtures, or with virtual nodes).

## Related Issue

Fixes #7653

## Changes

- `frontend/src/components/node/List.tsx`:
  - Added optional chaining to `node.status?.conditions?.find(...)` in the `ready` column.
  - Refactored `roles` column to cleanly use existing `node.getRoles()`.
  - Added optional chaining to `node.status?.nodeInfo?.kubeletVersion` and `node.status?.nodeInfo?.operatingSystem`.
  - Guarded software column render block against missing `status.nodeInfo`.
- `frontend/src/components/node/Details.tsx`:
  - Added optional chaining to `NodeReadyLabel` to prevent crashes when `node.status` is undefined.
- `frontend/src/lib/k8s/node.ts`:
  - Added optional chaining in `getExternalIP()` and `getInternalIP()` when accessing `this.status?.addresses`.
- Added unit tests:
  - `frontend/src/lib/k8s/node.test.ts`: Validates `getRoles()`, `getInternalIP()`, and `getExternalIP()` with and without `status`.
  - `frontend/src/components/node/List.test.tsx`: Validates `NodeList` columns handle nodes with `status: undefined` without throwing.

## Steps to Test

1. Run frontend unit tests:
   ```bash
   npm test -- src/lib/k8s/node.test.ts
   npm test -- src/components/node/List.test.tsx
   ```
2. Verify linter and type checks pass:
   ```bash
   npm run frontend:lint
   npm run frontend:tsc
   ```
3. Load NodeList with minimal or newly created mock nodes missing `status` and verify the table renders gracefully.
