### PR TITLE
backend: kubeconfig: Clear current-context on active context removal

### DIFF
--- a/backend/pkg/kubeconfig/file.go
+++ b/backend/pkg/kubeconfig/file.go
@@ -166,6 +166,10 @@ func RemoveContextFromFile(contextName string, path string) error {
 
 	delete(config.Contexts, contextName)
 
+	if config.CurrentContext == contextName {
+		config.CurrentContext = ""
+	}
+
 	removeOrphanedClusterAndUser(config, clusterToRemove, userToRemove)
 
 	return clientcmd.WriteToFile(*config, path)

--- a/backend/pkg/kubeconfig/file_test.go
+++ b/backend/pkg/kubeconfig/file_test.go
@@ -228,6 +228,7 @@ func TestRemoveContextFromFile(t *testing.T) {
 	// check if the minikube context exists
 	_, ok := apiConf.Contexts["minikube"]
 	assert.False(t, ok)
+	assert.Empty(t, apiConf.CurrentContext)
 
 	// delete temp kubeconfig file and lock file
 	err = os.Remove("./test_data/config_copy")
@@ -237,6 +238,33 @@ func TestRemoveContextFromFile(t *testing.T) {
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		require.NoError(t, err)
 	}
+}
+
+func TestRemoveContextFromFile_PreservesCurrentContext(t *testing.T) {
+	data, err := os.ReadFile("./test_data/kubeconfig1")
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	err = os.WriteFile("./test_data/config_copy_current", data, 0o600) //nolint:gosec
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, os.Remove("./test_data/config_copy_current"))
+
+		if err := os.Remove("./test_data/config_copy_current.lock"); err != nil && !errors.Is(err, os.ErrNotExist) {
+			require.NoError(t, err)
+		}
+	})
+
+	err = kubeconfig.RemoveContextFromFile("docker-desktop", "./test_data/config_copy_current")
+	require.NoError(t, err)
+
+	apiConf, err := clientcmd.LoadFromFile("./test_data/config_copy_current")
+	require.NoError(t, err)
+
+	_, ok := apiConf.Contexts["docker-desktop"]
+	assert.False(t, ok)
+	assert.Equal(t, "minikube", apiConf.CurrentContext)
 }
 
 func TestRemoveContextFromFile_NonExistentContext(t *testing.T) {


### PR DESCRIPTION
## Summary

Deleting a cluster that's the active context in a kubeconfig left `current-context` pointing at a context that no longer exists, which breaks kubectl until you pick a new one by hand This clears `current-context` when the removed context was the active one

## Related Issue

Fixes #7636

## Changes

- `backend/pkg/kubeconfig/file.go`: clear `config.CurrentContext` in `RemoveContextFromFile` if it matches the context being removed
- `backend/pkg/kubeconfig/file_test.go`: assert `current-context` is cleared in the existing test, and add a test that removing a non-active context leaves it alone

## Steps to Test

1. Make a kubeconfig with two contexts and set `current-context` to one of them
2. Run `headlamp-server -kubeconfig <path> -enable-dynamic-clusters -allow-kubeconfig-changes` and delete that cluster from the UI
3. Before: `current-context` still names the deleted context and `kubectl get pods` fails with `context was not found`. After: it empty and kubectl says `current-context is not set`
4. `cd backend && go test ./pkg/kubeconfig/ -run TestRemoveContextFromFile -v`

