### PR TITLE
frontend: fix zero-desired workloads shown as Unhealthy

### DIFF
--- a/frontend/src/components/project/ProjectResourcesTab.test.tsx
+++ b/frontend/src/components/project/ProjectResourcesTab.test.tsx
@@ -19,6 +19,7 @@ import { fireEvent, render, renderHook, screen } from '@testing-library/react';
 import type React from 'react';
 import { KubeObject } from '../../lib/k8s/KubeObject';
 import {
+  getWorkloadHealthText,
   ProjectResourcesTab,
   resourcePaneStyles,
   useResourceCategoriesList,
@@ -306,5 +307,64 @@ describe('ProjectResourcesTab', () => {
     fireEvent.click(screen.getAllByRole('button', { name: 'Show Logs' })[0]);
     fireEvent.click(screen.getAllByRole('button', { name: 'Terminal / Exec' })[0]);
     expect(mockActivityLaunch).toHaveBeenCalledTimes(2);
+  });
+  it('does not label a scaled-to-zero Deployment as Unhealthy in the rendered table', () => {
+    const projectResources = [
+      resource('Deployment', 'deployment-zero-scaled', {
+        category: 'Workloads',
+        isScalable: true,
+        spec: { replicas: 0 },
+        status: { readyReplicas: 0 },
+      }),
+    ];
+
+    render(
+      <ProjectResourcesTab
+        projectResources={projectResources}
+        selectedCategoryName="Workloads"
+        setSelectedCategoryName={() => {}}
+      />
+    );
+
+    // no healthStatus override → getStatus mock returns 'success', matching the icon
+    // that KubeObjectStatus.tsx already produces for 0/0 in the real app
+    expect(screen.getByText('Healthy')).toBeInTheDocument();
+    expect(screen.queryByText('Unhealthy')).not.toBeInTheDocument();
+  });
+});
+
+describe('getWorkloadHealthText', () => {
+  it.each(['Deployment', 'StatefulSet'] as const)(
+    'reports a %s scaled to zero as Healthy, not Unhealthy',
+    kind => {
+      const zeroScaled = resource(kind, 'zero-scaled', {
+        spec: { replicas: 0 },
+        status: { readyReplicas: 0 },
+      });
+      expect(getWorkloadHealthText(zeroScaled)).toBe('Healthy');
+    }
+  );
+
+  it('reports a DaemonSet with zero desired replicas as Healthy, not Unhealthy', () => {
+    const zeroScaled = resource('DaemonSet', 'zero-scaled', {
+      status: { numberReady: 0, desiredNumberScheduled: 0 },
+    });
+    expect(getWorkloadHealthText(zeroScaled)).toBe('Healthy');
+  });
+
+  it('still reports Unhealthy when ready is zero but replicas are desired', () => {
+    const unhealthy = resource('Deployment', 'unhealthy', {
+      spec: { replicas: 3 },
+      status: { readyReplicas: 0 },
+    });
+    expect(getWorkloadHealthText(unhealthy)).toBe('Unhealthy');
+  });
+
+  it('still reports Degraded when ready is below a positive desired count', () => {
+    const degraded = resource('StatefulSet', 'degraded', {
+      spec: { replicas: 3 },
+      status: { readyReplicas: 1 },
+    });
+    expect(getWorkloadHealthText(degraded)).toBe('Degraded');
   });
 });

--- a/frontend/src/components/project/ProjectResourcesTab.tsx
+++ b/frontend/src/components/project/ProjectResourcesTab.tsx
@@ -74,6 +74,46 @@ export const useResourceCategoriesList = (resources: KubeObject[]) => {
   }, [resources]);
 };
 
+// add above the ProjectResourcesTab component, or near useResourceCategoriesList
+
+export type WorkloadHealthText = 'Healthy' | 'Degraded' | 'Unhealthy' | 'Pending' | 'Failed';
+
+export function getWorkloadHealthText(resource: KubeObject): WorkloadHealthText {
+  const kind = resource.kind;
+
+  if (kind === 'Deployment' || kind === 'StatefulSet') {
+    const workload = resource as Deployment | StatefulSet;
+    const desired = workload.spec?.replicas || 0;
+    const ready = workload.status?.readyReplicas || 0;
+    if (desired === 0) return 'Healthy';
+    if (ready === 0) return 'Unhealthy';
+    if (ready < desired) return 'Degraded';
+    return 'Healthy';
+  }
+
+  if (kind === 'DaemonSet') {
+    const daemonSet = resource as DaemonSet;
+    const desired = daemonSet.status?.desiredNumberScheduled || 0;
+    const ready = daemonSet.status?.numberReady || 0;
+    if (desired === 0) return 'Healthy';
+    if (ready === 0) return 'Unhealthy';
+    if (ready < desired) return 'Degraded';
+    return 'Healthy';
+  }
+
+  if (kind === 'Pod') {
+    const pod = resource as Pod;
+    const phase = pod.status?.phase;
+    const conditions = pod.status?.conditions || [];
+    const ready = conditions.find((c: any) => c.type === 'Ready')?.status === 'True';
+
+    if (phase === 'Failed' || phase === 'CrashLoopBackOff') return 'Failed';
+    if (phase === 'Pending' || !ready) return 'Pending';
+  }
+
+  return 'Healthy';
+}
+
 interface ProjectResourcesTabProps {
   projectResources: KubeObject[];
   showClusterColumn?: boolean;
@@ -135,82 +175,12 @@ export function ProjectResourcesTab({
       {
         id: 'health',
         gridTemplate: 'min-content',
-        accessorFn: resource => {
-          const kind = resource.kind;
-          if (kind === 'Deployment') {
-            const deployment = resource as Deployment;
-            const spec = deployment.spec;
-            const status = deployment.status;
-            if (status?.readyReplicas === 0) return 'Unhealthy';
-            if ((status?.readyReplicas || 0) < (spec?.replicas || 0)) return 'Degraded';
-          } else if (kind === 'StatefulSet') {
-            const statefulSet = resource as StatefulSet;
-            const spec = statefulSet.spec;
-            const status = statefulSet.status;
-            if (status?.readyReplicas === 0) return 'Unhealthy';
-            if ((status?.readyReplicas || 0) < (spec?.replicas || 0)) return 'Degraded';
-          } else if (kind === 'DaemonSet') {
-            const daemonSet = resource as DaemonSet;
-            const status = daemonSet.status;
-            if (status?.numberReady === 0) return 'Unhealthy';
-            if ((status?.numberReady || 0) < (status?.desiredNumberScheduled || 0))
-              return 'Degraded';
-          } else if (kind === 'Pod') {
-            const pod = resource as Pod;
-            const phase = pod.status?.phase;
-            const conditions = pod.status?.conditions || [];
-            const ready = conditions.find((c: any) => c.type === 'Ready')?.status === 'True';
-
-            if (phase === 'Failed' || phase === 'CrashLoopBackOff') return 'Failed';
-            if (phase === 'Pending' || !ready) return 'Pending';
-          }
-          return 'Healthy';
-        },
+        accessorFn: resource => getWorkloadHealthText(resource),
         header: t('Health'),
         Cell: ({ row }) => {
           const resource = row.original;
-          const kind = resource.kind;
-          let healthText = 'Healthy';
           const status = getStatus(resource);
-
-          if (kind === 'Deployment') {
-            const deployment = resource as Deployment;
-            const spec = deployment.spec;
-            const status = deployment.status;
-            if (status?.readyReplicas === 0) {
-              healthText = 'Unhealthy';
-            } else if ((status?.readyReplicas || 0) < (spec?.replicas || 0)) {
-              healthText = 'Degraded';
-            }
-          } else if (kind === 'StatefulSet') {
-            const statefulSet = resource as StatefulSet;
-            const spec = statefulSet.spec;
-            const status = statefulSet.status;
-            if (status?.readyReplicas === 0) {
-              healthText = 'Unhealthy';
-            } else if ((status?.readyReplicas || 0) < (spec?.replicas || 0)) {
-              healthText = 'Degraded';
-            }
-          } else if (kind === 'DaemonSet') {
-            const daemonSet = resource as DaemonSet;
-            const status = daemonSet.status;
-            if (status?.numberReady === 0) {
-              healthText = 'Unhealthy';
-            } else if ((status?.numberReady || 0) < (status?.desiredNumberScheduled || 0)) {
-              healthText = 'Degraded';
-            }
-          } else if (kind === 'Pod') {
-            const pod = resource as Pod;
-            const phase = pod.status?.phase;
-            const conditions = pod.status?.conditions || [];
-            const ready = conditions.find((c: any) => c.type === 'Ready')?.status === 'True';
-
-            if (phase === 'Failed' || phase === 'CrashLoopBackOff') {
-              healthText = 'Failed';
-            } else if (phase === 'Pending' || !ready) {
-              healthText = 'Pending';
-            }
-          }
+          const healthText = getWorkloadHealthText(resource);
 
           return (
             <StatusLabel status={status} sx={{ alignItems: 'center' }}>
@@ -222,9 +192,7 @@ export function ProjectResourcesTab({
                     ? 'mdi:alert'
                     : 'mdi:check-circle'
                 }
-                style={{
-                  fontSize: 16,
-                }}
+                style={{ fontSize: 16 }}
               />
               {healthText}
             </StatusLabel>


### PR DESCRIPTION
## Summary

Deployment, StatefulSet, and DaemonSet health checks in ProjectResourcesTab short-circuited to Unhealthy whenever ready replicas were zero, even when the desired count was also zero (e.g. deliberately scaled to 0). This also produced a mismatched success icon next to the Unhealthy text, since the shared getStatus() logic in KubeObjectStatus already treated 0/0 as healthy.

## Related Issue

Fixes #7642

## Changes

- Extracted a single `getWorkloadHealthText()` helper used by both the health column's `accessorFn` and its `Cell` renderer, replacing the previous duplicated logic.
- A zero desired count now returns `Healthy` before the ready/desired comparison runs, for Deployment, StatefulSet, and DaemonSet.
- Added regression tests covering all three workload kinds at 0/0, plus a render-level test confirming the health text and status icon now agree.

## Steps to Test
1. Open a Project containing a Deployment or StatefulSet scaled to 0 replicas, or a DaemonSet with `desiredNumberScheduled: 0`.
2. Go to the Project's Resources tab and select the workload's category.
3. Confirm the Health column shows "Healthy" (not "Unhealthy"), with an icon that matches the text.
4. Existing Degraded/Unhealthy behavior for positive desired counts is unchanged (see updated ProjectResourcesTab.test.tsx).

## Notes for the Reviewer

None.